### PR TITLE
[recipes][primitives] Link Gmail import and content fingerprint dedup

### DIFF
--- a/primitives/content-fingerprint-dedup/README.md
+++ b/primitives/content-fingerprint-dedup/README.md
@@ -144,7 +144,8 @@ Rows inserted before this primitive was added will have NULL fingerprints. Run t
 
 ## Extensions That Use This
 
-- All import recipes benefit from this primitive — it makes any import safely re-runnable.
+- **[Email History Import](../../recipes/email-history-import/README.md)** — Gmail import computes SHA-256 fingerprints on each email and sends them to the ingest endpoint. With this primitive deployed, re-running an import produces zero duplicates.
+- All other import recipes (ChatGPT, Google Activity, etc.) benefit from this primitive — it makes any import safely re-runnable.
 - Webhook-based capture (Slack, Telegram) is protected against retry-induced duplicates.
 - Multi-source capture (Chrome extension + MCP server) avoids cross-channel duplicates.
 

--- a/recipes/email-history-import/README.md
+++ b/recipes/email-history-import/README.md
@@ -105,7 +105,7 @@ deno run --allow-net --allow-read --allow-write --allow-env pull-gmail.ts --list
 Each imported email becomes one row in the `thoughts` table:
 - `content`: Email body with context prefix (`[Email from X | Subject: Y | Date: Z]`)
 - `metadata`: LLM-extracted topics, type, people, etc. plus `source: "gmail"`, `gmail_id`, `gmail_labels`, `gmail_thread_id`
-- `content_fingerprint`: SHA-256 hash for dedup (aligns with PR #54)
+- `content_fingerprint`: SHA-256 hash for dedup (see [content fingerprint primitive](../../primitives/content-fingerprint-dedup/README.md))
 - `embedding`: Generated server-side from content (truncated to model limit)
 
 ## Troubleshooting


### PR DESCRIPTION
## Summary
- Updates Gmail import README to link to the merged content fingerprint primitive (replaces forward PR #54 reference)
- Updates fingerprint primitive to list Gmail import as a concrete consumer in "Extensions That Use This"
- Cross-links the two contributions so users can follow the relationship

## Context
PR #38 (Gmail import) and PR #54 (content fingerprint dedup) are designed to work together. Now that both are merged, this PR connects the documentation so the relationship is discoverable.

## Test plan
- [ ] Gmail import README link resolves to the primitive
- [ ] Primitive README link resolves to Gmail import
- [ ] No other files changed

🤖 Generated with [Claude Code](https://claude.com/claude-code)