### PR TITLE
[docs] Add Codex setup guide with startup_timeout_sec

### DIFF
--- a/docs/01-getting-started.md
+++ b/docs/01-getting-started.md
@@ -687,7 +687,30 @@ claude mcp add --transport http open-brain \
 </details>
 
 <details>
-<summary>🤖 <strong>7.4 — Other Clients (Cursor, VS Code Copilot, Windsurf)</strong></summary>
+<summary>🤖 <strong>7.4 — OpenAI Codex</strong></summary>
+
+Codex uses `mcp-remote` to bridge to remote MCP servers. Add the following to your `~/.codex/config.toml`:
+
+```toml
+[mcp_servers.open-brain]
+command = "npx"
+args = [
+  "-y",
+  "mcp-remote",
+  "https://YOUR_PROJECT_REF.supabase.co/functions/v1/open-brain-mcp?key=your-access-key-from-step-5"
+]
+startup_timeout_sec = 30
+```
+
+> [!CAUTION]
+> The `startup_timeout_sec = 30` line is required. Without it, Codex times out after 10 seconds because `mcp-remote` needs longer to establish the connection to the remote Supabase edge function. If you see `MCP client for open-brain timed out after 10 seconds`, add or increase this value.
+
+Restart Codex and the four Open Brain tools should be available immediately.
+
+</details>
+
+<details>
+<summary>🤖 <strong>7.5 — Other Clients (Cursor, VS Code Copilot, Windsurf)</strong></summary>
 
 Every MCP client handles remote servers slightly differently. The server accepts your access key two ways — pick whichever your client supports:
 


### PR DESCRIPTION
## What does this do?

Adds OpenAI Codex as a named client in the getting-started guide (Step 7.4) with the exact `config.toml` snippet needed to connect.

The key finding: Codex's default MCP startup timeout is 10 seconds, but `mcp-remote` needs ~15-20s to establish the StreamableHTTP connection to a remote Supabase edge function. Without `startup_timeout_sec = 30`, Codex silently fails with:

```
⚠ MCP client for `open-brain` timed out after 10 seconds.
```

This is not documented anywhere and cost significant debugging time.

## Requirements

- OpenAI Codex (tested on v0.116.0)
- Node.js (for npx/mcp-remote)

## Testing

Tested on a personal Supabase deployment:
- Codex without `startup_timeout_sec` → timeout error ❌
- Codex with `startup_timeout_sec = 30` → all 4 tools load ✅
- Codex `search_thoughts` → returns results from shared brain ✅

## Checklist

- [x] I have read CONTRIBUTING.md
- [x] No credentials or API keys in any file
- [x] Tested on my own Open Brain instance