### PR TITLE
Add issue templates, PR template, and custom labels (Phase 2)

### DIFF
--- a/.github/ISSUE_TEMPLATE/blank.yml
+++ b/.github/ISSUE_TEMPLATE/blank.yml
@@ -1,0 +1,10 @@
+name: Blank Issue
+description: Open a blank issue — use this if nothing else fits
+labels: []
+body:
+  - type: textarea
+    id: content
+    attributes:
+      label: What's on your mind?
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -1,0 +1,58 @@
+name: Bug Report
+description: Something isn't working as documented
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for reporting a bug! Please fill out the details below so we can help.
+
+  - type: input
+    id: contribution
+    attributes:
+      label: Which contribution?
+      description: The name and category (e.g., "recipes/email-history-import")
+      placeholder: recipes/email-history-import
+    validations:
+      required: true
+
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened?
+      description: Describe what went wrong. Include any error messages you saw.
+      placeholder: "I followed step 3 but got an error saying..."
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: What did you expect?
+      description: What should have happened instead?
+    validations:
+      required: true
+
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to reproduce
+      description: How can we see the same problem?
+      placeholder: |
+        1. Go to '...'
+        2. Run '...'
+        3. See error
+    validations:
+      required: true
+
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment
+      description: Any relevant details about your setup.
+      placeholder: |
+        - Supabase plan: Free
+        - OS: macOS 15
+        - Node version: 22
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,2 @@
+blank_issues_enabled: false
+contact_links: []

--- a/.github/ISSUE_TEMPLATE/feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yml
@@ -1,0 +1,37 @@
+name: Feature Request
+description: Suggest an improvement to an existing contribution or to the repo itself
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Have an idea to make something better? We'd love to hear it.
+
+  - type: dropdown
+    id: area
+    attributes:
+      label: What area does this relate to?
+      options:
+        - An existing contribution (recipe, schema, dashboard, integration)
+        - Repo structure or templates
+        - CI/CD or automation
+        - Documentation
+        - Other
+    validations:
+      required: true
+
+  - type: textarea
+    id: description
+    attributes:
+      label: What would you like to see?
+      description: Describe the improvement. What problem does it solve?
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Have you tried any workarounds or considered other approaches?
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/non-technical-contribution.yml
+++ b/.github/ISSUE_TEMPLATE/non-technical-contribution.yml
@@ -1,0 +1,39 @@
+name: Non-Technical Contribution
+description: Share knowledge, workflows, or ideas without writing code
+labels: ["non-technical", "help-wanted"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        You don't need to be a developer to contribute to Open Brain. If you have a workflow, an idea, or knowledge that would help others — we want to hear it. A community mentor will help turn your idea into a contribution with full credit to you.
+
+  - type: textarea
+    id: description
+    attributes:
+      label: What would you like to share?
+      description: Describe your idea, workflow, or knowledge. Be as detailed as you'd like — the more context, the easier it is for a mentor to help shape it into a contribution.
+      placeholder: |
+        Example: "I use Open Brain to track every restaurant recommendation I get from friends. Each morning I check what's nearby for lunch. Here's how I organize it..."
+    validations:
+      required: true
+
+  - type: dropdown
+    id: type
+    attributes:
+      label: What kind of contribution is this?
+      options:
+        - A workflow or use case I want to document
+        - An idea for something that should exist
+        - Feedback on an existing contribution
+        - Documentation improvement
+        - Other
+    validations:
+      required: true
+
+  - type: textarea
+    id: context
+    attributes:
+      label: Any additional context?
+      description: Screenshots, links, or anything else that helps explain your idea.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/recipe-submission.yml
+++ b/.github/ISSUE_TEMPLATE/recipe-submission.yml
@@ -1,0 +1,71 @@
+name: Recipe / Contribution Idea
+description: Propose a new recipe, schema, dashboard, or integration
+labels: ["contribution-idea"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Have something you've built on Open Brain, or an idea for something that should exist? Tell us about it. You don't need to have code ready — ideas are welcome.
+
+  - type: dropdown
+    id: category
+    attributes:
+      label: Category
+      description: Where would this contribution live?
+      options:
+        - Recipe (step-by-step build)
+        - Schema (database extension)
+        - Dashboard (frontend template)
+        - Integration (MCP extension, webhook, capture source)
+        - Not sure
+    validations:
+      required: true
+
+  - type: input
+    id: name
+    attributes:
+      label: Name
+      description: A short name for the contribution
+      placeholder: "Gmail label import"
+    validations:
+      required: true
+
+  - type: textarea
+    id: description
+    attributes:
+      label: What does it do?
+      description: 1-3 sentences. What capability does this add to Open Brain?
+    validations:
+      required: true
+
+  - type: textarea
+    id: requirements
+    attributes:
+      label: What does it need?
+      description: External services, tools, or APIs required (if you know)
+      placeholder: "Gmail API, Node.js 18+"
+    validations:
+      required: false
+
+  - type: dropdown
+    id: difficulty
+    attributes:
+      label: Estimated difficulty
+      options:
+        - Beginner (< 30 min, mostly copy-paste)
+        - Intermediate (30-60 min, some configuration)
+        - Advanced (1+ hours, custom code)
+        - Not sure
+    validations:
+      required: false
+
+  - type: dropdown
+    id: status
+    attributes:
+      label: Do you have this working already?
+      options:
+        - "Yes — I've built it and can submit a PR"
+        - "Partially — I have a working prototype"
+        - "No — this is an idea I'd like to see built"
+    validations:
+      required: true

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,24 @@
+## Contribution Type
+
+<!-- Check one -->
+- [ ] Recipe (`/recipes`)
+- [ ] Schema (`/schemas`)
+- [ ] Dashboard (`/dashboards`)
+- [ ] Integration (`/integrations`)
+- [ ] Repo improvement (docs, CI, templates)
+
+## What does this do?
+
+<!-- 1-3 sentences describing what this contribution adds or changes -->
+
+## Requirements
+
+<!-- What external services, tools, or APIs does this need? (e.g., Gmail API, Node.js 18+) -->
+
+## Checklist
+
+- [ ] I've read [CONTRIBUTING.md](../CONTRIBUTING.md)
+- [ ] My contribution has a `README.md` with prerequisites, step-by-step instructions, and expected outcome
+- [ ] My `metadata.json` has all required fields
+- [ ] I tested this on my own Open Brain instance
+- [ ] No credentials, API keys, or secrets are included


### PR DESCRIPTION
## Summary
- **5 issue templates** (YAML forms): bug report, feature request, recipe/contribution idea, non-technical contribution, blank
- **PR template** with contribution type selector and checklist
- **10 custom labels** created directly on the repo: `recipe`, `schema`, `dashboard`, `integration`, `needs-review`, `needs-revision`, `ready-to-merge`, `non-technical`, `contribution-idea`, `discussion`

Covers requirements GH-01, GH-02, GH-03.

## Test plan
- [ ] Navigate to Issues > New Issue and verify all 5 templates render correctly
- [ ] Open a draft PR and verify the PR template loads with checkboxes
- [ ] Check repo labels page to confirm all custom labels exist

🤖 Generated with [Claude Code](https://claude.com/claude-code)