### PR TITLE
[extensions] Fix user_id foreign key constraint blocking all inserts

### DIFF
--- a/extensions/family-calendar/index.ts
+++ b/extensions/family-calendar/index.ts
@@ -34,6 +34,11 @@ app.post("*", async (c) => {
     Deno.env.get("SUPABASE_SERVICE_ROLE_KEY")!,
   );
 
+  const userId = Deno.env.get("DEFAULT_USER_ID");
+  if (!userId) {
+    return c.json({ error: "DEFAULT_USER_ID not configured" }, 500);
+  }
+
   const server = new McpServer({ name: "family-calendar", version: "1.0.0" });
 
   // Tool: add_family_member
@@ -41,7 +46,6 @@ app.post("*", async (c) => {
     "add_family_member",
     "Add a person to your household roster",
     {
-      user_id: z.string().describe("User ID (UUID)"),
       name: z.string().describe("Person's name"),
       relationship: z.string().optional().describe("Relationship to you (e.g. 'self', 'spouse', 'child', 'parent')"),
       birth_date: z.string().optional().describe("Birth date (YYYY-MM-DD format)"),
@@ -51,7 +55,7 @@ app.post("*", async (c) => {
       const { data, error } = await supabase
         .from("family_members")
         .insert({
-          user_id: args.user_id,
+          user_id: userId,
           name: args.name,
           relationship: args.relationship,
           birth_date: args.birth_date,
@@ -78,7 +82,6 @@ app.post("*", async (c) => {
     "add_activity",
     "Schedule an activity or recurring event",
     {
-      user_id: z.string().describe("User ID (UUID)"),
       family_member_id: z.string().optional().describe("Family member ID (null for whole family)"),
       title: z.string().describe("Activity title"),
       activity_type: z.string().optional().describe("Type: 'sports', 'medical', 'school', 'social', etc."),
@@ -94,7 +97,7 @@ app.post("*", async (c) => {
       const { data, error } = await supabase
         .from("activities")
         .insert({
-          user_id: args.user_id,
+          user_id: userId,
           family_member_id: args.family_member_id || null,
           title: args.title,
           activity_type: args.activity_type,
@@ -127,7 +130,6 @@ app.post("*", async (c) => {
     "get_week_schedule",
     "Get all activities for a given week, grouped by day",
     {
-      user_id: z.string().describe("User ID (UUID)"),
       week_start: z.string().describe("Monday of the week (YYYY-MM-DD format)"),
       family_member_id: z.string().optional().describe("Optional: filter by family member"),
     },
@@ -145,7 +147,7 @@ app.post("*", async (c) => {
           family_members:family_member_id (name, relationship)
         `
         )
-        .eq("user_id", args.user_id)
+        .eq("user_id", userId)
         .or(
           `and(start_date.lte.${weekEnd.toISOString().split("T")[0]},or(end_date.gte.${args.week_start},end_date.is.null)),day_of_week.not.is.null`
         );
@@ -174,7 +176,6 @@ app.post("*", async (c) => {
     "search_activities",
     "Search activities by title, type, or family member name",
     {
-      user_id: z.string().describe("User ID (UUID)"),
       query: z.string().optional().describe("Search query"),
       activity_type: z.string().optional().describe("Optional: filter by activity type"),
       family_member_id: z.string().optional().describe("Optional: filter by family member"),
@@ -188,7 +189,7 @@ app.post("*", async (c) => {
           family_members:family_member_id (name, relationship)
         `
         )
-        .eq("user_id", args.user_id);
+        .eq("user_id", userId);
 
       if (args.query) {
         query = query.ilike("title", `%${args.query}%`);
@@ -224,7 +225,6 @@ app.post("*", async (c) => {
     "add_important_date",
     "Add a date to remember (birthday, anniversary, deadline)",
     {
-      user_id: z.string().describe("User ID (UUID)"),
       family_member_id: z.string().optional().describe("Family member ID (null for family-wide)"),
       title: z.string().describe("Event title"),
       date_value: z.string().describe("Date (YYYY-MM-DD format)"),
@@ -236,7 +236,7 @@ app.post("*", async (c) => {
       const { data, error } = await supabase
         .from("important_dates")
         .insert({
-          user_id: args.user_id,
+          user_id: userId,
           family_member_id: args.family_member_id || null,
           title: args.title,
           date_value: args.date_value,
@@ -265,7 +265,6 @@ app.post("*", async (c) => {
     "get_upcoming_dates",
     "Get important dates in the next N days",
     {
-      user_id: z.string().describe("User ID (UUID)"),
       days_ahead: z.number().optional().describe("How many days to look ahead (default 30)"),
     },
     async (args) => {
@@ -282,7 +281,7 @@ app.post("*", async (c) => {
           family_members:family_member_id (name, relationship)
         `
         )
-        .eq("user_id", args.user_id)
+        .eq("user_id", userId)
         .gte("date_value", today.toISOString().split("T")[0])
         .lte("date_value", futureDate.toISOString().split("T")[0])
         .order("date_value");

--- a/extensions/family-calendar/schema.sql
+++ b/extensions/family-calendar/schema.sql
@@ -4,7 +4,7 @@
 -- Family members in your household
 CREATE TABLE family_members (
     id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
-    user_id UUID REFERENCES auth.users(id) ON DELETE CASCADE NOT NULL,
+    user_id UUID NOT NULL,
     name TEXT NOT NULL,
     relationship TEXT, -- e.g. 'self', 'spouse', 'child', 'parent'
     birth_date DATE,
@@ -15,7 +15,7 @@ CREATE TABLE family_members (
 -- Scheduled events and recurring activities
 CREATE TABLE activities (
     id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
-    user_id UUID REFERENCES auth.users(id) ON DELETE CASCADE NOT NULL,
+    user_id UUID NOT NULL,
     family_member_id UUID REFERENCES family_members, -- null means whole family
     title TEXT NOT NULL,
     activity_type TEXT, -- e.g. 'sports', 'medical', 'school', 'social'
@@ -32,7 +32,7 @@ CREATE TABLE activities (
 -- Birthdays, anniversaries, deadlines
 CREATE TABLE important_dates (
     id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
-    user_id UUID REFERENCES auth.users(id) ON DELETE CASCADE NOT NULL,
+    user_id UUID NOT NULL,
     family_member_id UUID REFERENCES family_members, -- null for family-wide dates
     title TEXT NOT NULL,
     date_value DATE NOT NULL,

--- a/extensions/home-maintenance/index.ts
+++ b/extensions/home-maintenance/index.ts
@@ -44,6 +44,11 @@ app.post("*", async (c) => {
     Deno.env.get("SUPABASE_SERVICE_ROLE_KEY")!,
   );
 
+  const userId = Deno.env.get("DEFAULT_USER_ID");
+  if (!userId) {
+    return c.json({ error: "DEFAULT_USER_ID not configured" }, 500);
+  }
+
   const server = new McpServer(
     { name: "home-maintenance", version: "1.0.0" },
   );
@@ -53,7 +58,6 @@ app.post("*", async (c) => {
     "add_maintenance_task",
     "Create a new maintenance task (recurring or one-time)",
     {
-      user_id: z.string().describe("User ID (UUID)"),
       name: z.string().describe("Name of the maintenance task"),
       category: z.string().optional().describe("Category (e.g. 'hvac', 'plumbing', 'exterior', 'appliance', 'landscaping')"),
       frequency_days: z.number().optional().describe("How often this task repeats (in days). Null for one-time tasks. E.g. 90 for quarterly, 365 for annual"),
@@ -63,12 +67,12 @@ app.post("*", async (c) => {
     },
     async (args) => {
       try {
-        const { user_id, name, category, frequency_days, next_due, priority, notes } = args;
+        const { name, category, frequency_days, next_due, priority, notes } = args;
 
         const { data, error } = await supabase
           .from("maintenance_tasks")
           .insert({
-            user_id,
+            user_id: userId,
             name,
             category: category || null,
             frequency_days: frequency_days || null,
@@ -109,7 +113,6 @@ app.post("*", async (c) => {
     "Log that a maintenance task was completed. Automatically updates task's last_completed and calculates next_due.",
     {
       task_id: z.string().describe("ID of the maintenance task (UUID)"),
-      user_id: z.string().describe("User ID (UUID)"),
       completed_at: z.string().optional().describe("When the work was completed (ISO 8601 timestamp). Defaults to now if not provided."),
       performed_by: z.string().optional().describe("Who performed the work (e.g. 'self', vendor name)"),
       cost: z.number().optional().describe("Cost in dollars (or your currency)"),
@@ -118,7 +121,7 @@ app.post("*", async (c) => {
     },
     async (args) => {
       try {
-        const { task_id, user_id, completed_at, performed_by, cost, notes, next_action } = args;
+        const { task_id, completed_at, performed_by, cost, notes, next_action } = args;
 
         // Insert the maintenance log
         // The database trigger will automatically update the parent task's last_completed and next_due
@@ -126,7 +129,7 @@ app.post("*", async (c) => {
           .from("maintenance_logs")
           .insert({
             task_id,
-            user_id,
+            user_id: userId,
             completed_at: completed_at || new Date().toISOString(),
             performed_by: performed_by || null,
             cost: cost || null,
@@ -177,12 +180,11 @@ app.post("*", async (c) => {
     "get_upcoming_maintenance",
     "List maintenance tasks due in the next N days",
     {
-      user_id: z.string().describe("User ID (UUID)"),
       days_ahead: z.number().optional().describe("Number of days to look ahead (default 30)"),
     },
     async (args) => {
       try {
-        const { user_id, days_ahead = 30 } = args;
+        const { days_ahead = 30 } = args;
 
         const cutoffDate = new Date();
         cutoffDate.setDate(cutoffDate.getDate() + days_ahead);
@@ -190,7 +192,7 @@ app.post("*", async (c) => {
         const { data, error } = await supabase
           .from("maintenance_tasks")
           .select("*")
-          .eq("user_id", user_id)
+          .eq("user_id", userId)
           .not("next_due", "is", null)
           .lte("next_due", cutoffDate.toISOString())
           .order("next_due", { ascending: true });
@@ -225,7 +227,6 @@ app.post("*", async (c) => {
     "search_maintenance_history",
     "Search maintenance logs by task name, category, or date range",
     {
-      user_id: z.string().describe("User ID (UUID)"),
       task_name: z.string().optional().describe("Filter by task name (partial match)"),
       category: z.string().optional().describe("Filter by category"),
       date_from: z.string().optional().describe("Start date for filtering (ISO 8601 date string)"),
@@ -233,7 +234,7 @@ app.post("*", async (c) => {
     },
     async (args) => {
       try {
-        const { user_id, task_name, category, date_from, date_to } = args;
+        const { task_name, category, date_from, date_to } = args;
 
         // First, build a query to get relevant task IDs if filtering by name or category
         let taskIds: string[] | null = null;
@@ -242,7 +243,7 @@ app.post("*", async (c) => {
           let taskQuery = supabase
             .from("maintenance_tasks")
             .select("id")
-            .eq("user_id", user_id);
+            .eq("user_id", userId);
 
           if (task_name) {
             taskQuery = taskQuery.ilike("name", `%${task_name}%`);
@@ -286,7 +287,7 @@ app.post("*", async (c) => {
               category
             )
           `)
-          .eq("user_id", user_id);
+          .eq("user_id", userId);
 
         if (taskIds) {
           logQuery = logQuery.in("task_id", taskIds);

--- a/extensions/home-maintenance/schema.sql
+++ b/extensions/home-maintenance/schema.sql
@@ -5,7 +5,7 @@
 -- Recurring or one-time maintenance items
 CREATE TABLE IF NOT EXISTS maintenance_tasks (
     id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
-    user_id UUID REFERENCES auth.users(id) ON DELETE CASCADE NOT NULL,
+    user_id UUID NOT NULL,
     name TEXT NOT NULL,
     category TEXT, -- e.g. 'hvac', 'plumbing', 'exterior', 'appliance', 'landscaping'
     frequency_days INTEGER, -- null for one-time tasks; e.g. 90 for quarterly, 365 for annual
@@ -22,7 +22,7 @@ CREATE TABLE IF NOT EXISTS maintenance_tasks (
 CREATE TABLE IF NOT EXISTS maintenance_logs (
     id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
     task_id UUID REFERENCES maintenance_tasks(id) ON DELETE CASCADE NOT NULL,
-    user_id UUID REFERENCES auth.users(id) ON DELETE CASCADE NOT NULL,
+    user_id UUID NOT NULL,
     completed_at TIMESTAMPTZ DEFAULT now() NOT NULL,
     performed_by TEXT, -- who did the work (self, vendor name, etc.)
     cost DECIMAL(10, 2), -- cost in dollars (or your currency)

--- a/extensions/household-knowledge/README.md
+++ b/extensions/household-knowledge/README.md
@@ -22,7 +22,7 @@ A database and MCP server for storing and retrieving household facts — paint c
 ## What You'll Learn
 
 - Basic table design with PostgreSQL
-- Foreign key relationships to user accounts
+- User-scoped data isolation with environment variables
 - Simple MCP tool creation
 - JSONB patterns for flexible metadata storage
 - Text search with ILIKE patterns
@@ -50,6 +50,7 @@ SUPABASE (from your Open Brain setup)
   Project ref:           ____________
 
 GENERATED DURING SETUP
+  Default User ID:       ____________
   MCP Access Key:        ____________
   MCP Server URL:        ____________
   MCP Connection URL:    ____________
@@ -70,7 +71,24 @@ Run the SQL in `schema.sql` in your Supabase SQL Editor:
 
 Copy and paste the contents of `schema.sql` and click Run.
 
-### 2. Deploy the MCP Server
+### 2. Generate Your User ID
+
+The extension needs a user ID to scope your data. Generate a UUID and save it in your credential tracker:
+
+```bash
+# macOS / Linux
+uuidgen | tr '[:upper:]' '[:lower:]'
+
+# Or use any UUID generator — the value just needs to be unique to you
+```
+
+Set it as an environment variable for your Edge Function:
+
+```bash
+supabase secrets set DEFAULT_USER_ID=your-generated-uuid-here
+```
+
+### 3. Deploy the MCP Server
 
 Follow the [Deploy an Edge Function](../../primitives/deploy-edge-function/) guide using these values:
 
@@ -79,7 +97,7 @@ Follow the [Deploy an Edge Function](../../primitives/deploy-edge-function/) gui
 | Function name | `household-knowledge-mcp` |
 | Download path | `extensions/household-knowledge` |
 
-### 3. Connect to Your AI
+### 4. Connect to Your AI
 
 Follow the [Remote MCP Connection](../../primitives/remote-mcp/) guide to connect this extension to Claude Desktop, ChatGPT, Claude Code, or any other MCP client.
 
@@ -88,7 +106,7 @@ Follow the [Remote MCP Connection](../../primitives/remote-mcp/) guide to connec
 | Connector name | `Household Knowledge` |
 | URL | Your **MCP Connection URL** from the credential tracker |
 
-### 4. Test the Extension
+### 5. Test the Extension
 
 Try these commands with Claude:
 
@@ -139,10 +157,10 @@ For common issues (connection errors, 401s, deployment problems), see [Common Tr
 
 **Extension-specific issues:**
 
-**"Permission denied" errors**
-- The service role key bypasses RLS, so this suggests a configuration issue
-- Verify the user_id being passed exists in `auth.users`
-- Check that foreign key constraints are not blocking inserts
+**"Permission denied" or foreign key errors on insert**
+- Verify `DEFAULT_USER_ID` is set: `supabase secrets list` should show it
+- The service role key bypasses RLS, so permission errors usually mean a missing env var
+- If you ran an older version of `schema.sql` that had `REFERENCES auth.users(id)`, drop and recreate the tables with the updated schema
 
 ## Next Steps
 

--- a/extensions/household-knowledge/index.ts
+++ b/extensions/household-knowledge/index.ts
@@ -42,6 +42,11 @@ app.post("*", async (c) => {
     Deno.env.get("SUPABASE_SERVICE_ROLE_KEY")!,
   );
 
+  const userId = Deno.env.get("DEFAULT_USER_ID");
+  if (!userId) {
+    return c.json({ error: "DEFAULT_USER_ID not configured" }, 500);
+  }
+
   const server = new McpServer(
     { name: "household-knowledge", version: "1.0.0" },
   );
@@ -51,19 +56,18 @@ app.post("*", async (c) => {
     "add_household_item",
     "Add a new household item (paint color, appliance, measurement, document, etc.)",
     {
-      user_id: z.string().describe("User ID (UUID) - typically auth.uid()"),
       name: z.string().describe("Name or description of the item"),
       category: z.string().optional().describe("Category (e.g. 'paint', 'appliance', 'measurement', 'document')"),
       location: z.string().optional().describe("Location in the home (e.g. 'Living Room', 'Kitchen')"),
       details: z.string().optional().describe("Flexible metadata as JSON string (e.g. '{\"brand\": \"Sherwin Williams\", \"color\": \"Sea Salt\"}')"),
       notes: z.string().optional().describe("Additional notes or context"),
     },
-    async ({ user_id, name, category, location, details, notes }) => {
+    async ({ name, category, location, details, notes }) => {
       try {
         const { data, error } = await supabase
           .from("household_items")
           .insert({
-            user_id,
+            user_id: userId,
             name,
             category: category || null,
             location: location || null,
@@ -102,17 +106,16 @@ app.post("*", async (c) => {
     "search_household_items",
     "Search household items by name, category, or location",
     {
-      user_id: z.string().describe("User ID (UUID)"),
       query: z.string().optional().describe("Search term (searches name, category, location, and notes)"),
       category: z.string().optional().describe("Filter by specific category"),
       location: z.string().optional().describe("Filter by specific location"),
     },
-    async ({ user_id, query, category, location }) => {
+    async ({ query, category, location }) => {
       try {
         let queryBuilder = supabase
           .from("household_items")
           .select("*")
-          .eq("user_id", user_id);
+          .eq("user_id", userId);
 
         if (category) {
           queryBuilder = queryBuilder.ilike("category", `%${category}%`);
@@ -160,15 +163,14 @@ app.post("*", async (c) => {
     "Get full details of a specific household item by ID",
     {
       item_id: z.string().describe("Item ID (UUID)"),
-      user_id: z.string().describe("User ID (UUID) for authorization"),
     },
-    async ({ item_id, user_id }) => {
+    async ({ item_id }) => {
       try {
         const { data, error } = await supabase
           .from("household_items")
           .select("*")
           .eq("id", item_id)
-          .eq("user_id", user_id)
+          .eq("user_id", userId)
           .single();
 
         if (error) {
@@ -203,7 +205,6 @@ app.post("*", async (c) => {
     "add_vendor",
     "Add a service provider (plumber, electrician, landscaper, etc.)",
     {
-      user_id: z.string().describe("User ID (UUID)"),
       name: z.string().describe("Vendor name"),
       service_type: z.string().optional().describe("Type of service (e.g. 'plumber', 'electrician', 'landscaper')"),
       phone: z.string().optional().describe("Phone number"),
@@ -213,12 +214,12 @@ app.post("*", async (c) => {
       rating: z.number().min(1).max(5).optional().describe("Rating from 1-5"),
       last_used: z.string().optional().describe("Date last used (YYYY-MM-DD format)"),
     },
-    async ({ user_id, name, service_type, phone, email, website, notes, rating, last_used }) => {
+    async ({ name, service_type, phone, email, website, notes, rating, last_used }) => {
       try {
         const { data, error } = await supabase
           .from("household_vendors")
           .insert({
-            user_id,
+            user_id: userId,
             name,
             service_type: service_type || null,
             phone: phone || null,
@@ -260,15 +261,14 @@ app.post("*", async (c) => {
     "list_vendors",
     "List service providers, optionally filtered by service type",
     {
-      user_id: z.string().describe("User ID (UUID)"),
       service_type: z.string().optional().describe("Filter by service type (e.g. 'plumber', 'electrician')"),
     },
-    async ({ user_id, service_type }) => {
+    async ({ service_type }) => {
       try {
         let queryBuilder = supabase
           .from("household_vendors")
           .select("*")
-          .eq("user_id", user_id);
+          .eq("user_id", userId);
 
         if (service_type) {
           queryBuilder = queryBuilder.ilike("service_type", `%${service_type}%`);

--- a/extensions/household-knowledge/schema.sql
+++ b/extensions/household-knowledge/schema.sql
@@ -5,7 +5,7 @@
 -- Stores facts about things in your home (paint colors, appliances, measurements, etc.)
 CREATE TABLE IF NOT EXISTS household_items (
     id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
-    user_id UUID REFERENCES auth.users(id) ON DELETE CASCADE NOT NULL,
+    user_id UUID NOT NULL,
     name TEXT NOT NULL,
     category TEXT, -- e.g. 'paint', 'appliance', 'measurement', 'document'
     location TEXT, -- where in the home this item is
@@ -19,7 +19,7 @@ CREATE TABLE IF NOT EXISTS household_items (
 -- Tracks service providers (plumbers, electricians, landscapers, etc.)
 CREATE TABLE IF NOT EXISTS household_vendors (
     id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
-    user_id UUID REFERENCES auth.users(id) ON DELETE CASCADE NOT NULL,
+    user_id UUID NOT NULL,
     name TEXT NOT NULL,
     service_type TEXT, -- e.g. 'plumber', 'electrician', 'landscaper'
     phone TEXT,

--- a/extensions/job-hunt/index.ts
+++ b/extensions/job-hunt/index.ts
@@ -20,7 +20,6 @@ const app = new Hono();
 
 // Zod schemas for tool inputs
 const addCompanySchema = z.object({
-  user_id: z.string().describe("User ID (UUID)"),
   name: z.string().describe("Company name"),
   industry: z.string().optional().describe("Industry"),
   website: z.string().optional().describe("Company website"),
@@ -32,7 +31,6 @@ const addCompanySchema = z.object({
 });
 
 const addJobPostingSchema = z.object({
-  user_id: z.string().describe("User ID (UUID)"),
   company_id: z.string().describe("Company ID (UUID)"),
   title: z.string().describe("Job title"),
   url: z.string().optional().describe("Job posting URL"),
@@ -48,7 +46,6 @@ const addJobPostingSchema = z.object({
 });
 
 const submitApplicationSchema = z.object({
-  user_id: z.string().describe("User ID (UUID)"),
   job_posting_id: z.string().describe("Job posting ID (UUID)"),
   status: z.enum(["draft", "applied", "screening", "interviewing", "offer", "accepted", "rejected", "withdrawn"]).optional().describe("Application status (default: applied)"),
   applied_date: z.string().optional().describe("Date applied (YYYY-MM-DD)"),
@@ -59,7 +56,6 @@ const submitApplicationSchema = z.object({
 });
 
 const scheduleInterviewSchema = z.object({
-  user_id: z.string().describe("User ID (UUID)"),
   application_id: z.string().describe("Application ID (UUID)"),
   interview_type: z.enum(["phone_screen", "technical", "behavioral", "system_design", "hiring_manager", "team", "final"]).describe("Type of interview"),
   scheduled_at: z.string().optional().describe("Interview date/time (ISO 8601)"),
@@ -70,34 +66,30 @@ const scheduleInterviewSchema = z.object({
 });
 
 const logInterviewNotesSchema = z.object({
-  user_id: z.string().describe("User ID (UUID)"),
   interview_id: z.string().describe("Interview ID (UUID)"),
   feedback: z.string().optional().describe("Post-interview reflection"),
   rating: z.number().min(1).max(5).optional().describe("Your assessment of how it went (1-5)"),
 });
 
 const getPipelineOverviewSchema = z.object({
-  user_id: z.string().describe("User ID (UUID)"),
   days_ahead: z.number().optional().describe("Number of days to look ahead for interviews (default: 7)"),
 });
 
 const getUpcomingInterviewsSchema = z.object({
-  user_id: z.string().describe("User ID (UUID)"),
   days_ahead: z.number().optional().describe("Number of days to look ahead (default: 14)"),
 });
 
 const linkContactToProfessionalCRMSchema = z.object({
-  user_id: z.string().describe("User ID (UUID)"),
   job_contact_id: z.string().describe("Job contact ID (UUID)"),
 });
 // Tool handlers
-async function handleAddCompany(supabase: any, args: z.infer<typeof addCompanySchema>): Promise<string> {
-  const { user_id, name, industry, website, size, location, remote_policy, notes, glassdoor_rating } = args;
+async function handleAddCompany(supabase: any, args: z.infer<typeof addCompanySchema>, userId: string): Promise<string> {
+  const { name, industry, website, size, location, remote_policy, notes, glassdoor_rating } = args;
 
   const { data, error } = await supabase
     .from("companies")
     .insert({
-      user_id,
+      user_id: userId,
       name,
       industry: industry || null,
       website: website || null,
@@ -121,16 +113,16 @@ async function handleAddCompany(supabase: any, args: z.infer<typeof addCompanySc
   }, null, 2);
 }
 
-async function handleAddJobPosting(supabase: any, args: z.infer<typeof addJobPostingSchema>): Promise<string> {
+async function handleAddJobPosting(supabase: any, args: z.infer<typeof addJobPostingSchema>, userId: string): Promise<string> {
   const {
-    user_id, company_id, title, url, salary_min, salary_max, salary_currency,
+    company_id, title, url, salary_min, salary_max, salary_currency,
     requirements, nice_to_haves, notes, source, posted_date, closing_date
   } = args;
 
   const { data, error } = await supabase
     .from("job_postings")
     .insert({
-      user_id,
+      user_id: userId,
       company_id,
       title,
       url: url || null,
@@ -158,16 +150,16 @@ async function handleAddJobPosting(supabase: any, args: z.infer<typeof addJobPos
   }, null, 2);
 }
 
-async function handleSubmitApplication(supabase: any, args: z.infer<typeof submitApplicationSchema>): Promise<string> {
+async function handleSubmitApplication(supabase: any, args: z.infer<typeof submitApplicationSchema>, userId: string): Promise<string> {
   const {
-    user_id, job_posting_id, status, applied_date, resume_version,
+    job_posting_id, status, applied_date, resume_version,
     cover_letter_notes, referral_contact, notes
   } = args;
 
   const { data, error } = await supabase
     .from("applications")
     .insert({
-      user_id,
+      user_id: userId,
       job_posting_id,
       status: status || "applied",
       applied_date: applied_date || null,
@@ -190,16 +182,16 @@ async function handleSubmitApplication(supabase: any, args: z.infer<typeof submi
   }, null, 2);
 }
 
-async function handleScheduleInterview(supabase: any, args: z.infer<typeof scheduleInterviewSchema>): Promise<string> {
+async function handleScheduleInterview(supabase: any, args: z.infer<typeof scheduleInterviewSchema>, userId: string): Promise<string> {
   const {
-    user_id, application_id, interview_type, scheduled_at, duration_minutes,
+    application_id, interview_type, scheduled_at, duration_minutes,
     interviewer_name, interviewer_title, notes
   } = args;
 
   const { data, error } = await supabase
     .from("interviews")
     .insert({
-      user_id,
+      user_id: userId,
       application_id,
       interview_type,
       scheduled_at: scheduled_at || null,
@@ -223,8 +215,8 @@ async function handleScheduleInterview(supabase: any, args: z.infer<typeof sched
   }, null, 2);
 }
 
-async function handleLogInterviewNotes(supabase: any, args: z.infer<typeof logInterviewNotesSchema>): Promise<string> {
-  const { user_id, interview_id, feedback, rating } = args;
+async function handleLogInterviewNotes(supabase: any, args: z.infer<typeof logInterviewNotesSchema>, userId: string): Promise<string> {
+  const { interview_id, feedback, rating } = args;
 
   const { data, error } = await supabase
     .from("interviews")
@@ -234,7 +226,7 @@ async function handleLogInterviewNotes(supabase: any, args: z.infer<typeof logIn
       status: "completed",
     })
     .eq("id", interview_id)
-    .eq("user_id", user_id)
+    .eq("user_id", userId)
     .select()
     .single();
 
@@ -249,15 +241,15 @@ async function handleLogInterviewNotes(supabase: any, args: z.infer<typeof logIn
   }, null, 2);
 }
 
-async function handleGetPipelineOverview(supabase: any, args: z.infer<typeof getPipelineOverviewSchema>): Promise<string> {
-  const { user_id, days_ahead } = args;
+async function handleGetPipelineOverview(supabase: any, args: z.infer<typeof getPipelineOverviewSchema>, userId: string): Promise<string> {
+  const { days_ahead } = args;
   const daysToCheck = days_ahead || 7;
 
   // Get application counts by status
   const { data: applications, error: appError } = await supabase
     .from("applications")
     .select("status")
-    .eq("user_id", user_id);
+    .eq("user_id", userId);
 
   if (appError) {
     throw new Error(`Failed to get applications: ${appError.message}`);
@@ -284,7 +276,7 @@ async function handleGetPipelineOverview(supabase: any, args: z.infer<typeof get
         )
       )
     `)
-    .eq("user_id", user_id)
+    .eq("user_id", userId)
     .eq("status", "scheduled")
     .gte("scheduled_at", new Date().toISOString())
     .lte("scheduled_at", futureDate.toISOString())
@@ -303,8 +295,8 @@ async function handleGetPipelineOverview(supabase: any, args: z.infer<typeof get
   }, null, 2);
 }
 
-async function handleGetUpcomingInterviews(supabase: any, args: z.infer<typeof getUpcomingInterviewsSchema>): Promise<string> {
-  const { user_id, days_ahead } = args;
+async function handleGetUpcomingInterviews(supabase: any, args: z.infer<typeof getUpcomingInterviewsSchema>, userId: string): Promise<string> {
+  const { days_ahead } = args;
   const daysToCheck = days_ahead || 14;
 
   const futureDate = new Date();
@@ -322,7 +314,7 @@ async function handleGetUpcomingInterviews(supabase: any, args: z.infer<typeof g
         )
       )
     `)
-    .eq("user_id", user_id)
+    .eq("user_id", userId)
     .eq("status", "scheduled")
     .gte("scheduled_at", new Date().toISOString())
     .lte("scheduled_at", futureDate.toISOString())
@@ -339,15 +331,15 @@ async function handleGetUpcomingInterviews(supabase: any, args: z.infer<typeof g
   }, null, 2);
 }
 
-async function handleLinkContactToProfessionalCRM(supabase: any, args: z.infer<typeof linkContactToProfessionalCRMSchema>): Promise<string> {
-  const { user_id, job_contact_id } = args;
+async function handleLinkContactToProfessionalCRM(supabase: any, args: z.infer<typeof linkContactToProfessionalCRMSchema>, userId: string): Promise<string> {
+  const { job_contact_id } = args;
 
   // Get the job contact
   const { data: jobContact, error: contactError } = await supabase
     .from("job_contacts")
     .select("*")
     .eq("id", job_contact_id)
-    .eq("user_id", user_id)
+    .eq("user_id", userId)
     .single();
 
   if (contactError) {
@@ -383,7 +375,7 @@ async function handleLinkContactToProfessionalCRM(supabase: any, args: z.infer<t
   const { data: professionalContact, error: crmError } = await supabase
     .from("professional_contacts")
     .insert({
-      user_id,
+      user_id: userId,
       name: jobContact.name,
       company: companyName,
       title: jobContact.title,
@@ -407,7 +399,7 @@ async function handleLinkContactToProfessionalCRM(supabase: any, args: z.infer<t
     .from("job_contacts")
     .update({ professional_crm_contact_id: professionalContact.id })
     .eq("id", job_contact_id)
-    .eq("user_id", user_id)
+    .eq("user_id", userId)
     .select()
     .single();
 
@@ -460,6 +452,11 @@ app.post("*", async (c) => {
     }
   );
 
+  const userId = Deno.env.get("DEFAULT_USER_ID");
+  if (!userId) {
+    return c.json({ error: "DEFAULT_USER_ID not configured" }, 500);
+  }
+
   // Create MCP server
   const server = new McpServer({ name: "job-hunt", version: "1.0.0" });
 
@@ -478,56 +475,56 @@ app.post("*", async (c) => {
     "add_company",
     "Add a company to track in your job search",
     addCompanySchema.shape,
-    async (args) => wrap(() => handleAddCompany(supabase, args))
+    async (args) => wrap(() => handleAddCompany(supabase, args, userId))
   );
 
   server.tool(
     "add_job_posting",
     "Add a job posting at a company",
     addJobPostingSchema.shape,
-    async (args) => wrap(() => handleAddJobPosting(supabase, args))
+    async (args) => wrap(() => handleAddJobPosting(supabase, args, userId))
   );
 
   server.tool(
     "submit_application",
     "Record a submitted application",
     submitApplicationSchema.shape,
-    async (args) => wrap(() => handleSubmitApplication(supabase, args))
+    async (args) => wrap(() => handleSubmitApplication(supabase, args, userId))
   );
 
   server.tool(
     "schedule_interview",
     "Schedule an interview for an application",
     scheduleInterviewSchema.shape,
-    async (args) => wrap(() => handleScheduleInterview(supabase, args))
+    async (args) => wrap(() => handleScheduleInterview(supabase, args, userId))
   );
 
   server.tool(
     "log_interview_notes",
     "Add feedback/notes after an interview and mark it as completed",
     logInterviewNotesSchema.shape,
-    async (args) => wrap(() => handleLogInterviewNotes(supabase, args))
+    async (args) => wrap(() => handleLogInterviewNotes(supabase, args, userId))
   );
 
   server.tool(
     "get_pipeline_overview",
     "Get a dashboard summary: application counts by status, upcoming interviews, recent activity",
     getPipelineOverviewSchema.shape,
-    async (args) => wrap(() => handleGetPipelineOverview(supabase, args))
+    async (args) => wrap(() => handleGetPipelineOverview(supabase, args, userId))
   );
 
   server.tool(
     "get_upcoming_interviews",
     "List interviews in the next N days with full company/role context",
     getUpcomingInterviewsSchema.shape,
-    async (args) => wrap(() => handleGetUpcomingInterviews(supabase, args))
+    async (args) => wrap(() => handleGetUpcomingInterviews(supabase, args, userId))
   );
 
   server.tool(
     "link_contact_to_professional_crm",
     "CROSS-EXTENSION: Link a job contact to Extension 5 Professional CRM, creating a professional_contacts record",
     linkContactToProfessionalCRMSchema.shape,
-    async (args) => wrap(() => handleLinkContactToProfessionalCRM(supabase, args))
+    async (args) => wrap(() => handleLinkContactToProfessionalCRM(supabase, args, userId))
   );
 
   // Connect transport and handle request

--- a/extensions/job-hunt/schema.sql
+++ b/extensions/job-hunt/schema.sql
@@ -5,7 +5,7 @@
 -- Organizations you're tracking in your job search
 CREATE TABLE IF NOT EXISTS companies (
     id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
-    user_id UUID REFERENCES auth.users(id) ON DELETE CASCADE NOT NULL,
+    user_id UUID NOT NULL,
     name TEXT NOT NULL,
     industry TEXT,
     website TEXT,
@@ -23,7 +23,7 @@ CREATE TABLE IF NOT EXISTS companies (
 CREATE TABLE IF NOT EXISTS job_postings (
     id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
     company_id UUID REFERENCES companies(id) ON DELETE CASCADE NOT NULL,
-    user_id UUID REFERENCES auth.users(id) ON DELETE CASCADE NOT NULL,
+    user_id UUID NOT NULL,
     title TEXT NOT NULL,
     url TEXT,
     salary_min INTEGER,
@@ -43,7 +43,7 @@ CREATE TABLE IF NOT EXISTS job_postings (
 CREATE TABLE IF NOT EXISTS applications (
     id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
     job_posting_id UUID REFERENCES job_postings(id) ON DELETE CASCADE NOT NULL,
-    user_id UUID REFERENCES auth.users(id) ON DELETE CASCADE NOT NULL,
+    user_id UUID NOT NULL,
     status TEXT DEFAULT 'applied' CHECK (status IN ('draft', 'applied', 'screening', 'interviewing', 'offer', 'accepted', 'rejected', 'withdrawn')),
     applied_date DATE,
     response_date DATE,
@@ -60,7 +60,7 @@ CREATE TABLE IF NOT EXISTS applications (
 CREATE TABLE IF NOT EXISTS interviews (
     id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
     application_id UUID REFERENCES applications(id) ON DELETE CASCADE NOT NULL,
-    user_id UUID REFERENCES auth.users(id) ON DELETE CASCADE NOT NULL,
+    user_id UUID NOT NULL,
     interview_type TEXT CHECK (interview_type IN ('phone_screen', 'technical', 'behavioral', 'system_design', 'hiring_manager', 'team', 'final')),
     scheduled_at TIMESTAMPTZ,
     duration_minutes INTEGER,
@@ -77,7 +77,7 @@ CREATE TABLE IF NOT EXISTS interviews (
 -- People associated with your job search
 CREATE TABLE IF NOT EXISTS job_contacts (
     id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
-    user_id UUID REFERENCES auth.users(id) ON DELETE CASCADE NOT NULL,
+    user_id UUID NOT NULL,
     company_id UUID REFERENCES companies(id) ON DELETE SET NULL,
     name TEXT NOT NULL,
     title TEXT,

--- a/extensions/meal-planning/index.ts
+++ b/extensions/meal-planning/index.ts
@@ -34,6 +34,11 @@ app.post("*", async (c) => {
     Deno.env.get("SUPABASE_SERVICE_ROLE_KEY")!,
   );
 
+  const userId = Deno.env.get("DEFAULT_USER_ID");
+  if (!userId) {
+    return c.json({ error: "DEFAULT_USER_ID not configured" }, 500);
+  }
+
   const server = new McpServer({ name: "meal-planning", version: "1.0.0" });
 
   // add_recipe tool
@@ -41,7 +46,6 @@ app.post("*", async (c) => {
     "add_recipe",
     "Add a recipe with ingredients and instructions",
     {
-      user_id: z.string().describe("User ID (UUID)"),
       name: z.string().describe("Recipe name"),
       cuisine: z.string().optional().describe("Cuisine type"),
       prep_time_minutes: z.number().optional().describe("Prep time in minutes"),
@@ -61,7 +65,7 @@ app.post("*", async (c) => {
       const { data, error } = await supabase
         .from("recipes")
         .insert({
-          user_id: args.user_id,
+          user_id: userId,
           name: args.name,
           cuisine: args.cuisine,
           prep_time_minutes: args.prep_time_minutes,
@@ -95,7 +99,6 @@ app.post("*", async (c) => {
     "search_recipes",
     "Search recipes by name, cuisine, tags, or ingredient",
     {
-      user_id: z.string().describe("User ID (UUID)"),
       query: z.string().optional().describe("Search query for name"),
       cuisine: z.string().optional().describe("Filter by cuisine"),
       tag: z.string().optional().describe("Filter by tag"),
@@ -105,7 +108,7 @@ app.post("*", async (c) => {
       let query = supabase
         .from("recipes")
         .select("*")
-        .eq("user_id", args.user_id);
+        .eq("user_id", userId);
 
       if (args.query) {
         query = query.ilike("name", `%${args.query}%`);
@@ -209,7 +212,6 @@ app.post("*", async (c) => {
     "create_meal_plan",
     "Plan meals for a week",
     {
-      user_id: z.string().describe("User ID (UUID)"),
       week_start: z.string().describe("Monday of the week (YYYY-MM-DD)"),
       meals: z.array(z.object({
         day_of_week: z.string(),
@@ -223,7 +225,7 @@ app.post("*", async (c) => {
     async (args) => {
       // Insert multiple meal plan entries
       const mealEntries = args.meals.map((meal: any) => ({
-        user_id: args.user_id,
+        user_id: userId,
         week_start: args.week_start,
         day_of_week: meal.day_of_week,
         meal_type: meal.meal_type,
@@ -256,7 +258,6 @@ app.post("*", async (c) => {
     "get_meal_plan",
     "View the meal plan for a given week",
     {
-      user_id: z.string().describe("User ID (UUID)"),
       week_start: z.string().describe("Monday of the week (YYYY-MM-DD)"),
     },
     async (args) => {
@@ -268,7 +269,7 @@ app.post("*", async (c) => {
           recipes:recipe_id (name, cuisine, prep_time_minutes, cook_time_minutes)
         `
         )
-        .eq("user_id", args.user_id)
+        .eq("user_id", userId)
         .eq("week_start", args.week_start)
         .order("day_of_week")
         .order("meal_type");
@@ -291,7 +292,6 @@ app.post("*", async (c) => {
     "generate_shopping_list",
     "Auto-generate a shopping list from a week's meal plan by aggregating recipe ingredients",
     {
-      user_id: z.string().describe("User ID (UUID)"),
       week_start: z.string().describe("Monday of the week (YYYY-MM-DD)"),
     },
     async (args) => {
@@ -304,7 +304,7 @@ app.post("*", async (c) => {
           recipes:recipe_id (id, ingredients, name)
         `
         )
-        .eq("user_id", args.user_id)
+        .eq("user_id", userId)
         .eq("week_start", args.week_start);
 
       if (mealError) throw mealError;
@@ -345,7 +345,7 @@ app.post("*", async (c) => {
       const { data: existing } = await supabase
         .from("shopping_lists")
         .select("id")
-        .eq("user_id", args.user_id)
+        .eq("user_id", userId)
         .eq("week_start", args.week_start)
         .single();
 
@@ -369,7 +369,7 @@ app.post("*", async (c) => {
         const { data, error } = await supabase
           .from("shopping_lists")
           .insert({
-            user_id: args.user_id,
+            user_id: userId,
             week_start: args.week_start,
             items,
           })

--- a/extensions/meal-planning/schema.sql
+++ b/extensions/meal-planning/schema.sql
@@ -4,7 +4,7 @@
 -- Recipe collection
 CREATE TABLE recipes (
     id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
-    user_id UUID REFERENCES auth.users NOT NULL,
+    user_id UUID NOT NULL,
     name TEXT NOT NULL,
     cuisine TEXT,
     prep_time_minutes INTEGER,
@@ -22,7 +22,7 @@ CREATE TABLE recipes (
 -- Weekly meal planning
 CREATE TABLE meal_plans (
     id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
-    user_id UUID REFERENCES auth.users NOT NULL,
+    user_id UUID NOT NULL,
     week_start DATE NOT NULL, -- should be a Monday
     day_of_week TEXT NOT NULL, -- 'monday', 'tuesday', etc.
     meal_type TEXT NOT NULL CHECK (meal_type IN ('breakfast', 'lunch', 'dinner', 'snack')),
@@ -36,7 +36,7 @@ CREATE TABLE meal_plans (
 -- Auto-generated or manual grocery lists
 CREATE TABLE shopping_lists (
     id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
-    user_id UUID REFERENCES auth.users NOT NULL,
+    user_id UUID NOT NULL,
     week_start DATE NOT NULL,
     items JSONB NOT NULL DEFAULT '[]', -- array of {name, quantity, unit, purchased: bool, recipe_id}
     notes TEXT,

--- a/extensions/professional-crm/index.ts
+++ b/extensions/professional-crm/index.ts
@@ -54,6 +54,11 @@ app.post("*", async (c) => {
     },
   );
 
+  const userId = Deno.env.get("DEFAULT_USER_ID");
+  if (!userId) {
+    return c.json({ error: "DEFAULT_USER_ID not configured" }, 500);
+  }
+
   const server = new McpServer({ name: "professional-crm", version: "1.0.0" });
 
   // Tool 1: add_professional_contact
@@ -61,7 +66,6 @@ app.post("*", async (c) => {
     "add_professional_contact",
     "Add a new professional contact to your network",
     {
-      user_id: z.string().describe("User ID (UUID)"),
       name: z.string().describe("Contact's full name"),
       company: z.string().optional().describe("Company name"),
       title: z.string().optional().describe("Job title"),
@@ -72,11 +76,11 @@ app.post("*", async (c) => {
       tags: z.array(z.string()).optional().describe("Tags for categorization (e.g., ['ai', 'consulting', 'conference'])"),
       notes: z.string().optional().describe("Additional notes about this contact"),
     },
-    async ({ user_id, name, company, title, email, phone, linkedin_url, how_we_met, tags, notes }) => {
+    async ({ name, company, title, email, phone, linkedin_url, how_we_met, tags, notes }) => {
       const { data, error } = await supabase
         .from("professional_contacts")
         .insert({
-          user_id,
+          user_id: userId,
           name,
           company: company || null,
           title: title || null,
@@ -114,15 +118,14 @@ app.post("*", async (c) => {
     "search_contacts",
     "Search professional contacts by name, company, or tags",
     {
-      user_id: z.string().describe("User ID (UUID)"),
       query: z.string().optional().describe("Search term (searches name, company, title, notes)"),
       tags: z.array(z.string()).optional().describe("Filter by specific tags"),
     },
-    async ({ user_id, query, tags }) => {
+    async ({ query, tags }) => {
       let queryBuilder = supabase
         .from("professional_contacts")
         .select("*")
-        .eq("user_id", user_id);
+        .eq("user_id", userId);
 
       if (query) {
         queryBuilder = queryBuilder.or(
@@ -160,7 +163,6 @@ app.post("*", async (c) => {
     "log_interaction",
     "Log an interaction with a contact (automatically updates last_contacted)",
     {
-      user_id: z.string().describe("User ID (UUID)"),
       contact_id: z.string().describe("Contact ID (UUID)"),
       interaction_type: z.enum(["meeting", "email", "call", "coffee", "event", "linkedin", "other"]).describe("Type of interaction"),
       occurred_at: z.string().optional().describe("When the interaction occurred (ISO 8601 timestamp, defaults to now)"),
@@ -168,11 +170,11 @@ app.post("*", async (c) => {
       follow_up_needed: z.boolean().optional().describe("Whether a follow-up is needed"),
       follow_up_notes: z.string().optional().describe("Notes about the follow-up"),
     },
-    async ({ user_id, contact_id, interaction_type, occurred_at, summary, follow_up_needed, follow_up_notes }) => {
+    async ({ contact_id, interaction_type, occurred_at, summary, follow_up_needed, follow_up_notes }) => {
       const { data, error } = await supabase
         .from("contact_interactions")
         .insert({
-          user_id,
+          user_id: userId,
           contact_id,
           interaction_type,
           occurred_at: occurred_at || new Date().toISOString(),
@@ -209,16 +211,15 @@ app.post("*", async (c) => {
     "get_contact_history",
     "Get a contact's full profile and all interactions, ordered by date",
     {
-      user_id: z.string().describe("User ID (UUID)"),
       contact_id: z.string().describe("Contact ID (UUID)"),
     },
-    async ({ user_id, contact_id }) => {
+    async ({ contact_id }) => {
       // Get contact details
       const { data: contact, error: contactError } = await supabase
         .from("professional_contacts")
         .select("*")
         .eq("id", contact_id)
-        .eq("user_id", user_id)
+        .eq("user_id", userId)
         .single();
 
       if (contactError) {
@@ -230,7 +231,7 @@ app.post("*", async (c) => {
         .from("contact_interactions")
         .select("*")
         .eq("contact_id", contact_id)
-        .eq("user_id", user_id)
+        .eq("user_id", userId)
         .order("occurred_at", { ascending: false });
 
       if (interactionsError) {
@@ -242,7 +243,7 @@ app.post("*", async (c) => {
         .from("opportunities")
         .select("*")
         .eq("contact_id", contact_id)
-        .eq("user_id", user_id)
+        .eq("user_id", userId)
         .order("created_at", { ascending: false });
 
       if (opportunitiesError) {
@@ -271,7 +272,6 @@ app.post("*", async (c) => {
     "create_opportunity",
     "Create a new opportunity/deal, optionally linked to a contact",
     {
-      user_id: z.string().describe("User ID (UUID)"),
       contact_id: z.string().optional().describe("Contact ID (UUID) - optional"),
       title: z.string().describe("Opportunity title"),
       description: z.string().optional().describe("Detailed description"),
@@ -280,11 +280,11 @@ app.post("*", async (c) => {
       expected_close_date: z.string().optional().describe("Expected close date (YYYY-MM-DD)"),
       notes: z.string().optional().describe("Additional notes"),
     },
-    async ({ user_id, contact_id, title, description, stage, value, expected_close_date, notes }) => {
+    async ({ contact_id, title, description, stage, value, expected_close_date, notes }) => {
       const { data, error } = await supabase
         .from("opportunities")
         .insert({
-          user_id,
+          user_id: userId,
           contact_id: contact_id || null,
           title,
           description: description || null,
@@ -320,10 +320,9 @@ app.post("*", async (c) => {
     "get_follow_ups_due",
     "List contacts with follow-ups due in the past or next N days",
     {
-      user_id: z.string().describe("User ID (UUID)"),
       days_ahead: z.number().optional().describe("Number of days to look ahead (default: 7)"),
     },
-    async ({ user_id, days_ahead }) => {
+    async ({ days_ahead }) => {
       const daysToCheck = days_ahead || 7;
 
       const today = new Date().toISOString().split('T')[0];
@@ -334,7 +333,7 @@ app.post("*", async (c) => {
       const { data, error } = await supabase
         .from("professional_contacts")
         .select("*")
-        .eq("user_id", user_id)
+        .eq("user_id", userId)
         .not("follow_up_date", "is", null)
         .lte("follow_up_date", futureDateStr)
         .order("follow_up_date", { ascending: true });
@@ -369,17 +368,16 @@ app.post("*", async (c) => {
     "link_thought_to_contact",
     "CROSS-EXTENSION: Link a thought from your core Open Brain to a professional contact",
     {
-      user_id: z.string().describe("User ID (UUID)"),
       thought_id: z.string().describe("Thought ID (UUID) from core Open Brain thoughts table"),
       contact_id: z.string().describe("Contact ID (UUID)"),
     },
-    async ({ user_id, thought_id, contact_id }) => {
+    async ({ thought_id, contact_id }) => {
       // Retrieve the thought from core Open Brain
       const { data: thought, error: thoughtError } = await supabase
         .from("thoughts")
         .select("*")
         .eq("id", thought_id)
-        .eq("user_id", user_id)
+        .eq("user_id", userId)
         .single();
 
       if (thoughtError) {
@@ -395,7 +393,7 @@ app.post("*", async (c) => {
         .from("professional_contacts")
         .select("*")
         .eq("id", contact_id)
-        .eq("user_id", user_id)
+        .eq("user_id", userId)
         .single();
 
       if (contactError) {
@@ -410,7 +408,7 @@ app.post("*", async (c) => {
         .from("professional_contacts")
         .update({ notes: updatedNotes })
         .eq("id", contact_id)
-        .eq("user_id", user_id)
+        .eq("user_id", userId)
         .select()
         .single();
 

--- a/extensions/professional-crm/schema.sql
+++ b/extensions/professional-crm/schema.sql
@@ -5,7 +5,7 @@
 -- People in your professional network
 CREATE TABLE IF NOT EXISTS professional_contacts (
     id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
-    user_id UUID REFERENCES auth.users(id) ON DELETE CASCADE NOT NULL,
+    user_id UUID NOT NULL,
     name TEXT NOT NULL,
     company TEXT,
     title TEXT,
@@ -26,7 +26,7 @@ CREATE TABLE IF NOT EXISTS professional_contacts (
 CREATE TABLE IF NOT EXISTS contact_interactions (
     id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
     contact_id UUID REFERENCES professional_contacts(id) ON DELETE CASCADE NOT NULL,
-    user_id UUID REFERENCES auth.users(id) ON DELETE CASCADE NOT NULL,
+    user_id UUID NOT NULL,
     interaction_type TEXT NOT NULL CHECK (interaction_type IN ('meeting', 'email', 'call', 'coffee', 'event', 'linkedin', 'other')),
     occurred_at TIMESTAMPTZ DEFAULT now() NOT NULL,
     summary TEXT NOT NULL,
@@ -39,7 +39,7 @@ CREATE TABLE IF NOT EXISTS contact_interactions (
 -- Deals, projects, or potential collaborations
 CREATE TABLE IF NOT EXISTS opportunities (
     id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
-    user_id UUID REFERENCES auth.users(id) ON DELETE CASCADE NOT NULL,
+    user_id UUID NOT NULL,
     contact_id UUID REFERENCES professional_contacts(id) ON DELETE SET NULL,
     title TEXT NOT NULL,
     description TEXT,


### PR DESCRIPTION
## Summary

Fixes #56 — reported by @kevingoldsmith. All 6 extensions fail on insert operations (add vendor, add item, etc.) due to a foreign key constraint against `auth.users`.

## Root Cause Analysis

The schemas define `user_id UUID REFERENCES auth.users(id) ON DELETE CASCADE NOT NULL`, but the MCP servers connect using the **service role key** (not an authenticated user session). This means:

1. `auth.uid()` is always `null` in this context
2. Claude/ChatGPT doesn't know the user's Supabase auth UUID
3. The AI guesses or fabricates a UUID for the `user_id` tool parameter
4. The FK constraint rejects the insert because the UUID doesn't exist in `auth.users`
5. **Read operations work fine** — they just return empty results for non-matching user_ids (which is why `list_vendors` worked but `add_vendor` failed in the original report)

This is a design-level bug, not a typo — the FK pattern doesn't work with the service role key approach that all OB1 MCP servers use.

## What Changed (all 6 extensions)

### Schema files (6 files)
- Removed `REFERENCES auth.users(id) ON DELETE CASCADE` from all `user_id` columns
- Kept `user_id UUID NOT NULL` — it's still a logical grouping field, just not enforced against auth

### MCP servers (6 files)
- Added `DEFAULT_USER_ID` environment variable read at server startup
- Returns 500 with clear error message if not configured
- Removed `user_id` from all tool parameter schemas — the AI no longer needs to guess a UUID
- All insert/query operations use the env var instead

### Documentation (1 file)
- Updated `extensions/household-knowledge/README.md` with new Step 2: Generate Your User ID
- Added `DEFAULT_USER_ID` to credential tracker
- Updated troubleshooting section

### Files touched
| Extension | schema.sql | index.ts |
|-----------|-----------|---------|
| household-knowledge | ✅ | ✅ |
| home-maintenance | ✅ | ✅ |
| family-calendar | ✅ | ✅ |
| meal-planning | ✅ | ✅ |
| professional-crm | ✅ | ✅ |
| job-hunt | ✅ | ✅ |

## Testing Status

**This has NOT been tested against a live Supabase instance yet.** The changes are mechanically straightforward (remove FK, move user_id from tool params to env var), but given the scope (13 files, 6 extensions), we want validation from someone who has a working OB1 setup.

@kevingoldsmith — you originally reported this bug and have a working Supabase instance. Would you be willing to test the household-knowledge extension with this branch? The steps would be:

1. Re-run the updated `schema.sql` in your SQL editor (drop + recreate the tables, or just run the new version if starting fresh)
2. Set the env var: `supabase secrets set DEFAULT_USER_ID=$(uuidgen | tr '[:upper:]' '[:lower:]')`
3. Redeploy the edge function
4. Try `Add a vendor: Mike's Plumbing, phone 555-1234` again

If that works, the same pattern applies to the other 5 extensions.

## Test plan

- [ ] Verify household-knowledge `add_vendor` and `add_household_item` no longer hit FK constraint
- [ ] Verify `search_household_items` and `list_vendors` still return results
- [ ] Verify error message when `DEFAULT_USER_ID` is not set
- [ ] Spot-check one other extension (e.g., home-maintenance `add_maintenance_task`)
- [ ] Confirm no `REFERENCES auth.users` remain in any extension schema

🤖 Generated with [Claude Code](https://claude.com/claude-code)