### PR TITLE
[integrations] Kubernetes self-hosted deployment with pgvector

### DIFF
--- a/integrations/kubernetes-deployment/Dockerfile
+++ b/integrations/kubernetes-deployment/Dockerfile
@@ -1,0 +1,17 @@
+FROM denoland/deno:2.3.3
+
+WORKDIR /app
+
+# Copy dependency manifest and cache dependencies
+COPY deno.json ./
+RUN deno install
+
+# Copy server source
+COPY index.ts ./
+
+# Run as non-root
+USER deno
+
+EXPOSE 8000
+
+CMD ["deno", "run", "--allow-net", "--allow-env", "--allow-read", "index.ts"]

--- a/integrations/kubernetes-deployment/README.md
+++ b/integrations/kubernetes-deployment/README.md
@@ -1,0 +1,176 @@
+# Kubernetes Self-Hosted Deployment
+
+> Deploy Open Brain on Kubernetes with self-hosted PostgreSQL + pgvector, replacing Supabase with fully self-managed infrastructure.
+
+## What It Does
+
+This integration provides Kubernetes manifests and a modified MCP server that connects directly to PostgreSQL instead of Supabase. Your thoughts database, embeddings, and MCP endpoint all run on your own cluster. The MCP HTTP endpoint is served via Kubernetes Ingress, making it a remote endpoint accessible by URL from any MCP client.
+
+## Prerequisites
+
+- Working Kubernetes cluster (tested on K3s v1.31, works with any K8s distribution)
+- `kubectl` configured for your cluster
+- Docker installed (for building the MCP server image)
+- An embedding/chat API provider (OpenRouter, OpenAI, or a local model with OpenAI-compatible API)
+- An ingress controller (Traefik, nginx-ingress, etc.) if you want external access
+
+## Credential Tracker
+
+Copy this block into a text editor and fill it in as you go.
+
+```text
+KUBERNETES DEPLOYMENT -- CREDENTIAL TRACKER
+--------------------------------------------
+
+POSTGRESQL
+  Password:              ____________
+
+MCP SERVER
+  Access key:            ____________
+
+EMBEDDING/CHAT API
+  API base URL:          ____________
+  API key:               ____________
+  Embedding model:       ____________
+  Chat model:            ____________
+
+--------------------------------------------
+```
+
+## Steps
+
+### 1. Build the MCP Server Docker Image
+
+From this directory, build and import the image:
+
+```bash
+docker build -t openbrain-mcp-server:latest .
+
+# For K3s:
+docker save openbrain-mcp-server:latest | sudo k3s ctr images import -
+
+# For minikube:
+minikube image load openbrain-mcp-server:latest
+
+# For other clusters, push to your registry:
+docker tag openbrain-mcp-server:latest your-registry/openbrain-mcp-server:latest
+docker push your-registry/openbrain-mcp-server:latest
+```
+
+### 2. Configure Secrets
+
+```bash
+cp k8s/secrets.yml.example k8s/secrets.yml
+```
+
+Edit `k8s/secrets.yml` with your actual credentials. **Never commit this file.**
+
+### 3. Deploy to Kubernetes
+
+```bash
+kubectl apply -f k8s/secrets.yml
+kubectl apply -f k8s/openbrain.yml
+```
+
+### 4. Verify Deployment
+
+```bash
+# Check pod status
+kubectl get pods -n openbrain
+
+# Check database is initialized
+kubectl exec -n openbrain openbrain-0 -c db -- \
+  psql -U postgres -d openbrain -c '\dt'
+
+# Test MCP endpoint (via port-forward)
+kubectl port-forward -n openbrain svc/openbrain 8000:8000 &
+curl -X POST http://localhost:8000 \
+  -H "x-brain-key: YOUR_ACCESS_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"jsonrpc":"2.0","method":"tools/list","id":1}'
+```
+
+### 5. Connect Your MCP Client
+
+For Claude Desktop or any MCP-compatible client, configure the remote MCP endpoint:
+
+```json
+{
+  "mcpServers": {
+    "openbrain": {
+      "url": "http://openbrain.openbrain.svc.cluster.local:8000",
+      "transport": "http",
+      "headers": {
+        "x-brain-key": "YOUR_ACCESS_KEY"
+      }
+    }
+  }
+}
+```
+
+If you've configured an Ingress, use your external URL instead:
+
+```json
+{
+  "mcpServers": {
+    "openbrain": {
+      "url": "https://brain.yourdomain.com",
+      "transport": "http",
+      "headers": {
+        "x-brain-key": "YOUR_ACCESS_KEY"
+      }
+    }
+  }
+}
+```
+
+## Using a Local LLM Instead of OpenRouter
+
+To use a local model (e.g., Ollama, BitNet, llama.cpp) for embeddings and chat, update the environment variables in `k8s/openbrain.yml`:
+
+```yaml
+- name: EMBEDDING_API_BASE
+  value: "http://your-local-model:8080/v1"
+- name: EMBEDDING_API_KEY
+  value: "not-needed"
+- name: EMBEDDING_MODEL
+  value: "your-model-name"
+- name: CHAT_API_BASE
+  value: "http://your-local-model:8080/v1"
+- name: CHAT_API_KEY
+  value: "not-needed"
+- name: CHAT_MODEL
+  value: "your-model-name"
+```
+
+If your embedding model produces a different vector dimension than 1536, update the `vector(1536)` in the init SQL to match.
+
+## Expected Outcome
+
+After deployment you should see:
+
+- `openbrain-0` pod running with 2 containers (db + mcp-server)
+- PostgreSQL with `thoughts` table and `match_thoughts` function
+- MCP endpoint responding to `tools/list` with 4 tools: `search_thoughts`, `list_thoughts`, `thought_stats`, `capture_thought`
+- Thoughts captured via any MCP client are stored in your self-hosted database
+
+## Troubleshooting
+
+**Pod stuck in CrashLoopBackOff (mcp-server)**
+- Check logs: `kubectl logs -n openbrain openbrain-0 -c mcp-server`
+- Most common cause: invalid API key or unreachable embedding API base URL
+- For local models, ensure the model service is running and accessible from the cluster
+
+**Database not initialized / tables missing**
+- The init SQL runs only on first startup. If the data volume already exists with an old database, the init script is skipped.
+- To re-initialize: delete the data volume directory and restart the pod
+- `kubectl delete pod openbrain-0 -n openbrain` (StatefulSet will recreate it)
+
+**Embedding dimension mismatch**
+- If you see errors about vector dimensions, your embedding model produces vectors of a different size than expected
+- Check your model's output dimension and update `vector(1536)` in the init SQL ConfigMap
+- Drop and recreate the `thoughts` table if changing dimensions on an existing database
+
+**Connection refused to database**
+- Containers in the same pod communicate via `127.0.0.1` — this is normal Kubernetes multi-container pod behavior
+- Check that the `db` container is ready: `kubectl logs -n openbrain openbrain-0 -c db`

--- a/integrations/kubernetes-deployment/deno.json
+++ b/integrations/kubernetes-deployment/deno.json
@@ -1,0 +1,9 @@
+{
+  "imports": {
+    "@hono/mcp": "npm:@hono/mcp@0.1.1",
+    "@modelcontextprotocol/sdk": "npm:@modelcontextprotocol/sdk@1.24.3",
+    "hono": "npm:hono@4.9.2",
+    "zod": "npm:zod@4.1.13",
+    "postgres": "https://deno.land/x/postgres@v0.19.3/mod.ts"
+  }
+}

--- a/integrations/kubernetes-deployment/index.ts
+++ b/integrations/kubernetes-deployment/index.ts
@@ -1,0 +1,428 @@
+/**
+ * Open Brain MCP Server - Kubernetes Self-Hosted Version
+ *
+ * This is a modified version of the OB1 server that connects directly to
+ * PostgreSQL + pgvector instead of Supabase. All MCP tools and the Hono
+ * HTTP layer are preserved; only the data access layer is changed.
+ *
+ * Environment variables:
+ *   DB_HOST, DB_PORT, DB_NAME, DB_USER, DB_PASSWORD - PostgreSQL connection
+ *   EMBEDDING_API_BASE - Base URL for OpenAI-compatible embedding API
+ *   EMBEDDING_API_KEY - API key for the embedding service
+ *   EMBEDDING_MODEL - Model name for embeddings (default: text-embedding-3-small)
+ *   CHAT_API_BASE - Base URL for OpenAI-compatible chat API (defaults to EMBEDDING_API_BASE)
+ *   CHAT_API_KEY - API key for chat service (defaults to EMBEDDING_API_KEY)
+ *   CHAT_MODEL - Model name for metadata extraction (default: gpt-4o-mini)
+ *   MCP_ACCESS_KEY - Authentication key for MCP endpoint
+ */
+
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { StreamableHTTPTransport } from "@hono/mcp";
+import { Hono } from "hono";
+import { z } from "zod";
+import { Pool } from "postgres";
+
+// --- Configuration ---
+
+const DB_HOST = Deno.env.get("DB_HOST") || "127.0.0.1";
+const DB_PORT = parseInt(Deno.env.get("DB_PORT") || "5432", 10);
+const DB_NAME = Deno.env.get("DB_NAME") || "openbrain";
+const DB_USER = Deno.env.get("DB_USER") || "postgres";
+const DB_PASSWORD = Deno.env.get("DB_PASSWORD")!;
+
+const EMBEDDING_API_BASE = Deno.env.get("EMBEDDING_API_BASE") || "https://openrouter.ai/api/v1";
+const EMBEDDING_API_KEY = Deno.env.get("EMBEDDING_API_KEY") || Deno.env.get("OPENROUTER_API_KEY") || "";
+const EMBEDDING_MODEL = Deno.env.get("EMBEDDING_MODEL") || "openai/text-embedding-3-small";
+
+const CHAT_API_BASE = Deno.env.get("CHAT_API_BASE") || EMBEDDING_API_BASE;
+const CHAT_API_KEY = Deno.env.get("CHAT_API_KEY") || EMBEDDING_API_KEY;
+const CHAT_MODEL = Deno.env.get("CHAT_MODEL") || "openai/gpt-4o-mini";
+
+const MCP_ACCESS_KEY = Deno.env.get("MCP_ACCESS_KEY")!;
+
+// --- PostgreSQL Connection Pool ---
+
+const pool = new Pool({
+  hostname: DB_HOST,
+  port: DB_PORT,
+  database: DB_NAME,
+  user: DB_USER,
+  password: DB_PASSWORD,
+}, 20);
+
+// --- Embedding & Metadata Extraction ---
+
+async function getEmbedding(text: string): Promise<number[]> {
+  const r = await fetch(`${EMBEDDING_API_BASE}/embeddings`, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${EMBEDDING_API_KEY}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      model: EMBEDDING_MODEL,
+      input: text,
+    }),
+  });
+  if (!r.ok) {
+    const msg = await r.text().catch(() => "");
+    throw new Error(`Embedding API failed: ${r.status} ${msg}`);
+  }
+  const d = await r.json();
+  return d.data[0].embedding;
+}
+
+async function extractMetadata(text: string): Promise<Record<string, unknown>> {
+  const r = await fetch(`${CHAT_API_BASE}/chat/completions`, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${CHAT_API_KEY}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      model: CHAT_MODEL,
+      response_format: { type: "json_object" },
+      messages: [
+        {
+          role: "system",
+          content: `Extract metadata from the user's captured thought. Return JSON with:
+- "people": array of people mentioned (empty if none)
+- "action_items": array of implied to-dos (empty if none)
+- "dates_mentioned": array of dates YYYY-MM-DD (empty if none)
+- "topics": array of 1-3 short topic tags (always at least one)
+- "type": one of "observation", "task", "idea", "reference", "person_note"
+Only extract what's explicitly there.`,
+        },
+        { role: "user", content: text },
+      ],
+    }),
+  });
+  const d = await r.json();
+  try {
+    return JSON.parse(d.choices[0].message.content);
+  } catch {
+    return { topics: ["uncategorized"], type: "observation" };
+  }
+}
+
+// --- MCP Server Setup ---
+
+const server = new McpServer({
+  name: "open-brain",
+  version: "1.0.0",
+});
+
+// Tool 1: Semantic Search (replaces supabase.rpc with raw SQL)
+server.registerTool(
+  "search_thoughts",
+  {
+    title: "Search Thoughts",
+    description:
+      "Search captured thoughts by meaning. Use this when the user asks about a topic, person, or idea they've previously captured.",
+    inputSchema: {
+      query: z.string().describe("What to search for"),
+      limit: z.number().optional().default(10),
+      threshold: z.number().optional().default(0.5),
+    },
+  },
+  async ({ query, limit, threshold }) => {
+    try {
+      const qEmb = await getEmbedding(query);
+      const embStr = `[${qEmb.join(",")}]`;
+
+      const client = await pool.connect();
+      try {
+        const result = await client.queryObject<{
+          content: string;
+          metadata: Record<string, unknown>;
+          similarity: number;
+          created_at: string;
+        }>(
+          `SELECT content, metadata, created_at,
+                  1 - (embedding <=> $1::vector) AS similarity
+           FROM thoughts
+           WHERE 1 - (embedding <=> $1::vector) >= $2
+           ORDER BY embedding <=> $1::vector
+           LIMIT $3`,
+          [embStr, threshold, limit]
+        );
+
+        if (!result.rows.length) {
+          return {
+            content: [{ type: "text" as const, text: `No thoughts found matching "${query}".` }],
+          };
+        }
+
+        const results = result.rows.map((t, i) => {
+          const m = t.metadata || {};
+          const parts = [
+            `--- Result ${i + 1} (${(t.similarity * 100).toFixed(1)}% match) ---`,
+            `Captured: ${new Date(t.created_at).toLocaleDateString()}`,
+            `Type: ${m.type || "unknown"}`,
+          ];
+          if (Array.isArray(m.topics) && m.topics.length)
+            parts.push(`Topics: ${(m.topics as string[]).join(", ")}`);
+          if (Array.isArray(m.people) && m.people.length)
+            parts.push(`People: ${(m.people as string[]).join(", ")}`);
+          if (Array.isArray(m.action_items) && m.action_items.length)
+            parts.push(`Actions: ${(m.action_items as string[]).join("; ")}`);
+          parts.push(`\n${t.content}`);
+          return parts.join("\n");
+        });
+
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: `Found ${result.rows.length} thought(s):\n\n${results.join("\n\n")}`,
+            },
+          ],
+        };
+      } finally {
+        client.release();
+      }
+    } catch (err: unknown) {
+      return {
+        content: [{ type: "text" as const, text: `Error: ${(err as Error).message}` }],
+        isError: true,
+      };
+    }
+  }
+);
+
+// Tool 2: List Recent (replaces supabase query builder with raw SQL)
+server.registerTool(
+  "list_thoughts",
+  {
+    title: "List Recent Thoughts",
+    description:
+      "List recently captured thoughts with optional filters by type, topic, person, or time range.",
+    inputSchema: {
+      limit: z.number().optional().default(10),
+      type: z.string().optional().describe("Filter by type: observation, task, idea, reference, person_note"),
+      topic: z.string().optional().describe("Filter by topic tag"),
+      person: z.string().optional().describe("Filter by person mentioned"),
+      days: z.number().optional().describe("Only thoughts from the last N days"),
+    },
+  },
+  async ({ limit, type, topic, person, days }) => {
+    try {
+      const conditions: string[] = [];
+      const params: unknown[] = [];
+      let paramIdx = 1;
+
+      if (type) {
+        conditions.push(`metadata->>'type' = $${paramIdx}`);
+        params.push(type);
+        paramIdx++;
+      }
+      if (topic) {
+        conditions.push(`metadata->'topics' ? $${paramIdx}`);
+        params.push(topic);
+        paramIdx++;
+      }
+      if (person) {
+        conditions.push(`metadata->'people' ? $${paramIdx}`);
+        params.push(person);
+        paramIdx++;
+      }
+      if (days) {
+        conditions.push(`created_at >= NOW() - INTERVAL '${days} days'`);
+      }
+
+      const whereClause = conditions.length ? `WHERE ${conditions.join(" AND ")}` : "";
+
+      const client = await pool.connect();
+      try {
+        const result = await client.queryObject<{
+          content: string;
+          metadata: Record<string, unknown>;
+          created_at: string;
+        }>(
+          `SELECT content, metadata, created_at
+           FROM thoughts
+           ${whereClause}
+           ORDER BY created_at DESC
+           LIMIT $${paramIdx}`,
+          [...params, limit]
+        );
+
+        if (!result.rows.length) {
+          return { content: [{ type: "text" as const, text: "No thoughts found." }] };
+        }
+
+        const results = result.rows.map((t, i) => {
+          const m = t.metadata || {};
+          const tags = Array.isArray(m.topics) ? (m.topics as string[]).join(", ") : "";
+          return `${i + 1}. [${new Date(t.created_at).toLocaleDateString()}] (${m.type || "??"}${tags ? " - " + tags : ""})\n   ${t.content}`;
+        });
+
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: `${result.rows.length} recent thought(s):\n\n${results.join("\n\n")}`,
+            },
+          ],
+        };
+      } finally {
+        client.release();
+      }
+    } catch (err: unknown) {
+      return {
+        content: [{ type: "text" as const, text: `Error: ${(err as Error).message}` }],
+        isError: true,
+      };
+    }
+  }
+);
+
+// Tool 3: Stats (replaces supabase queries with raw SQL)
+server.registerTool(
+  "thought_stats",
+  {
+    title: "Thought Statistics",
+    description: "Get a summary of all captured thoughts: totals, types, top topics, and people.",
+    inputSchema: {},
+  },
+  async () => {
+    try {
+      const client = await pool.connect();
+      try {
+        const countResult = await client.queryObject<{ count: number }>(
+          "SELECT COUNT(*)::int AS count FROM thoughts"
+        );
+
+        const dataResult = await client.queryObject<{
+          metadata: Record<string, unknown>;
+          created_at: string;
+        }>(
+          "SELECT metadata, created_at FROM thoughts ORDER BY created_at DESC"
+        );
+
+        const count = countResult.rows[0]?.count || 0;
+        const data = dataResult.rows;
+
+        const types: Record<string, number> = {};
+        const topics: Record<string, number> = {};
+        const people: Record<string, number> = {};
+
+        for (const r of data) {
+          const m = r.metadata || {};
+          if (m.type) types[m.type as string] = (types[m.type as string] || 0) + 1;
+          if (Array.isArray(m.topics))
+            for (const t of m.topics) topics[t as string] = (topics[t as string] || 0) + 1;
+          if (Array.isArray(m.people))
+            for (const p of m.people) people[p as string] = (people[p as string] || 0) + 1;
+        }
+
+        const sort = (o: Record<string, number>): [string, number][] =>
+          Object.entries(o)
+            .sort((a, b) => b[1] - a[1])
+            .slice(0, 10);
+
+        const lines: string[] = [
+          `Total thoughts: ${count}`,
+          `Date range: ${
+            data.length
+              ? new Date(data[data.length - 1].created_at).toLocaleDateString() +
+                " -> " +
+                new Date(data[0].created_at).toLocaleDateString()
+              : "N/A"
+          }`,
+          "",
+          "Types:",
+          ...sort(types).map(([k, v]) => `  ${k}: ${v}`),
+        ];
+
+        if (Object.keys(topics).length) {
+          lines.push("", "Top topics:");
+          for (const [k, v] of sort(topics)) lines.push(`  ${k}: ${v}`);
+        }
+
+        if (Object.keys(people).length) {
+          lines.push("", "People mentioned:");
+          for (const [k, v] of sort(people)) lines.push(`  ${k}: ${v}`);
+        }
+
+        return { content: [{ type: "text" as const, text: lines.join("\n") }] };
+      } finally {
+        client.release();
+      }
+    } catch (err: unknown) {
+      return {
+        content: [{ type: "text" as const, text: `Error: ${(err as Error).message}` }],
+        isError: true,
+      };
+    }
+  }
+);
+
+// Tool 4: Capture Thought (replaces supabase insert with raw SQL)
+server.registerTool(
+  "capture_thought",
+  {
+    title: "Capture Thought",
+    description:
+      "Save a new thought to the Open Brain. Generates an embedding and extracts metadata automatically.",
+    inputSchema: {
+      content: z.string().describe("The thought to capture"),
+    },
+  },
+  async ({ content }) => {
+    try {
+      const [embedding, metadata] = await Promise.all([
+        getEmbedding(content),
+        extractMetadata(content),
+      ]);
+
+      const embStr = `[${embedding.join(",")}]`;
+      const meta = { ...metadata, source: "mcp" };
+
+      const client = await pool.connect();
+      try {
+        await client.queryObject(
+          `INSERT INTO thoughts (content, embedding, metadata)
+           VALUES ($1, $2::vector, $3::jsonb)`,
+          [content, embStr, JSON.stringify(meta)]
+        );
+      } finally {
+        client.release();
+      }
+
+      let confirmation = `Captured as ${meta.type || "thought"}`;
+      if (Array.isArray(meta.topics) && meta.topics.length)
+        confirmation += ` -- ${(meta.topics as string[]).join(", ")}`;
+      if (Array.isArray(meta.people) && meta.people.length)
+        confirmation += ` | People: ${(meta.people as string[]).join(", ")}`;
+      if (Array.isArray(meta.action_items) && meta.action_items.length)
+        confirmation += ` | Actions: ${(meta.action_items as string[]).join("; ")}`;
+
+      return {
+        content: [{ type: "text" as const, text: confirmation }],
+      };
+    } catch (err: unknown) {
+      return {
+        content: [{ type: "text" as const, text: `Error: ${(err as Error).message}` }],
+        isError: true,
+      };
+    }
+  }
+);
+
+// --- Hono App with Auth Check ---
+
+const app = new Hono();
+
+app.all("*", async (c) => {
+  const provided = c.req.header("x-brain-key") || new URL(c.req.url).searchParams.get("key");
+  if (!provided || provided !== MCP_ACCESS_KEY) {
+    return c.json({ error: "Invalid or missing access key" }, 401);
+  }
+
+  const transport = new StreamableHTTPTransport();
+  await server.connect(transport);
+  return transport.handleRequest(c);
+});
+
+Deno.serve({ port: parseInt(Deno.env.get("PORT") || "8000", 10) }, app.fetch);

--- a/integrations/kubernetes-deployment/k8s/init.sql
+++ b/integrations/kubernetes-deployment/k8s/init.sql
@@ -1,0 +1,48 @@
+-- Open Brain schema for self-hosted PostgreSQL + pgvector
+-- This replaces the Supabase-managed schema with a standalone version.
+-- Compatible with the OB1 MCP server tools (search_thoughts, list_thoughts, etc.)
+
+CREATE EXTENSION IF NOT EXISTS vector;
+
+CREATE TABLE IF NOT EXISTS thoughts (
+    id BIGSERIAL PRIMARY KEY,
+    content TEXT NOT NULL,
+    embedding vector(1536),
+    metadata JSONB DEFAULT '{}'::jsonb,
+    created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE INDEX IF NOT EXISTS idx_thoughts_created_at ON thoughts (created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_thoughts_metadata ON thoughts USING GIN (metadata);
+
+-- match_thoughts function for vector similarity search
+-- This replaces the Supabase RPC function
+CREATE OR REPLACE FUNCTION match_thoughts(
+    query_embedding vector(1536),
+    match_threshold FLOAT DEFAULT 0.5,
+    match_count INT DEFAULT 10,
+    filter JSONB DEFAULT '{}'::jsonb
+)
+RETURNS TABLE (
+    id BIGINT,
+    content TEXT,
+    metadata JSONB,
+    similarity FLOAT,
+    created_at TIMESTAMP WITH TIME ZONE
+)
+LANGUAGE plpgsql
+AS $$
+BEGIN
+    RETURN QUERY
+    SELECT
+        t.id,
+        t.content,
+        t.metadata,
+        (1 - (t.embedding <=> query_embedding))::FLOAT AS similarity,
+        t.created_at
+    FROM thoughts t
+    WHERE 1 - (t.embedding <=> query_embedding) >= match_threshold
+    ORDER BY t.embedding <=> query_embedding
+    LIMIT match_count;
+END;
+$$;

--- a/integrations/kubernetes-deployment/k8s/openbrain.yml
+++ b/integrations/kubernetes-deployment/k8s/openbrain.yml
@@ -1,0 +1,222 @@
+---
+# Open Brain - Self-hosted on Kubernetes
+# Multi-container pod: PostgreSQL+pgvector + MCP Server (Deno)
+# Containers share network namespace (communicate via 127.0.0.1)
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: openbrain
+
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: openbrain-init-sql
+  namespace: openbrain
+data:
+  init.sql: |
+    CREATE EXTENSION IF NOT EXISTS vector;
+
+    CREATE TABLE IF NOT EXISTS thoughts (
+        id BIGSERIAL PRIMARY KEY,
+        content TEXT NOT NULL,
+        embedding vector(1536),
+        metadata JSONB DEFAULT '{}'::jsonb,
+        created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP
+    );
+
+    CREATE INDEX IF NOT EXISTS idx_thoughts_created_at ON thoughts (created_at DESC);
+    CREATE INDEX IF NOT EXISTS idx_thoughts_metadata ON thoughts USING GIN (metadata);
+
+    CREATE OR REPLACE FUNCTION match_thoughts(
+        query_embedding vector(1536),
+        match_threshold FLOAT DEFAULT 0.5,
+        match_count INT DEFAULT 10,
+        filter JSONB DEFAULT '{}'::jsonb
+    )
+    RETURNS TABLE (
+        id BIGINT,
+        content TEXT,
+        metadata JSONB,
+        similarity FLOAT,
+        created_at TIMESTAMP WITH TIME ZONE
+    )
+    LANGUAGE plpgsql
+    AS $$
+    BEGIN
+        RETURN QUERY
+        SELECT
+            t.id,
+            t.content,
+            t.metadata,
+            (1 - (t.embedding <=> query_embedding))::FLOAT AS similarity,
+            t.created_at
+        FROM thoughts t
+        WHERE 1 - (t.embedding <=> query_embedding) >= match_threshold
+        ORDER BY t.embedding <=> query_embedding
+        LIMIT match_count;
+    END;
+    $$;
+
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: openbrain
+  namespace: openbrain
+spec:
+  serviceName: "openbrain"
+  replicas: 1
+  selector:
+    matchLabels:
+      app: openbrain
+  template:
+    metadata:
+      labels:
+        app: openbrain
+    spec:
+      containers:
+        # Container 1: PostgreSQL + pgvector
+        - name: db
+          image: ankane/pgvector:v0.5.1
+          env:
+            - name: POSTGRES_USER
+              value: "postgres"
+            - name: POSTGRES_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: openbrain-secret
+                  key: postgres-password
+            - name: POSTGRES_DB
+              value: "openbrain"
+          ports:
+            - containerPort: 5432
+          volumeMounts:
+            - name: db-data
+              mountPath: /var/lib/postgresql/data
+            - name: init-sql
+              mountPath: /docker-entrypoint-initdb.d/init.sql
+              subPath: init.sql
+          readinessProbe:
+            tcpSocket:
+              port: 5432
+            initialDelaySeconds: 10
+            periodSeconds: 10
+          resources:
+            requests:
+              cpu: 250m
+              memory: 256Mi
+            limits:
+              memory: 1Gi
+
+        # Container 2: Open Brain MCP Server (Deno)
+        - name: mcp-server
+          image: openbrain-mcp-server:latest
+          imagePullPolicy: IfNotPresent
+          ports:
+            - containerPort: 8000
+              name: http
+          env:
+            - name: DB_HOST
+              value: "127.0.0.1"
+            - name: DB_PORT
+              value: "5432"
+            - name: DB_NAME
+              value: "openbrain"
+            - name: DB_USER
+              value: "postgres"
+            - name: DB_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: openbrain-secret
+                  key: postgres-password
+            - name: MCP_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: openbrain-secret
+                  key: mcp-access-key
+            # Configure your embedding/chat API provider:
+            # For OpenRouter (default):
+            - name: EMBEDDING_API_BASE
+              value: "https://openrouter.ai/api/v1"
+            - name: EMBEDDING_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: openbrain-secret
+                  key: embedding-api-key
+            - name: EMBEDDING_MODEL
+              value: "openai/text-embedding-3-small"
+            - name: CHAT_API_BASE
+              value: "https://openrouter.ai/api/v1"
+            - name: CHAT_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: openbrain-secret
+                  key: chat-api-key
+            - name: CHAT_MODEL
+              value: "openai/gpt-4o-mini"
+            - name: PORT
+              value: "8000"
+          readinessProbe:
+            tcpSocket:
+              port: 8000
+            initialDelaySeconds: 10
+            periodSeconds: 10
+          resources:
+            requests:
+              cpu: 100m
+              memory: 128Mi
+            limits:
+              memory: 512Mi
+
+      volumes:
+        - name: db-data
+          hostPath:
+            path: /var/openbrain/db
+            type: DirectoryOrCreate
+        - name: init-sql
+          configMap:
+            name: openbrain-init-sql
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: openbrain
+  namespace: openbrain
+spec:
+  selector:
+    app: openbrain
+  ports:
+    - protocol: TCP
+      port: 8000
+      targetPort: http
+      name: mcp
+  type: ClusterIP
+
+---
+# Optional: Ingress for remote MCP access
+# Uncomment and configure for your ingress controller
+# apiVersion: networking.k8s.io/v1
+# kind: Ingress
+# metadata:
+#   name: openbrain
+#   namespace: openbrain
+# spec:
+#   ingressClassName: nginx  # or traefik, etc.
+#   tls:
+#   - hosts:
+#     - brain.yourdomain.com
+#     secretName: brain-tls
+#   rules:
+#     - host: brain.yourdomain.com
+#       http:
+#         paths:
+#           - path: /
+#             pathType: Prefix
+#             backend:
+#               service:
+#                 name: openbrain
+#                 port:
+#                   number: 8000

--- a/integrations/kubernetes-deployment/k8s/secrets.yml.example
+++ b/integrations/kubernetes-deployment/k8s/secrets.yml.example
@@ -1,0 +1,21 @@
+# Open Brain Kubernetes Secrets
+# Copy this file, fill in your values, and apply with kubectl apply -f secrets.yml
+# NEVER commit real credentials to version control!
+apiVersion: v1
+kind: Secret
+metadata:
+  name: openbrain-secret
+  namespace: openbrain
+type: Opaque
+stringData:
+  # PostgreSQL password
+  postgres-password: "CHANGE-ME-postgres-password"
+
+  # MCP access key (clients authenticate with this)
+  mcp-access-key: "CHANGE-ME-random-access-key"
+
+  # Embedding API key (OpenRouter, OpenAI, or local model proxy)
+  embedding-api-key: "CHANGE-ME-your-api-key"
+
+  # Chat API key (defaults to embedding-api-key if using same provider)
+  chat-api-key: "CHANGE-ME-your-api-key"

--- a/integrations/kubernetes-deployment/metadata.json
+++ b/integrations/kubernetes-deployment/metadata.json
@@ -1,0 +1,20 @@
+{
+  "name": "Kubernetes Self-Hosted Deployment",
+  "description": "Deploy Open Brain on Kubernetes with self-hosted PostgreSQL + pgvector, replacing Supabase with fully self-managed infrastructure.",
+  "category": "integrations",
+  "author": {
+    "name": "Marvin",
+    "github": "velo"
+  },
+  "version": "1.0.0",
+  "requires": {
+    "open_brain": true,
+    "services": ["Kubernetes", "PostgreSQL", "pgvector"],
+    "tools": ["kubectl", "Docker"]
+  },
+  "tags": ["kubernetes", "k8s", "self-hosted", "postgresql", "pgvector", "deployment", "infrastructure"],
+  "difficulty": "advanced",
+  "estimated_time": "60 minutes",
+  "created": "2026-03-22",
+  "updated": "2026-03-22"
+}


### PR DESCRIPTION
## Summary

- Self-hosted alternative to Supabase using **PostgreSQL + pgvector** on Kubernetes
- Modified MCP server (Deno) that connects directly to PostgreSQL instead of Supabase client
- Includes K8s manifests (StatefulSet with multi-container pod, Service, ConfigMap, Ingress template)
- Configurable embedding/chat API via environment variables — works with OpenRouter, OpenAI, or any local LLM with OpenAI-compatible API
- Complete documentation with setup steps, troubleshooting, and local LLM instructions

## What's Included

```
integrations/kubernetes-deployment/
├── README.md              # Full setup guide with troubleshooting
├── metadata.json          # Integration metadata
├── Dockerfile             # Deno MCP server container
├── deno.json              # Dependencies (postgres driver replaces supabase-js)
├── index.ts               # Modified MCP server (direct PostgreSQL)
└── k8s/
    ├── openbrain.yml      # StatefulSet, Service, ConfigMap, Ingress template
    ├── init.sql            # Schema with pgvector + match_thoughts function
    └── secrets.yml.example # Credential template (no real secrets)
```

## Key Changes from Upstream Server

The `index.ts` preserves all 4 MCP tools (`search_thoughts`, `list_thoughts`, `thought_stats`, `capture_thought`) and the Hono HTTP layer. The data access layer is changed:

- `@supabase/supabase-js` → `deno-postgres` (direct PostgreSQL pool)
- `supabase.rpc("match_thoughts", ...)` → raw SQL with `<=>` cosine distance operator
- `supabase.from("thoughts").select(...)` → raw SQL queries
- `supabase.from("thoughts").insert(...)` → raw SQL INSERT with `::vector` cast

The MCP HTTP endpoint served via Kubernetes Ingress is a remote endpoint accessible by URL, consistent with MCP architecture.

## Test plan

- [x] Deployed on personal K3s homelab cluster (single-node)
- [x] PostgreSQL + pgvector initialized with thoughts schema and match_thoughts function
- [x] MCP server accessible via Kubernetes Ingress URL
- [x] No credentials in committed files (secrets.yml.example with placeholders only)
- [x] All files within `integrations/kubernetes-deployment/` scope
- [ ] Community testing on other K8s distributions (EKS, GKE, minikube)

🤖 Generated with [Claude Code](https://claude.com/claude-code)