### PR TITLE
[docs] Add Open Brain capture guideline for memory sync

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,6 +30,7 @@ Every contribution lives in its own subfolder under the right category and must 
 - **No binary blobs** over 1MB. No `.exe`, `.dmg`, `.zip`, `.tar.gz`.
 - **No `DROP TABLE`, `DROP DATABASE`, `TRUNCATE`, or unqualified `DELETE FROM`** in SQL files.
 - **MCP servers must be remote (Supabase Edge Functions), not local.** Never use `claude_desktop_config.json`, `StdioServerTransport`, or local Node.js servers. All extensions deploy as Edge Functions and connect via Claude Desktop's custom connectors UI (Settings → Connectors → Add custom connector → paste URL). See `docs/01-getting-started.md` Step 7 for the pattern.
+- **When saving memories (dreaming/autodream), also capture each new memory to Open Brain via `mcp__open-brain__capture_thought`.** Every memory file write should have a corresponding brain capture so that memories are accessible across all connected AI clients.
 
 ## PR Standards
 


### PR DESCRIPTION
## Summary
- Adds a guard rail to `CLAUDE.md` instructing Claude Code to capture each memory/autodream save to Open Brain via `mcp__open-brain__capture_thought`
- Ensures local Claude Code memories are also written to the shared brain, making them accessible from all connected AI clients (ChatGPT, Claude Desktop, Codex) and across devices

## Test plan
- [ ] Verify the new bullet appears in the Guard Rails section of `CLAUDE.md`
- [ ] Confirm no other sections were modified
- [ ] Start a new Claude Code session in this repo, trigger autodream, and verify both a local memory file and a brain capture are created

🤖 Generated with [Claude Code](https://claude.com/claude-code)