### PR TITLE
[core] Make capture_thought compatible with content-fingerprint-dedup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,12 @@ supabase/
 
 # Recipe credentials & runtime state
 .env
+.env.local
+.env.*.local
 credentials.json
 token.json
 gmail-sync-log.json
 sync-log.json
+
+# Deno lock files
+deno.lock

--- a/dashboards/open-brain-dashboard/.env.example
+++ b/dashboards/open-brain-dashboard/.env.example
@@ -1,0 +1,8 @@
+# Copy this file to .env.local and fill in your values.
+# Tip: symlink from the repo root so all dashboards share one file:
+#   ln -s ../../.env.local dashboards/open-brain-dashboard/.env.local
+
+MCP_URL=https://your-project.supabase.co/functions/v1/open-brain-mcp
+MCP_KEY=your-mcp-access-key
+PUBLIC_SUPABASE_URL=https://your-project.supabase.co
+PUBLIC_SUPABASE_ANON_KEY=your-anon-key

--- a/extensions/family-calendar/.env.example
+++ b/extensions/family-calendar/.env.example
@@ -1,0 +1,6 @@
+# These are set automatically by Supabase when you deploy an Edge Function.
+# You only need to set MCP_ACCESS_KEY manually.
+
+SUPABASE_URL=https://your-project.supabase.co
+SUPABASE_SERVICE_ROLE_KEY=your-service-role-key
+MCP_ACCESS_KEY=your-mcp-access-key

--- a/extensions/home-maintenance/.env.example
+++ b/extensions/home-maintenance/.env.example
@@ -1,0 +1,6 @@
+# These are set automatically by Supabase when you deploy an Edge Function.
+# You only need to set MCP_ACCESS_KEY manually.
+
+SUPABASE_URL=https://your-project.supabase.co
+SUPABASE_SERVICE_ROLE_KEY=your-service-role-key
+MCP_ACCESS_KEY=your-mcp-access-key

--- a/extensions/household-knowledge/.env.example
+++ b/extensions/household-knowledge/.env.example
@@ -1,0 +1,6 @@
+# These are set automatically by Supabase when you deploy an Edge Function.
+# You only need to set MCP_ACCESS_KEY manually.
+
+SUPABASE_URL=https://your-project.supabase.co
+SUPABASE_SERVICE_ROLE_KEY=your-service-role-key
+MCP_ACCESS_KEY=your-mcp-access-key

--- a/extensions/job-hunt/.env.example
+++ b/extensions/job-hunt/.env.example
@@ -1,0 +1,6 @@
+# These are set automatically by Supabase when you deploy an Edge Function.
+# You only need to set MCP_ACCESS_KEY manually.
+
+SUPABASE_URL=https://your-project.supabase.co
+SUPABASE_SERVICE_ROLE_KEY=your-service-role-key
+MCP_ACCESS_KEY=your-mcp-access-key

--- a/extensions/meal-planning/.env.example
+++ b/extensions/meal-planning/.env.example
@@ -1,0 +1,6 @@
+# These are set automatically by Supabase when you deploy an Edge Function.
+# You only need to set MCP_ACCESS_KEY manually.
+
+SUPABASE_URL=https://your-project.supabase.co
+SUPABASE_SERVICE_ROLE_KEY=your-service-role-key
+MCP_ACCESS_KEY=your-mcp-access-key

--- a/extensions/professional-crm/.env.example
+++ b/extensions/professional-crm/.env.example
@@ -1,0 +1,6 @@
+# These are set automatically by Supabase when you deploy an Edge Function.
+# You only need to set MCP_ACCESS_KEY manually.
+
+SUPABASE_URL=https://your-project.supabase.co
+SUPABASE_SERVICE_ROLE_KEY=your-service-role-key
+MCP_ACCESS_KEY=your-mcp-access-key

--- a/server/index.ts
+++ b/server/index.ts
@@ -316,17 +316,53 @@ server.registerTool(
         extractMetadata(content),
       ]);
 
-      const { error } = await supabase.from("thoughts").insert({
-        content,
-        embedding,
-        metadata: { ...metadata, source: "mcp" },
+      // Try to use the upsert_thought RPC if the user has installed the content-fingerprint-dedup primitive
+      const { data: upsertResult, error: upsertError } = await supabase.rpc("upsert_thought", {
+        p_content: content,
+        p_payload: { metadata: { ...metadata, source: "mcp" } },
       });
 
-      if (error) {
+      let thoughtId: string;
+
+      // If the RPC doesn't exist (PGRST202), fallback to standard insert
+      if (upsertError && upsertError.code === "PGRST202") {
+        const { data: insertData, error: insertError } = await supabase
+          .from("thoughts")
+          .insert({
+            content,
+            embedding,
+            metadata: { ...metadata, source: "mcp" },
+          })
+          .select("id")
+          .single();
+
+        if (insertError) {
+          return {
+            content: [{ type: "text" as const, text: `Failed to capture: ${insertError.message}` }],
+            isError: true,
+          };
+        }
+        thoughtId = insertData.id;
+      } else if (upsertError) {
+        // Some other error occurred with the RPC
         return {
-          content: [{ type: "text" as const, text: `Failed to capture: ${error.message}` }],
+          content: [{ type: "text" as const, text: `Failed to capture: ${upsertError.message}` }],
           isError: true,
         };
+      } else {
+        // RPC succeeded, now we need to update the embedding
+        thoughtId = upsertResult?.id;
+        const { error: embError } = await supabase
+          .from("thoughts")
+          .update({ embedding })
+          .eq("id", thoughtId);
+
+        if (embError) {
+          return {
+            content: [{ type: "text" as const, text: `Failed to save embedding: ${embError.message}` }],
+            isError: true,
+          };
+        }
       }
 
       const meta = metadata as Record<string, unknown>;


### PR DESCRIPTION
## Summary
- Updates the core MCP server (`server/index.ts`) to attempt using the `upsert_thought` RPC if the user has installed the `content-fingerprint-dedup` primitive.
- If the RPC doesn't exist (returns `PGRST202`), it gracefully falls back to the standard `insert`.
- This ensures that users who install the deduplication primitive don't break their core MCP server's `capture_thought` tool due to the new unique constraint.

## Test plan
- [x] Verified that `capture_thought` successfully calls `upsert_thought` when the primitive is installed.
- [x] Verified that the embedding is correctly updated on the returned row.
- [ ] (Needs verification) Ensure that the fallback works correctly on a fresh instance without the primitive installed.

Made with [Cursor](https://cursor.com)