### PR TITLE
fix(server): URL-decode MCP key query param to preserve literal + characters

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -355,8 +355,12 @@ server.registerTool(
 const app = new Hono();
 
 app.all("*", async (c) => {
-  // Accept access key via header OR URL query parameter
-  const provided = c.req.header("x-brain-key") || new URL(c.req.url).searchParams.get("key");
+  // Accept access key via header OR URL query parameter.
+  // Note: URLSearchParams treats '+' as a space, so we parse the raw query string
+  // and use decodeURIComponent (which preserves literal '+') instead.
+  const rawKeySegment = new URL(c.req.url).search.slice(1).split("&").find((p) => p.startsWith("key="));
+  const keyFromQuery = rawKeySegment ? decodeURIComponent(rawKeySegment.slice(4)) : null;
+  const provided = c.req.header("x-brain-key") || keyFromQuery;
   if (!provided || provided !== MCP_ACCESS_KEY) {
     return c.json({ error: "Invalid or missing access key" }, 401);
   }
@@ -367,3 +371,4 @@ app.all("*", async (c) => {
 });
 
 Deno.serve(app.fetch);
+


### PR DESCRIPTION
Fixes #70.

## Problem

`URLSearchParams.get("key")` treats `+` as a space (HTML form-encoding behavior). When a user's `MCP_ACCESS_KEY` contains a literal `+` and they pass it as a URL query parameter — e.g., `?key=abc+def` — the server receives `"abc def"` instead of `"abc+def"`, causing a silent auth failure.

This is a real-world failure mode when key generation uses base64 encoding (which can produce `+`, `/`, and `=`).

## Fix

Parse the raw query string with `decodeURIComponent` instead of `URLSearchParams.get()`. `decodeURIComponent` decodes percent-encoded sequences (`%2B` → `+`) but leaves literal `+` untouched, matching how the key was stored.

```ts
// Before:
const provided = c.req.header("x-brain-key") || new URL(c.req.url).searchParams.get("key");

// After:
const rawKeySegment = new URL(c.req.url).search.slice(1).split("&").find((p) => p.startsWith("key="));
const keyFromQuery = rawKeySegment ? decodeURIComponent(rawKeySegment.slice(4)) : null;
const provided = c.req.header("x-brain-key") || keyFromQuery;
```

## Behaviour after fix

| Scenario | Before | After |
|---|---|---|
| Key `abc+def` via `?key=abc+def` | `"abc def"` ❌ | `"abc+def"` ✅ |
| Key `abc+def` via `?key=abc%2Bdef` | `"abc+def"` ✅ | `"abc+def"` ✅ |
| Key passed via `x-brain-key` header | unaffected ✅ | unaffected ✅ |
| Hex-only key (no special chars) | works ✅ | works ✅ |

The `x-brain-key` header path is unaffected — headers are never form-encoded.