### PR TITLE
[infra] Add SOUL.md and automated soul check for PRs and issues

### DIFF
--- a/.github/workflows/ob1-review.yml
+++ b/.github/workflows/ob1-review.yml
@@ -591,3 +591,152 @@ jobs:
         run: |
           echo "One or more review checks failed. See the PR comment for details."
           exit 1
+
+      # ─── Soul Check (non-blocking, advisory) ──────────────────────────
+      # Evaluates PR alignment with OB1's mission using an LLM.
+      # Posts a separate comment. Never blocks merge.
+
+      - name: Soul check
+        if: always() && steps.changed.outputs.contrib_dirs != ''
+        continue-on-error: true
+        env:
+          OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
+          CONTRIB_DIRS: ${{ steps.changed.outputs.contrib_dirs }}
+          CHANGED_FILES: ${{ steps.changed.outputs.files }}
+        run: |
+          # Skip if no API key configured
+          if [ -z "$OPENROUTER_API_KEY" ]; then
+            echo "soul_comment=*Soul check skipped — OPENROUTER_API_KEY not configured.*" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+
+          # Skip if SOUL.md doesn't exist
+          if [ ! -f "SOUL.md" ]; then
+            echo "soul_comment=*Soul check skipped — SOUL.md not found.*" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+
+          SOUL=$(cat SOUL.md)
+          PR_TITLE="${{ github.event.pull_request.title }}"
+          PR_BODY=$(jq -r '.pull_request.body // ""' "$GITHUB_EVENT_PATH" | head -c 2000)
+
+          # Read contribution README (first contribution folder)
+          CONTRIB_DIR=$(echo "$CONTRIB_DIRS" | head -1)
+          README_EXCERPT=""
+          if [ -f "$CONTRIB_DIR/README.md" ]; then
+            README_EXCERPT=$(head -c 3000 "$CONTRIB_DIR/README.md")
+          fi
+
+          # Read metadata
+          METADATA=""
+          if [ -f "$CONTRIB_DIR/metadata.json" ]; then
+            METADATA=$(cat "$CONTRIB_DIR/metadata.json")
+          fi
+
+          # Build the prompt
+          SYSTEM_PROMPT="You are the voice of Open Brain (OB1), an open-source project. You evaluate whether contributions align with the project's soul and values. You speak as OB1 itself — welcoming, direct, specific, and constructive. You never reject ideas outright. When something doesn't fit, you suggest how it could be adapted. Personal, creative, wellness, and non-technical use cases are explicitly valued."
+
+          # Use jq to safely build the JSON payload with proper escaping
+          USER_CONTENT=$(jq -n \
+            --arg soul "$SOUL" \
+            --arg title "$PR_TITLE" \
+            --arg body "$PR_BODY" \
+            --arg files "$CHANGED_FILES" \
+            --arg readme "$README_EXCERPT" \
+            --arg metadata "$METADATA" \
+            '$"Evaluate this contribution against the OB1 soul document.\n\n<soul_document>\n\($soul)\n</soul_document>\n\n<contribution>\nTitle: \($title)\n\nDescription:\n\($body)\n\nFiles changed:\n\($files)\n\nmetadata.json:\n\($metadata)\n\nREADME excerpt:\n\($readme)\n</contribution>\n\nRespond in this exact JSON format:\n{\n  \"alignment\": \"strong_fit\" or \"likely_fit\" or \"needs_discussion\" or \"potential_misfit\",\n  \"summary\": \"2-3 sentences. Speak as OB1. Be specific about what this adds and how it connects to the mission. If alignment is unclear or a misfit, be constructive — suggest how it could be adapted.\",\n  \"highlights\": \"One sentence about what is good or interesting about this contribution.\",\n  \"concerns\": \"Specific concerns, or none if no concerns. If there are concerns, suggest a path forward.\"\n}\n\nAlignment definitions:\n- strong_fit: Clearly serves the core thesis. No concerns.\n- likely_fit: Serves the mission with minor questions or suggestions.\n- needs_discussion: Not clearly aligned or misaligned. An admin should weigh in.\n- potential_misfit: Appears to violate a This Doesnt Belong criterion. Suggest adaptation.\n\nBe generous. When in doubt, choose the more welcoming alignment level."')
+
+          PAYLOAD=$(jq -n \
+            --arg system "$SYSTEM_PROMPT" \
+            --arg user "$USER_CONTENT" \
+            '{
+              "model": "openai/gpt-4o-mini",
+              "response_format": {"type": "json_object"},
+              "messages": [
+                {"role": "system", "content": $system},
+                {"role": "user", "content": $user}
+              ],
+              "temperature": 0.3
+            }')
+
+          # Call OpenRouter
+          RESPONSE=$(curl -s -X POST "https://openrouter.ai/api/v1/chat/completions" \
+            -H "Authorization: Bearer $OPENROUTER_API_KEY" \
+            -H "Content-Type: application/json" \
+            -d "$PAYLOAD" \
+            --max-time 30)
+
+          # Parse response
+          LLM_CONTENT=$(echo "$RESPONSE" | jq -r '.choices[0].message.content // empty')
+          if [ -z "$LLM_CONTENT" ]; then
+            echo "soul_comment=*Soul check failed — could not get LLM response.*" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+
+          ALIGNMENT=$(echo "$LLM_CONTENT" | jq -r '.alignment // "unknown"')
+          SUMMARY=$(echo "$LLM_CONTENT" | jq -r '.summary // "No summary available."')
+          HIGHLIGHTS=$(echo "$LLM_CONTENT" | jq -r '.highlights // ""')
+          CONCERNS=$(echo "$LLM_CONTENT" | jq -r '.concerns // "none"')
+
+          # Map alignment to emoji and label
+          case "$ALIGNMENT" in
+            strong_fit)     LABEL="Strong Fit"; EMOJI="✨" ;;
+            likely_fit)     LABEL="Likely Fit"; EMOJI="👍" ;;
+            needs_discussion) LABEL="Needs Discussion"; EMOJI="🤔" ;;
+            potential_misfit)  LABEL="Potential Misfit"; EMOJI="⚠️" ;;
+            *)              LABEL="Unknown"; EMOJI="❓" ;;
+          esac
+
+          # Build the comment
+          SOUL_COMMENT="### ${EMOJI} Soul Check: ${LABEL}\n\n${SUMMARY}"
+
+          if [ -n "$HIGHLIGHTS" ] && [ "$HIGHLIGHTS" != "none" ]; then
+            SOUL_COMMENT="${SOUL_COMMENT}\n\n**Highlights:** ${HIGHLIGHTS}"
+          fi
+
+          if [ -n "$CONCERNS" ] && [ "$CONCERNS" != "none" ] && [ "$CONCERNS" != "None" ] && [ "$CONCERNS" != "None." ]; then
+            SOUL_COMMENT="${SOUL_COMMENT}\n\n**To consider:** ${CONCERNS}"
+          fi
+
+          SOUL_COMMENT="${SOUL_COMMENT}\n\n---\n*Advisory check based on [SOUL.md](../blob/main/SOUL.md). Human reviewers make the final call.*"
+
+          # Output for next step
+          echo "soul_comment<<EOF" >> $GITHUB_OUTPUT
+          echo -e "$SOUL_COMMENT" >> $GITHUB_OUTPUT
+          echo "EOF" >> $GITHUB_OUTPUT
+
+      - name: Post soul check comment
+        if: always() && steps.changed.outputs.contrib_dirs != ''
+        continue-on-error: true
+        uses: actions/github-script@v7
+        env:
+          SOUL_COMMENT: ${{ steps.soul.outputs.soul_comment || '*Soul check did not produce a result.*' }}
+        with:
+          script: |
+            const body = process.env.SOUL_COMMENT;
+            if (!body || body === '*Soul check did not produce a result.*') return;
+
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+            });
+            const soulComment = comments.find(c =>
+              c.user.type === 'Bot' && c.body.includes('Soul Check')
+            );
+
+            if (soulComment) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: soulComment.id,
+                body: body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                body: body,
+              });
+            }

--- a/.github/workflows/soul-check-issues.yml
+++ b/.github/workflows/soul-check-issues.yml
@@ -1,0 +1,114 @@
+name: Soul Check (Issues)
+
+# Evaluates new issues against SOUL.md to help contributors
+# understand if their idea fits OB1 before they start building.
+# Advisory only — never closes or rejects issues.
+
+on:
+  issues:
+    types: [opened]
+
+permissions:
+  issues: write
+
+jobs:
+  soul-check:
+    name: Soul Check
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Evaluate issue alignment
+        id: soul
+        continue-on-error: true
+        env:
+          OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
+        run: |
+          # Skip if no API key configured
+          if [ -z "$OPENROUTER_API_KEY" ]; then
+            exit 0
+          fi
+
+          # Skip if SOUL.md doesn't exist
+          if [ ! -f "SOUL.md" ]; then
+            exit 0
+          fi
+
+          SOUL=$(cat SOUL.md)
+          ISSUE_TITLE=$(jq -r '.issue.title // ""' "$GITHUB_EVENT_PATH")
+          ISSUE_BODY=$(jq -r '.issue.body // ""' "$GITHUB_EVENT_PATH" | head -c 3000)
+          ISSUE_LABELS=$(jq -r '[.issue.labels[].name] | join(", ")' "$GITHUB_EVENT_PATH" 2>/dev/null || echo "")
+
+          # Skip for bug reports and questions — soul check is for contribution ideas
+          if echo "$ISSUE_LABELS" | grep -qiE '(bug|question|help)'; then
+            exit 0
+          fi
+
+          SYSTEM_PROMPT="You are the voice of Open Brain (OB1), an open-source project. Someone has opened an issue — it might be a contribution idea, a feature request, or a proposal. You evaluate whether it aligns with the project's soul. You speak as OB1 — welcoming, direct, specific, and constructive. You never discourage people. When something doesn't fit, you suggest how it could be adapted or where it might belong instead. Personal, creative, wellness, and non-technical use cases are explicitly valued."
+
+          USER_CONTENT=$(jq -n \
+            --arg soul "$SOUL" \
+            --arg title "$ISSUE_TITLE" \
+            --arg body "$ISSUE_BODY" \
+            --arg labels "$ISSUE_LABELS" \
+            '$"Evaluate this issue against the OB1 soul document.\n\n<soul_document>\n\($soul)\n</soul_document>\n\n<issue>\nTitle: \($title)\nLabels: \($labels)\n\nBody:\n\($body)\n</issue>\n\nRespond in this exact JSON format:\n{\n  \"alignment\": \"strong_fit\" or \"likely_fit\" or \"needs_discussion\" or \"potential_misfit\",\n  \"response\": \"2-4 sentences. Speak as OB1 directly to the issue author. Be welcoming. If it fits, say why and suggest which category (recipes/schemas/dashboards/integrations) it might land in. If alignment is unclear, ask clarifying questions. If it doesnt fit, be kind and suggest alternatives or adaptations.\"\n}\n\nBe generous. Encourage people. When in doubt, ask questions rather than flagging misalignment."')
+
+          PAYLOAD=$(jq -n \
+            --arg system "$SYSTEM_PROMPT" \
+            --arg user "$USER_CONTENT" \
+            '{
+              "model": "openai/gpt-4o-mini",
+              "response_format": {"type": "json_object"},
+              "messages": [
+                {"role": "system", "content": $system},
+                {"role": "user", "content": $user}
+              ],
+              "temperature": 0.3
+            }')
+
+          RESPONSE=$(curl -s -X POST "https://openrouter.ai/api/v1/chat/completions" \
+            -H "Authorization: Bearer $OPENROUTER_API_KEY" \
+            -H "Content-Type: application/json" \
+            -d "$PAYLOAD" \
+            --max-time 30)
+
+          LLM_CONTENT=$(echo "$RESPONSE" | jq -r '.choices[0].message.content // empty')
+          if [ -z "$LLM_CONTENT" ]; then
+            exit 0
+          fi
+
+          ALIGNMENT=$(echo "$LLM_CONTENT" | jq -r '.alignment // "unknown"')
+          RESPONSE_TEXT=$(echo "$LLM_CONTENT" | jq -r '.response // ""')
+
+          case "$ALIGNMENT" in
+            strong_fit)       EMOJI="✨" ;;
+            likely_fit)       EMOJI="👍" ;;
+            needs_discussion) EMOJI="🤔" ;;
+            potential_misfit)  EMOJI="💡" ;;
+            *)                EMOJI="🧠" ;;
+          esac
+
+          COMMENT="${EMOJI} ${RESPONSE_TEXT}\n\n---\n*I'm an automated check that evaluates ideas against [what Open Brain is about](../blob/main/SOUL.md). A human will follow up.*"
+
+          echo "comment<<EOF" >> $GITHUB_OUTPUT
+          echo -e "$COMMENT" >> $GITHUB_OUTPUT
+          echo "EOF" >> $GITHUB_OUTPUT
+
+      - name: Post comment
+        if: steps.soul.outputs.comment != ''
+        continue-on-error: true
+        uses: actions/github-script@v7
+        env:
+          SOUL_COMMENT: ${{ steps.soul.outputs.comment }}
+        with:
+          script: |
+            const body = process.env.SOUL_COMMENT;
+            if (!body) return;
+
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              body: body,
+            });

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,6 +2,8 @@
 
 ## Before You Contribute
 
+Read **[SOUL.md](SOUL.md)** first — it defines what Open Brain is, what belongs here, and what doesn't. Every PR and issue gets an automated alignment check against this document.
+
 You need a working Open Brain setup. If you haven't built one yet, start with the [Open Brain guide](docs/01-getting-started.md). Every contribution you submit should be tested against your own instance first — don't submit something you haven't run yourself.
 
 ## Not a Developer? You Can Still Contribute.
@@ -173,7 +175,7 @@ As you contribute, you'll progress through these levels. Every level is achievab
 
 Non-code contributions count at every level. Testing recipes, mentoring non-technical contributors, improving documentation, and triaging issues all count toward progression.
 
-## The 11 Automated Review Rules
+## The Automated Review
 
 Every PR is checked against these rules. All must pass before human review.
 
@@ -187,4 +189,6 @@ Every PR is checked against these rules. All must pass before human review.
 8. **No binary blobs** — No files over 1MB, no `.exe`, `.dmg`, `.zip`, `.tar.gz`
 9. **README completeness** — Contribution README includes Prerequisites, step-by-step instructions, and expected outcome sections
 10. **Primitive dependencies** — If a contribution declares `requires_primitives`, the primitives must exist in the repo and be linked in the README
-11. **LLM clarity review** — *(Planned for v2)* Automated check that instructions are clear and complete
+11. **Soul check** — An LLM evaluates whether the contribution aligns with [SOUL.md](SOUL.md) and posts an advisory comment. This check is non-blocking — it flags alignment questions for human reviewers but never prevents a merge.
+12. **Scope check** — All changed files must be within the contribution folder
+13. **Internal links** — Relative links in READMEs must point to files that exist

--- a/SOUL.md
+++ b/SOUL.md
@@ -1,0 +1,52 @@
+# The Soul of Open Brain
+
+This document defines what Open Brain is, what belongs here, and what doesn't. It's read by humans considering contributions and by an automated LLM check that evaluates alignment on every PR and issue.
+
+If you're thinking about contributing, read this first. If something you want to build doesn't fit, that doesn't mean it's a bad idea — it just means it might belong somewhere else.
+
+## Core Thesis
+
+Your AI memory shouldn't be locked inside one app. Open Brain is a database with vector search and an open protocol — built so that every AI tool you use shares the same persistent memory of you. One brain. All of them.
+
+## This Belongs in OB1
+
+- **Capture pathways** — new ways to get knowledge into Open Brain (importers, integrations, capture tools)
+- **Retrieval pathways** — new ways to search, surface, or use knowledge from Open Brain
+- **Processing capabilities** — transforms, summaries, connections, or analysis of stored knowledge
+- **Schema extensions** — new tables or metadata structures that extend what Open Brain can track
+- **Dashboards and UIs** — visual interfaces for browsing, reviewing, or managing your brain
+- **Teaching through building** — contributions that help people learn AI infrastructure concepts by building something useful
+- **Works with the standard schema** — builds on the `thoughts` table, MCP protocol, and Supabase/OpenRouter stack
+- **Runs on free-tier services or local tools** — accessible to anyone, not just people with paid accounts
+- **Personal, creative, wellness, and non-technical use cases** — these are first-class, not afterthoughts
+
+## This Doesn't Belong
+
+- **Platform lock-in** — if it only works with one AI tool and can't be adapted, it misses the point
+- **Paid-only dependencies** — if there's no free-tier or local alternative, it creates a barrier
+- **Core infrastructure changes** — the `thoughts` table schema and MCP server are upstream concerns, not community contribution scope
+- **Duplicates without improvement** — if an existing contribution does the same thing, the new one needs to be meaningfully better
+- **Complexity without proportional value** — a recipe that takes 2 hours to set up needs to deliver 2 hours of value
+- **External data storage** — the user's data stays in their own Supabase instance, always
+- **Closed-source dependencies** — if the contribution requires proprietary software that can't be swapped out
+
+## Values (For Judgment Calls)
+
+When something doesn't clearly fit the lists above, use these values to decide:
+
+- **Portability over features** — a simpler tool that works across 5 AI clients beats a powerful one that only works in one
+- **Simplicity over power** — a 20-minute recipe beats a 2-hour recipe if both achieve similar goals
+- **User ownership** — the user controls their data, their instance, their choices
+- **Progressive learning** — contributions should teach the user something, not just hand them a black box
+- **Tangents are gold** — personal, wellness, creative, relational use cases often contain the highest-value ideas. Never dismiss them as "not technical enough"
+- **Working code over perfect code** — a tested, shipped contribution beats an elegant one that never lands
+- **Community over gatekeeping** — when in doubt, help shape a contribution to fit rather than rejecting it
+
+## How This Document Is Used
+
+1. **Contributors** read it before starting work to check alignment
+2. **Reviewers** reference it when evaluating PRs and issues
+3. **An automated LLM check** evaluates every PR and issue against this document and posts an advisory comment
+4. **Maintainers** update it as the project evolves — this is a living document
+
+The automated check is advisory, not blocking. It flags potential misalignment for human reviewers. It never auto-rejects contributions.


### PR DESCRIPTION
## Summary

Adds an automated LLM-powered alignment check that evaluates every PR and issue against a new `SOUL.md` document. Advisory only — never blocks merge, never auto-rejects.

**Requires:** An `OPENROUTER_API_KEY` GitHub Actions secret to go live. Without it, the check gracefully skips. Cost: ~$0.001 per PR/issue (~$0.20/month at current volume).

## What's included

- **`SOUL.md`** — Structured definition of what OB1 is, what belongs, what doesn't, and values for judgment calls. Machine-readable by LLMs, human-readable by contributors.
- **Soul check on PRs** (added to `ob1-review.yml`) — Sends contribution details + SOUL.md to gpt-4o-mini, posts advisory comment with alignment score and constructive feedback.
- **Soul check on issues** (new `soul-check-issues.yml`) — Same check on new issues, helping contributors understand fit before they start building. Skips bugs/questions.
- **CONTRIBUTING.md update** — References SOUL.md, documents the new checks.

## How it presents to contributors

Speaks *as* OB1 — welcoming, direct, always constructive:

> ✨ **Soul Check: Strong Fit**
> This adds a new capture pathway — importing ChatGPT conversations into Open Brain. Directly serves the portable-memory thesis and runs on free-tier services.
>
> **Highlights:** Production-tested with real numbers, includes both cloud and local LLM options.

For alignment concerns:

> 🤔 **Soul Check: Needs Discussion**
> This requires a paid API with no free alternative. Open Brain values accessibility — could this work with a free-tier option? An admin will weigh in.

## How SOUL.md differs from CONTRIBUTING.md

- `CONTRIBUTING.md` = **how** to contribute (file structure, metadata format, PR rules). Building code.
- `SOUL.md` = **what** to contribute and **why**. Zoning laws.
- Existing CI enforces CONTRIBUTING.md (13 mechanical pass/fail checks).
- Soul check evaluates SOUL.md alignment (advisory, non-blocking, LLM-powered).

## Why

Each PR/issue, one of us manually evaluates mission fit — usually by asking an LLM ourselves. As contributions scale, this becomes the difference between a project that maintains its identity and one that becomes a junk drawer. Cost is roughly the same (~$0.001/check vs. us doing it manually), time savings add up.

## To activate after merge

```bash
gh secret set OPENROUTER_API_KEY
```

## Test plan

- [x] YAML validates for both workflow files
- [x] Markdown lints clean
- [x] Graceful skip when no API key configured (tested by current state — no key, no errors)
- [ ] End-to-end test after secret is added (open a test issue, verify comment appears)