### PR TITLE
[primitives] Fix Cursor MCP connection docs

### DIFF
--- a/primitives/remote-mcp/README.md
+++ b/primitives/remote-mcp/README.md
@@ -3,7 +3,7 @@
 A guide to connecting your Open Brain extensions to any AI client. Deploy once as a Supabase Edge Function, connect from anywhere.
 
 **Jump to your client:**
-[Claude Desktop](#claude-desktop) | [ChatGPT](#chatgpt) | [Claude Code](#claude-code) | [Cursor / Windsurf / VS Code / Zed](#other-clients-cursor-windsurf-vs-code-zed) | [Troubleshooting](#troubleshooting)
+[Claude Desktop](#claude-desktop) | [ChatGPT](#chatgpt) | [Claude Code](#claude-code) | [Cursor](#cursor) | [Other Clients](#other-clients-windsurf-vs-code-zed) | [Troubleshooting](#troubleshooting)
 
 ## What You Need
 
@@ -55,13 +55,31 @@ claude mcp add --transport http extension-name \
 
 Replace `extension-name` with a short name (e.g., `household-knowledge`, `family-calendar`), the URL with your MCP Server URL (without the `?key=` part), and `your-access-key` with your MCP Access Key.
 
-## Other Clients (Cursor, Windsurf, VS Code, Zed)
+## Cursor
+
+Cursor supports remote MCP servers natively. Add this to your `~/.cursor/mcp.json`:
+
+```json
+{
+  "mcpServers": {
+    "extension-name": {
+      "url": "https://YOUR_PROJECT_REF.supabase.co/functions/v1/extension-mcp?key=your-access-key"
+    }
+  }
+}
+```
+
+Restart Cursor and the extension's tools should appear in Settings → Features → MCP.
+
+> Do **not** use `mcp-remote` for Cursor. Newer versions of `mcp-remote` attempt OAuth client registration, which fails against Open Brain's simple key-based auth. Cursor's native `url` field works directly.
+
+## Other Clients (Windsurf, VS Code, Zed)
 
 Every MCP client handles remote servers slightly differently. Your extension accepts the access key two ways — pick whichever your client supports:
 
 **Option A: URL with key (easiest).** If your client has a field for a remote MCP server URL, paste the full MCP Connection URL including `?key=your-access-key`. This works for any client that supports remote MCP without requiring headers.
 
-**Option B: mcp-remote bridge.** If your client only supports local stdio servers (configured via a JSON config file), use `mcp-remote` to bridge to the remote server. This requires Node.js installed.
+**Option B: mcp-remote bridge (if your client only supports stdio).** Use `mcp-remote` to bridge to the remote server. This requires Node.js installed. Pass the access key via the URL query parameter (not a header) to avoid OAuth discovery issues with newer versions of `mcp-remote`:
 
 ```json
 {
@@ -69,20 +87,16 @@ Every MCP client handles remote servers slightly differently. Your extension acc
     "extension-name": {
       "command": "npx",
       "args": [
+        "-y",
         "mcp-remote",
-        "https://YOUR_PROJECT_REF.supabase.co/functions/v1/extension-mcp",
-        "--header",
-        "x-access-key:${ACCESS_KEY}"
-      ],
-      "env": {
-        "ACCESS_KEY": "your-access-key"
-      }
+        "https://YOUR_PROJECT_REF.supabase.co/functions/v1/extension-mcp?key=your-access-key"
+      ]
     }
   }
 }
 ```
 
-> Note: no space after the colon in `x-access-key:${ACCESS_KEY}`. Some clients have a bug where spaces inside args get mangled.
+> Older examples pass the access key via `--header`. This breaks with `mcp-remote@latest` because it now attempts OAuth client registration before sending custom headers. Pass the key via the `?key=` query parameter instead.
 
 ## Troubleshooting
 
@@ -99,7 +113,8 @@ Every MCP client handles remote servers slightly differently. Your extension acc
 **Getting 401 errors**
 - The access key doesn't match what's stored in Supabase secrets
 - Double-check that the `?key=` value in your URL matches your MCP Access Key exactly
-- If using the header approach (Claude Code or mcp-remote), the header must be `x-access-key` (lowercase, with the dash)
+- If using the header approach (Claude Code), the core Open Brain server uses `x-brain-key` while extension servers use `x-access-key`
+- Prefer the `?key=` query parameter approach to avoid header name confusion
 
 **Tools work but responses are slow**
 - First request on a cold Edge Function takes a few seconds to warm up

--- a/primitives/remote-mcp/README.md
+++ b/primitives/remote-mcp/README.md
@@ -5,10 +5,12 @@ A guide to connecting your Open Brain extensions to any AI client. Deploy once a
 **Jump to your client:**
 [Claude Desktop](#claude-desktop) | [ChatGPT](#chatgpt) | [Claude Code](#claude-code) | [Cursor](#cursor) | [Other Clients](#other-clients-windsurf-vs-code-zed) | [Troubleshooting](#troubleshooting)
 
-## What You Need
+## Prerequisites
 
 - Your **MCP Connection URL** (from the extension's credential tracker — looks like `https://YOUR_REF.supabase.co/functions/v1/extension-mcp?key=your-access-key`)
 - The AI client you want to connect
+
+## Step-by-step Instructions
 
 ## Claude Desktop
 
@@ -120,6 +122,10 @@ Every MCP client handles remote servers slightly differently. Your extension acc
 - First request on a cold Edge Function takes a few seconds to warm up
 - Subsequent calls are faster
 - Check your Supabase project region — pick the one closest to you
+
+## Expected Outcome
+
+After following the steps for your client, your Open Brain extension should appear as a connected MCP server and its tools should be available inside that AI client without needing a local MCP bridge.
 
 ## Extensions That Use This
 

--- a/primitives/troubleshooting/README.md
+++ b/primitives/troubleshooting/README.md
@@ -13,7 +13,8 @@ Solutions for issues that come up across any Open Brain extension. If your probl
 **"Getting 401 Unauthorized"**
 - The access key doesn't match what's stored in Supabase secrets
 - Double-check that the `?key=` value in your Connection URL matches your MCP Access Key exactly
-- If using header-based auth (Claude Code or mcp-remote), the header must be `x-access-key` (lowercase, with the dash)
+- If using header-based auth (Claude Code), the core Open Brain server expects `x-brain-key` while extension servers expect `x-access-key` — prefer using the `?key=` query parameter to avoid confusion
+- Do not use `mcp-remote` with `--header` for Cursor — use Cursor's native `url` field instead (see [Remote MCP Connection](../remote-mcp/))
 - Verify the secret is set: `supabase secrets list` should show `MCP_ACCESS_KEY`
 - Try regenerating the key: `openssl rand -hex 32`, then `supabase secrets set MCP_ACCESS_KEY=new-key` and update your Connection URL
 


### PR DESCRIPTION
## Summary
- Adds a dedicated **Cursor** section (7.5) to the getting-started guide and remote-mcp primitive with native `url` config — no `mcp-remote` needed.
- Updates the `mcp-remote` fallback examples (for clients that still need stdio bridging) to pass the access key via `?key=` query parameter instead of `--header`, avoiding OAuth client registration failures with `mcp-remote@latest`.
- Clarifies that the core Open Brain server uses `x-brain-key` while extension servers use `x-access-key` in the troubleshooting guides.

## Why
`mcp-remote@latest` now defaults to `http-first` transport, which attempts OAuth client registration before forwarding custom headers. Open Brain uses simple key-based auth (not OAuth), so this registration attempt fails with a `ServerError`. Since Cursor natively supports remote MCP servers via the `url` field (like Sentry's config), `mcp-remote` is unnecessary and actively harmful.

## Files changed
- `docs/01-getting-started.md` — Split "Other Clients" into dedicated Cursor (7.5) and Other Clients (7.6) sections
- `primitives/remote-mcp/README.md` — Added Cursor section, updated mcp-remote examples, fixed 401 troubleshooting
- `primitives/troubleshooting/README.md` — Clarified header names and added Cursor-specific guidance

## Test plan
- [x] Verified Cursor connects successfully with native `url` field config (`~/.cursor/mcp.json`)
- [x] Verified `mcp-remote` with `?key=` query parameter works for stdio-only clients
- [x] Confirmed `mcp-remote` with `--header` fails with OAuth `ServerError` on `mcp-remote@latest`


Made with [Cursor](https://cursor.com)