### PR TITLE
[recipes] Gmail import: direct Supabase insert with fingerprint dedup

### DIFF
--- a/recipes/email-history-import/.env.example
+++ b/recipes/email-history-import/.env.example
@@ -1,8 +1,14 @@
 # Open Brain Email History Import
-# Copy this file to .env and fill in your values
+# Copy this file to .env and fill in your values.
+# Then: export $(cat .env | xargs)
 
-# Your Supabase ingest-thought Edge Function URL
-INGEST_URL=https://YOUR_REF.supabase.co/functions/v1/ingest-thought
+# Supabase (from your Open Brain setup — Credential Tracker)
+SUPABASE_URL=https://YOUR_PROJECT_REF.supabase.co
+SUPABASE_SERVICE_ROLE_KEY=your-service-role-key-here
 
-# Your Supabase service role key (not the anon key — RLS blocks anon inserts)
-INGEST_KEY=your-service-role-key
+# OpenRouter (for embedding generation and metadata extraction)
+OPENROUTER_API_KEY=sk-or-v1-your-key-here
+
+# Optional: Custom ingest endpoint (use with --ingest-endpoint flag)
+# INGEST_URL=https://YOUR_PROJECT_REF.supabase.co/functions/v1/ingest-thought
+# INGEST_KEY=your-ingest-key-here

--- a/recipes/email-history-import/README.md
+++ b/recipes/email-history-import/README.md
@@ -6,7 +6,7 @@ Your email is full of decisions, commitments, and context that your AI has never
 
 ## What It Does
 
-Pulls your Gmail history via the Gmail API and loads each email into Open Brain as a single thought. Long emails are stored in full — truncation for embedding happens server-side. Each thought includes a SHA-256 content fingerprint for dedup.
+Pulls your Gmail history via the Gmail API and loads each email into Open Brain as a single thought. The script generates embeddings and extracts metadata (topics, people, action items) locally via OpenRouter, then inserts directly into Supabase with SHA-256 content fingerprint dedup.
 
 **One email = one thought.** No chunking, no parent/child relationships. This aligns with how the OB1 community handles long content (truncate for embedding, store full content).
 
@@ -16,7 +16,7 @@ Pulls your Gmail history via the Gmail API and loads each email into Open Brain 
 - Deno runtime installed
 - Google Cloud project with Gmail API enabled
 - Gmail API OAuth credentials (Client ID + Client Secret)
-- Your `ingest-thought` endpoint URL and key
+- OpenRouter API key (same one from your Open Brain setup)
 
 ## Credential Tracker
 
@@ -28,9 +28,8 @@ EMAIL HISTORY IMPORT -- CREDENTIAL TRACKER
 
 FROM YOUR OPEN BRAIN SETUP
   Supabase Project URL:  ____________
-  Supabase Secret key:   ____________
-  Ingest URL:            ____________/functions/v1/ingest-thought
-  Ingest Key:            ____________
+  Supabase Service Key:  ____________
+  OpenRouter API Key:    ____________
 
 GENERATED DURING SETUP
   Google Cloud Project ID:     ____________
@@ -47,8 +46,9 @@ GENERATED DURING SETUP
 3. **Set environment variables:**
 
    ```bash
-   export INGEST_URL=https://YOUR_REF.supabase.co/functions/v1/ingest-thought
-   export INGEST_KEY=your-service-role-key
+   export SUPABASE_URL=https://YOUR_REF.supabase.co
+   export SUPABASE_SERVICE_ROLE_KEY=your-service-role-key
+   export OPENROUTER_API_KEY=sk-or-v1-your-key
    ```
 
 4. **First run — authenticate:**
@@ -65,8 +65,8 @@ GENERATED DURING SETUP
 # Dry run — see what would be imported
 deno run --allow-net --allow-read --allow-write --allow-env pull-gmail.ts --dry-run
 
-# Import sent emails from the last 7 days
-deno run --allow-net --allow-read --allow-write --allow-env pull-gmail.ts --window=7d
+# Import sent emails from the last 90 days
+deno run --allow-net --allow-read --allow-write --allow-env pull-gmail.ts --window=90d --limit=500
 
 # Import starred emails
 deno run --allow-net --allow-read --allow-write --allow-env pull-gmail.ts --labels=STARRED
@@ -79,11 +79,18 @@ deno run --allow-net --allow-read --allow-write --allow-env pull-gmail.ts --list
 
 | Flag | Default | Description |
 |------|---------|-------------|
-| `--window=` | `24h` | Time window: `24h`, `7d`, `30d`, `1y`, `all` |
+| `--window=` | `24h` | Time window: `24h`, `7d`, `30d`, `90d`, `1y`, `all` |
 | `--labels=` | `SENT` | Comma-separated Gmail labels |
 | `--limit=` | `50` | Max emails to process |
 | `--dry-run` | off | Preview without ingesting |
 | `--list-labels` | off | List all Gmail labels and exit |
+| `--ingest-endpoint` | off | Use `INGEST_URL`/`INGEST_KEY` instead of Supabase direct insert |
+
+### Ingestion modes
+
+**Default (Supabase direct insert)** — The script generates embeddings and extracts metadata via OpenRouter, then inserts directly into Supabase with content fingerprint dedup. Requires `SUPABASE_URL`, `SUPABASE_SERVICE_ROLE_KEY`, `OPENROUTER_API_KEY`. This matches the pattern used by the ChatGPT import and MCP server.
+
+**`--ingest-endpoint`** — POSTs to a custom Edge Function endpoint that handles embedding and metadata server-side. Requires `INGEST_URL` and `INGEST_KEY`. Use this if you have a custom ingest-thought function deployed.
 
 ## How It Works
 
@@ -91,7 +98,9 @@ deno run --allow-net --allow-read --allow-write --allow-env pull-gmail.ts --list
 2. **Extract** body (base64 decode, HTML-to-text, strip quoted replies and signatures)
 3. **Filter** out noise (no-reply senders, receipts, auto-generated, <10 words)
 4. **Deduplicate** via sync-log (tracks Gmail message IDs already imported)
-5. **Ingest** each email as one thought with SHA-256 content fingerprint and metadata
+5. **Embed** content via OpenRouter (`text-embedding-3-small`)
+6. **Classify** via LLM (topics, type, people, action items)
+7. **Upsert** into Supabase with SHA-256 [content fingerprint](../../primitives/content-fingerprint-dedup/README.md) — re-running produces zero duplicates
 
 ### What gets filtered out
 
@@ -104,14 +113,16 @@ deno run --allow-net --allow-read --allow-write --allow-env pull-gmail.ts --list
 
 Each imported email becomes one row in the `thoughts` table:
 - `content`: Email body with context prefix (`[Email from X | Subject: Y | Date: Z]`)
-- `metadata`: LLM-extracted topics, type, people, etc. plus `source: "gmail"`, `gmail_id`, `gmail_labels`, `gmail_thread_id`
-- `content_fingerprint`: SHA-256 hash for dedup (see [content fingerprint primitive](../../primitives/content-fingerprint-dedup/README.md))
-- `embedding`: Generated server-side from content (truncated to model limit)
+- `embedding`: 1536-dim vector for semantic search (truncated to 8K chars)
+- `metadata`: LLM-extracted topics, type, people, action items, plus `source: "gmail"`, `gmail_id`, `gmail_labels`, `gmail_thread_id`
+- `content_fingerprint`: Normalized SHA-256 hash for dedup (see [content fingerprint primitive](../../primitives/content-fingerprint-dedup/README.md))
 
 ## Troubleshooting
 
 **OAuth flow fails:** Make sure your redirect URI in Google Cloud Console is `http://localhost:3847/callback`.
 
-**No thoughts appear:** Check that `INGEST_KEY` is your service role key (not the anon key). RLS blocks anon inserts.
+**No thoughts appear:** Check that `SUPABASE_SERVICE_ROLE_KEY` is your service role key (not the anon key). RLS blocks anon inserts.
 
-**Re-running imports the same emails:** The `sync-log.json` file tracks imported Gmail IDs. Delete it to re-import everything.
+**Re-running imports the same emails:** The `sync-log.json` file tracks imported Gmail IDs. Delete it to re-import everything. Content fingerprints provide a second layer of dedup at the database level.
+
+**Embedding/metadata errors:** Verify your `OPENROUTER_API_KEY` has credits. The script calls OpenRouter for both embedding generation and metadata extraction.

--- a/recipes/email-history-import/pull-gmail.ts
+++ b/recipes/email-history-import/pull-gmail.ts
@@ -3,19 +3,25 @@
 /**
  * Open Brain — Gmail Pull Script
  *
- * Fetches emails from Gmail via REST API, cleans them, and POSTs each
- * as a single thought to the ingest-thought endpoint. Long emails are
- * stored in full (truncation for embedding happens server-side).
+ * Fetches emails from Gmail via REST API, cleans them, generates embeddings
+ * and metadata, and inserts each as a thought into Supabase with SHA-256
+ * content fingerprint dedup.
+ *
+ * Ingestion modes:
+ *   Default:              Supabase direct insert (requires SUPABASE_URL,
+ *                         SUPABASE_SERVICE_ROLE_KEY, OPENROUTER_API_KEY)
+ *   --ingest-endpoint:    Custom endpoint (requires INGEST_URL, INGEST_KEY)
  *
  * Usage:
  *   deno run --allow-net --allow-read --allow-write --allow-env pull-gmail.ts [options]
  *
  * Options:
- *   --window=24h|7d|30d|1y|all    Time window to fetch (default: 24h)
- *   --labels=SENT,STARRED          Comma-separated Gmail labels (default: SENT)
- *   --dry-run                      Parse and show emails without ingesting
- *   --limit=N                      Max emails to process (default: 50)
- *   --list-labels                  List all Gmail labels and exit
+ *   --window=24h|7d|30d|90d|1y|all  Time window to fetch (default: 24h)
+ *   --labels=SENT,STARRED           Comma-separated Gmail labels (default: SENT)
+ *   --dry-run                       Parse and show emails without ingesting
+ *   --limit=N                       Max emails to process (default: 50)
+ *   --list-labels                   List all Gmail labels and exit
+ *   --ingest-endpoint               Use INGEST_URL/INGEST_KEY instead of Supabase direct
  */
 
 // ─── Configuration ───────────────────────────────────────────────────────────
@@ -28,8 +34,16 @@ const SYNC_LOG_PATH = `${SCRIPT_DIR}sync-log.json`;
 const GMAIL_API = "https://gmail.googleapis.com/gmail/v1/users/me";
 const SCOPES = ["https://www.googleapis.com/auth/gmail.readonly"];
 
+// Supabase direct insert (default mode)
+const SUPABASE_URL = Deno.env.get("SUPABASE_URL") || "";
+const SUPABASE_SERVICE_ROLE_KEY = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY") || "";
+const OPENROUTER_API_KEY = Deno.env.get("OPENROUTER_API_KEY") || "";
+
+// Edge Function endpoint (--ingest-endpoint mode)
 const INGEST_URL = Deno.env.get("INGEST_URL") || "";
 const INGEST_KEY = Deno.env.get("INGEST_KEY") || "";
+
+const OPENROUTER_BASE = "https://openrouter.ai/api/v1";
 
 // ─── Sync Log (deduplication) ────────────────────────────────────────────────
 
@@ -69,6 +83,7 @@ interface CliArgs {
   dryRun: boolean;
   limit: number;
   listLabels: boolean;
+  ingestEndpoint: boolean;
 }
 
 function parseArgs(): CliArgs {
@@ -78,6 +93,7 @@ function parseArgs(): CliArgs {
     dryRun: false,
     limit: 50,
     listLabels: false,
+    ingestEndpoint: false,
   };
 
   for (const arg of Deno.args) {
@@ -91,6 +107,8 @@ function parseArgs(): CliArgs {
       args.limit = parseInt(arg.split("=")[1], 10);
     } else if (arg === "--list-labels") {
       args.listLabels = true;
+    } else if (arg === "--ingest-endpoint") {
+      args.ingestEndpoint = true;
     }
   }
 
@@ -280,13 +298,16 @@ function windowToQuery(window: string): string {
     case "30d":
       after = new Date(now.getTime() - 30 * 24 * 60 * 60 * 1000);
       break;
+    case "90d":
+      after = new Date(now.getTime() - 90 * 24 * 60 * 60 * 1000);
+      break;
     case "1y":
       after = new Date(now.getTime() - 365 * 24 * 60 * 60 * 1000);
       break;
     case "all":
       return "";
     default:
-      console.error(`Unknown window: ${window}. Use 24h, 7d, 30d, 1y, or all.`);
+      console.error(`Unknown window: ${window}. Use 24h, 7d, 30d, 90d, 1y, or all.`);
       Deno.exit(1);
   }
 
@@ -559,6 +580,69 @@ function processEmail(msg: GmailMessage): ProcessedEmail | null {
   };
 }
 
+// ─── Embedding & Metadata (Supabase direct mode) ───────────────────────────
+
+async function getEmbedding(text: string): Promise<number[]> {
+  const truncated = text.slice(0, 8000);
+  const res = await fetch(`${OPENROUTER_BASE}/embeddings`, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${OPENROUTER_API_KEY}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      model: "openai/text-embedding-3-small",
+      input: truncated,
+    }),
+  });
+  if (!res.ok) {
+    const msg = await res.text().catch(() => "");
+    throw new Error(`Embedding failed: ${res.status} ${msg}`);
+  }
+  const d = await res.json();
+  return d.data[0].embedding;
+}
+
+async function extractMetadata(text: string): Promise<Record<string, unknown>> {
+  const res = await fetch(`${OPENROUTER_BASE}/chat/completions`, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${OPENROUTER_API_KEY}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      model: "openai/gpt-4o-mini",
+      response_format: { type: "json_object" },
+      messages: [
+        {
+          role: "system",
+          content: `Extract metadata from the user's captured thought. Return JSON with:
+- "people": array of people mentioned (empty if none)
+- "action_items": array of implied to-dos (empty if none)
+- "dates_mentioned": array of dates YYYY-MM-DD (empty if none)
+- "topics": array of 1-3 short topic tags (always at least one)
+- "type": one of "observation", "task", "idea", "reference", "person_note"
+Only extract what's explicitly there.`,
+        },
+        { role: "user", content: text },
+      ],
+    }),
+  });
+  const d = await res.json();
+  try {
+    return JSON.parse(d.choices[0].message.content);
+  } catch {
+    return { topics: ["uncategorized"], type: "observation" };
+  }
+}
+
+// ─── Content Fingerprint (normalized, matches upsert_thought RPC) ───────────
+
+async function contentFingerprint(text: string): Promise<string> {
+  const normalized = text.toLowerCase().trim().replace(/\s+/g, " ");
+  return await sha256(normalized);
+}
+
 // ─── Ingestion ───────────────────────────────────────────────────────────────
 
 interface IngestResult {
@@ -567,17 +651,111 @@ interface IngestResult {
   type?: string;
   topics?: string[];
   error?: string;
+  duplicate?: boolean;
 }
 
-async function ingestThought(
+let fingerprintSupported: boolean | null = null;
+
+async function ingestThoughtDirect(
   content: string,
   source: string,
   extraMetadata?: Record<string, unknown>,
 ): Promise<IngestResult> {
-  if (!INGEST_URL) {
-    return { ok: false, error: "INGEST_URL not set" };
+  const fingerprint = await contentFingerprint(content);
+
+  const [embedding, metadata] = await Promise.all([
+    getEmbedding(content),
+    extractMetadata(content),
+  ]);
+
+  const row: Record<string, unknown> = {
+    content,
+    embedding,
+    metadata: { ...metadata, source, ...extraMetadata },
+  };
+
+  if (fingerprintSupported !== false) {
+    row.content_fingerprint = fingerprint;
   }
 
+  const res = await fetch(`${SUPABASE_URL}/rest/v1/thoughts`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      apikey: SUPABASE_SERVICE_ROLE_KEY,
+      Authorization: `Bearer ${SUPABASE_SERVICE_ROLE_KEY}`,
+      Prefer: "return=representation",
+    },
+    body: JSON.stringify(row),
+  });
+
+  // 409 = duplicate fingerprint — content already exists, treat as success
+  if (res.status === 409) {
+    const meta = metadata as Record<string, unknown>;
+    return {
+      ok: true,
+      type: meta.type as string,
+      topics: meta.topics as string[],
+      duplicate: true,
+    };
+  }
+
+  // If fingerprint column doesn't exist, retry without it
+  if (!res.ok && fingerprintSupported === null) {
+    const body = await res.text();
+    if (body.includes("content_fingerprint")) {
+      fingerprintSupported = false;
+      console.log("   (content_fingerprint column not found — inserting without dedup)");
+      console.log("   Run the SQL from primitives/content-fingerprint-dedup to enable dedup.\n");
+      delete row.content_fingerprint;
+      const retry = await fetch(`${SUPABASE_URL}/rest/v1/thoughts`, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          apikey: SUPABASE_SERVICE_ROLE_KEY,
+          Authorization: `Bearer ${SUPABASE_SERVICE_ROLE_KEY}`,
+          Prefer: "return=representation",
+        },
+        body: JSON.stringify(row),
+      });
+      if (!retry.ok) {
+        const retryBody = await retry.text();
+        return { ok: false, error: `HTTP ${retry.status}: ${retryBody}` };
+      }
+      const data = await retry.json();
+      const meta = metadata as Record<string, unknown>;
+      return {
+        ok: true,
+        id: Array.isArray(data) ? data[0]?.id : data?.id,
+        type: meta.type as string,
+        topics: meta.topics as string[],
+      };
+    }
+    return { ok: false, error: `HTTP ${res.status}: ${body}` };
+  }
+
+  if (!res.ok) {
+    const body = await res.text();
+    return { ok: false, error: `HTTP ${res.status}: ${body}` };
+  }
+
+  if (fingerprintSupported === null) fingerprintSupported = true;
+
+  const data = await res.json();
+  const meta = metadata as Record<string, unknown>;
+  return {
+    ok: true,
+    id: Array.isArray(data) ? data[0]?.id : data?.id,
+    type: meta.type as string,
+    topics: meta.topics as string[],
+  };
+}
+
+async function ingestThoughtEndpoint(
+  content: string,
+  source: string,
+  extraMetadata?: Record<string, unknown>,
+): Promise<IngestResult> {
   const fingerprint = await sha256(content);
 
   const body: Record<string, unknown> = {
@@ -634,19 +812,36 @@ async function main() {
     labelMap.set(l.id, l.name);
   }
 
+  // Determine ingestion mode
+  const useEndpoint = args.ingestEndpoint;
+  const ingestMode = args.dryRun ? "DRY RUN" : useEndpoint ? "Edge Function endpoint" : "Supabase direct insert";
+
   // Normal pull mode
   const query = windowToQuery(args.window);
   console.log(`\nFetching emails...`);
   console.log(`  Labels: ${args.labels.join(", ")}`);
   console.log(`  Window: ${args.window}${query ? ` (${query})` : ""}`);
   console.log(`  Limit:  ${args.limit}`);
-  console.log(`  Mode:   ${args.dryRun ? "DRY RUN (no ingestion)" : "LIVE"}`);
+  console.log(`  Mode:   ${ingestMode}`);
 
-  if (!args.dryRun && !INGEST_URL) {
-    console.error("\nINGEST_URL environment variable is required for live mode.");
-    console.error("Set it to your ingest-thought endpoint URL.");
-    console.error("Example: export INGEST_URL=https://YOUR_REF.supabase.co/functions/v1/ingest-thought");
-    Deno.exit(1);
+  if (!args.dryRun) {
+    if (useEndpoint) {
+      if (!INGEST_URL || !INGEST_KEY) {
+        console.error("\nINGEST_URL and INGEST_KEY are required with --ingest-endpoint.");
+        console.error("Example: export INGEST_URL=https://YOUR_REF.supabase.co/functions/v1/ingest-thought");
+        Deno.exit(1);
+      }
+    } else {
+      if (!SUPABASE_URL || !SUPABASE_SERVICE_ROLE_KEY) {
+        console.error("\nSUPABASE_URL and SUPABASE_SERVICE_ROLE_KEY are required for live mode.");
+        console.error("Example: export SUPABASE_URL=https://YOUR_REF.supabase.co");
+        Deno.exit(1);
+      }
+      if (!OPENROUTER_API_KEY) {
+        console.error("\nOPENROUTER_API_KEY is required for embedding + metadata extraction.");
+        Deno.exit(1);
+      }
+    }
   }
 
   const syncLog = await loadSyncLog();
@@ -706,12 +901,15 @@ async function main() {
     };
 
     const content = buildEmailContent(email.body, email.from, email.subject, email.date);
-    const result = await ingestThought(content, "gmail", emailMeta);
+    const result = useEndpoint
+      ? await ingestThoughtEndpoint(content, "gmail", emailMeta)
+      : await ingestThoughtDirect(content, "gmail", emailMeta);
 
     if (result.ok) {
       ingested++;
       syncLog.ingested_ids[ref.id] = new Date().toISOString();
-      console.log(`   -> Ingested: ${result.type} — ${(result.topics || []).join(", ")}`);
+      const dupTag = result.duplicate ? " (duplicate — skipped)" : "";
+      console.log(`   -> Ingested: ${result.type} — ${(result.topics || []).join(", ")}${dupTag}`);
     } else {
       errors++;
       console.error(`   -> ERROR: ${result.error}`);


### PR DESCRIPTION
## Summary

- Aligns Gmail import with the ChatGPT import pattern — script-side embedding + metadata extraction via OpenRouter, direct Supabase REST insert
- SHA-256 content fingerprint for database-level dedup (uses column from PR #54)
- Backward compat via `--ingest-endpoint` flag for users with custom Edge Functions
- Graceful fallback if `content_fingerprint` column not yet added
- Added `90d` time window option

## Why

The Gmail import was the only recipe that depended on an untracked Edge Function for ingestion. Every other import path (ChatGPT, MCP server, Slack capture) does direct Supabase insert with script-side embedding. This PR brings Gmail in line with that standard pattern (see #61 for the full analysis).

## What Changed

| File | Change |
|------|--------|
| `pull-gmail.ts` | Added `getEmbedding()`, `extractMetadata()`, `contentFingerprint()`, `ingestThoughtDirect()`. Default mode is now direct Supabase insert. Old Edge Function path preserved as `--ingest-endpoint` |
| `.env.example` | Updated to `SUPABASE_URL`, `SUPABASE_SERVICE_ROLE_KEY`, `OPENROUTER_API_KEY` (matches ChatGPT import) |
| `README.md` | Rewritten for new defaults, documents both ingestion modes, updated credential tracker |

## Tested

- [x] Deno type-check passes
- [x] Dry run works with `--window=90d`
- [x] Live import: 4 emails ingested via direct Supabase insert, zero errors
- [x] `content_fingerprint` confirmed SET on new rows
- [x] Fallback works when column doesn't exist (tested before column was added)
- [x] Sync-log dedup still works (skips already-imported Gmail IDs)
- [x] Env var validation catches missing config before doing work

## Migration for existing users

Users currently using `INGEST_URL`/`INGEST_KEY` can either:
1. Switch to the new default (set `SUPABASE_URL`, `SUPABASE_SERVICE_ROLE_KEY`, `OPENROUTER_API_KEY`)
2. Keep their existing setup by adding `--ingest-endpoint` flag

## Test plan

- [x] Items above
- [ ] Community feedback on env var change

Relates to #61

🤖 Generated with [Claude Code](https://claude.com/claude-code)