### PR TITLE
[server] Add CORS preflight + Accept header fix for Claude Desktop

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -350,15 +350,42 @@ server.registerTool(
   }
 );
 
-// --- Hono App with Auth Check ---
+// --- Hono App with Auth + CORS ---
+
+const corsHeaders = {
+  "Access-Control-Allow-Origin": "*",
+  "Access-Control-Allow-Headers": "authorization, x-client-info, apikey, content-type, x-brain-key, accept, mcp-session-id",
+  "Access-Control-Allow-Methods": "GET, POST, OPTIONS, DELETE",
+};
 
 const app = new Hono();
+
+// CORS preflight — required for browser/Electron-based clients (Claude Desktop, claude.ai)
+app.options("*", (c) => {
+  return c.text("ok", 200, corsHeaders);
+});
 
 app.all("*", async (c) => {
   // Accept access key via header OR URL query parameter
   const provided = c.req.header("x-brain-key") || new URL(c.req.url).searchParams.get("key");
   if (!provided || provided !== MCP_ACCESS_KEY) {
-    return c.json({ error: "Invalid or missing access key" }, 401);
+    return c.json({ error: "Invalid or missing access key" }, 401, corsHeaders);
+  }
+
+  // Fix: Claude Desktop connectors don't send the Accept header that
+  // StreamableHTTPTransport requires. Build a patched request if missing.
+  // See: https://github.com/NateBJones-Projects/OB1/issues/33
+  if (!c.req.header("accept")?.includes("text/event-stream")) {
+    const headers = new Headers(c.req.raw.headers);
+    headers.set("Accept", "application/json, text/event-stream");
+    const patched = new Request(c.req.raw.url, {
+      method: c.req.raw.method,
+      headers,
+      body: c.req.raw.body,
+      // @ts-ignore -- duplex required for streaming body in Deno
+      duplex: "half",
+    });
+    Object.defineProperty(c.req, "raw", { value: patched, writable: true });
   }
 
   const transport = new StreamableHTTPTransport();


### PR DESCRIPTION
## What does this do?

Adds two fixes to the core `server/index.ts` that enable Claude Desktop (and other browser/Electron-based clients) to connect to Open Brain MCP servers:

1. **CORS preflight handler** — Claude Desktop sends an OPTIONS preflight before POST. Without CORS headers, the preflight returns 405 and the connection fails silently. This adds an OPTIONS route returning proper `Access-Control-Allow-*` headers.

2. **Accept header patch** — Applies the same fix from PR #38 to the core server template. Claude Desktop doesn't send `Accept: application/json, text/event-stream`, which `StreamableHTTPTransport` requires. The patch injects the header before the transport sees the request.

## Why both fixes?

PR #38 applied the Accept header fix to all 6 extension Edge Functions but not to `server/index.ts`. New users deploying from the getting-started guide hit this immediately. The CORS fix was not addressed in #38 or anywhere else — it's a separate failure mode where the OPTIONS preflight is rejected before the Accept header ever matters.

## Requirements

- Supabase Edge Function deployment (standard setup)
- No new dependencies

## Testing

Tested on a personal Supabase deployment (`rumbrain` project):
- `curl` OPTIONS → 200 with CORS headers ✅
- `curl` POST without Accept header → 200 with valid MCP response ✅
- `curl` POST with Accept header → 200 (no regression) ✅
- Claude Code direct HTTP → tools work ✅
- Claude Desktop via mcp-remote → tools work ✅
- Codex via mcp-remote → tools work ✅

Closes #33 (for core server template).

## Checklist

- [x] I have read CONTRIBUTING.md
- [x] No credentials or API keys in any file
- [x] Tested on my own Open Brain instance