### PR TITLE
[recipes] Gemini Takeout import — Google AI Studio conversations

### DIFF
--- a/recipes/gemini-takeout-import/.env.example
+++ b/recipes/gemini-takeout-import/.env.example
@@ -1,0 +1,9 @@
+# Open Brain credentials
+SUPABASE_URL=https://your-project-ref.supabase.co
+SUPABASE_SERVICE_ROLE_KEY=your-service-role-key-here
+
+# OpenRouter API key (for embeddings)
+OPENROUTER_API_KEY=sk-or-v1-your-key-here
+
+# Optional: override the embedding model (default: openai/text-embedding-3-small)
+# EMBEDDING_MODEL=openai/text-embedding-3-small

--- a/recipes/gemini-takeout-import/README.md
+++ b/recipes/gemini-takeout-import/README.md
@@ -1,0 +1,83 @@
+# Gemini Takeout Import
+
+> Import Google Gemini AI conversations into Open Brain as searchable thoughts.
+
+## What It Does
+
+Parses Google Takeout's Gemini Apps export (HTML format) and imports each conversation entry as a thought with embeddings. Your Gemini AI conversation history becomes semantically searchable in Open Brain.
+
+## Prerequisites
+
+- Working Open Brain setup ([guide](../../docs/01-getting-started.md))
+- **Google Takeout export** with Gemini Apps data (HTML format)
+- **Node.js 18+** installed
+- **OpenRouter API key** for embedding generation
+
+## Credential Tracker
+
+```text
+GEMINI TAKEOUT IMPORT -- CREDENTIAL TRACKER
+--------------------------------------
+
+FROM YOUR OPEN BRAIN SETUP
+  Supabase URL:          ____________
+  Service Role Key:      ____________
+
+FROM OPENROUTER
+  API Key:               ____________
+
+--------------------------------------
+```
+
+## Steps
+
+1. **Export your Gemini data from Google Takeout:**
+   - Go to [Google Takeout](https://takeout.google.com/)
+   - Deselect all, then select **Gemini Apps**
+   - Choose **HTML** format
+   - Export and download the archive
+   - Extract and find the `My Activity` HTML file
+
+2. **Copy this recipe folder** and install dependencies:
+   ```bash
+   cd gemini-takeout-import
+   npm install
+   ```
+
+3. **Create `.env`** with your credentials (see `.env.example`):
+   ```env
+   SUPABASE_URL=https://your-project.supabase.co
+   SUPABASE_SERVICE_ROLE_KEY=your-service-role-key
+   OPENROUTER_API_KEY=sk-or-v1-your-key
+   ```
+
+4. **Preview what will be imported** (dry run):
+   ```bash
+   node import-gemini.mjs /path/to/MyActivity.html --dry-run
+   ```
+
+5. **Run the import:**
+   ```bash
+   node import-gemini.mjs /path/to/MyActivity.html
+   ```
+
+## Expected Outcome
+
+After running the import:
+- Each Gemini conversation entry becomes a thought with `source_type: gemini_import`
+- Prompts are preserved and prefixed in the content
+- Running `search_thoughts { query: "explain quantum computing" }` finds relevant Gemini conversations
+- Dry run shows: `[1/500] Would import: "Gemini: explain quantum computing" (1240 chars)`
+
+**Scale reference:** Tested with 26 MB of Gemini HTML → 8,000+ thoughts imported.
+
+## Troubleshooting
+
+**Issue: No entries found**
+Make sure the HTML file contains `class="outer-cell"` elements. Gemini's takeout format uses this CSS class to separate entries. If the file is empty or in a different format, re-export from Google Takeout.
+
+**Issue: Garbled text in imported thoughts**
+HTML entity decoding handles common entities (&amp;, &lt;, etc.) but unusual Unicode may not decode perfectly. The imported text should still be searchable.
+
+**Issue: Feedback entries being imported**
+Entries starting with "Gave feedback:" are automatically filtered out as noise.

--- a/recipes/gemini-takeout-import/import-gemini.mjs
+++ b/recipes/gemini-takeout-import/import-gemini.mjs
@@ -14,6 +14,7 @@
 
 import { createClient } from "@supabase/supabase-js";
 import { createHash } from "crypto";
+import { existsSync } from "fs";
 import { readFile } from "fs/promises";
 import { config } from "dotenv";
 
@@ -43,6 +44,13 @@ const limit = parseInt(args[args.indexOf("--limit") + 1]) || Infinity;
 
 if (!filePath) {
   console.error("Usage: node import-gemini.mjs /path/to/gemini-export.html [--dry-run] [--skip N] [--limit N]");
+  process.exit(1);
+}
+
+if (!existsSync(filePath)) {
+  console.error(`Error: Input file not found: ${filePath}`);
+  console.error("Make sure the path to your Gemini Takeout export is correct.");
+  console.error("Download it from Google Takeout → Gemini Apps → My Activity.");
   process.exit(1);
 }
 

--- a/recipes/gemini-takeout-import/import-gemini.mjs
+++ b/recipes/gemini-takeout-import/import-gemini.mjs
@@ -1,0 +1,206 @@
+#!/usr/bin/env node
+/**
+ * Gemini Takeout Import for Open Brain (OB1-compatible)
+ *
+ * Parses Google Gemini AI conversation exports (HTML takeout format) and imports
+ * each conversation entry as a thought with embeddings.
+ *
+ * Usage:
+ *   node import-gemini.mjs /path/to/gemini-export.html [--dry-run] [--skip N] [--limit N]
+ *
+ * The HTML file comes from Google Takeout → Gemini Apps → My Activity.
+ * Entries are separated by <div class="outer-cell"> elements.
+ */
+
+import { createClient } from "@supabase/supabase-js";
+import { createHash } from "crypto";
+import { readFile } from "fs/promises";
+import { config } from "dotenv";
+
+config();
+
+// ── Configuration ────────────────────────────────────────────────────────
+
+const SUPABASE_URL = process.env.SUPABASE_URL;
+const SUPABASE_SERVICE_ROLE_KEY = process.env.SUPABASE_SERVICE_ROLE_KEY;
+const OPENROUTER_API_KEY = process.env.OPENROUTER_API_KEY;
+const EMBEDDING_MODEL = process.env.EMBEDDING_MODEL || "openai/text-embedding-3-small";
+
+if (!SUPABASE_URL || !SUPABASE_SERVICE_ROLE_KEY || !OPENROUTER_API_KEY) {
+  console.error("Missing required env vars: SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY, OPENROUTER_API_KEY");
+  process.exit(1);
+}
+
+const supabase = createClient(SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY);
+
+// ── CLI Arguments ────────────────────────────────────────────────────────
+
+const args = process.argv.slice(2);
+const filePath = args.find((a) => !a.startsWith("--"));
+const dryRun = args.includes("--dry-run");
+const skip = parseInt(args[args.indexOf("--skip") + 1]) || 0;
+const limit = parseInt(args[args.indexOf("--limit") + 1]) || Infinity;
+
+if (!filePath) {
+  console.error("Usage: node import-gemini.mjs /path/to/gemini-export.html [--dry-run] [--skip N] [--limit N]");
+  process.exit(1);
+}
+
+// ── Helpers ──────────────────────────────────────────────────────────────
+
+function contentFingerprint(text) {
+  const normalized = text.trim().replace(/\s+/g, " ").toLowerCase();
+  return createHash("sha256").update(normalized).digest("hex");
+}
+
+function stripHtml(html) {
+  return html
+    .replace(/<br\s*\/?>/gi, "\n")
+    .replace(/<[^>]+>/g, "")
+    .replace(/&amp;/g, "&")
+    .replace(/&lt;/g, "<")
+    .replace(/&gt;/g, ">")
+    .replace(/&quot;/g, '"')
+    .replace(/&#39;/g, "'")
+    .replace(/&nbsp;/g, " ")
+    .trim();
+}
+
+function parseGeminiEntries(html) {
+  // Split on outer-cell divs
+  const cells = html.split(/class="outer-cell/);
+  const entries = [];
+
+  for (let i = 1; i < cells.length; i++) {
+    const cell = cells[i];
+    const text = stripHtml(cell);
+
+    // Skip noise
+    if (text.length < 20) continue;
+    if (text.startsWith("Gave feedback:")) continue;
+
+    // Extract prompt if present
+    const promptMatch = text.match(/Prompted\s+(.+?)(?:\n|$)/);
+    const prompt = promptMatch ? promptMatch[1].trim() : "";
+
+    // Try to extract a timestamp
+    const dateMatch = cell.match(/(\w+ \d+, \d{4},?\s*\d+:\d+:\d+\s*(?:AM|PM)?)/i);
+    const timestamp = dateMatch ? new Date(dateMatch[1]).toISOString() : null;
+
+    const content = prompt ? `Prompted: ${prompt}\n\n${text}` : text;
+    entries.push({ content, timestamp, prompt });
+  }
+
+  return entries;
+}
+
+async function getEmbedding(text) {
+  const truncated = text.length > 8000 ? text.substring(0, 8000) : text;
+  const response = await fetch("https://openrouter.ai/api/v1/embeddings", {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${OPENROUTER_API_KEY}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({ model: EMBEDDING_MODEL, input: truncated }),
+  });
+
+  if (!response.ok) {
+    const msg = await response.text().catch(() => "");
+    throw new Error(`Embedding failed: ${response.status} ${msg}`);
+  }
+
+  const data = await response.json();
+  return data.data[0].embedding;
+}
+
+async function upsertThought(content, metadata, embedding, createdAt) {
+  const { data, error } = await supabase.rpc("upsert_thought", {
+    p_content: content,
+    p_payload: {
+      type: "reference",
+      source_type: "gemini_import",
+      importance: 3,
+      quality_score: 50,
+      sensitivity_tier: "standard",
+      metadata: {
+        ...metadata,
+        source: "gemini_import",
+        source_type: "gemini_import",
+      },
+      embedding: JSON.stringify(embedding),
+      created_at: createdAt,
+    },
+  });
+
+  if (error) throw new Error(`upsert_thought failed: ${error.message}`);
+  return data;
+}
+
+// ── Main ─────────────────────────────────────────────────────────────────
+
+async function main() {
+  console.log(`Gemini Takeout Import`);
+  console.log(`File: ${filePath}`);
+  console.log(`Mode: ${dryRun ? "DRY RUN" : "LIVE IMPORT"}`);
+  console.log();
+
+  const html = await readFile(filePath, "utf-8");
+  console.log(`File size: ${(html.length / 1024 / 1024).toFixed(1)} MB`);
+
+  const entries = parseGeminiEntries(html);
+  console.log(`Found ${entries.length} Gemini entries`);
+
+  const toProcess = entries.slice(skip, skip + limit);
+  console.log(`Processing ${toProcess.length} entries (skip=${skip}, limit=${limit === Infinity ? "all" : limit})`);
+  console.log();
+
+  let imported = 0;
+  let skipped = 0;
+  let errors = 0;
+
+  for (let i = 0; i < toProcess.length; i++) {
+    const entry = toProcess[i];
+
+    try {
+      if (entry.content.trim().length < 50) {
+        skipped++;
+        continue;
+      }
+
+      const fingerprint = contentFingerprint(entry.content);
+      const createdAt = entry.timestamp || new Date().toISOString();
+      const title = entry.prompt
+        ? `Gemini: ${entry.prompt.substring(0, 80)}`
+        : `Gemini entry (${createdAt.slice(0, 10)})`;
+
+      if (dryRun) {
+        console.log(`[${i + 1}/${toProcess.length}] Would import: "${title}" (${entry.content.length} chars)`);
+        imported++;
+        continue;
+      }
+
+      const embedding = await getEmbedding(entry.content);
+      const result = await upsertThought(
+        entry.content,
+        { title, content_fingerprint: fingerprint },
+        embedding,
+        createdAt
+      );
+
+      console.log(`[${i + 1}/${toProcess.length}] ${result.action}: #${result.thought_id} "${title}"`);
+      imported++;
+    } catch (err) {
+      console.error(`[${i + 1}/${toProcess.length}] Error: ${err.message}`);
+      errors++;
+    }
+  }
+
+  console.log();
+  console.log(`Done! Imported: ${imported}, Skipped: ${skipped}, Errors: ${errors}`);
+}
+
+main().catch((err) => {
+  console.error("Fatal error:", err);
+  process.exit(1);
+});

--- a/recipes/gemini-takeout-import/metadata.json
+++ b/recipes/gemini-takeout-import/metadata.json
@@ -1,0 +1,20 @@
+{
+  "name": "Gemini Takeout Import",
+  "description": "Import Google Gemini AI conversation exports (HTML takeout format) into Open Brain as searchable thoughts.",
+  "category": "recipes",
+  "author": {
+    "name": "Alan Shurafa",
+    "github": "alanshurafa"
+  },
+  "version": "1.0.0",
+  "requires": {
+    "open_brain": true,
+    "services": ["OpenRouter API", "Supabase", "Google Takeout"],
+    "tools": ["Node.js 18+"]
+  },
+  "tags": ["import", "gemini", "google", "ai-history", "takeout"],
+  "difficulty": "beginner",
+  "estimated_time": "20 minutes",
+  "created": "2026-03-15",
+  "updated": "2026-03-15"
+}

--- a/recipes/gemini-takeout-import/package.json
+++ b/recipes/gemini-takeout-import/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "ob1-recipe-gemini-takeout-import",
+  "version": "1.0.0",
+  "description": "Import Google Gemini AI conversation exports into Open Brain as searchable thoughts",
+  "type": "module",
+  "main": "import-gemini.mjs",
+  "scripts": {
+    "import": "node import-gemini.mjs",
+    "dry-run": "node import-gemini.mjs --dry-run"
+  },
+  "dependencies": {
+    "@supabase/supabase-js": "^2.49.0",
+    "dotenv": "^16.4.0"
+  }
+}


### PR DESCRIPTION
## Summary
- Standalone Node.js script that imports Gemini conversations from Google Takeout HTML export into Open Brain
- Parses `MyActivity.html` entries, extracts prompts and AI responses, handles noise filtering
- Embeds via OpenRouter and inserts via `upsert_thought` RPC with content fingerprint dedup
- CLI flags: `--dry-run`, `--skip N`, `--limit N`

## Scale
Tested against **8,000+ thoughts** from a production Google Takeout export.

## Files
- `recipes/gemini-takeout-import/import-gemini.mjs` — Main import script (206 lines)
- `recipes/gemini-takeout-import/README.md` — Setup guide with prerequisites and troubleshooting
- `recipes/gemini-takeout-import/metadata.json` — OB1 recipe metadata
- `recipes/gemini-takeout-import/package.json` — Dependencies
- `recipes/gemini-takeout-import/.env.example` — Credential template

## Test plan
- [x] Tested against real Google Takeout Gemini export (8K+ thoughts imported)
- [x] Dry-run mode verified
- [x] Content fingerprint dedup prevents duplicates on re-run
- [x] Skip/limit flags work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)