### PR TITLE
[docs] Add recipe discovery to user flow + Gmail import polish

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ node_modules/
 supabase/
 
 # Recipe credentials & runtime state
+.env
 credentials.json
 token.json
 gmail-sync-log.json

--- a/docs/01-getting-started.md
+++ b/docs/01-getting-started.md
@@ -809,6 +809,17 @@ Your Open Brain is live. Now make it work for you. The **[Companion Prompts](02-
 
 Start with the Memory Migration. If you have an existing second brain, run the Second Brain Migration next. Then use the Spark to figure out what to capture going forward. The templates build the daily habit. The weekly review closes the loop.
 
+### Then start importing your data
+
+The companion prompts pull out what your AI already knows. **Recipes** go further — they connect directly to your existing services and bulk-import real data.
+
+| Recipe | What It Does | Time |
+| ------ | ------------ | ---- |
+| [Email History Import](../recipes/email-history-import/) | Pull your Gmail archive into searchable thoughts | 30 min |
+| [ChatGPT Conversation Import](../recipes/chatgpt-conversation-import/) | Ingest your full ChatGPT data export | 30 min |
+
+Browse all recipes in [`/recipes`](../recipes/).
+
 ---
 
 *Built by Nate B. Jones — companion to "Your Second Brain Is Closed. Your AI Can't Use It. Here's the Fix."*

--- a/docs/02-companion-prompts.md
+++ b/docs/02-companion-prompts.md
@@ -457,6 +457,12 @@ For each theme (3-5):
 
 Your Open Brain is infrastructure. These prompts are the habits that make it compound. The Memory Migration gets you off the ground with context you've already built. The Second Brain Migration brings over everything you've captured in other systems so you don't start from zero. The Spark shows you where your brain fits into YOUR life, not someone else's. The templates build the daily habit. The weekly review closes the loop. Use them in order the first week, then keep the review as your Friday ritual.
 
+## What's Next — Recipes
+
+The companion prompts work with what your AI already knows. To bring in data from external services — your Gmail history, your ChatGPT conversations, your blog archives — check out the [recipes](../recipes/). Each one connects to a specific service, handles the messy parts (auth, filtering, dedup), and loads clean data into your Open Brain.
+
+Start with whichever source has the most signal for you. For most people, that's [Email History Import](../recipes/email-history-import/) (30 minutes, imports Gmail) or [ChatGPT Conversation Import](../recipes/chatgpt-conversation-import/) (30 minutes, imports your full ChatGPT export).
+
 ---
 
 *Built by [Nate B. Jones](https://natesnewsletter.substack.com/) — companion to [Build Your Open Brain](01-getting-started.md).*

--- a/docs/03-faq.md
+++ b/docs/03-faq.md
@@ -48,6 +48,22 @@ And don't forget the Supabase AI assistant covered in the [setup guide](01-getti
 
 ---
 
+## Importing Data
+
+### "Can I import my Gmail into the Open Brain?"
+
+Yes. The [Email History Import](../recipes/email-history-import/) recipe connects to Gmail via OAuth, pulls emails by label and time window, strips noise (signatures, quoted replies, auto-generated messages), and loads each email as a thought with sender, subject, and date metadata. Takes about 30 minutes to set up. You need a Google Cloud project with Gmail API enabled.
+
+### "How do I import my ChatGPT conversations?"
+
+Export your data from ChatGPT (Settings → Data controls → Export data), then use the [ChatGPT Conversation Import](../recipes/chatgpt-conversation-import/) recipe. It processes the JSON export, extracts the meaningful exchanges, and loads them as thoughts. Unlike the manual approach described in the FAQ above, this handles the full export automatically.
+
+### "What other data sources can I import?"
+
+Check [`/recipes`](../recipes/) for the current list. The community is actively building importers for Google Activity (Takeout), Twitter/X archives, Claude conversations, Gemini, and more. Each recipe is a standalone build — pick the ones that match your data.
+
+---
+
 ## "How does this work with Obsidian?"
 
 Short answer: it doesn't, and it's not supposed to.

--- a/recipes/email-history-import/.env.example
+++ b/recipes/email-history-import/.env.example
@@ -1,0 +1,8 @@
+# Open Brain Email History Import
+# Copy this file to .env and fill in your values
+
+# Your Supabase ingest-thought Edge Function URL
+INGEST_URL=https://YOUR_REF.supabase.co/functions/v1/ingest-thought
+
+# Your Supabase service role key (not the anon key — RLS blocks anon inserts)
+INGEST_KEY=your-service-role-key

--- a/recipes/email-history-import/README.md
+++ b/recipes/email-history-import/README.md
@@ -2,6 +2,8 @@
 
 > Import your Gmail email history into Open Brain as searchable, embedded thoughts.
 
+Your email is full of decisions, commitments, and context that your AI has never seen. This recipe connects to Gmail, pulls the emails that matter (filtering out receipts, auto-replies, and noise), and loads them into your Open Brain. Once imported, your AI can recall what you said to someone three months ago, find that pricing discussion from last quarter, or surface commitments you forgot about.
+
 ## What It Does
 
 Pulls your Gmail history via the Gmail API and loads each email into Open Brain as a single thought. Long emails are stored in full — truncation for embedding happens server-side. Each thought includes a SHA-256 content fingerprint for dedup.


### PR DESCRIPTION
## Summary

- **Getting-started guide:** Added "Then start importing your data" section at the end, pointing to Gmail and ChatGPT import recipes with time estimates
- **Companion prompts:** Added "What's Next — Recipes" bridge section so users finishing the prompts know where to go next
- **FAQ:** Added "Importing Data" section with 3 entries (Gmail, ChatGPT, other sources) — now discoverable via search
- **Email history import README:** Added value framing paragraph at the top explaining *why* you'd want this
- **`.env.example`:** New file in the email-history-import recipe with the two required env vars
- **`.gitignore`:** Added `.env` (was missing — `credentials.json` and `token.json` were covered but not `.env`)

## Why

The recipe folder was invisible in the documented user path (getting-started → companion prompts → extensions). Someone following the guides would never discover Gmail import unless they browsed the GitHub file tree. These changes create a natural flow from setup → prompts → recipes.

## Test plan

- [ ] Read through user flow: getting-started ending → companion prompts ending → recipes → email-history-import README — should feel like natural progression with no dead ends
- [ ] Search FAQ for "gmail" and "import" — should land on new section
- [ ] Verify all relative links resolve (`../recipes/email-history-import/`, etc.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)