### PR TITLE
[recipes] Source filtering for Open Brain thoughts

### DIFF
--- a/recipes/source-filtering/README.md
+++ b/recipes/source-filtering/README.md
@@ -1,0 +1,170 @@
+# Source Filtering
+
+> Filter and search thoughts by source, backfill metadata for early imports.
+
+## What It Does
+
+Source filtering lets you scope `search_thoughts`, `list_thoughts`, and `thought_stats` to a single source type (e.g., `mcp`, `gmail`, `chatgpt`, `obsidian`). The backfill script adds structured metadata (type, topics, people, sentiment) to thoughts that were imported without LLM extraction — like bulk email imports that went straight into Supabase.
+
+## Prerequisites
+
+- Working Open Brain setup ([guide](../../docs/01-getting-started.md))
+- Deno 1.40+ (for backfill script only)
+- Supabase project URL and service role key
+- OpenRouter API key (for backfill script only)
+
+## Credential Tracker
+
+Copy this block into a text editor and fill it in as you go.
+
+```text
+SOURCE FILTERING -- CREDENTIAL TRACKER
+--------------------------------------
+
+FROM YOUR OPEN BRAIN SETUP
+  Supabase Project URL:        ____________
+  Supabase Service Role Key:   ____________
+
+FOR BACKFILL ONLY
+  OpenRouter API Key:          ____________
+
+--------------------------------------
+```
+
+## Steps
+
+### Step 1: Check your sources
+
+Run this query in the Supabase SQL Editor to see what sources exist in your brain:
+
+```sql
+SELECT metadata->>'source' AS source, COUNT(*) AS count
+FROM thoughts
+GROUP BY metadata->>'source'
+ORDER BY count DESC;
+```
+
+You'll see something like:
+
+| source   | count |
+|----------|-------|
+| gmail    | 1200  |
+| mcp      | 180   |
+| chatgpt  | 50    |
+| *null*   | 15    |
+
+### Step 2: Use source filtering
+
+Source filtering works with three MCP tools. Pass the `source` parameter to scope results:
+
+**search_thoughts** — semantic search within a single source:
+```
+"Search my gmail thoughts for conversations about the product roadmap"
+→ search_thoughts({ query: "product roadmap", source: "gmail" })
+```
+
+**list_thoughts** — recent thoughts from a specific source:
+```
+"Show me my last 10 ChatGPT thoughts"
+→ list_thoughts({ limit: 10, source: "chatgpt" })
+```
+
+**thought_stats** — stats scoped to a source:
+```
+"How many gmail thoughts do I have?"
+→ thought_stats({ source: "gmail" })
+```
+
+Without the `source` parameter, all three tools return results across all sources (existing behavior).
+
+### Step 3: Check if you need backfill
+
+If you imported thoughts without going through `capture_thought` (e.g., bulk email import via direct Supabase insert), those thoughts may be missing LLM-extracted metadata like `type`, `topics`, and `people`. Check:
+
+```sql
+SELECT COUNT(*) AS missing_metadata
+FROM thoughts
+WHERE metadata->>'type' IS NULL;
+```
+
+If this returns 0, you're done — skip to Step 6. If it returns a number, continue to Step 4.
+
+### Step 4: Set up environment variables for backfill
+
+```bash
+export SUPABASE_URL="https://your-project.supabase.co"
+export SUPABASE_SERVICE_ROLE_KEY="your-service-role-key"
+export OPENROUTER_API_KEY="your-openrouter-key"
+```
+
+### Step 5: Run the backfill
+
+Start with a dry run to see what would be updated:
+
+```bash
+deno run --allow-net --allow-env backfill-metadata.ts --dry-run --limit=10
+```
+
+Then run a small live batch:
+
+```bash
+deno run --allow-net --allow-env backfill-metadata.ts --limit=10
+```
+
+If that looks good, run the full backfill:
+
+```bash
+deno run --allow-net --allow-env backfill-metadata.ts --limit=1000
+```
+
+You can also scope the backfill to a specific source:
+
+```bash
+deno run --allow-net --allow-env backfill-metadata.ts --source=gmail --limit=500
+```
+
+### Step 6: Verify
+
+Run `thought_stats` (or `thought_stats({ source: "gmail" })`) — the output should now include a "By source:" breakdown and "By type:" categories for backfilled thoughts.
+
+You can also verify in SQL:
+
+```sql
+SELECT metadata->>'type' AS type, COUNT(*)
+FROM thoughts
+WHERE metadata->>'type' IS NOT NULL
+GROUP BY metadata->>'type'
+ORDER BY count DESC;
+```
+
+## Expected Outcome
+
+- `thought_stats` shows a "By source:" section with counts per source
+- `search_thoughts` with `source: "gmail"` returns only Gmail-sourced thoughts
+- `search_thoughts` without `source` returns thoughts from all sources
+- Backfilled thoughts now have `type`, `topics`, `people`, `sentiment`, and `action_items` in their metadata
+
+## Troubleshooting
+
+**Thoughts have `null` source**
+Some early thoughts were captured before source tracking was added. You can backfill the source field manually:
+```sql
+UPDATE thoughts SET metadata = metadata || '{"source": "mcp"}'::jsonb
+WHERE metadata->>'source' IS NULL;
+```
+
+**Backfill says "Found 0 thought(s) missing metadata"**
+All your thoughts already have LLM-extracted metadata. This happens if everything was imported through `capture_thought`, which extracts metadata automatically.
+
+**Rate limiting from OpenRouter**
+The script batches requests (default 10 concurrent) with a 500ms pause between batches. If you hit rate limits, reduce the batch size:
+```bash
+deno run --allow-net --allow-env backfill-metadata.ts --batch-size=3
+```
+
+**Source strings are case-sensitive**
+`source: "Gmail"` won't match `source: "gmail"`. Sources are stored lowercase. If you have mixed-case sources from a custom import, normalize them:
+```sql
+UPDATE thoughts SET metadata = jsonb_set(metadata, '{source}', to_jsonb(LOWER(metadata->>'source')))
+WHERE metadata->>'source' IS DISTINCT FROM LOWER(metadata->>'source');
+```

--- a/recipes/source-filtering/backfill-metadata.ts
+++ b/recipes/source-filtering/backfill-metadata.ts
@@ -1,0 +1,210 @@
+#!/usr/bin/env -S deno run --allow-net --allow-env
+
+/**
+ * Open Brain — Retroactive Metadata Extraction
+ *
+ * Finds thoughts missing LLM-extracted metadata (type, topics, people, etc.)
+ * and backfills them using the same gpt-4o-mini extraction prompt that
+ * capture_thought uses.
+ *
+ * Typical use: email-imported thoughts that were inserted via Supabase direct
+ * (skipping the ingest endpoint) have embeddings but no structured metadata.
+ *
+ * Usage:
+ *   deno run --allow-net --allow-env scripts/backfill-metadata.ts [options]
+ *
+ * Options:
+ *   --source=gmail          Only backfill thoughts from this source (default: all)
+ *   --limit=100             Max thoughts to process (default: 100)
+ *   --dry-run               Show what would be updated without writing
+ *   --batch-size=10         Concurrent requests per batch (default: 10)
+ *
+ * Requires: SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY, OPENROUTER_API_KEY
+ */
+
+const SUPABASE_URL = Deno.env.get("SUPABASE_URL");
+const SUPABASE_SERVICE_ROLE_KEY = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY");
+const OPENROUTER_API_KEY = Deno.env.get("OPENROUTER_API_KEY");
+
+if (!SUPABASE_URL || !SUPABASE_SERVICE_ROLE_KEY || !OPENROUTER_API_KEY) {
+  console.error("Missing required env vars: SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY, OPENROUTER_API_KEY");
+  Deno.exit(1);
+}
+
+const OPENROUTER_BASE = "https://openrouter.ai/api/v1";
+
+// ─── Args ────────────────────────────────────────────────────────────────────
+
+interface Args {
+  source: string | null;
+  limit: number;
+  dryRun: boolean;
+  batchSize: number;
+}
+
+function parseArgs(): Args {
+  const args: Args = { source: null, limit: 100, dryRun: false, batchSize: 10 };
+  for (const arg of Deno.args) {
+    if (arg.startsWith("--source=")) args.source = arg.split("=")[1];
+    else if (arg.startsWith("--limit=")) args.limit = parseInt(arg.split("=")[1]);
+    else if (arg === "--dry-run") args.dryRun = true;
+    else if (arg.startsWith("--batch-size=")) args.batchSize = parseInt(arg.split("=")[1]);
+  }
+  return args;
+}
+
+// ─── Metadata Extraction (same prompt as MCP server) ─────────────────────────
+
+const EXTRACT_PROMPT = `Extract metadata from the user's captured thought. Return JSON with:
+- "people": array of people mentioned (empty if none)
+- "action_items": array of implied to-dos (empty if none)
+- "dates_mentioned": array of dates YYYY-MM-DD (empty if none)
+- "topics": array of 1-3 short topic tags (always at least one)
+- "type": one of "observation", "task", "idea", "reference", "person_note"
+- "sentiment": one of "positive", "negative", "neutral", "mixed"
+Only extract what's explicitly there.`;
+
+async function extractMetadata(text: string): Promise<Record<string, unknown>> {
+  const r = await fetch(`${OPENROUTER_BASE}/chat/completions`, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${OPENROUTER_API_KEY}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      model: "openai/gpt-4o-mini",
+      response_format: { type: "json_object" },
+      messages: [
+        { role: "system", content: EXTRACT_PROMPT },
+        { role: "user", content: text },
+      ],
+    }),
+  });
+
+  if (!r.ok) {
+    const msg = await r.text().catch(() => "");
+    throw new Error(`OpenRouter failed: ${r.status} ${msg}`);
+  }
+
+  const d = await r.json();
+  try {
+    return JSON.parse(d.choices[0].message.content);
+  } catch {
+    return { topics: ["uncategorized"], type: "observation" };
+  }
+}
+
+// ─── Supabase helpers ────────────────────────────────────────────────────────
+
+const headers = {
+  "Content-Type": "application/json",
+  "apikey": SUPABASE_SERVICE_ROLE_KEY,
+  "Authorization": `Bearer ${SUPABASE_SERVICE_ROLE_KEY}`,
+};
+
+interface Thought {
+  id: string;
+  content: string;
+  metadata: Record<string, unknown>;
+}
+
+async function fetchThoughtsMissingMetadata(source: string | null, limit: number): Promise<Thought[]> {
+  // Find thoughts where metadata has no 'type' key (the primary indicator of LLM extraction)
+  let url = `${SUPABASE_URL}/rest/v1/thoughts?select=id,content,metadata&order=created_at.desc&limit=${limit}`;
+
+  // metadata->>'type' is null means no LLM extraction was done
+  url += `&metadata->>type=is.null`;
+
+  if (source) {
+    url += `&metadata->>source=eq.${source}`;
+  }
+
+  const res = await fetch(url, { headers });
+  if (!res.ok) {
+    const err = await res.text();
+    throw new Error(`Failed to fetch thoughts: ${res.status} ${err}`);
+  }
+  return await res.json();
+}
+
+async function updateThoughtMetadata(id: string, metadata: Record<string, unknown>): Promise<boolean> {
+  const res = await fetch(`${SUPABASE_URL}/rest/v1/thoughts?id=eq.${id}`, {
+    method: "PATCH",
+    headers: { ...headers, "Prefer": "return=minimal" },
+    body: JSON.stringify({ metadata }),
+  });
+  return res.ok;
+}
+
+// ─── Main ────────────────────────────────────────────────────────────────────
+
+async function main() {
+  const args = parseArgs();
+
+  console.log(`\nOpen Brain — Metadata Backfill`);
+  console.log(`  Source filter: ${args.source || "all"}`);
+  console.log(`  Limit: ${args.limit}`);
+  console.log(`  Batch size: ${args.batchSize}`);
+  console.log(`  Mode: ${args.dryRun ? "DRY RUN" : "LIVE"}\n`);
+
+  const thoughts = await fetchThoughtsMissingMetadata(args.source, args.limit);
+  console.log(`Found ${thoughts.length} thought(s) missing metadata.\n`);
+
+  if (thoughts.length === 0) return;
+
+  let updated = 0;
+  let errors = 0;
+
+  // Process in batches
+  for (let i = 0; i < thoughts.length; i += args.batchSize) {
+    const batch = thoughts.slice(i, i + args.batchSize);
+    const batchNum = Math.floor(i / args.batchSize) + 1;
+    const totalBatches = Math.ceil(thoughts.length / args.batchSize);
+    console.log(`Batch ${batchNum}/${totalBatches} (${batch.length} thoughts)...`);
+
+    const results = await Promise.allSettled(
+      batch.map(async (thought) => {
+        const extracted = await extractMetadata(thought.content);
+
+        if (args.dryRun) {
+          console.log(`  [DRY] ${thought.id}: type=${extracted.type}, topics=${(extracted.topics as string[])?.join(", ")}`);
+          return;
+        }
+
+        // Merge: keep existing metadata (source, gmail_labels, etc.), add extracted fields
+        const merged = { ...thought.metadata, ...extracted };
+        const ok = await updateThoughtMetadata(thought.id, merged);
+
+        if (ok) {
+          updated++;
+          console.log(`  ✓ ${thought.id}: type=${extracted.type}, topics=${(extracted.topics as string[])?.join(", ")}`);
+        } else {
+          errors++;
+          console.error(`  ✗ ${thought.id}: update failed`);
+        }
+      }),
+    );
+
+    for (const r of results) {
+      if (r.status === "rejected") {
+        errors++;
+        console.error(`  ✗ Error: ${r.reason}`);
+      }
+    }
+
+    // Rate limit between batches
+    if (i + args.batchSize < thoughts.length) {
+      await new Promise((r) => setTimeout(r, 500));
+    }
+  }
+
+  console.log(`\nDone.`);
+  if (!args.dryRun) {
+    console.log(`  Updated: ${updated}`);
+    console.log(`  Errors: ${errors}`);
+  } else {
+    console.log(`  Would update: ${thoughts.length} thoughts`);
+  }
+}
+
+main();

--- a/recipes/source-filtering/metadata.json
+++ b/recipes/source-filtering/metadata.json
@@ -1,0 +1,20 @@
+{
+  "name": "Source Filtering",
+  "description": "Filter thoughts by source (mcp, gmail, chatgpt, obsidian) and backfill missing metadata for early imports.",
+  "category": "recipes",
+  "author": {
+    "name": "Matt Hallett",
+    "github": "matthallett1"
+  },
+  "version": "1.0.0",
+  "requires": {
+    "open_brain": true,
+    "services": ["OpenRouter"],
+    "tools": ["Deno 1.40+"]
+  },
+  "tags": ["source", "filtering", "metadata", "backfill", "search"],
+  "difficulty": "beginner",
+  "estimated_time": "15 minutes",
+  "created": "2026-03-13",
+  "updated": "2026-03-13"
+}


### PR DESCRIPTION
## Summary

- Adds `recipes/source-filtering/` with README, metadata.json, and backfill script
- Documents how to use the `source` parameter on `search_thoughts`, `list_thoughts`, and `thought_stats`
- Includes `backfill-metadata.ts` for retroactive LLM metadata extraction on bulk-imported thoughts (e.g., Gmail imports that skipped `capture_thought`)
- Graduated backfill workflow: dry-run → small batch → full run

## Test plan

- [ ] Run Step 1 SQL query to verify source distribution visibility
- [ ] Use `search_thoughts` with `source: "mcp"` — should return only MCP thoughts
- [ ] Same search without `source` — should return all sources
- [ ] Run `thought_stats` — should show "By source:" breakdown
- [ ] If un-extracted thoughts exist: `--dry-run` backfill, then small live batch

🤖 Generated with [Claude Code](https://claude.com/claude-code)