### PR TITLE
Add welcome bot, auto-labeler, and markdown linting (Phase 3)

### DIFF
--- a/.github/workflows/auto-label.yml
+++ b/.github/workflows/auto-label.yml
@@ -1,0 +1,58 @@
+name: Auto-Label PRs
+
+on:
+  pull_request:
+    types: [opened, synchronize]
+    branches: [main]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  label:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Detect contribution types and apply labels
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const { data: files } = await github.rest.pulls.listFiles({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.issue.number,
+              per_page: 100,
+            });
+
+            const labels = new Set();
+            const pathMap = {
+              'recipes/': 'recipe',
+              'schemas/': 'schema',
+              'dashboards/': 'dashboard',
+              'integrations/': 'integration',
+            };
+
+            for (const file of files) {
+              for (const [prefix, label] of Object.entries(pathMap)) {
+                if (file.filename.startsWith(prefix) && !file.filename.includes('_template/')) {
+                  labels.add(label);
+                }
+              }
+            }
+
+            if (labels.size > 0) {
+              await github.rest.issues.addLabels({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                labels: [...labels],
+              });
+              console.log(`Applied labels: ${[...labels].join(', ')}`);
+            } else {
+              console.log('No contribution directories detected, no labels applied.');
+            }

--- a/.github/workflows/markdown-lint.yml
+++ b/.github/workflows/markdown-lint.yml
@@ -1,0 +1,29 @@
+name: Markdown Lint
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+    branches: [main]
+    paths:
+      - '**/*.md'
+
+permissions:
+  contents: read
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Install markdownlint-cli2
+        run: npm install -g markdownlint-cli2
+
+      - name: Run markdownlint
+        run: markdownlint-cli2 "**/*.md" "#node_modules"

--- a/.github/workflows/welcome.yml
+++ b/.github/workflows/welcome.yml
@@ -1,0 +1,79 @@
+name: Welcome New Contributors
+
+on:
+  issues:
+    types: [opened]
+  pull_request_target:
+    types: [opened]
+
+permissions:
+  issues: write
+  pull-requests: write
+
+jobs:
+  welcome:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check if first-time contributor
+        id: check
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const creator = context.payload.sender.login;
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+
+            // Check for previous issues
+            const { data: issues } = await github.rest.issues.listForRepo({
+              owner, repo,
+              creator,
+              state: 'all',
+              per_page: 2,
+            });
+
+            // Check for previous PRs
+            const { data: prs } = await github.rest.pulls.list({
+              owner, repo,
+              state: 'all',
+              per_page: 100,
+            });
+            const userPRs = prs.filter(pr => pr.user.login === creator);
+
+            const isFirstIssue = context.eventName === 'issues' && issues.length <= 1;
+            const isFirstPR = context.eventName === 'pull_request_target' && userPRs.length <= 1;
+
+            core.setOutput('is_first', isFirstIssue || isFirstPR ? 'true' : 'false');
+            core.setOutput('event_type', context.eventName === 'issues' ? 'issue' : 'pr');
+
+      - name: Welcome message
+        if: steps.check.outputs.is_first == 'true'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const eventType = '${{ steps.check.outputs.event_type }}';
+            const creator = context.payload.sender.login;
+
+            let body;
+            if (eventType === 'pr') {
+              body = `Hey @${creator} — welcome to Open Brain Source! 👋
+
+Thanks for submitting your first PR. The automated review will run shortly and check things like metadata, folder structure, and README completeness. If anything needs fixing, the review comment will tell you exactly what.
+
+Once the automated checks pass, a human admin will review for quality and clarity. Expect a response within a few days.
+
+If you have questions, check out [CONTRIBUTING.md](../blob/main/CONTRIBUTING.md) or open an issue.`;
+            } else {
+              body = `Hey @${creator} — welcome to Open Brain Source! 👋
+
+Thanks for opening your first issue. Someone from the community will take a look soon.
+
+If you're interested in contributing (code or not), check out [CONTRIBUTING.md](../blob/main/CONTRIBUTING.md) — we have paths for developers and non-developers alike.`;
+            }
+
+            const issueNumber = context.issue?.number || context.payload.pull_request?.number;
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: issueNumber,
+              body: body,
+            });

--- a/.markdownlint.jsonc
+++ b/.markdownlint.jsonc
@@ -1,0 +1,25 @@
+{
+  // Permissive config: catch real problems, don't block on style nits
+  "default": true,
+
+  // Allow any line length — READMEs with tables and URLs get long
+  "MD013": false,
+
+  // Allow duplicate headings (common in contribution READMEs)
+  "MD024": false,
+
+  // Allow inline HTML (badges, images, comments)
+  "MD033": false,
+
+  // Allow bare URLs
+  "MD034": false,
+
+  // Allow trailing punctuation in headings
+  "MD026": false,
+
+  // Allow multiple top-level headings (some files have them)
+  "MD025": false,
+
+  // Allow non-blank lines before/after lists (common in quick docs)
+  "MD032": false
+}


### PR DESCRIPTION
## Summary
- **Welcome bot** (`welcome.yml`): auto-comments on first-time contributor PRs and issues with tailored messages
- **Auto-labeler** (`auto-label.yml`): applies `recipe`, `schema`, `dashboard`, `integration` labels based on which directories a PR touches
- **Markdown linting** (`markdown-lint.yml`): runs `markdownlint-cli2` on PRs that touch `.md` files, with permissive config (`.markdownlint.jsonc`)

Covers CI-01, CI-02, CI-04.

## Test plan
- [ ] Open a test issue from a new account to verify welcome message
- [ ] Open a test PR touching `recipes/` and verify `recipe` label is applied
- [ ] Open a test PR with a `.md` change and verify lint runs without false positives on existing files

🤖 Generated with [Claude Code](https://claude.com/claude-code)