### PR TITLE
[docs] Fix all 21 markdownlint errors across repo

### DIFF
--- a/docs/01-getting-started.md
+++ b/docs/01-getting-started.md
@@ -24,7 +24,6 @@ You're going to generate API keys, passwords, and IDs across three different ser
 >
 > 🛑🛑🛑 **Do not skip this.** 🛑🛑🛑
 
-
 ---
 
 ![Step 1](https://img.shields.io/badge/Step_1-Create_Your_Supabase_Project-E53935?style=for-the-badge)
@@ -328,6 +327,8 @@ supabase secrets set OPENROUTER_API_KEY=your-openrouter-key-here
 > [!NOTE]
 > `SUPABASE_URL` and `SUPABASE_SERVICE_ROLE_KEY` are automatically available inside Edge Functions — you don't need to set them.
 
+<!-- -->
+
 > [!CAUTION]
 > Make sure the access key you set here **exactly matches** what you saved in your credential tracker. If they don't match, you'll get 401 errors when connecting your AI.
 
@@ -350,14 +351,18 @@ curl -o supabase/functions/open-brain-mcp/deno.json https://raw.githubuserconten
 > [!TIP]
 > These commands download the server code and its dependencies file straight into the right folder. No need to create or edit any files yourself.
 
+<!-- -->
+
 > [!WARNING]
 > ❌ **`No such file or directory`** — you skipped the `supabase functions new` command above. Run it first, then retry the downloads.
 >
 > ❌ **`file exists`** — you already have files from a previous attempt. Delete the old folder and re-create it:
+>
 > ```bash
 > rm -rf supabase/functions/open-brain-mcp
 > supabase functions new open-brain-mcp
 > ```
+>
 > Then retry the curl commands.
 
 Verify the download worked — this should print the first line of the server code, **not** "Hello from Functions":
@@ -504,6 +509,8 @@ supabase secrets set OPENROUTER_API_KEY=your-openrouter-key-here
 > [!NOTE]
 > `SUPABASE_URL` and `SUPABASE_SERVICE_ROLE_KEY` are automatically available inside Edge Functions — you don't need to set them.
 
+<!-- -->
+
 > [!CAUTION]
 > Make sure the access key you set here **exactly matches** what you saved in your credential tracker. If they don't match, you'll get 401 errors when connecting your AI.
 
@@ -526,14 +533,18 @@ Invoke-WebRequest -Uri https://raw.githubusercontent.com/NateBJones-Projects/OB1
 > [!TIP]
 > These commands download the server code and its dependencies file straight into the right folder. No need to create or edit any files yourself.
 
+<!-- -->
+
 > [!WARNING]
 > ❌ **`No such file or directory`** — you skipped the `supabase functions new` command above. Run it first, then retry the downloads.
 >
 > ❌ **`file exists`** — you already have files from a previous attempt. Delete the old folder and re-create it:
+>
 > ```powershell
 > Remove-Item -Recurse supabase\functions\open-brain-mcp
 > supabase functions new open-brain-mcp
 > ```
+>
 > Then retry the download commands.
 
 Verify the download worked — this should print the first line of the server code, **not** "Hello from Functions":

--- a/extensions/_template/AGENT_SPEC.md
+++ b/extensions/_template/AGENT_SPEC.md
@@ -85,6 +85,7 @@ PostgreSQL DDL that runs in the Supabase SQL Editor. Must follow these rules:
 3. **Include indexes** for columns that will be queried frequently (user_id + any filter columns).
 
 4. **Include Row Level Security:**
+
    ```sql
    ALTER TABLE table_name ENABLE ROW LEVEL SECURITY;
 
@@ -101,6 +102,7 @@ PostgreSQL DDL that runs in the Supabase SQL Editor. Must follow these rules:
 7. **Use JSONB for flexible metadata fields** where the structure might vary (e.g., `details JSONB DEFAULT '{}'`).
 
 8. **Add update triggers** if the table has `updated_at`:
+
    ```sql
    CREATE OR REPLACE FUNCTION update_updated_at_column()
    RETURNS TRIGGER AS $$

--- a/recipes/email-history-import/README.md
+++ b/recipes/email-history-import/README.md
@@ -45,14 +45,18 @@ GENERATED DURING SETUP
 1. **Enable Gmail API** in your Google Cloud project
 2. **Create OAuth 2.0 credentials** (Desktop app type) and download as `credentials.json` into this folder
 3. **Set environment variables:**
+
    ```bash
    export INGEST_URL=https://YOUR_REF.supabase.co/functions/v1/ingest-thought
    export INGEST_KEY=your-service-role-key
    ```
+
 4. **First run — authenticate:**
+
    ```bash
    deno run --allow-net --allow-read --allow-write --allow-env pull-gmail.ts --dry-run --limit=5
    ```
+
    This opens a browser window for OAuth consent. After authorizing, your token is cached in `token.json`.
 
 ## Usage

--- a/recipes/source-filtering/README.md
+++ b/recipes/source-filtering/README.md
@@ -65,18 +65,21 @@ You'll see something like:
 Source filtering works with three MCP tools. Pass the `source` parameter to scope results:
 
 **search_thoughts** — semantic search within a single source:
+
 ```
 "Search my gmail thoughts for conversations about the product roadmap"
 → search_thoughts({ query: "product roadmap", source: "gmail" })
 ```
 
 **list_thoughts** — recent thoughts from a specific source:
+
 ```
 "Show me my last 10 ChatGPT thoughts"
 → list_thoughts({ limit: 10, source: "chatgpt" })
 ```
 
 **thought_stats** — stats scoped to a source:
+
 ```
 "How many gmail thoughts do I have?"
 → thought_stats({ source: "gmail" })
@@ -155,6 +158,7 @@ ORDER BY count DESC;
 
 **Thoughts have `null` source**
 Some early thoughts were captured before source tracking was added. You can backfill the source field manually:
+
 ```sql
 UPDATE thoughts SET metadata = metadata || '{"source": "mcp"}'::jsonb
 WHERE metadata->>'source' IS NULL;
@@ -165,12 +169,14 @@ All your thoughts already have LLM-extracted metadata. This happens if everythin
 
 **Rate limiting from OpenRouter**
 The script batches requests (default 10 concurrent) with a 500ms pause between batches. If you hit rate limits, reduce the batch size:
+
 ```bash
 deno run --allow-net --allow-env backfill-metadata.ts --batch-size=3
 ```
 
 **Source strings are case-sensitive**
 `source: "Gmail"` won't match `source: "gmail"`. Sources are stored lowercase. If you have mixed-case sources from a custom import, normalize them:
+
 ```sql
 UPDATE thoughts SET metadata = jsonb_set(metadata, '{source}', to_jsonb(LOWER(metadata->>'source')))
 WHERE metadata->>'source' IS DISTINCT FROM LOWER(metadata->>'source');


### PR DESCRIPTION
## Summary

- **MD012**: Remove double blank line in getting-started.md
- **MD028**: Add `<!-- -->` separators between consecutive GitHub alert blockquotes (NOTE/CAUTION, TIP/WARNING pairs) in both bash and powershell sections of getting-started.md
- **MD031**: Add blank lines around fenced code blocks in numbered lists (AGENT_SPEC.md, email-history-import README) and after bold text headers (source-filtering README troubleshooting section)

Fixes all 21 errors reported by the `Markdown Lint` CI check. These were all pre-existing — none introduced by PR #58.

## Test plan

- [ ] `Markdown Lint` CI check passes with 0 errors
- [ ] Verify rendered markdown still looks correct on GitHub (blockquote separators are invisible)

🤖 Generated with [Claude Code](https://claude.com/claude-code)