### PR TITLE
[recipes] Claude conversation export import

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -47,10 +47,22 @@ jobs:
                modifications, no local MCP servers (must use remote Edge Functions)?
             5. **Value** — Does this add something meaningfully different from
                existing contributions?
+            6. **Design patterns** — Does this follow OB1's established patterns?
+               Check for: direct Supabase insert or MCP ingest endpoint (not
+               custom servers), remote Edge Functions (not local Node.js),
+               Row Level Security on new tables, JSONB metadata fields,
+               environment variables for credentials (not hardcoded).
+            7. **Scope fit** — Is this appropriately sized for OB1, or is it
+               growing into its own project? Red flags: own package.json with
+               many dependencies, doesn't interact with the thoughts table,
+               needs independent deployment, or introduces its own auth system.
+               If it seems too big, suggest it could be a standalone project
+               that integrates with OB1 instead.
 
             Be constructive and welcoming. If a contribution needs work, explain
             what specifically needs to change. If it looks good, approve the PR.
 
             Important: The mechanical checks (file structure, metadata validation,
             SQL safety) are handled by a separate CI job. Focus your review on the
-            things that require judgment — clarity, alignment, value, and quality.
+            things that require judgment — clarity, alignment, value, design
+            patterns, scope fit, and quality.

--- a/recipes/claude-export-import/.env.example
+++ b/recipes/claude-export-import/.env.example
@@ -1,0 +1,9 @@
+# Open Brain credentials
+SUPABASE_URL=https://your-project-ref.supabase.co
+SUPABASE_SERVICE_ROLE_KEY=your-service-role-key-here
+
+# OpenRouter API key (for embeddings)
+OPENROUTER_API_KEY=sk-or-v1-your-key-here
+
+# Optional: override the embedding model (default: openai/text-embedding-3-small)
+# EMBEDDING_MODEL=openai/text-embedding-3-small

--- a/recipes/claude-export-import/README.md
+++ b/recipes/claude-export-import/README.md
@@ -1,0 +1,81 @@
+# Claude Export Import
+
+> Import Anthropic Claude conversation history into Open Brain as searchable thoughts.
+
+## What It Does
+
+Parses Claude's conversation export (JSON format) and imports each conversation as a thought with embeddings. Handles both `chat_messages` array and nested `content` block formats.
+
+## Prerequisites
+
+- Working Open Brain setup ([guide](../../docs/01-getting-started.md))
+- **Claude data export** — JSON file from Anthropic
+- **Node.js 18+** installed
+- **OpenRouter API key** for embedding generation
+
+## Credential Tracker
+
+```text
+CLAUDE EXPORT IMPORT -- CREDENTIAL TRACKER
+--------------------------------------
+
+FROM YOUR OPEN BRAIN SETUP
+  Supabase URL:          ____________
+  Service Role Key:      ____________
+
+FROM OPENROUTER
+  API Key:               ____________
+
+--------------------------------------
+```
+
+## Steps
+
+1. **Export your Claude data:**
+   - Go to [Claude Settings](https://claude.ai/settings) → Export data
+   - Download and extract the archive
+   - Find the conversations JSON file
+
+2. **Copy this recipe folder** and install dependencies:
+   ```bash
+   cd claude-export-import
+   npm install
+   ```
+
+3. **Create `.env`** with your credentials (see `.env.example`):
+   ```env
+   SUPABASE_URL=https://your-project.supabase.co
+   SUPABASE_SERVICE_ROLE_KEY=your-service-role-key
+   OPENROUTER_API_KEY=sk-or-v1-your-key
+   ```
+
+4. **Preview what will be imported** (dry run):
+   ```bash
+   node import-claude.mjs /path/to/conversations.json --dry-run
+   ```
+
+5. **Run the import:**
+   ```bash
+   node import-claude.mjs /path/to/conversations.json
+   ```
+
+## Expected Outcome
+
+After running the import:
+- Each Claude conversation becomes a thought with `source_type: claude_import`
+- Full USER/ASSISTANT transcripts are preserved
+- Consecutive duplicate messages are deduplicated
+- Running `search_thoughts { query: "code review discussion" }` finds relevant Claude conversations
+
+**Scale reference:** Tested with 800+ Claude conversations imported successfully.
+
+## Troubleshooting
+
+**Issue: JSON parse error**
+The file might contain a single conversation object instead of an array. The script handles both formats — if the error persists, check that the file is valid JSON.
+
+**Issue: Empty messages or missing content**
+Claude exports use different content formats across versions. The script handles `content[]` arrays, `.text` fields, and string content. If a specific format isn't handled, open an issue.
+
+**Issue: "sender" field not recognized**
+Claude uses `sender: "human"` or `sender: "assistant"`. Both are normalized to USER/ASSISTANT in the output.

--- a/recipes/claude-export-import/README.md
+++ b/recipes/claude-export-import/README.md
@@ -6,12 +6,17 @@
 
 Parses Claude's conversation export (JSON format) and imports each conversation as a thought with embeddings. Handles both `chat_messages` array and nested `content` block formats.
 
+## Security
+
+> **Security warning:** Claude conversation exports may contain API keys, tokens, or other secrets that were shared during conversations. Review your export files before importing to ensure no sensitive credentials are captured as thoughts.
+
 ## Prerequisites
 
 - Working Open Brain setup ([guide](../../docs/01-getting-started.md))
 - **Claude data export** — JSON file from Anthropic
 - **Node.js 18+** installed
 - **OpenRouter API key** for embedding generation
+- **`upsert_thought` RPC function** — This recipe calls the `upsert_thought` RPC function for idempotent imports. If you haven't set this up, see the [Content Fingerprint Dedup](../content-fingerprint-dedup/) recipe for the function definition.
 
 ## Credential Tracker
 

--- a/recipes/claude-export-import/README.md
+++ b/recipes/claude-export-import/README.md
@@ -16,7 +16,7 @@ Parses Claude's conversation export (JSON format) and imports each conversation 
 - **Claude data export** — JSON file from Anthropic
 - **Node.js 18+** installed
 - **OpenRouter API key** for embedding generation
-- **`upsert_thought` RPC function** — This recipe calls the `upsert_thought` RPC function for idempotent imports. If you haven't set this up, see the [Content Fingerprint Dedup](../content-fingerprint-dedup/) recipe for the function definition.
+- **`upsert_thought` RPC function** — This recipe calls the `upsert_thought` RPC function for idempotent imports. If you haven't set this up, see the [Content Fingerprint Dedup](../../primitives/content-fingerprint-dedup/) guide for the function definition.
 
 ## Credential Tracker
 

--- a/recipes/claude-export-import/import-claude.mjs
+++ b/recipes/claude-export-import/import-claude.mjs
@@ -1,0 +1,181 @@
+#!/usr/bin/env node
+/**
+ * Claude Export Import for Open Brain (OB1-compatible)
+ *
+ * Parses Anthropic Claude conversation exports (JSON format) and imports
+ * each conversation as a thought with embeddings.
+ *
+ * Usage:
+ *   node import-claude.mjs /path/to/claude-export.json [--dry-run] [--skip N] [--limit N]
+ */
+
+import { createClient } from "@supabase/supabase-js";
+import { createHash } from "crypto";
+import { readFile } from "fs/promises";
+import { config } from "dotenv";
+
+config();
+
+const SUPABASE_URL = process.env.SUPABASE_URL;
+const SUPABASE_SERVICE_ROLE_KEY = process.env.SUPABASE_SERVICE_ROLE_KEY;
+const OPENROUTER_API_KEY = process.env.OPENROUTER_API_KEY;
+const EMBEDDING_MODEL = process.env.EMBEDDING_MODEL || "openai/text-embedding-3-small";
+
+if (!SUPABASE_URL || !SUPABASE_SERVICE_ROLE_KEY || !OPENROUTER_API_KEY) {
+  console.error("Missing required env vars: SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY, OPENROUTER_API_KEY");
+  process.exit(1);
+}
+
+const supabase = createClient(SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY);
+
+const args = process.argv.slice(2);
+const filePath = args.find((a) => !a.startsWith("--"));
+const dryRun = args.includes("--dry-run");
+const skip = parseInt(args[args.indexOf("--skip") + 1]) || 0;
+const limit = parseInt(args[args.indexOf("--limit") + 1]) || Infinity;
+
+if (!filePath) {
+  console.error("Usage: node import-claude.mjs /path/to/claude-export.json [--dry-run] [--skip N] [--limit N]");
+  process.exit(1);
+}
+
+function contentFingerprint(text) {
+  const normalized = text.trim().replace(/\s+/g, " ").toLowerCase();
+  return createHash("sha256").update(normalized).digest("hex");
+}
+
+function extractMessageText(msg) {
+  // Claude exports have content as array of {type, text} objects or direct text
+  if (typeof msg.text === "string") return msg.text;
+  if (Array.isArray(msg.content)) {
+    return msg.content
+      .map((c) => (typeof c === "string" ? c : c.text || ""))
+      .filter(Boolean)
+      .join("\n");
+  }
+  if (typeof msg.content === "string") return msg.content;
+  return "";
+}
+
+function normalizeConversation(conv) {
+  const title = conv.name || conv.title || "Untitled";
+  const createdAt = conv.created_at || new Date().toISOString();
+  const conversationId = conv.uuid || conv.id || "";
+
+  const messages = [];
+  const chatMessages = conv.chat_messages || conv.messages || [];
+
+  for (const msg of chatMessages) {
+    const role = (msg.sender || msg.role || "unknown").toUpperCase();
+    if (role === "SYSTEM") continue;
+    const text = extractMessageText(msg).trim();
+    if (!text) continue;
+
+    // Dedup consecutive identical messages
+    const sig = `${role}|${text}`;
+    if (messages.length > 0 && messages[messages.length - 1].sig === sig) continue;
+
+    messages.push({
+      role: role === "HUMAN" || role === "USER" ? "USER" : "ASSISTANT",
+      text,
+      sig,
+    });
+  }
+
+  const transcript = messages.map((m) => `${m.role}: ${m.text}`).join("\n\n");
+  const content = `Conversation title: ${title}\nConversation created at: ${createdAt}\n\n${transcript}`;
+
+  return { title, createdAt, conversationId, content };
+}
+
+async function getEmbedding(text) {
+  const truncated = text.length > 8000 ? text.substring(0, 8000) : text;
+  const response = await fetch("https://openrouter.ai/api/v1/embeddings", {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${OPENROUTER_API_KEY}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({ model: EMBEDDING_MODEL, input: truncated }),
+  });
+  if (!response.ok) {
+    const msg = await response.text().catch(() => "");
+    throw new Error(`Embedding failed: ${response.status} ${msg}`);
+  }
+  const data = await response.json();
+  return data.data[0].embedding;
+}
+
+async function upsertThought(content, metadata, embedding, createdAt) {
+  const { data, error } = await supabase.rpc("upsert_thought", {
+    p_content: content,
+    p_payload: {
+      type: "reference",
+      source_type: "claude_import",
+      importance: 3,
+      quality_score: 50,
+      sensitivity_tier: "standard",
+      metadata: { ...metadata, source: "claude_import", source_type: "claude_import" },
+      embedding: JSON.stringify(embedding),
+      created_at: createdAt,
+    },
+  });
+  if (error) throw new Error(`upsert_thought failed: ${error.message}`);
+  return data;
+}
+
+async function main() {
+  console.log(`Claude Export Import`);
+  console.log(`File: ${filePath}`);
+  console.log(`Mode: ${dryRun ? "DRY RUN" : "LIVE IMPORT"}`);
+  console.log();
+
+  const raw = await readFile(filePath, "utf-8");
+  const parsed = JSON.parse(raw);
+  const conversations = Array.isArray(parsed) ? parsed : [parsed];
+
+  console.log(`Found ${conversations.length} conversations`);
+
+  const toProcess = conversations.slice(skip, skip + limit);
+  console.log(`Processing ${toProcess.length} (skip=${skip}, limit=${limit === Infinity ? "all" : limit})`);
+  console.log();
+
+  let imported = 0, skipped = 0, errors = 0;
+
+  for (let i = 0; i < toProcess.length; i++) {
+    const conv = toProcess[i];
+    try {
+      const { title, createdAt, conversationId, content } = normalizeConversation(conv);
+      if (content.trim().length < 100) { skipped++; continue; }
+
+      const truncated = content.length > 30000
+        ? content.substring(0, 30000) + "\n\n[... truncated]"
+        : content;
+      const fingerprint = contentFingerprint(truncated);
+
+      if (dryRun) {
+        console.log(`[${i + 1}/${toProcess.length}] Would import: "${title}" (${truncated.length} chars)`);
+        imported++;
+        continue;
+      }
+
+      const embedding = await getEmbedding(truncated);
+      const result = await upsertThought(
+        truncated,
+        { title, conversation_id: conversationId, content_fingerprint: fingerprint },
+        embedding,
+        createdAt
+      );
+      console.log(`[${i + 1}/${toProcess.length}] ${result.action}: #${result.thought_id} "${title}"`);
+      imported++;
+    } catch (err) {
+      console.error(`[${i + 1}/${toProcess.length}] Error: ${err.message}`);
+      errors++;
+    }
+  }
+
+  console.log();
+  console.log(`Done! Imported: ${imported}, Skipped: ${skipped}, Errors: ${errors}`);
+}
+
+main().catch((err) => { console.error("Fatal error:", err); process.exit(1); });

--- a/recipes/claude-export-import/metadata.json
+++ b/recipes/claude-export-import/metadata.json
@@ -1,0 +1,20 @@
+{
+  "name": "Claude Export Import",
+  "description": "Import Anthropic Claude conversation exports (JSON format) into Open Brain as searchable thoughts.",
+  "category": "recipes",
+  "author": {
+    "name": "Alan Shurafa",
+    "github": "alanshurafa"
+  },
+  "version": "1.0.0",
+  "requires": {
+    "open_brain": true,
+    "services": ["OpenRouter API", "Supabase"],
+    "tools": ["Node.js 18+"]
+  },
+  "tags": ["import", "claude", "anthropic", "conversations", "ai-history"],
+  "difficulty": "beginner",
+  "estimated_time": "15 minutes",
+  "created": "2026-03-15",
+  "updated": "2026-03-15"
+}

--- a/recipes/claude-export-import/package.json
+++ b/recipes/claude-export-import/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "ob1-recipe-claude-export-import",
+  "version": "1.0.0",
+  "description": "Import Anthropic Claude conversation exports into Open Brain as searchable thoughts",
+  "type": "module",
+  "main": "import-claude.mjs",
+  "scripts": {
+    "import": "node import-claude.mjs",
+    "dry-run": "node import-claude.mjs --dry-run"
+  },
+  "dependencies": {
+    "@supabase/supabase-js": "^2.49.0",
+    "dotenv": "^16.4.0"
+  }
+}


### PR DESCRIPTION
## Summary
- Standalone Node.js script that imports Claude conversation exports into Open Brain
- Handles Claude's content array format (`{type, text}` objects and direct text strings)
- Extracts conversation title, date, and ID metadata
- Truncates oversized content at 30K chars, min 100 char threshold
- CLI flags: `--dry-run`, `--skip N`, `--limit N`

## Scale
Tested against **800+ thoughts** from a production Claude export.

## Files
- `recipes/claude-export-import/import-claude.mjs` — Main import script (181 lines)
- `recipes/claude-export-import/README.md` — Setup guide
- `recipes/claude-export-import/metadata.json` — OB1 recipe metadata
- `recipes/claude-export-import/package.json` — Dependencies
- `recipes/claude-export-import/.env.example` — Credential template

## Test plan
- [x] Tested against real Claude conversation export
- [x] Content array format handling verified
- [x] Oversized content truncation works
- [x] Content fingerprint dedup prevents duplicates

🤖 Generated with [Claude Code](https://claude.com/claude-code)