### PR TITLE
[Core] Add delete_thought tool and expose thought IDs in search/list

### DIFF
--- a/integrations/kubernetes-deployment/index.ts
+++ b/integrations/kubernetes-deployment/index.ts
@@ -133,12 +133,13 @@ server.registerTool(
       const client = await pool.connect();
       try {
         const result = await client.queryObject<{
+          id: string;
           content: string;
           metadata: Record<string, unknown>;
           similarity: number;
           created_at: string;
         }>(
-          `SELECT content, metadata, created_at,
+          `SELECT id, content, metadata, created_at,
                   1 - (embedding <=> $1::vector) AS similarity
            FROM thoughts
            WHERE 1 - (embedding <=> $1::vector) >= $2
@@ -157,6 +158,7 @@ server.registerTool(
           const m = t.metadata || {};
           const parts = [
             `--- Result ${i + 1} (${(t.similarity * 100).toFixed(1)}% match) ---`,
+            `ID: ${t.id}`,
             `Captured: ${new Date(t.created_at).toLocaleDateString()}`,
             `Type: ${m.type || "unknown"}`,
           ];
@@ -235,11 +237,12 @@ server.registerTool(
       const client = await pool.connect();
       try {
         const result = await client.queryObject<{
+          id: string;
           content: string;
           metadata: Record<string, unknown>;
           created_at: string;
         }>(
-          `SELECT content, metadata, created_at
+          `SELECT id, content, metadata, created_at
            FROM thoughts
            ${whereClause}
            ORDER BY created_at DESC
@@ -254,7 +257,7 @@ server.registerTool(
         const results = result.rows.map((t, i) => {
           const m = t.metadata || {};
           const tags = Array.isArray(m.topics) ? (m.topics as string[]).join(", ") : "";
-          return `${i + 1}. [${new Date(t.created_at).toLocaleDateString()}] (${m.type || "??"}${tags ? " - " + tags : ""})\n   ${t.content}`;
+          return `${i + 1}. [${t.id}] [${new Date(t.created_at).toLocaleDateString()}] (${m.type || "??"}${tags ? " - " + tags : ""})\n   ${t.content}`;
         });
 
         return {
@@ -401,6 +404,62 @@ server.registerTool(
       return {
         content: [{ type: "text" as const, text: confirmation }],
       };
+    } catch (err: unknown) {
+      return {
+        content: [{ type: "text" as const, text: `Error: ${(err as Error).message}` }],
+        isError: true,
+      };
+    }
+  }
+);
+
+// Tool 5: Delete Thought
+server.registerTool(
+  "delete_thought",
+  {
+    title: "Delete Thought",
+    description:
+      "Delete a thought from the Open Brain by its ID. Irreversible — use search_thoughts or list_thoughts to confirm the correct ID before deleting. Operates across the full database regardless of user context (single-user deployments only).",
+    inputSchema: {
+      id: z.string().describe("The ID of the thought to delete (from search_thoughts or list_thoughts output)"),
+    },
+  },
+  async ({ id }) => {
+    try {
+      const client = await pool.connect();
+      try {
+        // First fetch the thought so we can confirm what was deleted
+        const existing = await client.queryObject<{ id: string; content: string; metadata: Record<string, unknown> }>(
+          `SELECT id, content, metadata FROM thoughts WHERE id = $1`,
+          [id]
+        );
+
+        if (!existing.rows.length) {
+          return {
+            content: [{ type: "text" as const, text: `No thought found with ID: ${id}` }],
+            isError: true,
+          };
+        }
+
+        await client.queryObject(`DELETE FROM thoughts WHERE id = $1`, [id]);
+
+        const t = existing.rows[0];
+        const m = (t.metadata || {}) as Record<string, unknown>;
+        const preview = t.content.length > 100
+          ? t.content.substring(0, 100) + "..."
+          : t.content;
+
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: `Deleted thought ${id} (${m.type || "unknown"}):\n${preview}`,
+            },
+          ],
+        };
+      } finally {
+        client.release();
+      }
     } catch (err: unknown) {
       return {
         content: [{ type: "text" as const, text: `Error: ${(err as Error).message}` }],

--- a/server/index.ts
+++ b/server/index.ts
@@ -370,7 +370,7 @@ server.registerTool(
   {
     title: "Delete Thought",
     description:
-      "Delete a thought from the Open Brain by its ID. Use search_thoughts or list_thoughts first to find the ID of the thought to delete.",
+      "Delete a thought from the Open Brain by its ID. Irreversible — use search_thoughts or list_thoughts to confirm the correct ID before deleting. Operates across the full database regardless of user context (single-user deployments only).",
     inputSchema: {
       id: z.string().describe("The UUID of the thought to delete (from search_thoughts or list_thoughts output)"),
     },

--- a/server/index.ts
+++ b/server/index.ts
@@ -113,6 +113,7 @@ server.registerTool(
       const results = data.map(
         (
           t: {
+            id: string;
             content: string;
             metadata: Record<string, unknown>;
             similarity: number;
@@ -123,6 +124,7 @@ server.registerTool(
           const m = t.metadata || {};
           const parts = [
             `--- Result ${i + 1} (${(t.similarity * 100).toFixed(1)}% match) ---`,
+            `ID: ${t.id}`,
             `Captured: ${new Date(t.created_at).toLocaleDateString()}`,
             `Type: ${m.type || "unknown"}`,
           ];
@@ -173,7 +175,7 @@ server.registerTool(
     try {
       let q = supabase
         .from("thoughts")
-        .select("content, metadata, created_at")
+        .select("id, content, metadata, created_at")
         .order("created_at", { ascending: false })
         .limit(limit);
 
@@ -201,12 +203,12 @@ server.registerTool(
 
       const results = data.map(
         (
-          t: { content: string; metadata: Record<string, unknown>; created_at: string },
+          t: { id: string; content: string; metadata: Record<string, unknown>; created_at: string },
           i: number
         ) => {
           const m = t.metadata || {};
           const tags = Array.isArray(m.topics) ? (m.topics as string[]).join(", ") : "";
-          return `${i + 1}. [${new Date(t.created_at).toLocaleDateString()}] (${m.type || "??"}${tags ? " - " + tags : ""})\n   ${t.content}`;
+          return `${i + 1}. [${t.id}] [${new Date(t.created_at).toLocaleDateString()}] (${m.type || "??"}${tags ? " - " + tags : ""})\n   ${t.content}`;
         }
       );
 
@@ -352,6 +354,66 @@ server.registerTool(
 
       return {
         content: [{ type: "text" as const, text: confirmation }],
+      };
+    } catch (err: unknown) {
+      return {
+        content: [{ type: "text" as const, text: `Error: ${(err as Error).message}` }],
+        isError: true,
+      };
+    }
+  }
+);
+
+// Tool 5: Delete Thought
+server.registerTool(
+  "delete_thought",
+  {
+    title: "Delete Thought",
+    description:
+      "Delete a thought from the Open Brain by its ID. Use search_thoughts or list_thoughts first to find the ID of the thought to delete.",
+    inputSchema: {
+      id: z.string().describe("The UUID of the thought to delete (from search_thoughts or list_thoughts output)"),
+    },
+  },
+  async ({ id }) => {
+    try {
+      // First fetch the thought so we can confirm what was deleted
+      const { data: existing, error: fetchError } = await supabase
+        .from("thoughts")
+        .select("id, content, metadata")
+        .eq("id", id)
+        .single();
+
+      if (fetchError || !existing) {
+        return {
+          content: [{ type: "text" as const, text: `No thought found with ID: ${id}` }],
+          isError: true,
+        };
+      }
+
+      const { error } = await supabase
+        .from("thoughts")
+        .delete()
+        .eq("id", id);
+
+      if (error) {
+        return {
+          content: [{ type: "text" as const, text: `Failed to delete: ${error.message}` }],
+          isError: true,
+        };
+      }
+
+      const m = (existing.metadata || {}) as Record<string, unknown>;
+      const preview = existing.content.length > 100
+        ? existing.content.substring(0, 100) + "..."
+        : existing.content;
+      return {
+        content: [
+          {
+            type: "text" as const,
+            text: `Deleted thought ${id} (${m.type || "unknown"}):\n${preview}`,
+          },
+        ],
       };
     } catch (err: unknown) {
       return {


### PR DESCRIPTION
## What this does

Adds a `delete_thought` tool to the core MCP server and surfaces thought IDs in `search_thoughts` and `list_thoughts` output so thoughts can be referenced for deletion.

**Problem:** Without a delete tool, stale or incorrect thoughts can only be superseded by capturing new "correction" entries, leading to clutter over time. There's no way to clean up the knowledge base from within an AI session.

**Solution:** Three small changes to `server/index.ts`:

1. **`delete_thought` tool** — Accepts a thought UUID, confirms the thought exists, deletes it, and returns a preview of what was removed
2. **`search_thoughts`** — Now includes `ID: <uuid>` in each result
3. **`list_thoughts`** — Now includes `[<uuid>]` prefix in each result, and selects the `id` column

The `match_thoughts` RPC already returns the `id` column — this just surfaces it in the tool output.

## What it requires

No new services or dependencies. Uses the existing `thoughts` table and Supabase client. The `delete_thought` tool requires `service_role` permissions (already used by all other tools).

## Tested

Deployed and tested on a live Supabase instance with the standard Open Brain schema. Confirmed:
- Deleting by valid ID returns confirmation with content preview
- Deleting a non-existent ID returns an error message
- IDs appear correctly in search and list output
- Existing tools (capture, search, list, stats) are unaffected