### PR TITLE
[recipes] Daily digest via Claude Code scheduled tasks

### DIFF
--- a/recipes/daily-digest/README.md
+++ b/recipes/daily-digest/README.md
@@ -1,21 +1,122 @@
 # Daily Digest
 
-> Automated daily summary of your recent thoughts, delivered via email or Slack.
+> Automated daily summary of your recent thoughts, delivered to your inbox.
 
 ## What It Does
 
-A Supabase Edge Function that runs on a cron schedule, queries your most recent thoughts, groups them by topic, and sends you a formatted summary. You wake up to a digest of everything your brain captured yesterday — themes, connections, and highlights.
+Queries your most recent Open Brain thoughts, groups them by type and topic, and delivers a formatted summary. You wake up to a digest of everything your brain captured yesterday.
 
-## Prerequisites
+There are two approaches — pick the one that fits your setup:
+
+| Approach | Infrastructure | Difficulty | Auto-send? |
+| -------- | -------------- | ---------- | ---------- |
+| **Claude Code Scheduled Task** (below) | None — uses MCP tools you already have | Beginner | Draft only (one-tap send) |
+| **Supabase Edge Function** (planned) | Edge Function + pg_cron + email service | Intermediate | Full auto-send |
+
+---
+
+## Approach A: Claude Code Scheduled Task
+
+Zero-infrastructure variant. If you already run Claude Code (or Claude Desktop's Code mode) with Open Brain MCP and Gmail MCP connected, this works today with no deployment.
+
+### Prerequisites
 
 - Working Open Brain setup ([guide](../../docs/01-getting-started.md))
+- Claude Code or Claude Desktop (Code mode) with:
+  - Open Brain MCP connected
+  - Gmail MCP connected (for email delivery)
+
+### How It Works
+
+Claude Code has built-in scheduled tasks (visible in Claude Desktop under the **Scheduled** tab). You install a skill file — a prompt template — that tells Claude what to do on each run:
+
+1. Query Open Brain for thoughts from the last 24 hours
+2. Organize them into a scannable digest (grouped by type, with topic/people tags)
+3. Create a Gmail draft addressed to you
+
+Claude *is* the LLM — no OpenRouter key needed.
+
+### Steps
+
+![Step 1](https://img.shields.io/badge/Step_1-Install_the_Skill_File-1E88E5?style=for-the-badge)
+
+Copy the skill template into your Claude scheduled tasks directory:
+
+```bash
+mkdir -p ~/.claude/scheduled-tasks/daily-digest
+cp recipes/daily-digest/daily-digest-skill.md ~/.claude/scheduled-tasks/daily-digest/SKILL.md
+```
+
+Then open the file and replace `YOUR_EMAIL@example.com` with your actual email address.
+
+> [!IMPORTANT]
+> The skill file is a local prompt — it never gets committed to any repo. Your email stays on your machine.
+
+---
+
+![Step 2](https://img.shields.io/badge/Step_2-Create_the_Scheduled_Task-1E88E5?style=for-the-badge)
+
+In any Claude Code session (or Claude Desktop Code mode), run:
+
+```
+/schedule
+```
+
+Or create it directly by telling Claude:
+
+> "Create a scheduled task called daily-digest that runs every day at 7am using the skill file at ~/.claude/scheduled-tasks/daily-digest/SKILL.md"
+
+The task will appear in Claude Desktop's **Scheduled** tab.
+
+---
+
+![Step 3](https://img.shields.io/badge/Step_3-Test_Run_and_Approve_Tools-1E88E5?style=for-the-badge)
+
+Click **"Run now"** from the Scheduled tab to do an initial test. On the first run, Claude will ask for permission to use the Open Brain and Gmail MCP tools. Approve them once — future runs will remember.
+
+> [!TIP]
+> If you haven't captured any thoughts recently, the digest will say so. Capture a few test thoughts first via `capture_thought` to see the full format.
+
+---
+
+### Expected Outcome
+
+Every morning, a Gmail draft appears in your inbox with:
+
+- A count of thoughts captured in the last 24 hours
+- Breakdown by type (observations, tasks, ideas, references, person notes)
+- Each thought's content (truncated), source, and topic/people tags
+- A summary header with top themes
+
+You review the draft and hit send (or just read it).
+
+### Troubleshooting
+
+**Issue: Scheduled task never fires**
+Solution: Claude Code must be running (or Claude Desktop must be open) at the scheduled time. If your machine was asleep, the task fires on next launch.
+
+**Issue: Task pauses waiting for permissions**
+Solution: Run it manually once via the Scheduled tab and approve the MCP tool permissions. They persist for future runs.
+
+**Issue: "No thoughts found" every day**
+Solution: Check that your Open Brain MCP is connected and has recent data. Run `list_thoughts` manually in a Claude Code session to verify.
+
+**Issue: Gmail draft not appearing**
+Solution: Verify your Gmail MCP connector is working. Try `gmail_create_draft` manually in a Claude session to test.
+
+---
+
+## Approach B: Supabase Edge Function (Planned)
+
+A fully self-contained approach using a Supabase Edge Function, pg_cron trigger, and an email service (Resend or SendGrid) for true automated delivery without Claude running. This approach is not yet implemented — contributions welcome.
+
+### Prerequisites (planned)
+
 - Supabase CLI installed (`npm i -g supabase`)
 - OpenRouter API key (for generating the summary)
-- One of: email sending service (Resend, SendGrid free tier) OR existing Slack webhook
+- Email service: Resend or SendGrid (free tier)
 
-## Credential Tracker
-
-Copy this block into a text editor and fill it in as you go.
+### Credential Tracker (for future Edge Function approach)
 
 ```text
 DAILY DIGEST -- CREDENTIAL TRACKER
@@ -26,46 +127,10 @@ FROM YOUR OPEN BRAIN SETUP
   Supabase Secret key:   ____________
   OpenRouter API key:    ____________
 
-DELIVERY METHOD (choose one)
-  [ ] Email service
-      Service name (Resend/SendGrid): ____________
-      API key:                         ____________
-      Sender email:                    ____________
-
-  [ ] Slack
-      Webhook URL:                     https://hooks.slack.com/services/____________
+DELIVERY METHOD
+  Email service (Resend/SendGrid): ____________
+  API key:                         ____________
+  Sender email:                    ____________
 
 --------------------------------------
 ```
-
-## Steps
-
-<!-- TODO: Fill in step-by-step instructions -->
-
-1. Clone this folder to your Supabase project's `supabase/functions/` directory
-2. Configure your environment variables (delivery method, API keys)
-3. Deploy the edge function: `supabase functions deploy daily-digest`
-4. Set up the cron trigger in Supabase (Database → Extensions → pg_cron)
-5. Test with a manual invocation
-6. Verify you receive the digest
-
-## Expected Outcome
-
-Every morning (or at your configured time), you receive a message containing:
-- A count of thoughts captured in the last 24 hours
-- Top themes/topics grouped by similarity
-- 2-3 "highlight" thoughts that are most unique or interesting
-- A brief AI-generated narrative connecting the day's thinking
-
-The digest arrives via your chosen delivery method (email or Slack message).
-
-## Troubleshooting
-
-**Issue: Edge function deploys but never fires**
-Solution: Make sure pg_cron extension is enabled and the cron job is configured correctly. Check `select * from cron.job` to verify it exists.
-
-**Issue: Digest arrives but is empty**
-Solution: The function queries thoughts from the last 24 hours. If you haven't captured anything recently, there's nothing to summarize. Test by capturing a few thoughts first.
-
-**Issue: Email delivery fails**
-Solution: Check your email service API key and sender domain. Resend requires domain verification. For testing, use Slack delivery instead.

--- a/recipes/daily-digest/daily-digest-skill.md
+++ b/recipes/daily-digest/daily-digest-skill.md
@@ -1,0 +1,22 @@
+---
+name: daily-digest
+description: Morning digest of yesterday's Open Brain thoughts, drafted to Gmail
+---
+
+You are running the Open Brain daily digest.
+
+1. Use the Open Brain MCP `list_thoughts` tool to get thoughts from the last 1 day (days: 1, limit: 50).
+
+2. If there are no thoughts, create a Gmail draft to YOUR_EMAIL@example.com with subject "Open Brain Daily Digest — [today's date]" and body "No new thoughts captured yesterday."
+
+3. If there are thoughts, organize them into a digest email:
+   - Subject: "Open Brain Daily Digest — [today's date]"
+   - Group thoughts by type (observations, tasks, ideas, references, person_notes)
+   - For each thought: show the content (truncated to ~100 chars if long), source, and any topics/people tags
+   - Add a summary section at the top with: total thought count, breakdown by type, top topics mentioned
+   - Keep the tone concise and scannable — this is a morning briefing, not a novel
+   - Use text/plain content type for maximum compatibility
+
+4. Create the draft using gmail_create_draft to YOUR_EMAIL@example.com.
+
+5. After creating the draft, confirm what was created (thought count, types found).

--- a/recipes/daily-digest/metadata.json
+++ b/recipes/daily-digest/metadata.json
@@ -1,19 +1,20 @@
 {
   "name": "Daily Digest",
-  "description": "Automated daily summary of recent thoughts delivered via email or Slack, powered by a Supabase Edge Function on a cron schedule.",
+  "description": "Automated daily summary of recent thoughts delivered via Gmail draft, powered by Claude Code scheduled tasks and Open Brain MCP. Zero infrastructure required.",
   "category": "recipes",
   "author": {
-    "name": "OB1 Team"
+    "name": "Matt Hallett",
+    "github": "matthallett"
   },
   "version": "1.0.0",
   "requires": {
     "open_brain": true,
-    "services": ["OpenRouter", "Resend or SendGrid or Slack"],
-    "tools": ["Supabase CLI"]
+    "services": ["Gmail MCP"],
+    "tools": ["Claude Code or Claude Desktop"]
   },
-  "tags": ["digest", "summary", "cron", "email", "slack", "automation"],
-  "difficulty": "intermediate",
-  "estimated_time": "30 minutes",
-  "created": "2026-03-11",
-  "updated": "2026-03-11"
+  "tags": ["digest", "summary", "email", "automation", "scheduled-task", "gmail", "claude-code"],
+  "difficulty": "beginner",
+  "estimated_time": "10 minutes",
+  "created": "2026-03-25",
+  "updated": "2026-03-25"
 }


### PR DESCRIPTION
## Summary

- Replaces the empty daily-digest stub with a working **zero-infrastructure approach** using Claude Code scheduled tasks + Open Brain MCP + Gmail MCP
- Adds a copyable skill file (`daily-digest-skill.md`) that users install locally and customize with their email
- Preserves the Supabase Edge Function approach as a planned "Approach B" for future contributors
- No OpenRouter, no Resend/SendGrid, no Edge Function deployment — just MCP tools users already have

## What it requires

- Claude Code or Claude Desktop (Code mode)
- Open Brain MCP connected
- Gmail MCP connected

## Tested

Tested on my own Open Brain instance (2,172 thoughts). Scheduled task fires, queries thoughts via MCP, creates a formatted Gmail draft grouped by type with topic/people tags.

## Notes

This is an early proof-of-concept. The Gmail MCP creates drafts (not auto-send), so it's a one-tap-to-send workflow. The Edge Function approach (Approach B) remains as a placeholder for a future full auto-send implementation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)