### PR TITLE
[schemas] Full-text search — keyword search RPC for thoughts

### DIFF
--- a/schemas/full-text-search/README.md
+++ b/schemas/full-text-search/README.md
@@ -17,6 +17,11 @@ PostgreSQL has a built-in full-text search engine that:
 2. Ranks results by relevance
 3. Runs entirely in the database — no external service needed
 
+## Prerequisites
+
+- Working Open Brain setup ([guide](../../docs/01-getting-started.md))
+- The `thoughts` table must already exist
+
 ## Setup
 
 ### Step 1: Add a text search index

--- a/schemas/full-text-search/README.md
+++ b/schemas/full-text-search/README.md
@@ -1,0 +1,100 @@
+# Full-Text Search
+
+> Keyword-based search for thoughts using PostgreSQL's built-in full-text search engine.
+
+## What It Is
+
+A `search_thoughts_text` RPC function that lets you find thoughts by keywords, phrases, or partial matches. This complements OB1's existing `match_thoughts` semantic search — sometimes you want to find the exact thought where you mentioned "quarterly review" or "Dr. Smith", not just thoughts that are semantically similar.
+
+## Why It Matters
+
+Semantic search is great for finding related concepts, but it can miss exact matches. If you captured a thought mentioning a specific person, date, project name, or technical term, keyword search finds it instantly. Together, semantic + text search covers both discovery and retrieval.
+
+## How It Works
+
+PostgreSQL has a built-in full-text search engine that:
+1. Converts text into searchable tokens (handles plurals, stop words, etc.)
+2. Ranks results by relevance
+3. Runs entirely in the database — no external service needed
+
+## Setup
+
+### Step 1: Add a text search index
+
+```sql
+-- Create a GIN index for fast full-text search
+CREATE INDEX idx_thoughts_fts ON thoughts
+USING gin (to_tsvector('english', content));
+```
+
+### Step 2: Create the search RPC
+
+```sql
+CREATE OR REPLACE FUNCTION search_thoughts_text(
+  p_query TEXT,
+  p_limit INT DEFAULT 20,
+  p_offset INT DEFAULT 0
+)
+RETURNS TABLE (
+  id UUID,
+  content TEXT,
+  metadata JSONB,
+  created_at TIMESTAMPTZ,
+  rank REAL
+)
+LANGUAGE sql STABLE
+AS $$
+  SELECT
+    t.id,
+    t.content,
+    t.metadata,
+    t.created_at,
+    ts_rank(to_tsvector('english', t.content), websearch_to_tsquery('english', p_query)) AS rank
+  FROM thoughts t
+  WHERE to_tsvector('english', t.content) @@ websearch_to_tsquery('english', p_query)
+  ORDER BY rank DESC
+  LIMIT p_limit
+  OFFSET p_offset;
+$$;
+```
+
+### Step 3: Test it
+
+```sql
+-- Find thoughts mentioning a specific term
+SELECT * FROM search_thoughts_text('quarterly review');
+
+-- Phrase search
+SELECT * FROM search_thoughts_text('"machine learning"');
+
+-- Boolean search
+SELECT * FROM search_thoughts_text('python OR javascript');
+```
+
+## Calling from the MCP Server
+
+The RPC can be called from an Edge Function or directly via the Supabase client:
+
+```typescript
+const { data, error } = await supabase.rpc("search_thoughts_text", {
+  p_query: "quarterly review",
+  p_limit: 10
+});
+```
+
+## Expected Outcome
+
+After setup, you can search thoughts by keyword with ranked results. The GIN index makes searches fast even on large tables (tested on 75K+ rows).
+
+## Troubleshooting
+
+**Issue: No results for a query that should match**
+The `websearch_to_tsquery` parser handles natural language queries, but very short or common words may be treated as stop words. Try more specific terms.
+
+**Issue: Slow queries on large tables**
+Make sure the GIN index was created (Step 1). Without it, PostgreSQL does a sequential scan.
+
+## Further Reading
+
+- [PostgreSQL Full-Text Search docs](https://www.postgresql.org/docs/current/textsearch.html)
+- [Supabase Full-Text Search guide](https://supabase.com/docs/guides/database/full-text-search)

--- a/schemas/full-text-search/metadata.json
+++ b/schemas/full-text-search/metadata.json
@@ -1,0 +1,20 @@
+{
+  "name": "Full-Text Search",
+  "description": "PostgreSQL full-text search RPC for keyword-based thought retrieval — complements the existing semantic vector search.",
+  "category": "schemas",
+  "author": {
+    "name": "Alan Shurafa",
+    "github": "alanshurafa"
+  },
+  "version": "1.0.0",
+  "requires": {
+    "open_brain": true,
+    "services": [],
+    "tools": []
+  },
+  "tags": ["search", "full-text", "postgresql", "tsvector", "keyword"],
+  "difficulty": "beginner",
+  "estimated_time": "5 minutes",
+  "created": "2026-03-16",
+  "updated": "2026-03-16"
+}

--- a/schemas/full-text-search/migration.sql
+++ b/schemas/full-text-search/migration.sql
@@ -1,0 +1,39 @@
+-- Full-Text Search for Open Brain
+-- Adds keyword-based search to complement existing semantic vector search.
+--
+-- Prerequisites: public.thoughts table exists
+
+-- 1. Create a GIN index for fast full-text search
+CREATE INDEX IF NOT EXISTS idx_thoughts_fts ON public.thoughts
+USING gin (to_tsvector('english', content));
+
+-- 2. Create the search RPC
+CREATE OR REPLACE FUNCTION public.search_thoughts_text(
+  p_query TEXT,
+  p_limit INT DEFAULT 20,
+  p_offset INT DEFAULT 0
+)
+RETURNS TABLE (
+  id UUID,
+  content TEXT,
+  metadata JSONB,
+  created_at TIMESTAMPTZ,
+  rank REAL
+)
+LANGUAGE sql STABLE
+AS $$
+  SELECT
+    t.id,
+    t.content,
+    t.metadata,
+    t.created_at,
+    ts_rank(to_tsvector('english', t.content), websearch_to_tsquery('english', p_query)) AS rank
+  FROM public.thoughts t
+  WHERE to_tsvector('english', t.content) @@ websearch_to_tsquery('english', p_query)
+  ORDER BY rank DESC
+  LIMIT p_limit
+  OFFSET p_offset;
+$$;
+
+-- Grant access to service_role
+GRANT EXECUTE ON FUNCTION public.search_thoughts_text TO service_role;


### PR DESCRIPTION
## Summary
- Adds `search_thoughts_text` RPC using PostgreSQL's built-in full-text search
- Creates GIN index on thoughts content for fast keyword queries
- Supports natural language queries, phrase search, and boolean operators via `websearch_to_tsquery`
- Complements the existing `match_thoughts` semantic vector search

## Why
Semantic search finds related concepts, but sometimes you need exact keyword matches — person names, project codes, dates, technical terms. This gives OB1 users both discovery (semantic) and retrieval (keyword) search modes.

## Scale
Tested against **75,000+ thoughts** in production. GIN index keeps queries fast.

## Test plan
- [x] Keyword search returns relevant results ranked by relevance
- [x] Phrase search works with quoted strings
- [x] Boolean operators (OR, AND, NOT) work
- [x] GIN index prevents sequential scans on large tables
- [x] RPC callable from Supabase client and Edge Functions

🤖 Generated with [Claude Code](https://claude.com/claude-code)