### PR TITLE
[integrations] Fix Slack Capture duplicate entries from webhook retries

### DIFF
--- a/integrations/slack-capture/README.md
+++ b/integrations/slack-capture/README.md
@@ -182,6 +182,14 @@ Deno.serve(async (req: Request): Promise<Response> => {
     const messageTs: string = event.ts;
     if (!messageText || messageText.trim() === "") return new Response("ok", { status: 200 });
 
+    // Deduplicate: Slack retries webhooks if response takes >3s, so check if we already captured this message
+    const { data: existing } = await supabase
+      .from("thoughts")
+      .select("id")
+      .contains("metadata", { slack_ts: messageTs })
+      .limit(1);
+    if (existing && existing.length > 0) return new Response("ok", { status: 200 });
+
     const [embedding, metadata] = await Promise.all([
       getEmbedding(messageText),
       extractMetadata(messageText),
@@ -306,7 +314,7 @@ Check Event Subscriptions — make sure both `message.channels` and `message.gro
 
 ### Slack creates duplicate database entries
 
-Slack retries webhook delivery if it doesn't get a response within 3 seconds. If your Edge Function takes longer than that (embedding + metadata extraction can take 4-5 seconds), Slack sends the event again, and you get two rows. This is a known edge case. The captures are identical, so it doesn't affect search — but if it bothers you, you can delete the duplicate row in the Supabase Table Editor.
+Slack retries webhook delivery if it doesn't get a response within 3 seconds. The Edge Function includes built-in deduplication — it checks for existing rows with the same `slack_ts` before processing. If you're still seeing duplicates, make sure you're on the latest version of the code (see Step 3) and have redeployed.
 
 ### Function runs but nothing in the database
 


### PR DESCRIPTION
## Contribution Type

<!-- Check one -->
- [x] Integration (`/integrations`)

## What does this do?

Adds deduplication to the Slack Capture Edge Function. Slack retries webhook delivery if it doesn't get a response within 3 seconds, and the function (embedding + metadata extraction) typically takes 4-5 seconds, causing duplicate rows in the database. The fix checks if a row with the same `slack_ts` already exists before processing, and returns early if found. Also updates the troubleshooting section to reflect the fix.

## Requirements

None new. Uses the same services as the existing Slack Capture integration:
- Supabase (Edge Functions + database)
- OpenRouter API (for embeddings and metadata extraction)
- Slack workspace + app

## Checklist

- [x] I've read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] My contribution has a `README.md` with prerequisites, step-by-step instructions, and expected outcome
- [x] My `metadata.json` has all required fields
- [x] I tested this on my own Open Brain instance
- [x] No credentials, API keys, or secrets are included
