### PR TITLE
[schemas] Ingestion jobs schema for document ingest

### DIFF
--- a/schemas/ingestion-jobs/README.md
+++ b/schemas/ingestion-jobs/README.md
@@ -13,21 +13,6 @@ Jobs support a **dry-run workflow**: extract and reconcile without writing to `t
 - Working Open Brain setup ([guide](../../docs/01-getting-started.md))
 - The `thoughts` table must already exist
 
-## Credential Tracker
-
-Copy this block into a text editor and fill it in as you go.
-
-```text
-INGESTION JOBS -- CREDENTIAL TRACKER
---------------------------------------
-
-SUPABASE (from your Open Brain setup)
-  Project URL:           ____________
-  Service role key:      ____________
-
---------------------------------------
-```
-
 ## Schema Overview
 
 ### `ingestion_jobs` table
@@ -120,11 +105,37 @@ After running the migration:
 - Row-level security enabled on both tables (service-role access only)
 - The `input_hash` unique constraint prevents duplicate job creation for the same input document
 
+## Lifecycle Flow
+
+A typical ingestion follows this sequence:
+
+```
+1. CREATE JOB          status='pending'
+       │
+2. EXTRACT             status='extracting'
+   LLM splits doc      Items created with action='pending', status='pending'
+   into atomic items
+       │
+3. RECONCILE           status='extracting'
+   Each item compared   Items updated: action='add'|'skip'|'append_evidence'|'create_revision'
+   to existing thoughts                  status='ready'
+       │
+4. DRY-RUN COMPLETE    status='dry_run_complete'
+   Pause for review     All items have action + reason set
+       │
+5. EXECUTE             status='executing'
+   Approved items       Items: status='executed' or 'failed'
+   written to thoughts
+       │
+6. COMPLETE            status='complete'
+   Counts tallied       added_count, skipped_count, appended_count, revised_count updated
+```
+
 ## Design Notes
 
 - All IDs are `uuid` to match Open Brain's standard ID types.
 - `input_hash` has a unique constraint for idempotency — submitting the same document twice returns the existing job instead of creating a duplicate.
-- The `action` field on items captures the reconciliation decision *before* execution, making dry-run previews possible. The `status` field tracks whether that decision has been carried out.
+- The `action` and `status` fields on items serve different purposes: `action` captures the reconciliation decision (what *should* happen — `add`, `skip`, `append_evidence`, `create_revision`), while `status` tracks execution progress (whether that decision *has been* carried out — `pending`, `ready`, `executed`, `failed`). Both default to `'pending'` but at different lifecycle stages.
 - `matched_thought_id` and `result_thought_id` are nullable `uuid` references rather than formal foreign keys, allowing the schema to work even if referenced thoughts are deleted.
 
 ## Troubleshooting

--- a/schemas/ingestion-jobs/README.md
+++ b/schemas/ingestion-jobs/README.md
@@ -1,0 +1,145 @@
+# Ingestion Jobs
+
+> Track document ingestion through extract, deduplicate, reconcile, and execute lifecycle stages.
+
+## What It Does
+
+Adds two tables — `ingestion_jobs` and `ingestion_items` — plus an `append_thought_evidence` RPC that together track the full lifecycle of ingesting raw documents into the `thoughts` table. Each job represents a single ingest invocation. Each item represents an individual thought extracted from that document, along with the dedup decision and execution status.
+
+Jobs support a **dry-run workflow**: extract and reconcile without writing to `thoughts`, review the plan, then execute the approved items in a second pass.
+
+## Prerequisites
+
+- Working Open Brain setup ([guide](../../docs/01-getting-started.md))
+- The `thoughts` table must already exist
+
+## Credential Tracker
+
+Copy this block into a text editor and fill it in as you go.
+
+```text
+INGESTION JOBS -- CREDENTIAL TRACKER
+--------------------------------------
+
+SUPABASE (from your Open Brain setup)
+  Project URL:           ____________
+  Service role key:      ____________
+
+--------------------------------------
+```
+
+## Schema Overview
+
+### `ingestion_jobs` table
+
+| Column | Type | Description |
+|--------|------|-------------|
+| `id` | `uuid` (PK) | Auto-generated via `gen_random_uuid()` |
+| `source_label` | `text` | Human-readable label for the input source (e.g. filename, URL) |
+| `input_hash` | `text` (unique) | SHA-256 hash of the input text for idempotency |
+| `input_length` | `int` | Character count of the raw input |
+| `status` | `text` | Lifecycle state: `pending` → `extracting` → `dry_run_complete` → `executing` → `complete` (or `failed`) |
+| `extracted_count` | `int` | Total thoughts extracted by the LLM |
+| `added_count` | `int` | Thoughts written as new rows |
+| `skipped_count` | `int` | Thoughts skipped (duplicate or near-duplicate) |
+| `appended_count` | `int` | Thoughts merged as evidence on existing rows |
+| `revised_count` | `int` | Thoughts written as revisions of existing rows |
+| `error_message` | `text` | Error detail when `status = 'failed'` |
+| `metadata` | `jsonb` | Arbitrary structured metadata (source_type, dry_run flag, etc.) |
+| `created_at` | `timestamptz` | Row creation timestamp |
+| `completed_at` | `timestamptz` | Timestamp when job reached terminal state |
+
+### `ingestion_items` table
+
+| Column | Type | Description |
+|--------|------|-------------|
+| `id` | `uuid` (PK) | Auto-generated via `gen_random_uuid()` |
+| `job_id` | `uuid` (FK) | References `ingestion_jobs(id)`, cascading delete |
+| `extracted_content` | `text` | The atomic thought content extracted by the LLM |
+| `action` | `text` | Reconciliation decision: `add`, `skip`, `append_evidence`, `create_revision` |
+| `status` | `text` | Execution state: `pending`, `ready`, `executed`, `failed` |
+| `reason` | `text` | Why this action was chosen (e.g. `fingerprint_match`, `no_semantic_match`) |
+| `matched_thought_id` | `uuid` | ID of the existing thought this item matched against, if any |
+| `similarity_score` | `numeric(5,4)` | Cosine similarity to the matched thought (NULL if no match) |
+| `result_thought_id` | `uuid` | ID of the thought created or updated by execution |
+| `error_message` | `text` | Error detail when `status = 'failed'` |
+| `metadata` | `jsonb` | Arbitrary structured metadata (type classification, etc.) |
+| `created_at` | `timestamptz` | Row creation timestamp |
+
+### `append_thought_evidence` RPC
+
+Appends a corroborating evidence entry to `metadata.evidence[]` on an existing thought. Idempotent via SHA-256 identity of the source label, excerpt, and thought ID combined. Safe to call multiple times with the same input.
+
+## Steps
+
+**1. Open the Supabase SQL Editor**
+
+Go to your Supabase Dashboard → SQL Editor → New query.
+
+**2. Run the migration**
+
+Copy the contents of [`migration.sql`](./migration.sql) and execute it in the SQL Editor.
+
+**3. Verify the tables exist**
+
+Run this query to confirm:
+
+```sql
+select table_name from information_schema.tables
+where table_schema = 'public'
+  and table_name in ('ingestion_jobs', 'ingestion_items');
+```
+
+You should see both tables listed.
+
+**4. Verify the RPC exists**
+
+```sql
+select routine_name from information_schema.routines
+where routine_schema = 'public'
+  and routine_name = 'append_thought_evidence';
+```
+
+**5. Test with a sample job**
+
+```sql
+-- Create a test job
+insert into public.ingestion_jobs (input_hash, source_label, status)
+values ('test-hash-123', 'test document', 'pending')
+returning id;
+
+-- Create a test item (use the job id from above)
+insert into public.ingestion_items (job_id, extracted_content, action, status, reason)
+values ('<job-id>', 'Test thought content', 'add', 'ready', 'no_semantic_match');
+
+-- Clean up
+delete from public.ingestion_jobs where input_hash = 'test-hash-123';
+```
+
+## Expected Outcome
+
+After running the migration:
+
+- Two new tables: `ingestion_jobs` and `ingestion_items`
+- One new RPC: `append_thought_evidence`
+- One index: `ingestion_items_job_id_idx`
+- Row-level security enabled on both tables (service-role access only)
+- The `input_hash` unique constraint prevents duplicate job creation for the same input document
+
+## Design Notes
+
+- All IDs are `uuid` to match Open Brain's standard ID types.
+- `input_hash` has a unique constraint for idempotency — submitting the same document twice returns the existing job instead of creating a duplicate.
+- The `action` field on items captures the reconciliation decision *before* execution, making dry-run previews possible. The `status` field tracks whether that decision has been carried out.
+- `matched_thought_id` and `result_thought_id` are nullable `uuid` references rather than formal foreign keys, allowing the schema to work even if referenced thoughts are deleted.
+
+## Troubleshooting
+
+**Issue: `relation "public.thoughts" does not exist`**
+Solution: You need to complete your Open Brain setup first. The `thoughts` table must exist before applying this migration. Follow the [Getting Started guide](../../docs/01-getting-started.md).
+
+**Issue: `duplicate key value violates unique constraint "ingestion_jobs_input_hash_key"`**
+Solution: This means you've already ingested this exact document. Query the existing job: `select * from ingestion_jobs where input_hash = '<hash>';`. If you want to reprocess, use a versioned hash (e.g. append `-v2`).
+
+**Issue: `append_thought_evidence` returns `thought not found`**
+Solution: The thought ID you passed doesn't exist in the `thoughts` table. Verify the ID is correct: `select id from thoughts where id = '<uuid>';`.

--- a/schemas/ingestion-jobs/README.md
+++ b/schemas/ingestion-jobs/README.md
@@ -72,49 +72,43 @@ Appends a corroborating evidence entry to `metadata.evidence[]` on an existing t
 
 ## Step-by-step instructions
 
-**1. Open the Supabase SQL Editor**
+1. Open your Supabase Dashboard → SQL Editor → New query.
 
-Go to your Supabase Dashboard → SQL Editor → New query.
+2. Copy the contents of [`migration.sql`](./migration.sql) and execute it in the SQL Editor.
 
-**2. Run the migration**
+3. Verify the tables exist by running this query:
 
-Copy the contents of [`migration.sql`](./migration.sql) and execute it in the SQL Editor.
+   ```sql
+   select table_name from information_schema.tables
+   where table_schema = 'public'
+     and table_name in ('ingestion_jobs', 'ingestion_items');
+   ```
 
-**3. Verify the tables exist**
+   You should see both tables listed.
 
-Run this query to confirm:
+4. Verify the RPC exists:
 
-```sql
-select table_name from information_schema.tables
-where table_schema = 'public'
-  and table_name in ('ingestion_jobs', 'ingestion_items');
-```
+   ```sql
+   select routine_name from information_schema.routines
+   where routine_schema = 'public'
+     and routine_name = 'append_thought_evidence';
+   ```
 
-You should see both tables listed.
+5. Test with a sample job:
 
-**4. Verify the RPC exists**
+   ```sql
+   -- Create a test job
+   insert into public.ingestion_jobs (input_hash, source_label, status)
+   values ('test-hash-123', 'test document', 'pending')
+   returning id;
 
-```sql
-select routine_name from information_schema.routines
-where routine_schema = 'public'
-  and routine_name = 'append_thought_evidence';
-```
+   -- Create a test item (use the job id from above)
+   insert into public.ingestion_items (job_id, extracted_content, action, status, reason)
+   values ('<job-id>', 'Test thought content', 'add', 'ready', 'no_semantic_match');
 
-**5. Test with a sample job**
-
-```sql
--- Create a test job
-insert into public.ingestion_jobs (input_hash, source_label, status)
-values ('test-hash-123', 'test document', 'pending')
-returning id;
-
--- Create a test item (use the job id from above)
-insert into public.ingestion_items (job_id, extracted_content, action, status, reason)
-values ('<job-id>', 'Test thought content', 'add', 'ready', 'no_semantic_match');
-
--- Clean up
-delete from public.ingestion_jobs where input_hash = 'test-hash-123';
-```
+   -- Clean up
+   delete from public.ingestion_jobs where input_hash = 'test-hash-123';
+   ```
 
 ## Expected Outcome
 

--- a/schemas/ingestion-jobs/README.md
+++ b/schemas/ingestion-jobs/README.md
@@ -70,7 +70,7 @@ SUPABASE (from your Open Brain setup)
 
 Appends a corroborating evidence entry to `metadata.evidence[]` on an existing thought. Idempotent via SHA-256 identity of the source label, excerpt, and thought ID combined. Safe to call multiple times with the same input.
 
-## Steps
+## Step-by-step instructions
 
 **1. Open the Supabase SQL Editor**
 

--- a/schemas/ingestion-jobs/metadata.json
+++ b/schemas/ingestion-jobs/metadata.json
@@ -1,0 +1,20 @@
+{
+  "name": "Ingestion Jobs",
+  "description": "Track document ingestion through extract, deduplicate, reconcile, and execute lifecycle stages.",
+  "category": "schemas",
+  "author": {
+    "name": "Alan Shurafa",
+    "github": "alanshurafa"
+  },
+  "version": "1.0.0",
+  "requires": {
+    "open_brain": true,
+    "services": [],
+    "tools": []
+  },
+  "tags": ["ingestion", "extraction", "deduplication", "reconciliation", "pipeline"],
+  "difficulty": "beginner",
+  "estimated_time": "10 minutes",
+  "created": "2026-03-22",
+  "updated": "2026-03-22"
+}

--- a/schemas/ingestion-jobs/migration.sql
+++ b/schemas/ingestion-jobs/migration.sql
@@ -129,6 +129,7 @@ $$;
 -- Grant access to service_role
 grant select, insert, update, delete on table public.ingestion_jobs to service_role;
 grant select, insert, update, delete on table public.ingestion_items to service_role;
+grant execute on function public.append_thought_evidence to service_role;
 
 -- RLS: enable row-level security (no policies = service-role only by default)
 alter table public.ingestion_jobs enable row level security;

--- a/schemas/ingestion-jobs/migration.sql
+++ b/schemas/ingestion-jobs/migration.sql
@@ -83,7 +83,8 @@ begin
   select coalesce(metadata->'evidence', '[]'::jsonb)
     into v_current_evidence
     from public.thoughts
-   where id = p_thought_id;
+   where id = p_thought_id
+   for update;
 
   if not found then
     raise exception 'thought % not found', p_thought_id;
@@ -130,6 +131,7 @@ $$;
 grant select, insert, update, delete on table public.ingestion_jobs to service_role;
 grant select, insert, update, delete on table public.ingestion_items to service_role;
 grant execute on function public.append_thought_evidence to service_role;
+revoke execute on function public.append_thought_evidence(uuid, jsonb) from public;
 
 -- RLS: enable row-level security (no policies = service-role only by default)
 alter table public.ingestion_jobs enable row level security;

--- a/schemas/ingestion-jobs/migration.sql
+++ b/schemas/ingestion-jobs/migration.sql
@@ -1,0 +1,135 @@
+-- Ingestion Jobs schema for Open Brain
+-- Tracks document ingestion through extract, dedup, reconcile, and execute lifecycle
+--
+-- Prerequisites: public.thoughts table exists
+
+-- 1. ingestion_jobs -- one row per ingest invocation
+create table if not exists public.ingestion_jobs (
+  id              uuid primary key default gen_random_uuid(),
+  source_label    text,
+  input_hash      text not null unique,
+  input_length    int,
+  status          text not null default 'pending'
+                    check (status in (
+                      'pending', 'extracting', 'dry_run_complete',
+                      'executing', 'complete', 'failed'
+                    )),
+  extracted_count int default 0,
+  added_count     int default 0,
+  skipped_count   int default 0,
+  appended_count  int default 0,
+  revised_count   int default 0,
+  error_message   text,
+  metadata        jsonb default '{}'::jsonb,
+  created_at      timestamptz default now(),
+  completed_at    timestamptz
+);
+
+-- 2. ingestion_items -- individual extracted thoughts within a job
+create table if not exists public.ingestion_items (
+  id                uuid primary key default gen_random_uuid(),
+  job_id            uuid not null references public.ingestion_jobs(id) on delete cascade,
+  extracted_content text not null,
+  action            text not null default 'pending'
+                      check (action in (
+                        'pending', 'add', 'skip', 'append_evidence', 'create_revision'
+                      )),
+  status            text not null default 'pending'
+                      check (status in ('pending', 'ready', 'executed', 'failed')),
+  reason            text,
+  matched_thought_id uuid,
+  similarity_score  numeric(5,4),
+  result_thought_id uuid,
+  error_message     text,
+  metadata          jsonb default '{}'::jsonb,
+  created_at        timestamptz default now()
+);
+
+-- Indexes
+create index if not exists ingestion_items_job_id_idx
+  on public.ingestion_items (job_id);
+
+-- 3. append_thought_evidence RPC
+--    Appends to metadata.evidence[] on an existing thought.
+--    Idempotent via SHA-256 identity of (source_label || excerpt || thought_id).
+create or replace function public.append_thought_evidence(
+  p_thought_id uuid,
+  p_evidence   jsonb  -- {source, extracted_at, excerpt, source_label}
+)
+returns jsonb
+language plpgsql
+security definer
+as $$
+declare
+  v_identity text;
+  v_current_evidence jsonb;
+  v_entry jsonb;
+  v_count int;
+begin
+  -- Compute a stable identity for this evidence entry
+  v_identity := encode(
+    sha256(
+      convert_to(
+        coalesce(p_evidence->>'source_label', '') ||
+        coalesce(p_evidence->>'excerpt', '') ||
+        p_thought_id::text,
+        'UTF8'
+      )
+    ),
+    'hex'
+  );
+
+  -- Fetch current evidence array
+  select coalesce(metadata->'evidence', '[]'::jsonb)
+    into v_current_evidence
+    from public.thoughts
+   where id = p_thought_id;
+
+  if not found then
+    raise exception 'thought % not found', p_thought_id;
+  end if;
+
+  -- Check for duplicate by scanning existing identities
+  for v_entry in select jsonb_array_elements(v_current_evidence)
+  loop
+    if v_entry->>'_identity' = v_identity then
+      return jsonb_build_object(
+        'thought_id', p_thought_id,
+        'evidence_count', jsonb_array_length(v_current_evidence),
+        'action', 'already_exists'
+      );
+    end if;
+  end loop;
+
+  -- Append new evidence entry with identity tag
+  update public.thoughts
+     set metadata = jsonb_set(
+           coalesce(metadata, '{}'::jsonb),
+           '{evidence}',
+           v_current_evidence || jsonb_build_object(
+             '_identity', v_identity,
+             'source', p_evidence->'source',
+             'extracted_at', p_evidence->'extracted_at',
+             'excerpt', p_evidence->'excerpt',
+             'source_label', p_evidence->'source_label'
+           )
+         )
+   where id = p_thought_id;
+
+  v_count := jsonb_array_length(v_current_evidence) + 1;
+
+  return jsonb_build_object(
+    'thought_id', p_thought_id,
+    'evidence_count', v_count,
+    'action', 'appended'
+  );
+end;
+$$;
+
+-- Grant access to service_role
+grant select, insert, update, delete on table public.ingestion_jobs to service_role;
+grant select, insert, update, delete on table public.ingestion_items to service_role;
+
+-- RLS: enable row-level security (no policies = service-role only by default)
+alter table public.ingestion_jobs enable row level security;
+alter table public.ingestion_items enable row level security;


### PR DESCRIPTION
## Summary
- Adds `ingestion_jobs` and `ingestion_items` tables for tracking document ingestion lifecycle
- Includes `append_thought_evidence` RPC for idempotent evidence appending
- Supports dry-run workflow: extract and reconcile without writing, then execute approved items
- All IDs are UUID, RLS enabled (service-role only)

## Why
Document ingestion (extracting atomic thoughts from raw text) needs a tracking layer for the extract → deduplicate → reconcile → execute pipeline. This schema is the backbone that Smart Ingest and future extraction tools build on.

## Test plan
- [ ] Apply migration on a fresh Open Brain instance
- [ ] Create sample job + items
- [ ] Verify `append_thought_evidence` is idempotent on repeat calls
- [ ] Verify UUID flow works end to end

Tested against a production Open Brain instance with 75K+ thoughts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)