### PR TITLE
[integrations] Reflection MCP tools — capture, get, and search reasoning traces

### DIFF
--- a/integrations/reflection-mcp/README.md
+++ b/integrations/reflection-mcp/README.md
@@ -1,0 +1,122 @@
+# Reflection MCP Tools
+
+> MCP tool handlers for capturing and searching structured reasoning traces.
+
+## What It Does
+
+Adds three MCP tool handlers to an Open Brain MCP server for working with the `reflections` table. These tools let AI agents capture deliberation processes and search past reasoning by semantic similarity.
+
+## Prerequisites
+
+- Working Open Brain MCP server
+- **Reflections schema applied** — run `schemas/reflections/migration.sql` before using these tools
+- OpenAI API key (or compatible embedding provider) for generating embeddings
+
+## Tools
+
+### 1. `capture_reflection`
+
+Capture a new reasoning trace linked to a thought.
+
+**Parameters:**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `thought_id` | `string` (uuid) | No | ID of the related thought |
+| `trigger_context` | `string` | Yes | What prompted this reflection |
+| `options` | `array` | No | Options or paths considered |
+| `factors` | `array` | No | Factors, constraints, or trade-offs weighed |
+| `conclusion` | `string` | Yes | The decision or insight reached |
+| `confidence` | `number` | No | Confidence score from 0.0 to 1.0 |
+| `reflection_type` | `string` | No | One of: `decision`, `analysis`, `evaluation`, `planning`, `retrospective` |
+| `metadata` | `object` | No | Arbitrary structured metadata |
+
+**Behavior:**
+- Generates an embedding from the concatenation of `trigger_context` and `conclusion`.
+- Calls `upsert_reflection` RPC to insert the row.
+- Returns the new reflection ID.
+
+### 2. `get_reflection`
+
+Fetch a single reflection by its ID.
+
+**Parameters:**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `id` | `string` (uuid) | Yes | Reflection ID |
+
+**Behavior:**
+- Queries `public.reflections` by primary key.
+- Returns the full reflection record including all fields and linked `thought_id`.
+
+### 3. `search_reflections`
+
+Semantic search over past reasoning traces.
+
+**Parameters:**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `query` | `string` | Yes | Natural language search query |
+| `reflection_type` | `string` | No | Filter by type: `decision`, `analysis`, `evaluation`, `planning`, `retrospective` |
+| `limit` | `number` | No | Max results (default: 8, max: 50) |
+| `min_similarity` | `number` | No | Minimum cosine similarity threshold (default: 0.3) |
+
+**Behavior:**
+- Generates an embedding from the query string.
+- Calls `match_reflections` RPC with the embedding and filters.
+- Returns matching reflections ordered by similarity.
+
+## Integration Pattern
+
+These tool handlers are designed to be registered alongside the existing Open Brain MCP tools. Add them to your MCP server's tool list and route incoming tool calls to the appropriate handler.
+
+```typescript
+import { captureReflection, getReflection, searchReflections } from "./reflection-tools.ts";
+
+// In your MCP server tool registration:
+server.registerTool("capture_reflection", {
+  // ... schema definition
+}, async (params) => {
+  return captureReflection(params, supabase, openaiApiKey);
+});
+```
+
+Each handler:
+1. Validates input parameters
+2. Generates embeddings via your configured provider (for `capture_reflection` and `search_reflections`)
+3. Calls the corresponding Supabase RPC or query
+4. Returns structured JSON with `{ success, data?, error? }`
+
+## When to Use Reflections
+
+Reflections are most valuable when an agent or user faces a non-trivial choice. Good candidates:
+
+- **Decisions** — "Should we use PostgreSQL or DynamoDB?" with trade-offs documented
+- **Analyses** — Breaking down a complex problem into factors and evaluating each
+- **Evaluations** — Assessing quality, risk, or fit of a candidate or approach
+- **Planning** — Mapping out options for a future action and selecting an approach
+- **Retrospectives** — Looking back at an outcome and recording what was learned
+
+Reflections are not meant for routine captures. Use `capture_thought` for simple observations and facts; use `capture_reflection` when there is genuine deliberation worth preserving.
+
+## Expected Outcome
+
+After integrating these tools:
+
+- `capture_reflection` creates reasoning traces that are semantically searchable
+- `search_reflections` finds past reasoning by meaning, not just keywords
+- `get_reflection` retrieves full deliberation detail for a specific reflection
+- AI agents can recall why past decisions were made, improving consistency
+
+## Troubleshooting
+
+**Issue: `upsert_reflection failed: function public.upsert_reflection does not exist`**
+Solution: The reflections schema has not been applied. Run `schemas/reflections/migration.sql` in your Supabase SQL Editor first.
+
+**Issue: `Failed to generate query embedding`**
+Solution: Check that your OpenAI API key (or compatible provider key) is configured and has available credits.
+
+**Issue: `search_reflections` returns no results**
+Solution: Reflections need embeddings to be searchable. Ensure `capture_reflection` successfully generates an embedding (requires a working embedding provider). Check the `embedding` column: `SELECT id, embedding IS NOT NULL AS has_embedding FROM reflections;`

--- a/integrations/reflection-mcp/metadata.json
+++ b/integrations/reflection-mcp/metadata.json
@@ -1,0 +1,18 @@
+{
+  "name": "Reflection MCP Tools",
+  "description": "MCP tool handlers for capturing and searching structured reasoning traces. Requires the reflections schema.",
+  "category": "integrations",
+  "author": {
+    "name": "Alan Shurafa",
+    "github": "alanshurafa"
+  },
+  "version": "1.0.0",
+  "requires": {
+    "open_brain": true,
+    "services": ["OpenAI API or compatible embedding provider"],
+    "tools": ["Deno or Node.js 18+"]
+  },
+  "tags": ["mcp", "reasoning", "reflections", "tools"],
+  "difficulty": "intermediate",
+  "estimated_time": "15 minutes"
+}

--- a/integrations/reflection-mcp/reflection-tools.ts
+++ b/integrations/reflection-mcp/reflection-tools.ts
@@ -1,0 +1,213 @@
+/**
+ * Reflection MCP tool handlers for Open Brain.
+ *
+ * Three tools for working with the reflections schema:
+ *   1. capture_reflection  — Create a structured reasoning trace
+ *   2. get_reflection       — Fetch a reflection by ID
+ *   3. search_reflections   — Semantic search over past reasoning
+ *
+ * Prerequisites:
+ *   - reflections schema applied (schemas/reflections/migration.sql)
+ *   - Supabase client configured with service_role key
+ *   - Embedding function available (OpenAI text-embedding-3-small or compatible)
+ *
+ * Integration: Register these handlers with your MCP server's tool list.
+ * Each handler accepts validated parameters and returns structured JSON.
+ */
+
+import { createClient, SupabaseClient } from "npm:@supabase/supabase-js@2";
+
+// ── Types ───────────────────────────────────────────────────────────────────
+
+type ReflectionType =
+  | "decision"
+  | "analysis"
+  | "evaluation"
+  | "planning"
+  | "retrospective";
+
+interface CaptureReflectionParams {
+  thought_id?: string;
+  trigger_context: string;
+  options?: unknown[];
+  factors?: unknown[];
+  conclusion: string;
+  confidence?: number;
+  reflection_type?: ReflectionType;
+  metadata?: Record<string, unknown>;
+}
+
+interface SearchReflectionsParams {
+  query: string;
+  reflection_type?: ReflectionType;
+  limit?: number;
+  min_similarity?: number;
+}
+
+interface GetReflectionParams {
+  id: string;
+}
+
+// ── Embedding (adapt to your provider) ──────────────────────────────────────
+
+/**
+ * Generate a vector embedding for the given text.
+ * Replace this with your preferred embedding provider.
+ */
+async function embedText(
+  text: string,
+  apiKey: string,
+): Promise<number[] | null> {
+  const truncated = text.slice(0, 8000);
+  try {
+    const res = await fetch("https://api.openai.com/v1/embeddings", {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${apiKey}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        model: "text-embedding-3-small",
+        input: truncated,
+      }),
+    });
+    if (!res.ok) return null;
+    const json = await res.json();
+    return json.data?.[0]?.embedding ?? null;
+  } catch {
+    return null;
+  }
+}
+
+// ── Tool Handlers ───────────────────────────────────────────────────────────
+
+/**
+ * capture_reflection — Create a structured reasoning trace linked to a thought.
+ */
+export async function captureReflection(
+  params: CaptureReflectionParams,
+  supabase: SupabaseClient,
+  openaiApiKey: string,
+): Promise<{ success: boolean; data?: unknown; error?: string }> {
+  const {
+    thought_id,
+    trigger_context,
+    options = [],
+    factors = [],
+    conclusion,
+    confidence,
+    reflection_type = "decision",
+    metadata = {},
+  } = params;
+
+  if (!trigger_context?.trim()) {
+    return { success: false, error: "trigger_context is required" };
+  }
+  if (!conclusion?.trim()) {
+    return { success: false, error: "conclusion is required" };
+  }
+
+  // Generate embedding from trigger + conclusion for semantic search
+  const embeddingText = `${trigger_context} ${conclusion}`.slice(0, 8000);
+  const embedding = await embedText(embeddingText, openaiApiKey);
+
+  const { data, error } = await supabase.rpc("upsert_reflection", {
+    p_thought_id: thought_id ?? null,
+    p_trigger_context: trigger_context.trim(),
+    p_options: options,
+    p_factors: factors,
+    p_conclusion: conclusion.trim(),
+    p_confidence: confidence ?? null,
+    p_reflection_type: reflection_type,
+    p_embedding: embedding,
+    p_metadata: metadata,
+  });
+
+  if (error) {
+    return { success: false, error: `upsert_reflection failed: ${error.message}` };
+  }
+
+  return {
+    success: true,
+    data: {
+      reflection_id: data,
+      thought_id,
+      reflection_type,
+    },
+  };
+}
+
+/**
+ * get_reflection — Fetch a single reflection by its ID.
+ */
+export async function getReflection(
+  params: GetReflectionParams,
+  supabase: SupabaseClient,
+): Promise<{ success: boolean; data?: unknown; error?: string }> {
+  const { id } = params;
+
+  if (!id?.trim()) {
+    return { success: false, error: "id is required" };
+  }
+
+  const { data, error } = await supabase
+    .from("reflections")
+    .select(
+      "id, thought_id, trigger_context, options, factors, conclusion, confidence, reflection_type, metadata, created_at, updated_at",
+    )
+    .eq("id", id)
+    .maybeSingle();
+
+  if (error) {
+    return { success: false, error: `get_reflection query failed: ${error.message}` };
+  }
+  if (!data) {
+    return { success: false, error: `Reflection ${id} not found` };
+  }
+
+  return { success: true, data };
+}
+
+/**
+ * search_reflections — Semantic search over past reasoning traces.
+ */
+export async function searchReflections(
+  params: SearchReflectionsParams,
+  supabase: SupabaseClient,
+  openaiApiKey: string,
+): Promise<{ success: boolean; data?: unknown; error?: string }> {
+  const {
+    query,
+    reflection_type,
+    limit = 8,
+    min_similarity = 0.3,
+  } = params;
+
+  if (!query || query.length < 2) {
+    return { success: false, error: "query must be at least 2 characters" };
+  }
+
+  const queryEmbedding = await embedText(query, openaiApiKey);
+  if (!queryEmbedding) {
+    return { success: false, error: "Failed to generate query embedding" };
+  }
+
+  const { data, error } = await supabase.rpc("match_reflections", {
+    query_embedding: queryEmbedding,
+    match_threshold: min_similarity,
+    match_count: Math.min(limit, 50),
+    p_reflection_type: reflection_type ?? null,
+  });
+
+  if (error) {
+    return { success: false, error: `match_reflections failed: ${error.message}` };
+  }
+
+  return {
+    success: true,
+    data: {
+      results: data ?? [],
+      count: (data ?? []).length,
+    },
+  };
+}


### PR DESCRIPTION
## Summary

- Three MCP tool handlers: `capture_reflection`, `get_reflection`, `search_reflections`
- Structured deliberation capture with trigger context, options, factors, and conclusion
- Semantic search over past reasoning via HNSW embedding index
- Returns structured JSON with success/error handling

## Dependencies

**Requires `schemas/reflections/` to be applied first** — see PR #117.

## Test plan

- [ ] Apply reflections schema from `schemas/reflections/migration.sql`
- [ ] Register tool handlers in an MCP server
- [ ] Call `capture_reflection` with trigger_context + conclusion → verify reflection created
- [ ] Call `get_reflection` with the returned ID → verify full record returned
- [ ] Call `search_reflections` with a related query → verify semantic match

🤖 Generated with [Claude Code](https://claude.com/claude-code)