### PR TITLE
[recipes] Fingerprint dedup backfill and cleanup

### DIFF
--- a/recipes/fingerprint-dedup-backfill/.env.example
+++ b/recipes/fingerprint-dedup-backfill/.env.example
@@ -1,0 +1,3 @@
+# Supabase credentials (from your Open Brain setup)
+SUPABASE_URL=https://your-project-ref.supabase.co
+SUPABASE_SERVICE_ROLE_KEY=your-service-role-key-here

--- a/recipes/fingerprint-dedup-backfill/README.md
+++ b/recipes/fingerprint-dedup-backfill/README.md
@@ -1,0 +1,130 @@
+# Fingerprint Dedup Backfill
+
+> Backfill content fingerprints on existing thoughts and safely remove duplicates discovered during the process.
+
+## What It Does
+
+If you imported thoughts before the [Content Fingerprint Dedup](../../primitives/content-fingerprint-dedup/) primitive was in place, those rows will have a NULL `content_fingerprint`. This recipe computes fingerprints for all existing rows and then identifies and removes duplicates — rows whose content already exists in the table under a properly fingerprinted copy.
+
+Two scripts work together:
+
+1. **`backfill-fingerprints.mjs`** — Scans all NULL-fingerprint rows and patches each one with a computed SHA-256 fingerprint. Resumable via state file.
+
+2. **`delete-duplicates.mjs`** — Finds NULL-fingerprint rows whose content already has a fingerprinted copy in the table. Defaults to **report-only mode** (no deletions). Pass `--delete` to actually remove duplicates.
+
+## Prerequisites
+
+- Working Open Brain setup ([guide](../../docs/01-getting-started.md))
+- [Content Fingerprint Dedup](../../primitives/content-fingerprint-dedup/) primitive applied (so `content_fingerprint` column exists)
+- Node.js 18+
+
+## Credential Tracker
+
+Copy this block into a text editor and fill it in as you go.
+
+```text
+FINGERPRINT DEDUP BACKFILL -- CREDENTIAL TRACKER
+--------------------------------------
+
+FROM YOUR OPEN BRAIN SETUP
+  Supabase URL:            ____________
+  Service role key:        ____________
+
+--------------------------------------
+```
+
+## Steps
+
+**1. Clone or download this recipe**
+
+Copy the recipe folder to your local machine.
+
+**2. Configure credentials**
+
+Copy `.env.example` to `.env` and fill in your Supabase credentials:
+
+```bash
+cp .env.example .env
+# Edit .env with your Supabase URL and service role key
+```
+
+**3. Run the backfill**
+
+This computes and patches fingerprints for all rows where `content_fingerprint` is NULL:
+
+```bash
+node backfill-fingerprints.mjs
+```
+
+The script processes rows in batches of 1000, saving progress to `backfill-state.json` after each batch. If interrupted, it resumes from where it left off.
+
+**4. Generate a duplicate report**
+
+Before deleting anything, see what would be removed:
+
+```bash
+node delete-duplicates.mjs --report-only
+```
+
+This scans remaining NULL-fingerprint rows, computes their fingerprints, and reports how many are duplicates of existing fingerprinted rows — without deleting anything.
+
+**5. Remove duplicates (when ready)**
+
+Once you've reviewed the report and are satisfied:
+
+```bash
+node delete-duplicates.mjs --delete
+```
+
+> [!CAUTION]
+> The `--delete` flag permanently removes rows. Make sure you've reviewed the report first. The script also backfills fingerprints on any genuine orphan rows (those with no existing duplicate).
+
+## Expected Outcome
+
+After running both scripts:
+
+- Every row in the `thoughts` table has a non-NULL `content_fingerprint`
+- No duplicate content exists (each unique fingerprint appears once)
+- The `content_fingerprint` unique constraint is now fully enforceable
+
+Verify with:
+
+```sql
+-- Count remaining NULL fingerprints (should be 0)
+select count(*) from thoughts where content_fingerprint is null;
+
+-- Check for duplicate fingerprints (should return 0 rows)
+select content_fingerprint, count(*) as copies
+from thoughts
+where content_fingerprint is not null
+group by content_fingerprint
+having count(*) > 1
+limit 10;
+```
+
+## How the Fingerprint Is Computed
+
+The normalization matches the [Content Fingerprint Dedup](../../primitives/content-fingerprint-dedup/) primitive exactly:
+
+1. Trim whitespace and collapse runs of whitespace to single spaces
+2. Lowercase
+3. Strip trailing punctuation (`.!?;:,`)
+4. Strip possessives (`'s` and `\u2019s`)
+5. Strip trailing `s` from the last word if the word has 4+ characters
+6. SHA-256 hex digest of the result
+
+This means "The dog's toys." and "the dogs toy" produce the same fingerprint.
+
+## Troubleshooting
+
+**Issue: Script reports many "duplicate" PATCH errors (409 / 23505)**
+Solution: This means the computed fingerprint already exists on another row. The backfill script counts these but skips them — this is expected behavior. Run the cleanup script afterward to remove the duplicates.
+
+**Issue: Script hangs or times out on large tables**
+Solution: The scripts use cursor-based pagination and save state after each batch. If a request times out, the script retries after 5 seconds. For very large tables (100K+), expect the backfill to take 10-30 minutes.
+
+**Issue: `content_fingerprint` column doesn't exist**
+Solution: Apply the [Content Fingerprint Dedup](../../primitives/content-fingerprint-dedup/) primitive first. The column must exist before running these scripts.
+
+**Issue: Want to reset and start over**
+Solution: Delete the state file (`backfill-state.json` or `cleanup-state.json`) and run the script again. It will start from the beginning.

--- a/recipes/fingerprint-dedup-backfill/backfill-fingerprints.mjs
+++ b/recipes/fingerprint-dedup-backfill/backfill-fingerprints.mjs
@@ -1,0 +1,255 @@
+#!/usr/bin/env node
+/**
+ * Backfill content_fingerprint for all thoughts rows where it is NULL.
+ *
+ * Fingerprint normalization (matches content-fingerprint-dedup primitive):
+ *   1. Trim + collapse whitespace + lowercase
+ *   2. Strip trailing punctuation (.!?;:,)
+ *   3. Strip possessives ('s / \u2019s)
+ *   4. Strip trailing 's' from last word (if word length > 3)
+ *   5. SHA-256 hex of the normalized string
+ *
+ * Uses an id cursor so interrupted runs can resume from where they left off.
+ * State is saved to a local JSON file after each batch.
+ */
+
+import crypto from "node:crypto";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+// ── Load environment ────────────────────────────────────────────────────────
+
+function loadEnv(envPath) {
+  if (!fs.existsSync(envPath)) return {};
+  const raw = fs.readFileSync(envPath, "utf8");
+  const env = {};
+  for (const line of raw.split(/\r?\n/)) {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith("#")) continue;
+    const eq = trimmed.indexOf("=");
+    if (eq === -1) continue;
+    env[trimmed.slice(0, eq).trim()] = trimmed.slice(eq + 1).trim();
+  }
+  return env;
+}
+
+const env = {
+  ...loadEnv(path.join(__dirname, ".env")),
+  ...loadEnv(path.join(__dirname, ".env.local")),
+};
+
+const SUPABASE_URL = env.SUPABASE_URL || process.env.SUPABASE_URL;
+const SERVICE_ROLE_KEY =
+  env.SUPABASE_SERVICE_ROLE_KEY || process.env.SUPABASE_SERVICE_ROLE_KEY;
+
+if (!SUPABASE_URL || !SERVICE_ROLE_KEY) {
+  console.error(
+    "Missing SUPABASE_URL or SUPABASE_SERVICE_ROLE_KEY.\n" +
+      "Set them in .env, .env.local, or as environment variables."
+  );
+  process.exit(1);
+}
+
+const REST_BASE = `${SUPABASE_URL}/rest/v1`;
+const HEADERS = {
+  apikey: SERVICE_ROLE_KEY,
+  Authorization: `Bearer ${SERVICE_ROLE_KEY}`,
+  "Content-Type": "application/json",
+  Prefer: "return=minimal",
+};
+
+// ── Fingerprint logic (matches content-fingerprint-dedup primitive) ─────────
+
+/**
+ * Normalize text for fingerprint comparison.
+ * Must match the SQL `normalize_for_fingerprint(text)` function exactly.
+ */
+function normalizeForFingerprint(text) {
+  let s = String(text ?? "")
+    .trim()
+    .replace(/\s+/g, " ")
+    .toLowerCase();
+  if (!s) return "";
+
+  // Strip trailing punctuation
+  s = s.replace(/[.!?;:,]+$/, "");
+
+  // Strip possessives
+  s = s.replace(/['\u2019]s\b/g, "");
+
+  // Strip trailing 's' from last word if word length > 3
+  s = s.replace(/(\w{4,})s$/, "$1");
+
+  return s.trim();
+}
+
+function buildContentFingerprint(text) {
+  const normalized = normalizeForFingerprint(text);
+  if (!normalized) return "";
+  return crypto.createHash("sha256").update(normalized, "utf8").digest("hex");
+}
+
+// ── REST helpers ────────────────────────────────────────────────────────────
+
+async function fetchBatch(cursorId, batchSize) {
+  const url =
+    `${REST_BASE}/thoughts` +
+    `?content_fingerprint=is.null` +
+    `&id=gt.${cursorId}` +
+    `&select=id,content` +
+    `&limit=${batchSize}` +
+    `&order=id.asc`;
+  const res = await fetch(url, { headers: HEADERS });
+  if (!res.ok) {
+    const body = await res.text().catch(() => "");
+    throw new Error(`Fetch HTTP ${res.status} — ${body.slice(0, 300)}`);
+  }
+  const text = await res.text();
+  if (!text) return [];
+  return JSON.parse(text);
+}
+
+async function patchFingerprint(id, fingerprint) {
+  const url = `${REST_BASE}/thoughts?id=eq.${id}`;
+  const res = await fetch(url, {
+    method: "PATCH",
+    headers: HEADERS,
+    body: JSON.stringify({ content_fingerprint: fingerprint }),
+  });
+  if (!res.ok) {
+    const body = await res.text().catch(() => "");
+    throw new Error(`PATCH id=${id}: HTTP ${res.status} — ${body.slice(0, 200)}`);
+  }
+}
+
+async function patchBatch(updates) {
+  const CONCURRENCY = 20;
+  let done = 0;
+  let duplicates = 0;
+  let errors = 0;
+
+  for (let i = 0; i < updates.length; i += CONCURRENCY) {
+    const chunk = updates.slice(i, i + CONCURRENCY);
+    const results = await Promise.allSettled(
+      chunk.map(({ id, fingerprint }) => patchFingerprint(id, fingerprint))
+    );
+    for (const result of results) {
+      if (result.status === "fulfilled") {
+        done++;
+      } else {
+        const msg = result.reason?.message ?? String(result.reason);
+        if (msg.includes("409") || msg.includes("23505")) {
+          duplicates++;
+        } else {
+          errors++;
+          console.warn("  PATCH error:", msg.slice(0, 180));
+        }
+      }
+    }
+  }
+  return { done, duplicates, errors };
+}
+
+// ── State file for resume ───────────────────────────────────────────────────
+
+const STATE_FILE = path.join(__dirname, "backfill-state.json");
+
+function loadState() {
+  try {
+    return JSON.parse(fs.readFileSync(STATE_FILE, "utf8"));
+  } catch {
+    return {
+      cursorId: 0,
+      totalDone: 0,
+      totalDuplicates: 0,
+      totalErrors: 0,
+      batches: 0,
+    };
+  }
+}
+
+function saveState(state) {
+  fs.writeFileSync(STATE_FILE, JSON.stringify(state, null, 2));
+}
+
+// ── Main ────────────────────────────────────────────────────────────────────
+
+const BATCH_SIZE = 1000;
+
+async function main() {
+  const state = loadState();
+  console.log("=== Backfill content_fingerprint ===");
+  console.log(
+    `Resuming from cursor id=${state.cursorId} (${state.totalDone} already done)`
+  );
+  console.log(`Batch size: ${BATCH_SIZE}`);
+  console.log();
+
+  while (true) {
+    state.batches++;
+    process.stdout.write(
+      `Batch ${state.batches}: fetching from id>${state.cursorId}… `
+    );
+
+    let rows;
+    try {
+      rows = await fetchBatch(state.cursorId, BATCH_SIZE);
+    } catch (err) {
+      console.error("\n  Fetch error:", err.message, "— retrying in 5s…");
+      await new Promise((r) => setTimeout(r, 5000));
+      state.batches--;
+      continue;
+    }
+
+    if (!rows || rows.length === 0) {
+      console.log("(no rows) — Done.");
+      break;
+    }
+
+    console.log(`${rows.length} rows. Patching…`);
+
+    const updates = rows.map((row) => ({
+      id: row.id,
+      fingerprint: buildContentFingerprint(row.content ?? ""),
+    }));
+
+    const { done, duplicates, errors } = await patchBatch(updates);
+    state.totalDone += done;
+    state.totalDuplicates += duplicates;
+    state.totalErrors += errors;
+
+    const maxId = rows[rows.length - 1].id;
+    state.cursorId = typeof maxId === "number" ? maxId : maxId;
+    saveState(state);
+
+    const dupeStr =
+      duplicates > 0 ? `, ${duplicates} duplicates (skipped)` : "";
+    const errStr = errors > 0 ? `, ${errors} errors` : "";
+    console.log(
+      `  → ${done} patched${dupeStr}${errStr}. ` +
+        `Total: ${state.totalDone} patched, ${state.totalDuplicates} duplicates, ${state.totalErrors} errors. ` +
+        `Cursor: ${state.cursorId}`
+    );
+
+    await new Promise((r) => setTimeout(r, 150));
+  }
+
+  console.log();
+  console.log("=== COMPLETE ===");
+  console.log(`Total rows backfilled   : ${state.totalDone}`);
+  console.log(`Total duplicate skipped : ${state.totalDuplicates}`);
+  console.log(`Total other errors      : ${state.totalErrors}`);
+
+  try {
+    fs.unlinkSync(STATE_FILE);
+    console.log("State file cleaned up.");
+  } catch {}
+}
+
+main().catch((err) => {
+  console.error("Fatal:", err);
+  process.exit(1);
+});

--- a/recipes/fingerprint-dedup-backfill/delete-duplicates.mjs
+++ b/recipes/fingerprint-dedup-backfill/delete-duplicates.mjs
@@ -1,0 +1,338 @@
+#!/usr/bin/env node
+/**
+ * Find and remove duplicate thoughts that have NULL content_fingerprint
+ * when a canonical copy (with fingerprint) already exists.
+ *
+ * Default behavior: REPORT ONLY. Pass --delete to actually remove duplicates.
+ *
+ * Strategy:
+ *   1. Fetch batches of NULL-fingerprint rows (id cursor, ascending)
+ *   2. Compute fingerprint for each using canonical normalization
+ *   3. Batch-lookup which fingerprints already exist in the table
+ *   4. Report (or delete) confirmed duplicates
+ *   5. For genuine orphans (no duplicate), backfill the fingerprint
+ *
+ * Fingerprint normalization matches the content-fingerprint-dedup primitive:
+ *   trim + collapse whitespace + lowercase + strip trailing punctuation +
+ *   strip possessives + strip trailing 's' from words > 3 chars
+ */
+
+import crypto from "node:crypto";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+// ── Parse CLI flags ─────────────────────────────────────────────────────────
+
+const args = process.argv.slice(2);
+const DESTRUCTIVE = args.includes("--delete");
+const REPORT_ONLY = args.includes("--report-only") || !DESTRUCTIVE;
+
+// ── Load environment ────────────────────────────────────────────────────────
+
+function loadEnv(envPath) {
+  if (!fs.existsSync(envPath)) return {};
+  const raw = fs.readFileSync(envPath, "utf8");
+  const env = {};
+  for (const line of raw.split(/\r?\n/)) {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith("#")) continue;
+    const eq = trimmed.indexOf("=");
+    if (eq === -1) continue;
+    env[trimmed.slice(0, eq).trim()] = trimmed.slice(eq + 1).trim();
+  }
+  return env;
+}
+
+const env = {
+  ...loadEnv(path.join(__dirname, ".env")),
+  ...loadEnv(path.join(__dirname, ".env.local")),
+};
+
+const SUPABASE_URL = env.SUPABASE_URL || process.env.SUPABASE_URL;
+const SERVICE_ROLE_KEY =
+  env.SUPABASE_SERVICE_ROLE_KEY || process.env.SUPABASE_SERVICE_ROLE_KEY;
+
+if (!SUPABASE_URL || !SERVICE_ROLE_KEY) {
+  console.error(
+    "Missing SUPABASE_URL or SUPABASE_SERVICE_ROLE_KEY.\n" +
+      "Set them in .env, .env.local, or as environment variables."
+  );
+  process.exit(1);
+}
+
+const REST_BASE = `${SUPABASE_URL}/rest/v1`;
+const HEADERS = {
+  apikey: SERVICE_ROLE_KEY,
+  Authorization: `Bearer ${SERVICE_ROLE_KEY}`,
+  "Content-Type": "application/json",
+  Prefer: "return=minimal",
+};
+
+// ── Fingerprint logic (matches content-fingerprint-dedup primitive) ─────────
+
+function normalizeForFingerprint(text) {
+  let s = String(text ?? "")
+    .trim()
+    .replace(/\s+/g, " ")
+    .toLowerCase();
+  if (!s) return "";
+  s = s.replace(/[.!?;:,]+$/, "");
+  s = s.replace(/['\u2019]s\b/g, "");
+  s = s.replace(/(\w{4,})s$/, "$1");
+  return s.trim();
+}
+
+function buildFingerprint(text) {
+  const normalized = normalizeForFingerprint(text);
+  if (!normalized) return "";
+  return crypto.createHash("sha256").update(normalized, "utf8").digest("hex");
+}
+
+// ── REST helpers ────────────────────────────────────────────────────────────
+
+async function fetchBatch(cursorId, batchSize) {
+  const url =
+    `${REST_BASE}/thoughts` +
+    `?content_fingerprint=is.null` +
+    `&id=gt.${cursorId}` +
+    `&select=id,content` +
+    `&limit=${batchSize}` +
+    `&order=id.asc`;
+  const res = await fetch(url, { headers: HEADERS });
+  if (!res.ok) {
+    const body = await res.text().catch(() => "");
+    throw new Error(`Fetch HTTP ${res.status} — ${body.slice(0, 300)}`);
+  }
+  const text = await res.text();
+  if (!text) return [];
+  return JSON.parse(text);
+}
+
+async function checkFingerprintsExist(hashes) {
+  if (!hashes.length) return new Set();
+  const CHUNK = 100;
+  const existingSet = new Set();
+  for (let i = 0; i < hashes.length; i += CHUNK) {
+    const chunk = hashes.slice(i, i + CHUNK);
+    const inList = chunk.join(",");
+    const url = `${REST_BASE}/thoughts?content_fingerprint=in.(${inList})&select=content_fingerprint&limit=${CHUNK * 2}`;
+    const res = await fetch(url, { headers: HEADERS });
+    if (!res.ok) {
+      const body = await res.text().catch(() => "");
+      throw new Error(`CheckExists HTTP ${res.status} — ${body.slice(0, 200)}`);
+    }
+    const rows = await res.json();
+    for (const r of rows) {
+      if (r.content_fingerprint) existingSet.add(r.content_fingerprint);
+    }
+  }
+  return existingSet;
+}
+
+async function deleteIds(ids) {
+  if (!ids.length) return 0;
+  const CHUNK = 200;
+  let deleted = 0;
+  for (let i = 0; i < ids.length; i += CHUNK) {
+    const chunk = ids.slice(i, i + CHUNK);
+    const url = `${REST_BASE}/thoughts?id=in.(${chunk.join(",")})`;
+    const res = await fetch(url, { method: "DELETE", headers: HEADERS });
+    if (!res.ok) {
+      const body = await res.text().catch(() => "");
+      throw new Error(`DELETE HTTP ${res.status} — ${body.slice(0, 200)}`);
+    }
+    deleted += chunk.length;
+  }
+  return deleted;
+}
+
+async function patchFingerprint(id, fingerprint) {
+  const url = `${REST_BASE}/thoughts?id=eq.${id}`;
+  const res = await fetch(url, {
+    method: "PATCH",
+    headers: HEADERS,
+    body: JSON.stringify({ content_fingerprint: fingerprint }),
+  });
+  if (!res.ok) {
+    const body = await res.text().catch(() => "");
+    throw new Error(
+      `PATCH id=${id}: HTTP ${res.status} — ${body.slice(0, 200)}`
+    );
+  }
+}
+
+// ── State ───────────────────────────────────────────────────────────────────
+
+const STATE_FILE = path.join(__dirname, "cleanup-state.json");
+
+function loadState() {
+  try {
+    return JSON.parse(fs.readFileSync(STATE_FILE, "utf8"));
+  } catch {
+    return {
+      cursorId: 0,
+      totalDeleted: 0,
+      totalPatched: 0,
+      totalWouldDelete: 0,
+      totalErrors: 0,
+      batches: 0,
+    };
+  }
+}
+
+function saveState(state) {
+  fs.writeFileSync(STATE_FILE, JSON.stringify(state, null, 2));
+}
+
+// ── Main ────────────────────────────────────────────────────────────────────
+
+const BATCH_SIZE = 500;
+
+async function main() {
+  const state = loadState();
+
+  if (REPORT_ONLY) {
+    console.log("=== Duplicate Report (read-only) ===");
+    console.log(
+      "Run with --delete to actually remove duplicates.\n"
+    );
+  } else {
+    console.log("=== Delete Duplicate NULL-Fingerprint Rows ===");
+    console.log("WARNING: This will DELETE rows. Ctrl+C to abort.\n");
+  }
+
+  console.log(
+    `Resuming from cursor id=${state.cursorId} (deleted: ${state.totalDeleted}, patched: ${state.totalPatched})`
+  );
+  console.log(`Batch size: ${BATCH_SIZE}\n`);
+
+  while (true) {
+    state.batches++;
+    process.stdout.write(
+      `Batch ${state.batches}: fetching from id>${state.cursorId}… `
+    );
+
+    let rows;
+    try {
+      rows = await fetchBatch(state.cursorId, BATCH_SIZE);
+    } catch (err) {
+      console.error("\n  Fetch error:", err.message, "— retrying in 5s…");
+      await new Promise((r) => setTimeout(r, 5000));
+      state.batches--;
+      continue;
+    }
+
+    if (!rows || rows.length === 0) {
+      console.log("(no rows) — Done.");
+      break;
+    }
+
+    console.log(`${rows.length} rows`);
+
+    const rowsWithFp = rows.map((row) => ({
+      id: row.id,
+      fingerprint: buildFingerprint(row.content),
+    }));
+
+    const allHashes = rowsWithFp.map((r) => r.fingerprint);
+    let existingSet;
+    try {
+      existingSet = await checkFingerprintsExist(allHashes);
+    } catch (err) {
+      console.error(
+        "  Check-exists error:",
+        err.message,
+        "— retrying in 5s…"
+      );
+      await new Promise((r) => setTimeout(r, 5000));
+      state.batches--;
+      continue;
+    }
+
+    const duplicateRows = rowsWithFp.filter((r) =>
+      existingSet.has(r.fingerprint)
+    );
+    const orphanRows = rowsWithFp.filter(
+      (r) => !existingSet.has(r.fingerprint)
+    );
+
+    process.stdout.write(
+      `  ${duplicateRows.length} duplicates, ${orphanRows.length} orphans. `
+    );
+
+    if (REPORT_ONLY) {
+      state.totalWouldDelete += duplicateRows.length;
+      console.log(`(would delete ${duplicateRows.length})`);
+    } else {
+      // Delete duplicates
+      let deletedThisBatch = 0;
+      if (duplicateRows.length > 0) {
+        try {
+          deletedThisBatch = await deleteIds(
+            duplicateRows.map((r) => r.id)
+          );
+          state.totalDeleted += deletedThisBatch;
+        } catch (err) {
+          state.totalErrors++;
+          console.error("\n  DELETE error:", err.message);
+        }
+      }
+
+      // Patch genuine orphans
+      let patchedThisBatch = 0;
+      for (const { id, fingerprint } of orphanRows) {
+        try {
+          await patchFingerprint(id, fingerprint);
+          patchedThisBatch++;
+          state.totalPatched++;
+        } catch (err) {
+          state.totalErrors++;
+          console.warn(
+            `  PATCH orphan error id=${id}:`,
+            err.message.slice(0, 120)
+          );
+        }
+      }
+
+      console.log(
+        `Deleted ${deletedThisBatch}, patched ${patchedThisBatch}.`
+      );
+    }
+
+    // Advance cursor
+    const maxId = rows[rows.length - 1].id;
+    state.cursorId = maxId;
+    saveState(state);
+
+    console.log(
+      `  Totals: deleted=${state.totalDeleted}, patched=${state.totalPatched}, ` +
+        `would-delete=${state.totalWouldDelete}, errors=${state.totalErrors}. ` +
+        `Cursor: ${state.cursorId}`
+    );
+
+    await new Promise((r) => setTimeout(r, 200));
+  }
+
+  console.log();
+  console.log("=== COMPLETE ===");
+  if (REPORT_ONLY) {
+    console.log(`Total rows that would be deleted: ${state.totalWouldDelete}`);
+    console.log(`\nRun with --delete to actually remove them.`);
+  } else {
+    console.log(`Total rows deleted  : ${state.totalDeleted}`);
+    console.log(`Total rows patched  : ${state.totalPatched}`);
+    console.log(`Total errors        : ${state.totalErrors}`);
+  }
+
+  try {
+    fs.unlinkSync(STATE_FILE);
+  } catch {}
+}
+
+main().catch((err) => {
+  console.error("Fatal:", err);
+  process.exit(1);
+});

--- a/recipes/fingerprint-dedup-backfill/metadata.json
+++ b/recipes/fingerprint-dedup-backfill/metadata.json
@@ -1,0 +1,20 @@
+{
+  "name": "Fingerprint Dedup Backfill",
+  "description": "Backfill content fingerprints on existing thoughts and safely remove duplicates discovered during the process.",
+  "category": "recipes",
+  "author": {
+    "name": "Alan Shurafa",
+    "github": "alanshurafa"
+  },
+  "version": "1.0.0",
+  "requires": {
+    "open_brain": true,
+    "services": [],
+    "tools": ["Node.js 18+"]
+  },
+  "tags": ["deduplication", "fingerprint", "backfill", "data-quality", "cleanup"],
+  "difficulty": "beginner",
+  "estimated_time": "15 minutes",
+  "created": "2026-03-22",
+  "updated": "2026-03-22"
+}

--- a/recipes/fingerprint-dedup-backfill/package.json
+++ b/recipes/fingerprint-dedup-backfill/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "fingerprint-dedup-backfill",
+  "version": "1.0.0",
+  "description": "Backfill content fingerprints and remove duplicates from Open Brain thoughts table",
+  "type": "module",
+  "scripts": {
+    "backfill": "node backfill-fingerprints.mjs",
+    "report": "node delete-duplicates.mjs --report-only",
+    "cleanup": "node delete-duplicates.mjs"
+  }
+}


### PR DESCRIPTION
## Summary
- Backfill script computes SHA-256 content fingerprints for all NULL-fingerprint rows
- Cleanup script finds and removes duplicate rows (report-first, explicit --delete)
- Both scripts are resumable via state file and use cursor-based pagination
- Fingerprint normalization matches the merged Content Fingerprint Dedup primitive (#54)

## Why
If thoughts were imported before the fingerprint dedup primitive was in place, those rows have NULL `content_fingerprint`. This recipe makes existing data compatible with dedup and cleans up duplicates discovered during backfill.

## Safety
- Cleanup defaults to **report-only** mode — no deletions without `--delete` flag
- Both scripts save progress after each batch and resume from where they left off
- Re-running after completion is a safe no-op

## Test plan
- [ ] Backfill resumes from state after interruption
- [ ] Re-run after completion produces no changes
- [ ] Report mode shows candidate deletes without destructive action
- [ ] Script normalization matches the merged fingerprint primitive exactly

🤖 Generated with [Claude Code](https://claude.com/claude-code)