### PR TITLE
[schemas] Reflections — structured reasoning traces linked to thoughts

### DIFF
--- a/schemas/reflections/README.md
+++ b/schemas/reflections/README.md
@@ -1,0 +1,119 @@
+# Reflections
+
+> Structured reasoning traces linked to thoughts — capture deliberation processes with trigger context, options considered, factors weighed, and conclusions reached.
+
+## What It Does
+
+Adds a `reflections` table and two RPCs (`upsert_reflection`, `match_reflections`) that let you capture and search structured reasoning traces. Each reflection links to a thought and records why a decision was made, what options were considered, what factors influenced the outcome, and what conclusion was reached.
+
+This is useful for AI agents that need to recall past reasoning, or for personal knowledge systems where understanding *why* a decision was made is as important as the decision itself.
+
+## Prerequisites
+
+- Working Open Brain setup ([guide](../../docs/01-getting-started.md))
+- The `thoughts` table must already exist
+- pgvector extension enabled (included in the migration)
+
+## Schema Overview
+
+### `reflections` table
+
+| Column | Type | Description |
+|--------|------|-------------|
+| `id` | `uuid` (PK) | Auto-generated via `gen_random_uuid()` |
+| `thought_id` | `uuid` (FK) | References `thoughts(id)`, set null on delete |
+| `trigger_context` | `text` | What prompted this reflection |
+| `options` | `jsonb` | Options or paths that were considered |
+| `factors` | `jsonb` | Factors, constraints, or trade-offs that were weighed |
+| `conclusion` | `text` | The decision or insight reached |
+| `confidence` | `real` | Confidence score from 0.0 to 1.0 |
+| `reflection_type` | `text` | One of: `decision`, `analysis`, `evaluation`, `planning`, `retrospective` |
+| `embedding` | `vector(1536)` | For semantic search over reflections |
+| `metadata` | `jsonb` | Arbitrary structured metadata |
+| `created_at` | `timestamptz` | Row creation timestamp |
+| `updated_at` | `timestamptz` | Auto-updated on row change |
+
+### `upsert_reflection` RPC
+
+Insert or update a reflection by ID. If `p_id` is provided and exists, updates the existing row (merging metadata). If `p_id` is null, inserts a new row.
+
+### `match_reflections` RPC
+
+Semantic similarity search over reflection embeddings. Returns reflections ordered by cosine similarity, with optional filtering by `reflection_type`.
+
+## Step-by-step instructions
+
+1. Open your Supabase Dashboard → SQL Editor → New query.
+
+2. Copy the contents of [`migration.sql`](./migration.sql) and execute it in the SQL Editor.
+
+3. Verify the table exists:
+
+   ```sql
+   SELECT table_name FROM information_schema.tables
+   WHERE table_schema = 'public' AND table_name = 'reflections';
+   ```
+
+4. Verify the RPCs exist:
+
+   ```sql
+   SELECT routine_name FROM information_schema.routines
+   WHERE routine_schema = 'public'
+     AND routine_name IN ('upsert_reflection', 'match_reflections');
+   ```
+
+5. Test with a sample reflection:
+
+   ```sql
+   -- Create a test reflection (replace the thought ID with one from your table)
+   SELECT upsert_reflection(
+     p_thought_id := '<your-thought-uuid>'::uuid,
+     p_trigger_context := 'Should we use PostgreSQL or DynamoDB for the analytics service?',
+     p_options := '[{"label": "PostgreSQL", "pros": "SQL, window functions"}, {"label": "DynamoDB", "pros": "Serverless, auto-scaling"}]'::jsonb,
+     p_factors := '[{"factor": "Team experience", "weight": 0.8}, {"factor": "Cost", "weight": 0.6}]'::jsonb,
+     p_conclusion := 'PostgreSQL — team already has operational experience and we need window functions.',
+     p_reflection_type := 'decision'
+   );
+
+   -- Verify it was created
+   SELECT id, thought_id, reflection_type, conclusion
+   FROM reflections
+   ORDER BY created_at DESC
+   LIMIT 1;
+   ```
+
+## Expected Outcome
+
+After running the migration:
+
+- One new table: `reflections`
+- Two new RPCs: `upsert_reflection` and `match_reflections`
+- Three indexes: on `thought_id`, `reflection_type`, and `embedding` (HNSW)
+- One trigger: auto-updates `updated_at` on row change
+- Row-level security enabled (service-role access only)
+- Grants applied for `service_role` on the table and both functions
+
+## Reflection Types
+
+| Type | When to Use |
+|------|------------|
+| `decision` | Choosing between concrete options (tech stack, approach, vendor) |
+| `analysis` | Breaking down a complex problem into factors |
+| `evaluation` | Assessing quality, risk, or fit of something |
+| `planning` | Mapping out future actions and selecting an approach |
+| `retrospective` | Looking back at an outcome and recording lessons |
+
+## Troubleshooting
+
+**Issue: `relation "public.thoughts" does not exist`**
+Solution: Complete your Open Brain setup first. The `thoughts` table must exist before applying this migration. Follow the [Getting Started guide](../../docs/01-getting-started.md).
+
+**Issue: `type "extensions.vector" does not exist`**
+Solution: The pgvector extension is not enabled. The migration includes `create extension if not exists vector with schema extensions;` which should handle this automatically. If it fails, enable it manually in your Supabase Dashboard → Database → Extensions → search for "vector" and enable it.
+
+**Issue: `upsert_reflection` returns null**
+Solution: The thought ID you passed might not exist in the `thoughts` table. The FK has `on delete set null`, so deleted thoughts won't cause errors, but the `thought_id` column will be null.
+
+## Works Well With
+
+- **Reflection MCP Tools** — MCP tool handlers for `capture_reflection`, `get_reflection`, and `search_reflections`. See `integrations/reflection-mcp/` (coming soon).

--- a/schemas/reflections/metadata.json
+++ b/schemas/reflections/metadata.json
@@ -1,0 +1,16 @@
+{
+  "name": "Reflections",
+  "description": "Structured reasoning traces linked to thoughts — capture deliberation processes with trigger context, options considered, factors weighed, and conclusions reached.",
+  "category": "schemas",
+  "author": {
+    "name": "Alan Shurafa",
+    "github": "alanshurafa"
+  },
+  "version": "1.0.0",
+  "requires": {
+    "open_brain": true
+  },
+  "tags": ["reasoning", "decisions", "analysis", "deliberation"],
+  "difficulty": "intermediate",
+  "estimated_time": "10 minutes"
+}

--- a/schemas/reflections/migration.sql
+++ b/schemas/reflections/migration.sql
@@ -1,0 +1,159 @@
+-- Reflections schema for Open Brain
+-- Structured reasoning traces linked to thoughts
+--
+-- Prerequisites: pgvector extension enabled, public.thoughts table exists
+
+-- Enable pgvector if not already enabled
+create extension if not exists vector with schema extensions;
+
+-- Reflections table
+create table if not exists public.reflections (
+  id              uuid primary key default gen_random_uuid(),
+  thought_id      uuid references public.thoughts(id) on delete set null,
+  trigger_context text,
+  options         jsonb default '[]'::jsonb,
+  factors         jsonb default '[]'::jsonb,
+  conclusion      text,
+  confidence      real check (confidence is null or (confidence >= 0 and confidence <= 1)),
+  reflection_type text check (reflection_type in (
+    'decision', 'analysis', 'evaluation', 'planning', 'retrospective'
+  )),
+  embedding       extensions.vector(1536),
+  metadata        jsonb default '{}'::jsonb,
+  created_at      timestamptz default now(),
+  updated_at      timestamptz default now()
+);
+
+-- Indexes
+create index if not exists reflections_thought_id_idx
+  on public.reflections (thought_id);
+
+create index if not exists reflections_reflection_type_idx
+  on public.reflections (reflection_type);
+
+create index if not exists reflections_embedding_idx
+  on public.reflections
+  using hnsw (embedding extensions.vector_cosine_ops)
+  with (m = 16, ef_construction = 64);
+
+-- Auto-update updated_at on row change
+create or replace function public.reflections_update_timestamp()
+returns trigger as $$
+begin
+  new.updated_at = now();
+  return new;
+end;
+$$ language plpgsql;
+
+create trigger reflections_set_updated_at
+  before update on public.reflections
+  for each row
+  execute function public.reflections_update_timestamp();
+
+-- RPC: upsert_reflection
+-- Insert or update a reflection by ID
+create or replace function public.upsert_reflection(
+  p_id              uuid default null,
+  p_thought_id      uuid default null,
+  p_trigger_context text default null,
+  p_options         jsonb default '[]'::jsonb,
+  p_factors         jsonb default '[]'::jsonb,
+  p_conclusion      text default null,
+  p_confidence      real default null,
+  p_reflection_type text default null,
+  p_embedding       extensions.vector default null,
+  p_metadata        jsonb default '{}'::jsonb
+)
+returns uuid
+language plpgsql
+as $$
+declare
+  v_id uuid;
+begin
+  if p_id is not null then
+    insert into public.reflections (
+      id, thought_id, trigger_context, options, factors,
+      conclusion, confidence, reflection_type, embedding, metadata
+    ) values (
+      p_id, p_thought_id, p_trigger_context, p_options, p_factors,
+      p_conclusion, p_confidence, p_reflection_type, p_embedding, p_metadata
+    )
+    on conflict (id) do update set
+      thought_id      = coalesce(excluded.thought_id, reflections.thought_id),
+      trigger_context = coalesce(excluded.trigger_context, reflections.trigger_context),
+      options         = excluded.options,
+      factors         = excluded.factors,
+      conclusion      = coalesce(excluded.conclusion, reflections.conclusion),
+      confidence      = excluded.confidence,
+      reflection_type = coalesce(excluded.reflection_type, reflections.reflection_type),
+      embedding       = coalesce(excluded.embedding, reflections.embedding),
+      metadata        = reflections.metadata || excluded.metadata
+    returning id into v_id;
+  else
+    insert into public.reflections (
+      thought_id, trigger_context, options, factors,
+      conclusion, confidence, reflection_type, embedding, metadata
+    ) values (
+      p_thought_id, p_trigger_context, p_options, p_factors,
+      p_conclusion, p_confidence, p_reflection_type, p_embedding, p_metadata
+    )
+    returning id into v_id;
+  end if;
+
+  return v_id;
+end;
+$$;
+
+-- RPC: match_reflections
+-- Semantic similarity search over reflection embeddings
+create or replace function public.match_reflections(
+  query_embedding   extensions.vector(1536),
+  match_threshold   float default 0.3,
+  match_count       int default 10,
+  p_reflection_type text default null
+)
+returns table (
+  id              uuid,
+  thought_id      uuid,
+  trigger_context text,
+  options         jsonb,
+  factors         jsonb,
+  conclusion      text,
+  confidence      real,
+  reflection_type text,
+  metadata        jsonb,
+  similarity      float,
+  created_at      timestamptz
+)
+language plpgsql
+as $$
+begin
+  return query
+  select
+    r.id,
+    r.thought_id,
+    r.trigger_context,
+    r.options,
+    r.factors,
+    r.conclusion,
+    r.confidence,
+    r.reflection_type,
+    r.metadata,
+    1 - (r.embedding <=> query_embedding) as similarity,
+    r.created_at
+  from public.reflections r
+  where r.embedding is not null
+    and 1 - (r.embedding <=> query_embedding) > match_threshold
+    and (p_reflection_type is null or r.reflection_type = p_reflection_type)
+  order by r.embedding <=> query_embedding
+  limit match_count;
+end;
+$$;
+
+-- Grants
+grant select, insert, update, delete on table public.reflections to service_role;
+grant execute on function public.upsert_reflection(uuid, uuid, text, jsonb, jsonb, text, real, text, extensions.vector, jsonb) to service_role;
+grant execute on function public.match_reflections(extensions.vector, float, int, text) to service_role;
+
+-- RLS: enable row-level security (no policies = service-role only by default)
+alter table public.reflections enable row level security;

--- a/schemas/reflections/migration.sql
+++ b/schemas/reflections/migration.sql
@@ -45,6 +45,7 @@ begin
 end;
 $$ language plpgsql;
 
+drop trigger if exists reflections_set_updated_at on public.reflections;
 create trigger reflections_set_updated_at
   before update on public.reflections
   for each row
@@ -81,10 +82,10 @@ begin
     on conflict (id) do update set
       thought_id      = coalesce(excluded.thought_id, reflections.thought_id),
       trigger_context = coalesce(excluded.trigger_context, reflections.trigger_context),
-      options         = excluded.options,
-      factors         = excluded.factors,
+      options         = case when excluded.options = '[]'::jsonb then reflections.options else excluded.options end,
+      factors         = case when excluded.factors = '[]'::jsonb then reflections.factors else excluded.factors end,
       conclusion      = coalesce(excluded.conclusion, reflections.conclusion),
-      confidence      = excluded.confidence,
+      confidence      = coalesce(excluded.confidence, reflections.confidence),
       reflection_type = coalesce(excluded.reflection_type, reflections.reflection_type),
       embedding       = coalesce(excluded.embedding, reflections.embedding),
       metadata        = reflections.metadata || excluded.metadata


### PR DESCRIPTION
## Summary

- Adds `reflections` table with uuid PK, FK to `thoughts(id)`, and 5 reflection types (decision, analysis, evaluation, planning, retrospective)
- `upsert_reflection` RPC for insert-or-update by ID with metadata merging
- `match_reflections` RPC for semantic similarity search over reflection embeddings (HNSW index)
- Service-role grants, RLS enabled, auto-updated `updated_at` trigger

## Motivation

AI agents and personal knowledge systems benefit from recording not just decisions but the reasoning behind them. Reflections capture trigger context, options considered, factors weighed, and conclusions — making past deliberation searchable and reusable.

## Test plan

- [ ] Run `migration.sql` in Supabase SQL Editor
- [ ] Verify `reflections` table exists via `information_schema.tables`
- [ ] Verify both RPCs exist via `information_schema.routines`
- [ ] Insert a test reflection via `upsert_reflection` and verify it returns a uuid
- [ ] Update an existing reflection by passing `p_id` and verify metadata merge
- [ ] Verify `match_reflections` returns results when embedding is provided

🤖 Generated with [Claude Code](https://claude.com/claude-code)