### PR TITLE
[dashboards] Link Next.js dashboard to open-brain-rest dependency

### DIFF
--- a/dashboards/open-brain-dashboard-next/README.md
+++ b/dashboards/open-brain-dashboard-next/README.md
@@ -29,7 +29,7 @@ Provides 8 pages for managing your thoughts:
 
 ## Prerequisites
 
-- A working Open Brain setup with the **REST API gateway** (`open-brain-rest`) deployed
+- A working Open Brain setup with the **REST API gateway** ([`open-brain-rest`](../../integrations/open-brain-rest/README.md)) deployed — follow the integration guide to set up the backend
 - **Node.js 18+** installed
 - A **Vercel account** (free tier works) or any Node.js hosting
 
@@ -47,7 +47,7 @@ Provides 8 pages for managing your thoughts:
 
 ```bash
 # From the OB1 repo
-cd dashboards/open-brain-dashboard
+cd dashboards/open-brain-dashboard-next
 ```
 
 Or copy the folder to your own project directory.

--- a/dashboards/open-brain-dashboard-next/metadata.json
+++ b/dashboards/open-brain-dashboard-next/metadata.json
@@ -9,7 +9,7 @@
   "version": "1.0.0",
   "requires": {
     "open_brain": true,
-    "services": [],
+    "services": ["open-brain-rest Edge Function"],
     "tools": ["Node.js 18+"]
   },
   "tags": [
@@ -25,5 +25,5 @@
   "difficulty": "intermediate",
   "estimated_time": "30 minutes",
   "created": "2026-03-23",
-  "updated": "2026-03-23"
+  "updated": "2026-03-27"
 }

--- a/integrations/open-brain-rest/README.md
+++ b/integrations/open-brain-rest/README.md
@@ -1,0 +1,219 @@
+# Open Brain REST API
+
+> REST API gateway for the Open Brain thoughts database — required backend for the [Next.js Dashboard](../../dashboards/open-brain-dashboard-next/).
+
+## What It Does
+
+Deploys a Supabase Edge Function that provides 12 REST endpoints for searching, browsing, capturing, editing, and analyzing your thoughts. Non-MCP clients (web dashboards, webhooks, external tools) use this API to interact with your Open Brain.
+
+## Prerequisites
+
+- Working Open Brain setup ([guide](../../docs/01-getting-started.md))
+- An embedding API key: **OpenAI API key** (handles both embeddings and classification) **or** OpenRouter API key (embeddings only — capture works but metadata will be coarser)
+- Optionally, an **Anthropic API key** for richer metadata classification (type, topics, people extraction)
+- [Supabase CLI](https://supabase.com/docs/guides/cli) installed
+
+## Credential Tracker
+
+Copy this block into a text editor and fill it in as you go.
+
+```text
+OPEN BRAIN REST API -- CREDENTIAL TRACKER
+------------------------------------------
+
+FROM YOUR OPEN BRAIN SETUP
+  Project URL:            ____________
+  Project ref:            ____________
+  Function URL:           ____________  (filled after deploy)
+
+SECRETS TO SET
+  MCP_ACCESS_KEY:         ____________  (your Open Brain access key)
+  OPENAI_API_KEY:         ____________  (embeddings + classification)
+    -- OR --
+  OPENROUTER_API_KEY:     ____________  (embeddings only)
+
+OPTIONAL
+  ANTHROPIC_API_KEY:      ____________  (preferred classifier, richer metadata)
+
+------------------------------------------
+```
+
+## Steps
+
+![Step 1](https://img.shields.io/badge/Step_1-Apply_SQL_Migrations-1E88E5?style=for-the-badge)
+
+Run these SQL files **in order** in your Supabase project's SQL Editor. Each file is in the `sql/` folder of this integration.
+
+<details>
+<summary>📋 <strong>SQL: 01-schema-extensions.sql</strong> (click to expand)</summary>
+
+Adds a `serial_id` numeric surrogate key (for API compatibility with both UUID and BIGSERIAL base schemas), plus enrichment columns: `type`, `importance`, `quality_score`, `sensitivity_tier`, `source_type`, `content_fingerprint`.
+
+> [!IMPORTANT]
+> This migration auto-detects whether your `thoughts.id` column is UUID or integer and backfills `serial_id` accordingly. Run it before the other migrations.
+
+Copy and run the contents of [`sql/01-schema-extensions.sql`](sql/01-schema-extensions.sql).
+
+</details>
+
+<details>
+<summary>📋 <strong>SQL: 02-reflections-table.sql</strong> (click to expand)</summary>
+
+Creates the `reflections` table for decision traces and lesson records linked to thoughts.
+
+Copy and run the contents of [`sql/02-reflections-table.sql`](sql/02-reflections-table.sql).
+
+</details>
+
+<details>
+<summary>📋 <strong>SQL: 03-ingestion-tables.sql</strong> (click to expand)</summary>
+
+Creates `ingestion_jobs` and `ingestion_items` tables for the smart ingest pipeline.
+
+> [!NOTE]
+> The ingest endpoints (`/ingest`, `/ingestion-jobs`) require a separate `smart-ingest` Edge Function to be deployed. These tables are required for the dashboard's ingest page but the ingest flow is optional.
+
+Copy and run the contents of [`sql/03-ingestion-tables.sql`](sql/03-ingestion-tables.sql).
+
+</details>
+
+<details>
+<summary>📋 <strong>SQL: 04-rpcs.sql</strong> (click to expand)</summary>
+
+Creates all 8 RPC functions used by the REST API: `upsert_thought`, `match_thoughts`, `search_thoughts_text`, `brain_stats_aggregate`, `get_thought_connections`, `find_near_duplicates`, `upsert_reflection`, `match_reflections`.
+
+Copy and run the contents of [`sql/04-rpcs.sql`](sql/04-rpcs.sql).
+
+</details>
+
+<details>
+<summary>📋 <strong>SQL: 05-text-search-index.sql</strong> (click to expand)</summary>
+
+Adds full-text search support: a `tsv` tsvector column, GIN index, and auto-update trigger.
+
+> [!WARNING]
+> If you have a large number of existing thoughts, the initial backfill (`UPDATE thoughts SET tsv = ...`) may take a few seconds. This is normal.
+
+Copy and run the contents of [`sql/05-text-search-index.sql`](sql/05-text-search-index.sql).
+
+</details>
+
+✅ **Done when:** All 5 SQL files have run without errors.
+
+---
+
+![Step 2](https://img.shields.io/badge/Step_2-Deploy_the_Edge_Function-1E88E5?style=for-the-badge)
+
+**1. Create the function directory in your Supabase project:**
+
+```bash
+mkdir -p supabase/functions/open-brain-rest/utils
+```
+
+**2. Copy the function files from this integration into your project:**
+
+Copy the contents of `supabase/functions/open-brain-rest/` from this integration folder into your project's `supabase/functions/open-brain-rest/` directory. You need:
+- `index.ts`
+- `utils/open-brain-utils.ts`
+- `utils/ingest-config.ts`
+- `utils/sensitivity-patterns.ts`
+- `utils/sensitivity-patterns.json`
+
+**3. Set your secrets:**
+
+```bash
+supabase secrets set MCP_ACCESS_KEY=your-access-key
+supabase secrets set OPENAI_API_KEY=your-openai-key
+```
+
+Or if using OpenRouter instead of OpenAI:
+
+```bash
+supabase secrets set OPENROUTER_API_KEY=your-openrouter-key
+```
+
+Optionally, for richer metadata classification:
+
+```bash
+supabase secrets set ANTHROPIC_API_KEY=your-anthropic-key
+```
+
+> [!IMPORTANT]
+> Do **not** set `SUPABASE_URL` or `SUPABASE_SERVICE_ROLE_KEY` — Supabase injects these automatically into Edge Functions.
+
+**4. Deploy:**
+
+```bash
+supabase functions deploy open-brain-rest --no-verify-jwt
+```
+
+✅ **Done when:** The deploy command completes without errors.
+
+---
+
+![Step 3](https://img.shields.io/badge/Step_3-Test_the_API-1E88E5?style=for-the-badge)
+
+```bash
+curl -s \
+  -H "x-brain-key: YOUR_ACCESS_KEY" \
+  "https://YOUR-PROJECT-REF.supabase.co/functions/v1/open-brain-rest/health"
+```
+
+Expected response:
+
+```json
+{"ok": true, "service": "open-brain-rest", "timestamp": "..."}
+```
+
+✅ **Done when:** You see `"ok": true` in the response.
+
+## Expected Outcome
+
+After deployment, the following endpoints are available:
+
+| Endpoint | Method | Purpose |
+|----------|--------|---------|
+| `/health` | GET | Health check |
+| `/thoughts` | GET | Paginated browse with filters |
+| `/thought/:id` | GET | Fetch single thought |
+| `/thought/:id` | PUT | Update thought |
+| `/thought/:id` | DELETE | Delete thought |
+| `/thought/:id/connections` | GET | Related thoughts (hybrid scoring) |
+| `/thought/:id/reflection` | GET | Fetch reflections |
+| `/thought/:id/reflection` | POST | Create reflection |
+| `/search` | POST | Semantic + full-text search |
+| `/stats` | GET | Aggregate statistics |
+| `/capture` | POST | Create new thought |
+| `/duplicates` | GET | Near-duplicate detection |
+
+**Optional ingest endpoints** (require separate `smart-ingest` Edge Function):
+
+| Endpoint | Method | Purpose |
+|----------|--------|---------|
+| `/ingest` | POST | Smart extraction |
+| `/ingestion-jobs` | GET | List extraction jobs |
+| `/ingestion-jobs/:id` | GET | Job detail |
+| `/ingestion-jobs/:id/execute` | POST | Execute extraction |
+
+The [Next.js Dashboard](../../dashboards/open-brain-dashboard-next/) can now connect to this API by setting `NEXT_PUBLIC_API_URL` in its `.env` file.
+
+## Troubleshooting
+
+**Issue: `401 Unauthorized` on every request**
+Solution: Ensure your `x-brain-key` header value matches the `MCP_ACCESS_KEY` secret you set. Check with `supabase secrets list`.
+
+**Issue: Capture works but metadata is sparse (no topics, type defaults to "idea")**
+Solution: You're likely using only `OPENROUTER_API_KEY`, which handles embeddings but not classification. Set `OPENAI_API_KEY` (handles both) or add `ANTHROPIC_API_KEY` for the richest metadata extraction.
+
+**Issue: Text search returns no results but semantic search works**
+Solution: You may have skipped migration `05-text-search-index.sql`. Run it to create the tsvector column, GIN index, and auto-update trigger.
+
+**Issue: `permission denied for table thoughts` or similar**
+Solution: Run the GRANT statements from migration `01-schema-extensions.sql`. Supabase no longer auto-grants CRUD permissions to `service_role` on some projects.
+
+**Issue: `/ingest` returns an error about `smart-ingest` function**
+Solution: The ingest endpoint proxies to a separate `smart-ingest` Edge Function that is not included in this integration. The ingest flow is optional — all other endpoints work without it.
+
+## Tool Surface Area
+
+> This integration provides REST endpoints, not MCP tools — it does not add to your AI's context weight. However, if you're building on Open Brain with multiple integrations, see the [MCP Tool Audit & Optimization Guide](../../docs/05-tool-audit.md) for strategies on managing your tool count as your Open Brain grows.

--- a/integrations/open-brain-rest/README.md
+++ b/integrations/open-brain-rest/README.md
@@ -107,12 +107,12 @@ Copy and run the contents of [`sql/05-text-search-index.sql`](sql/05-text-search
 **1. Create the function directory in your Supabase project:**
 
 ```bash
-mkdir -p supabase/functions/open-brain-rest/utils
+mkdir -p function/utils
 ```
 
 **2. Copy the function files from this integration into your project:**
 
-Copy the contents of `supabase/functions/open-brain-rest/` from this integration folder into your project's `supabase/functions/open-brain-rest/` directory. You need:
+Copy the contents of `function/` from this integration folder into your project's `function/` directory. You need:
 - `index.ts`
 - `utils/open-brain-utils.ts`
 - `utils/ingest-config.ts`

--- a/integrations/open-brain-rest/function/index.ts
+++ b/integrations/open-brain-rest/function/index.ts
@@ -1,0 +1,752 @@
+/**
+ * open-brain-rest — REST API for Open Brain
+ *
+ * Provides simple REST endpoints for non-MCP clients (ChatGPT Actions, Gemini, etc.)
+ * Routes:
+ *   POST /search       — search thoughts (semantic or text)
+ *   POST /capture      — capture a new thought
+ *   GET  /thought/:id  — get single thought
+ *   PUT  /thought/:id  — update thought content
+ *   DELETE /thought/:id — delete thought
+ *   GET  /stats        — brain stats summary
+ *   GET  /health       — health check
+ *
+ * Auth: ?key= query param, x-brain-key header, or Authorization: Bearer <key>
+ */
+
+import { createClient } from "npm:@supabase/supabase-js@2";
+import {
+  embedText,
+  extractMetadata,
+  fallbackMetadata,
+  detectSensitivity,
+  resolveSensitivityTier,
+  applyEvergreenTag,
+  parseStructuredCapture,
+  mergeUniqueStrings,
+  normalizeStringArray,
+  prepareThoughtPayload,
+  computeContentFingerprint,
+  isRecord,
+  asString,
+  ALLOWED_TYPES,
+  safeEmbedding,
+} from "./utils/open-brain-utils.ts";
+
+import { SENSITIVITY_TIERS } from "./utils/ingest-config.ts";
+
+const SUPABASE_URL = Deno.env.get("SUPABASE_URL") ?? "";
+const SUPABASE_SERVICE_ROLE_KEY = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY") ?? "";
+const MCP_ACCESS_KEY = Deno.env.get("MCP_ACCESS_KEY") ?? "";
+const _SUPABASE_URL = SUPABASE_URL; // reference to suppress unused warning
+
+const supabase = createClient(SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY);
+
+const CORS_HEADERS = {
+  "Access-Control-Allow-Origin": "*",
+  "Access-Control-Allow-Methods": "GET, POST, PUT, PATCH, DELETE, OPTIONS",
+  "Access-Control-Allow-Headers": "Content-Type, Authorization, x-brain-key",
+  "Content-Type": "application/json",
+};
+
+Deno.serve(async (req) => {
+  // CORS preflight
+  if (req.method === "OPTIONS") {
+    return new Response(null, { status: 204, headers: CORS_HEADERS });
+  }
+
+  // Auth check
+  if (MCP_ACCESS_KEY && !isAuthorized(req)) {
+    return json({ error: "Unauthorized" }, 401);
+  }
+
+  const url = new URL(req.url);
+  // Strip the function name prefix from path for routing
+  const path = url.pathname
+    .replace(/^\/open-brain-rest/, "")
+    .replace(/\/+$/, "") || "/";
+
+  try {
+    if (path === "/health" || path === "/healthz" || path === "/") {
+      return json({ ok: true, service: "open-brain-rest", timestamp: new Date().toISOString() });
+    }
+
+    if (path === "/search" && req.method === "POST") {
+      return await handleSearch(req);
+    }
+
+    if (path === "/capture" && req.method === "POST") {
+      return await handleCapture(req);
+    }
+
+    // Paginated browse
+    if (path === "/thoughts" && req.method === "GET") {
+      return await handleBrowseThoughts(url);
+    }
+
+    // /thought/:id routes
+    const thoughtMatch = path.match(/^\/thought\/(\d+)$/);
+    if (thoughtMatch) {
+      const id = Number(thoughtMatch[1]);
+      if (req.method === "GET") {
+        const excludeRestricted = url.searchParams.get("exclude_restricted") !== "false";
+        return await handleGetThought(id, excludeRestricted);
+      }
+      if (req.method === "PUT") return await handleUpdateThought(id, req);
+      if (req.method === "DELETE") return await handleDeleteThought(id);
+    }
+
+    // /thought/:id/connections route
+    const connectionsMatch = path.match(/^\/thought\/(\d+)\/connections$/);
+    if (connectionsMatch && req.method === "GET") {
+      const thoughtId = Number(connectionsMatch[1]);
+      const excludeRestricted = url.searchParams.get("exclude_restricted") !== "false";
+      const limit = Math.min(Math.max(Number(url.searchParams.get("limit")) || 20, 1), 50);
+      return await handleGetConnections(thoughtId, limit, excludeRestricted);
+    }
+
+    // /thought/:id/reflection routes
+    const reflectionMatch = path.match(/^\/thought\/(\d+)\/reflection$/);
+    if (reflectionMatch) {
+      const thoughtId = Number(reflectionMatch[1]);
+      if (req.method === "GET") return await handleGetReflection(thoughtId);
+      if (req.method === "POST") return await handleCaptureReflection(thoughtId, req);
+    }
+
+    // Smart ingest routes
+    if (path === "/ingest" && req.method === "POST") {
+      return await handleIngest(req);
+    }
+
+    const executeMatch = path.match(/^\/ingestion-jobs\/(\d+)\/execute$/);
+    if (executeMatch && req.method === "POST") {
+      return await handleExecuteJob(Number(executeMatch[1]));
+    }
+
+    if (path === "/ingestion-jobs" && req.method === "GET") {
+      return await handleListJobs(url);
+    }
+
+    const jobDetailMatch = path.match(/^\/ingestion-jobs\/(\d+)$/);
+    if (jobDetailMatch && req.method === "GET") {
+      return await handleGetJob(Number(jobDetailMatch[1]));
+    }
+
+    if (path === "/duplicates" && req.method === "GET") {
+      return await handleFindDuplicates(url);
+    }
+
+    if (path === "/stats") {
+      return await handleStats(url);
+    }
+
+    return json({ error: "Not found", routes: ["/search", "/capture", "/thoughts", "/thought/:id", "/thought/:id/connections", "/thought/:id/reflection", "/ingest", "/ingestion-jobs", "/ingestion-jobs/:id", "/ingestion-jobs/:id/execute", "/duplicates", "/stats", "/health"] }, 404);
+  } catch (error) {
+    console.error("open-brain-rest error", error);
+    return json({ error: String(error) }, 500);
+  }
+});
+
+// ── Search ──────────────────────────────────────────────────────────────────
+
+async function handleSearch(req: Request): Promise<Response> {
+  const body = await req.json() as Record<string, unknown>;
+  const query = String(body.query ?? "").trim();
+  const mode = String(body.mode ?? "semantic");
+  const limit = Math.min(Math.max(Number(body.limit) || 25, 1), 100);
+  const page = Math.max(Number(body.page) || 1, 1);
+  const offset = (page - 1) * limit;
+  const minSimilarity = Math.min(Math.max(Number(body.min_similarity) || 0.3, 0), 1);
+  const excludeRestricted = body.exclude_restricted !== false; // default true
+
+  if (query.length < 2) {
+    return json({ error: "query must be at least 2 characters" }, 400);
+  }
+
+  if (mode === "text") {
+    // Use search_thoughts_text RPC which supports tsvector + boolean operators
+    // PostgreSQL websearch_to_tsquery handles: "quoted phrases", AND, OR, -NOT
+    const filter: Record<string, unknown> = {};
+    if (excludeRestricted) filter.exclude_restricted = true;
+    const { data, error } = await supabase.rpc("search_thoughts_text", {
+      p_query: query,
+      p_limit: limit,
+      p_filter: filter,
+      p_offset: offset,
+    });
+
+    if (error) throw new Error(`search failed: ${error.message}`);
+
+    const rows = data ?? [];
+    const totalCount = rows.length > 0 ? Number((rows[0] as Record<string, unknown>).total_count) : 0;
+
+    const results = rows.map((row: Record<string, unknown>) => ({
+      id: row.id,
+      content: row.content,
+      type: row.type,
+      source_type: row.source_type,
+      importance: row.importance,
+      metadata: row.metadata,
+      created_at: row.created_at,
+      rank: row.rank,
+    }));
+
+    return json({
+      results,
+      count: results.length,
+      total: totalCount,
+      page,
+      per_page: limit,
+      total_pages: Math.ceil(totalCount / limit),
+      mode: "text",
+    });
+  }
+
+  // Semantic search (default) — no pagination, returns top N by similarity
+  // Request extra rows when filtering restricted to ensure we return enough results
+  const fetchCount = excludeRestricted ? Math.min(limit + 20, 200) : limit;
+  const { data, error } = await supabase.rpc("match_thoughts", {
+    query_embedding: await embedText(query),
+    match_count: fetchCount,
+    match_threshold: minSimilarity,
+    filter: {},
+  });
+
+  if (error) throw new Error(`search failed: ${error.message}`);
+
+  let semanticRows = data ?? [];
+  if (excludeRestricted) {
+    semanticRows = semanticRows.filter((r: Record<string, unknown>) => r.sensitivity_tier !== "restricted");
+  }
+  semanticRows = semanticRows.slice(0, limit);
+
+  const results = semanticRows.map((row: Record<string, unknown>) => ({
+    id: row.id,
+    content: row.content,
+    type: (row.metadata as Record<string, unknown>)?.type ?? row.type,
+    similarity: row.similarity,
+    source_type: row.source_type,
+    created_at: row.created_at,
+  }));
+
+  return json({ results, count: results.length, total: results.length, page: 1, per_page: limit, total_pages: 1, mode: "semantic" });
+}
+
+// ── Capture ─────────────────────────────────────────────────────────────────
+
+/**
+ * POST /capture — Create a new thought via the canonical pipeline.
+ *
+ * Body fields:
+ *   content        (string, required)  — The thought text.
+ *   source         (string, optional)  — Capture source label (default: "rest_api").
+ *   source_type    (string, optional)  — Stored on the thought row; defaults to `source`.
+ *   metadata       (object, optional)  — Arbitrary JSON merged into the thought's metadata.
+ *                    Nested objects (e.g. { provenance: { source: "..." } }) are preserved
+ *                    as-is through prepareThoughtPayload → upsert_thought.
+ *   skip_classification (boolean, default false)
+ *       When true:  Skips the LLM-based metadata extraction step (type, summary,
+ *                   topics, tags, people, action_items). The embedding is still
+ *                   computed. Use this when the caller already provides pre-classified
+ *                   metadata in the `metadata` field.
+ *       When false: The full canonical enrichment pipeline runs — an LLM call
+ *                   extracts type, summary, topics, tags, people, and action_items
+ *                   from the content.
+ *   type, importance, topics, tags, sensitivity, quality_score
+ *       Legacy top-level overrides — mapped into metadata and take precedence
+ *       over body.metadata equivalents for backward compatibility.
+ */
+async function handleCapture(req: Request): Promise<Response> {
+  const body = await req.json() as Record<string, unknown>;
+  const content = String(body.content ?? "").trim();
+  const source = String(body.source ?? "rest_api").trim();
+  const sourceType = String(body.source_type ?? "").trim() || source;
+
+  if (!content) {
+    return json({ error: "content is required" }, 400);
+  }
+
+  // Pre-flight sensitivity check (restricted content blocked from cloud)
+  const detectedSensitivity = detectSensitivity(content);
+  if (detectedSensitivity.tier === "restricted") {
+    return json({ error: "Restricted content cannot be captured through cloud API" }, 403);
+  }
+
+  // Accept caller-supplied metadata (e.g. aboutness, provenance from Drive pipeline)
+  const bodyMetadata = isRecord(body.metadata) ? body.metadata : {};
+
+  // Map legacy top-level fields into metadata overrides for the canonical pipeline
+  // These win over body.metadata to preserve backward compatibility
+  const metadataOverrides: Record<string, unknown> = {};
+  if (body.type) metadataOverrides.type = body.type;
+  if (body.importance !== undefined) metadataOverrides.importance = body.importance;
+  if (body.topics) metadataOverrides.topics = body.topics;
+  if (body.tags) metadataOverrides.tags = body.tags;
+  if (body.sensitivity !== undefined) {
+    // Legacy numeric sensitivity → tier mapping
+    const numSens = Number(body.sensitivity) || 1;
+    if (numSens >= 3) metadataOverrides.sensitivity_tier = "restricted";
+    else if (numSens >= 2) metadataOverrides.sensitivity_tier = "personal";
+  }
+  if (body.quality_score !== undefined) metadataOverrides.quality_score = body.quality_score;
+
+  // Use canonical pipeline; skip LLM classification if caller already scored the content
+  const prepared = await prepareThoughtPayload(content, {
+    source,
+    source_type: sourceType,
+    metadata: { ...bodyMetadata, ...metadataOverrides },
+    skip_classification: body.skip_classification === true,
+  });
+
+  const { data, error } = await supabase.rpc("upsert_thought", {
+    p_content: prepared.content,
+    p_payload: {
+      type: prepared.type,
+      sensitivity_tier: prepared.sensitivity_tier,
+      importance: prepared.importance,
+      quality_score: prepared.quality_score,
+      source_type: prepared.source_type,
+      metadata: prepared.metadata,
+      created_at: new Date().toISOString(),
+      ...(safeEmbedding(prepared.embedding) && { embedding: prepared.embedding }),
+    },
+  });
+
+  if (error) throw new Error(`capture failed: ${error.message}`);
+
+  const result = data as { thought_id: number; action: string; content_fingerprint: string } | null;
+  if (!result?.thought_id) {
+    throw new Error("upsert_thought returned no result");
+  }
+
+  return json({
+    thought_id: result.thought_id,
+    action: result.action,
+    type: prepared.type,
+    sensitivity_tier: prepared.sensitivity_tier,
+    content_fingerprint: result.content_fingerprint,
+    message: `${result.action === "inserted" ? "Captured new" : "Updated"} thought #${result.thought_id} as ${prepared.type}`,
+  });
+}
+
+// ── Get Thought ─────────────────────────────────────────────────────────────
+
+async function handleGetThought(id: number, excludeRestricted: boolean): Promise<Response> {
+  const { data, error } = await supabase
+    .from("thoughts")
+    .select("serial_id, content, type, source_type, importance, quality_score, sensitivity_tier, metadata, created_at, updated_at")
+    .eq("serial_id", id)
+    .single();
+
+  if (error || !data) {
+    return json({ error: `Thought #${id} not found` }, 404);
+  }
+
+  if (excludeRestricted && data.sensitivity_tier === "restricted") {
+    return json({ error: "restricted" }, 403);
+  }
+
+  return json({ ...data, id: data.serial_id });
+}
+
+// ── Update Thought ──────────────────────────────────────────────────────────
+
+async function handleUpdateThought(id: number, req: Request): Promise<Response> {
+  const body = await req.json() as Record<string, unknown>;
+  const content = String(body.content ?? "").trim();
+
+  if (!content) {
+    return json({ error: "content is required" }, 400);
+  }
+
+  // Verify thought exists
+  const { data: existing, error: fetchErr } = await supabase
+    .from("thoughts")
+    .select("serial_id")
+    .eq("serial_id", id)
+    .single();
+
+  if (fetchErr || !existing) {
+    return json({ error: `Thought #${id} not found` }, 404);
+  }
+
+  // Re-embed the updated content
+  let embedding = null;
+  try {
+    embedding = await embedText(content);
+  } catch (_) {
+    // Continue without embedding — it can be backfilled later
+  }
+
+  const updates: Record<string, unknown> = {
+    content,
+    updated_at: new Date().toISOString(),
+  };
+
+  if (embedding) {
+    updates.embedding = embedding;
+  }
+
+  // Update optional fields if provided
+  if (body.type) {
+    const t = sanitizeType(String(body.type));
+    updates.type = t;
+  }
+  if (body.importance !== undefined) {
+    updates.importance = Math.min(Math.max(Number(body.importance) || 3, 1), 5);
+  }
+
+  const { error: updateErr } = await supabase
+    .from("thoughts")
+    .update(updates)
+    .eq("serial_id", id);
+
+  if (updateErr) throw new Error(`update failed: ${updateErr.message}`);
+
+  return json({ id, action: "updated", message: `Thought #${id} updated` });
+}
+
+// ── Delete Thought ──────────────────────────────────────────────────────────
+
+async function handleDeleteThought(id: number): Promise<Response> {
+  const { data: existing, error: fetchErr } = await supabase
+    .from("thoughts")
+    .select("serial_id")
+    .eq("serial_id", id)
+    .single();
+
+  if (fetchErr || !existing) {
+    return json({ error: `Thought #${id} not found` }, 404);
+  }
+
+  const { error: deleteErr } = await supabase
+    .from("thoughts")
+    .delete()
+    .eq("serial_id", id);
+
+  if (deleteErr) throw new Error(`delete failed: ${deleteErr.message}`);
+
+  return json({ id, action: "deleted", message: `Thought #${id} deleted` });
+}
+
+// ── Stats ───────────────────────────────────────────────────────────────────
+
+async function handleStats(url: URL): Promise<Response> {
+  const daysParam = url.searchParams.get("days");
+  const excludeRestricted = url.searchParams.get("exclude_restricted") !== "false";
+  // If no days param, show all-time stats
+  const allTime = !daysParam;
+  const sinceDays = allTime ? 0 : Math.max(Number(daysParam) || 30, 1);
+  const since = allTime ? null : new Date(Date.now() - (sinceDays * 86_400_000)).toISOString();
+
+  // Keep total counts exact and let the RPC handle full-dataset aggregates.
+  let countQuery = supabase.from("thoughts").select("serial_id", { count: "exact", head: true });
+  if (since) countQuery = countQuery.gte("created_at", since);
+  if (excludeRestricted) countQuery = countQuery.neq("sensitivity_tier", "restricted");
+  const [{ count: totalThoughts, error: countErr }, { data: aggregateData, error: aggregateErr }] =
+    await Promise.all([
+      countQuery,
+      supabase.rpc("brain_stats_aggregate", {
+        p_since_days: sinceDays,
+        p_exclude_restricted: excludeRestricted,
+      }),
+    ]);
+
+  if (countErr) throw new Error(`stats count failed: ${countErr.message}`);
+  if (aggregateErr) throw new Error(`stats aggregate failed: ${aggregateErr.message}`);
+
+  // Query 1: type counts (lightweight — no metadata, paginate to cover all rows)
+  const aggregate = isRecord(aggregateData) ? aggregateData : {};
+  const typeCounts = Object.fromEntries(
+    parseAggregateCounts(aggregate.top_types, "type").map(({ key, count }) => [key, count]),
+  );
+
+  // Build the returned topic list from the RPC aggregate payload.
+  const topTopics = parseAggregateCounts(aggregate.top_topics, "topic")
+    .slice(0, 15)
+    .map(({ key, count }) => ({ topic: key, count }));
+
+  return json({
+    total_thoughts: totalThoughts ?? 0,
+    window_days: allTime ? "all" : sinceDays,
+    types: typeCounts,
+    top_topics: topTopics,
+  });
+}
+
+// ── Paginated Browse ─────────────────────────────────────────────────────────
+
+async function handleBrowseThoughts(url: URL): Promise<Response> {
+  const page = Math.max(Number(url.searchParams.get("page")) || 1, 1);
+  const perPage = Math.min(Math.max(Number(url.searchParams.get("per_page")) || 20, 1), 100);
+  const type = url.searchParams.get("type")?.trim() || null;
+  const sourceType = url.searchParams.get("source_type")?.trim() || null;
+  const importanceMin = url.searchParams.get("importance_min") ? Number(url.searchParams.get("importance_min")) : null;
+  const qualityScoreMax = url.searchParams.get("quality_score_max") ? Number(url.searchParams.get("quality_score_max")) : null;
+  const sort = url.searchParams.get("sort") || "created_at";
+  const order = url.searchParams.get("order") === "asc" ? true : false;
+  const excludeRestricted = url.searchParams.get("exclude_restricted") !== "false"; // default true
+
+  const offset = (page - 1) * perPage;
+
+  // Count query
+  let countQuery = supabase.from("thoughts").select("serial_id", { count: "exact", head: true });
+  if (type) countQuery = countQuery.eq("type", type);
+  if (sourceType) countQuery = countQuery.eq("source_type", sourceType);
+  if (importanceMin !== null) countQuery = countQuery.gte("importance", importanceMin);
+  if (qualityScoreMax !== null) countQuery = countQuery.lte("quality_score", qualityScoreMax);
+  if (excludeRestricted) countQuery = countQuery.neq("sensitivity_tier", "restricted");
+
+  // Data query
+  let dataQuery = supabase
+    .from("thoughts")
+    .select("serial_id, content, type, source_type, importance, quality_score, sensitivity_tier, metadata, created_at, updated_at")
+    .order(sort as string, { ascending: order })
+    .range(offset, offset + perPage - 1);
+
+  if (type) dataQuery = dataQuery.eq("type", type);
+  if (sourceType) dataQuery = dataQuery.eq("source_type", sourceType);
+  if (importanceMin !== null) dataQuery = dataQuery.gte("importance", importanceMin);
+  if (qualityScoreMax !== null) dataQuery = dataQuery.lte("quality_score", qualityScoreMax);
+  if (excludeRestricted) dataQuery = dataQuery.neq("sensitivity_tier", "restricted");
+
+  const [countRes, dataRes] = await Promise.all([countQuery, dataQuery]);
+
+  if (dataRes.error) throw new Error(`browse failed: ${dataRes.error.message}`);
+
+  // Map serial_id to id in response
+  const rows = (dataRes.data ?? []).map((row: Record<string, unknown>) => ({
+    ...row,
+    id: row.serial_id,
+  }));
+
+  return json({
+    data: rows,
+    total: countRes.count ?? 0,
+    page,
+    per_page: perPage,
+  });
+}
+
+// ── Near-Duplicates ─────────────────────────────────────────────────────────
+
+async function handleFindDuplicates(url: URL): Promise<Response> {
+  const threshold = Math.min(Math.max(Number(url.searchParams.get("threshold")) || 0.85, 0.5), 0.99);
+  const limit = Math.min(Math.max(Number(url.searchParams.get("limit")) || 50, 1), 200);
+  const offset = Math.max(Number(url.searchParams.get("offset")) || 0, 0);
+
+  const { data, error } = await supabase.rpc("find_near_duplicates", {
+    p_threshold: threshold,
+    p_limit: limit,
+    p_offset: offset,
+  });
+
+  if (error) throw new Error(`find_near_duplicates failed: ${error.message}`);
+
+  return json({
+    pairs: data ?? [],
+    threshold,
+    limit,
+    offset,
+  });
+}
+
+// ── Smart Ingest ─────────────────────────────────────────────────────────────
+
+async function handleIngest(req: Request): Promise<Response> {
+  const body = await req.json() as Record<string, unknown>;
+
+  // auto_execute overrides dry_run for one-step ingest
+  if (body.auto_execute) {
+    body.dry_run = false;
+    delete body.auto_execute;
+  }
+
+  const SMART_INGEST_URL = `${SUPABASE_URL}/functions/v1/smart-ingest`;
+
+  const response = await fetch(SMART_INGEST_URL, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      "x-brain-key": MCP_ACCESS_KEY,
+    },
+    body: JSON.stringify(body),
+  });
+
+  const result = await response.json();
+  return json(result, response.status);
+}
+
+async function handleExecuteJob(jobId: number): Promise<Response> {
+  const SMART_INGEST_URL = `${SUPABASE_URL}/functions/v1/smart-ingest`;
+
+  const response = await fetch(`${SMART_INGEST_URL}/execute`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      "x-brain-key": MCP_ACCESS_KEY,
+    },
+    body: JSON.stringify({ job_id: jobId }),
+  });
+
+  const result = await response.json();
+  return json(result, response.status);
+}
+
+async function handleListJobs(url: URL): Promise<Response> {
+  const limit = Math.min(Math.max(Number(url.searchParams.get("limit")) || 20, 1), 100);
+  const status = url.searchParams.get("status")?.trim() || null;
+
+  let query = supabase
+    .from("ingestion_jobs")
+    .select("id, source_label, status, extracted_count, added_count, skipped_count, appended_count, revised_count, created_at, completed_at")
+    .order("created_at", { ascending: false })
+    .limit(limit);
+
+  if (status) query = query.eq("status", status);
+
+  const { data, error } = await query;
+  if (error) throw new Error(`list_ingestion_jobs failed: ${error.message}`);
+
+  return json({ jobs: data ?? [], count: (data ?? []).length });
+}
+
+async function handleGetJob(jobId: number): Promise<Response> {
+  const [jobRes, itemsRes] = await Promise.all([
+    supabase.from("ingestion_jobs").select("*").eq("id", jobId).single(),
+    supabase.from("ingestion_items").select("*").eq("job_id", jobId).order("id"),
+  ]);
+
+  if (jobRes.error || !jobRes.data) return json({ error: `Job #${jobId} not found` }, 404);
+
+  return json({ job: jobRes.data, items: itemsRes.data ?? [] });
+}
+
+// ── Connections ──────────────────────────────────────────────────────────────
+
+async function handleGetConnections(thoughtId: number, limit: number, excludeRestricted: boolean): Promise<Response> {
+  const { data, error } = await supabase.rpc("get_thought_connections", {
+    p_thought_id: thoughtId,
+    p_limit: limit,
+    p_exclude_restricted: excludeRestricted,
+  });
+
+  if (error) {
+    console.error("get_thought_connections RPC error:", error);
+    return json({ connections: [] });
+  }
+
+  const connections = (data ?? []).map((row: Record<string, unknown>) => ({
+    id: row.id,
+    type: row.type,
+    importance: row.importance,
+    preview: row.preview,
+    created_at: row.created_at,
+    shared_topics: row.shared_topics ?? [],
+    shared_people: row.shared_people ?? [],
+    overlap_count: row.overlap_count ?? 0,
+    score: row.score,
+    overlap_type: row.overlap_type,
+  }));
+
+  return json({ connections });
+}
+
+// ── Reflections ──────────────────────────────────────────────────────────────
+
+async function handleGetReflection(thoughtId: number): Promise<Response> {
+  const { data, error } = await supabase
+    .from("reflections")
+    .select("id, thought_id, trigger_context, options, factors, conclusion, confidence, reflection_type, metadata, created_at, updated_at")
+    .eq("thought_id", thoughtId);
+
+  if (error) throw new Error(`get_reflection failed: ${error.message}`);
+  if (!data || data.length === 0) {
+    return json({ error: `No reflections found for thought #${thoughtId}` }, 404);
+  }
+
+  return json({ reflections: data });
+}
+
+async function handleCaptureReflection(thoughtId: number, req: Request): Promise<Response> {
+  const body = await req.json() as Record<string, unknown>;
+  const triggerContext = String(body.trigger_context ?? "").trim() || null;
+  const conclusion = String(body.conclusion ?? "").trim() || null;
+  const reflectionType = String(body.reflection_type ?? "decision_trace").trim();
+  const options = body.options ?? [];
+  const factors = body.factors ?? [];
+
+  // Compute embedding for semantic search
+  const embeddingText = `${triggerContext ?? ""} ${conclusion ?? ""}`.trim().slice(0, 8000);
+  let embedding: number[] | null = null;
+  if (embeddingText) {
+    try { embedding = await embedText(embeddingText); } catch (_) { /* continue */ }
+  }
+
+  const { data, error } = await supabase.rpc("upsert_reflection", {
+    p_thought_id: thoughtId,
+    p_trigger_context: triggerContext,
+    p_options: options,
+    p_factors: factors,
+    p_conclusion: conclusion,
+    p_embedding: embedding,
+    p_reflection_type: reflectionType,
+    p_metadata: body.metadata ?? {},
+  });
+
+  if (error) throw new Error(`upsert_reflection failed: ${error.message}`);
+  const result = data as { reflection_id: number; action: string };
+
+  return json({
+    reflection_id: result.reflection_id,
+    thought_id: thoughtId,
+    action: result.action,
+    message: `${result.action === "inserted" ? "Captured" : "Updated"} reflection #${result.reflection_id}`,
+  });
+}
+
+// ── Helpers ─────────────────────────────────────────────────────────────────
+
+function sanitizeType(value: string): string {
+  const normalized = value.trim().toLowerCase();
+  return ALLOWED_TYPES.has(normalized) ? normalized : "idea";
+}
+
+function parseAggregateCounts(
+  value: unknown,
+  keyName: "type" | "topic",
+): Array<{ key: string; count: number }> {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+
+  return value
+    .map((entry) => {
+      if (!isRecord(entry)) {
+        return null;
+      }
+
+      const key = String(entry[keyName] ?? "").trim();
+      const count = Number(entry.count ?? 0);
+      if (!key || !Number.isFinite(count)) {
+        return null;
+      }
+
+      return { key, count };
+    })
+    .filter((entry): entry is { key: string; count: number } => entry !== null)
+    .sort((left, right) => right.count - left.count);
+}
+
+function isAuthorized(req: Request): boolean {
+  const url = new URL(req.url);
+  const key =
+    req.headers.get("x-brain-key")?.trim() ||
+    url.searchParams.get("key")?.trim() ||
+    (req.headers.get("authorization") ?? "").replace(/^Bearer\s+/i, "").trim();
+  return key === MCP_ACCESS_KEY;
+}
+
+function json(data: unknown, status = 200): Response {
+  return new Response(JSON.stringify(data, null, 2), { status, headers: CORS_HEADERS });
+}

--- a/integrations/open-brain-rest/function/utils/ingest-config.ts
+++ b/integrations/open-brain-rest/function/utils/ingest-config.ts
@@ -1,0 +1,109 @@
+/**
+ * Shared configuration constants for the ExoCortex ingestion pipeline.
+ *
+ * All values are plain constants with no runtime dependencies.
+ * Import individual names as needed:
+ *   import { EMBEDDING_MODEL, DEFAULT_TYPE } from "../_shared/ingest-config.ts";
+ */
+
+// ── Embedding ────────────────────────────────────────────────────────────────
+
+/** OpenAI embedding model used for vector search. */
+export const EMBEDDING_MODEL = "text-embedding-3-small";
+
+/** Dimensionality of the embedding vectors stored in pgvector. */
+export const EMBEDDING_DIMENSION = 1536;
+
+/** Maximum content length (chars) before truncation for embedding calls. */
+export const MAX_CONTENT_LENGTH = 8000;
+
+// ── Classifier models ────────────────────────────────────────────────────────
+
+/** Anthropic model used for metadata classification / enrichment. */
+export const CLASSIFIER_MODEL_ANTHROPIC = "claude-3-5-haiku-20241022";
+
+/** OpenAI model used as fallback classifier. */
+export const CLASSIFIER_MODEL_OPENAI = "gpt-4o-mini";
+
+// ── Thought defaults ─────────────────────────────────────────────────────────
+
+/** Default thought type when classification is unavailable. */
+export const DEFAULT_TYPE = "idea";
+
+/** Default importance score (1-5 scale). */
+export const DEFAULT_IMPORTANCE = 3;
+
+/** Default quality score (0-100 scale). */
+export const DEFAULT_QUALITY_SCORE = 50;
+
+/** Default sensitivity tier. */
+export const DEFAULT_SENSITIVITY_TIER = "standard";
+
+/** Default classifier confidence for unclassified thoughts. */
+export const DEFAULT_CONFIDENCE = 0.55;
+
+// ── Structured capture overrides ─────────────────────────────────────────────
+
+/**
+ * Confidence assigned to thoughts captured via structured input (MCP, REST,
+ * Telegram) where the caller supplies explicit type/topic metadata.
+ */
+export const STRUCTURED_CAPTURE_CONFIDENCE = 0.82;
+
+/** Importance assigned to structured captures (slightly elevated). */
+export const STRUCTURED_CAPTURE_IMPORTANCE = 4;
+
+// ── Sensitivity ──────────────────────────────────────────────────────────────
+
+/** Ordered sensitivity tiers — index 0 is least restrictive. */
+export const SENSITIVITY_TIERS = ["standard", "personal", "restricted"] as const;
+
+// ── Field length limits ──────────────────────────────────────────────────────
+
+/** Maximum character length for thought summaries. */
+export const MAX_SUMMARY_LENGTH = 160;
+
+/** Maximum character length for topic hint strings. */
+export const MAX_TOPIC_HINT_LENGTH = 80;
+
+/** Maximum character length for next-step / action-item strings. */
+export const MAX_NEXT_STEP_LENGTH = 180;
+
+/** Maximum number of tags that can be attached to a single thought. */
+export const MAX_TAGS_PER_THOUGHT = 12;
+
+// ── Classifier prompt ────────────────────────────────────────────────────────
+
+/**
+ * System prompt sent to the classifier model when extracting metadata
+ * (type, summary, topics, tags, people, action_items, confidence) from
+ * raw thought content.
+ */
+export const EXTRACTION_PROMPT = [
+  "You classify personal notes for a second-brain.",
+  "Return STRICT JSON with keys: type, summary, topics, tags, people, action_items, confidence.",
+  "",
+  "type must be one of: idea, task, person_note, reference, decision, lesson, meeting, journal.",
+  "summary: max 160 chars. topics: 1-3 short lowercase tags. tags: additional freeform labels.",
+  "people: names mentioned. action_items: implied to-dos. confidence: 0-1.",
+  "",
+  "CONFIDENCE CALIBRATION:",
+  "- 0.9+: Clearly personal — user's own decision, preference, lesson, health data",
+  "- 0.7-0.89: Probably personal but could be generic advice",
+  "- 0.5-0.69: Borderline — reads more like general knowledge than personal context",
+  "- Below 0.5: Generic advice, encyclopedia-grade facts, or vague filler",
+  "",
+  "Examples:",
+  "",
+  'Input: "Met with Sarah about the API redesign. She wants GraphQL instead of REST. We\'ll prototype both by Friday."',
+  'Output: {"type":"meeting","summary":"API redesign meeting with Sarah — prototyping GraphQL vs REST","topics":["api-design","graphql"],"tags":["architecture"],"people":["Sarah"],"action_items":["Prototype GraphQL API","Prototype REST API","Compare by Friday"],"confidence":0.95}',
+  "",
+  'Input: "I\'m going to use Supabase instead of Firebase. Better SQL support and the pgvector extension is critical for embeddings."',
+  'Output: {"type":"decision","summary":"Chose Supabase over Firebase for SQL and pgvector support","topics":["database","infrastructure"],"tags":["architecture"],"people":[],"action_items":[],"confidence":0.92}',
+  "",
+  'Input: "Never run database migrations during peak traffic hours. Learned this the hard way last Tuesday."',
+  'Output: {"type":"lesson","summary":"Avoid running DB migrations during peak traffic","topics":["devops","database"],"tags":["best-practice"],"people":[],"action_items":[],"confidence":0.90}',
+  "",
+  'Input: "The boiling point of water is 100\u00B0C at sea level."',
+  'Output: {"type":"reference","summary":"Boiling point of water at sea level","topics":["science"],"tags":["general-knowledge"],"people":[],"action_items":[],"confidence":0.3}',
+].join("\n");

--- a/integrations/open-brain-rest/function/utils/open-brain-utils.ts
+++ b/integrations/open-brain-rest/function/utils/open-brain-utils.ts
@@ -1,0 +1,738 @@
+// Shared utilities for Open Brain Edge Functions.
+// Both ingest-thought and open-brain-mcp import from here.
+
+import {
+  DEFAULT_TYPE,
+  DEFAULT_IMPORTANCE,
+  DEFAULT_QUALITY_SCORE,
+  DEFAULT_SENSITIVITY_TIER,
+  DEFAULT_CONFIDENCE,
+  STRUCTURED_CAPTURE_CONFIDENCE,
+  STRUCTURED_CAPTURE_IMPORTANCE,
+  SENSITIVITY_TIERS,
+  MAX_SUMMARY_LENGTH,
+  EXTRACTION_PROMPT,
+} from "./ingest-config.ts";
+
+export type ThoughtMetadata = {
+  type: string;
+  summary: string;
+  topics: string[];
+  tags: string[];
+  people: string[];
+  action_items: string[];
+  confidence: number;
+};
+
+/** Dimension count for text-embedding-3-small vectors. */
+export const EMBEDDING_DIMENSIONS = 1536;
+
+/** Returns the embedding if it has the correct dimension count, otherwise undefined. */
+export const safeEmbedding = (emb: number[] | null | undefined): number[] | undefined =>
+  Array.isArray(emb) && emb.length === EMBEDDING_DIMENSIONS ? emb : undefined;
+
+export const ALLOWED_TYPES = new Set([
+  "idea",
+  "task",
+  "person_note",
+  "reference",
+  "decision",
+  "lesson",
+  "meeting",
+  "journal",
+]);
+
+type ProviderEnv = {
+  openAiApiKey: string;
+  openAiEmbeddingModel: string;
+  anthropicApiKey: string;
+  anthropicClassifierModel: string;
+  // Fallback: OpenRouter key for embeddings if OPENAI_API_KEY not set
+  openRouterApiKey: string;
+  openRouterEmbeddingModel: string;
+};
+
+export type EmbeddingProvider = "openai";
+export type MetadataProvider = "anthropic" | "openai";
+
+function readProviderEnv(): ProviderEnv {
+  return {
+    openAiApiKey: Deno.env.get("OPENAI_API_KEY") ?? "",
+    openAiEmbeddingModel: Deno.env.get("OPENAI_EMBEDDING_MODEL") ?? "text-embedding-3-small",
+    anthropicApiKey: Deno.env.get("ANTHROPIC_API_KEY") ?? "",
+    anthropicClassifierModel: Deno.env.get("ANTHROPIC_CLASSIFIER_MODEL") ?? "claude-3-5-haiku-20241022",
+    openRouterApiKey: Deno.env.get("OPENROUTER_API_KEY") ?? "",
+    openRouterEmbeddingModel: Deno.env.get("OPENROUTER_EMBEDDING_MODEL") ?? "openai/text-embedding-3-small",
+  };
+}
+
+export function detectEmbeddingProvider(): EmbeddingProvider {
+  return "openai";
+}
+
+export function detectMetadataProvider(): MetadataProvider {
+  const env = readProviderEnv();
+  return env.anthropicApiKey ? "anthropic" : "openai";
+}
+
+export async function embedText(input: string, _provider?: EmbeddingProvider): Promise<number[]> {
+  const env = readProviderEnv();
+
+  // Prefer OpenAI direct, fall back to OpenRouter (which proxies to OpenAI)
+  if (env.openAiApiKey) {
+    const response = await fetch("https://api.openai.com/v1/embeddings", {
+      method: "POST",
+      headers: openAIHeaders(env.openAiApiKey),
+      body: JSON.stringify({ model: env.openAiEmbeddingModel, input }),
+    });
+
+    if (!response.ok) {
+      throw new Error(`OpenAI embedding failed (${response.status}): ${await response.text()}`);
+    }
+
+    const payload = await response.json();
+    const embedding = payload?.data?.[0]?.embedding;
+
+    if (!Array.isArray(embedding) || embedding.length === 0) {
+      throw new Error("OpenAI embedding response missing vector data");
+    }
+
+    return embedding as number[];
+  }
+
+  // Fallback: use OpenRouter to proxy OpenAI embeddings
+  if (env.openRouterApiKey) {
+    const response = await fetch("https://openrouter.ai/api/v1/embeddings", {
+      method: "POST",
+      headers: {
+        "Authorization": `Bearer ${env.openRouterApiKey}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ model: env.openRouterEmbeddingModel, input }),
+    });
+
+    if (!response.ok) {
+      throw new Error(`Embedding via proxy failed (${response.status}): ${await response.text()}`);
+    }
+
+    const payload = await response.json();
+    const embedding = payload?.data?.[0]?.embedding;
+
+    if (!Array.isArray(embedding) || embedding.length === 0) {
+      throw new Error("Embedding proxy response missing vector data");
+    }
+
+    return embedding as number[];
+  }
+
+  throw new Error("No embedding API key configured. Set OPENAI_API_KEY or OPENROUTER_API_KEY.");
+}
+
+// Classifier prompt is now in ingest-config.ts — imported as EXTRACTION_PROMPT
+const CLASSIFIER_PROMPT = EXTRACTION_PROMPT;
+
+export async function extractMetadata(input: string, provider?: MetadataProvider): Promise<ThoughtMetadata> {
+  const fallback = fallbackMetadata(input);
+  const resolved = provider ?? detectMetadataProvider();
+
+  // Try primary provider
+  try {
+    const raw = resolved === "anthropic"
+      ? await fetchAnthropicMetadata(input)
+      : await fetchOpenAIMetadata(input);
+
+    if (raw.trim()) {
+      const parsed = JSON.parse(raw);
+      return sanitizeMetadata(parsed, input);
+    }
+  } catch (err) {
+    console.warn("Primary metadata classification failed", resolved, err);
+  }
+
+  // Fallback: try the other provider
+  const fallbackProvider = resolved === "anthropic" ? "openai" : "anthropic";
+  try {
+    const raw = fallbackProvider === "anthropic"
+      ? await fetchAnthropicMetadata(input)
+      : await fetchOpenAIMetadata(input);
+
+    if (raw.trim()) {
+      const parsed = JSON.parse(raw);
+      return sanitizeMetadata(parsed, input);
+    }
+  } catch (err) {
+    console.warn("Fallback metadata classification failed", fallbackProvider, err);
+  }
+
+  return fallback;
+}
+
+export function fallbackMetadata(input: string): ThoughtMetadata {
+  return {
+    type: "idea",
+    summary: input.slice(0, 160),
+    topics: [],
+    tags: [],
+    people: [],
+    action_items: [],
+    confidence: 0.2,
+  };
+}
+
+export function sanitizeMetadata(value: unknown, sourceText: string): ThoughtMetadata {
+  const fallback = fallbackMetadata(sourceText);
+
+  if (!isRecord(value)) {
+    return fallback;
+  }
+
+  const typeCandidate = asString(value.type, fallback.type);
+  const type = ALLOWED_TYPES.has(typeCandidate) ? typeCandidate : fallback.type;
+
+  const summary = asString(value.summary, fallback.summary).trim().slice(0, 160) || fallback.summary;
+  const confidence = asNumber(value.confidence, fallback.confidence, 0, 1);
+
+  return {
+    type,
+    summary,
+    topics: normalizeStringArray(value.topics),
+    tags: normalizeStringArray(value.tags),
+    people: normalizeStringArray(value.people),
+    action_items: normalizeStringArray(value.action_items),
+    confidence,
+  };
+}
+
+export function applyEvergreenTag(content: string, metadata: Record<string, unknown>): Record<string, unknown> {
+  const result = { ...metadata };
+  const tags = normalizeStringArray(result.tags);
+
+  if (containsEvergreen(content)) {
+    const hasEvergreen = tags.some((tag) => tag.toLowerCase() === "evergreen");
+    if (!hasEvergreen) {
+      tags.push("evergreen");
+    }
+  }
+
+  result.tags = tags;
+  return result;
+}
+
+export function containsEvergreen(content: string): boolean {
+  return /\bevergreen\b/i.test(content);
+}
+
+export function normalizeStringArray(value: unknown): string[] {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+
+  return [...new Set(
+    value
+      .map((item) => (typeof item === "string" ? item.trim() : ""))
+      .filter((item) => item.length > 0)
+      .slice(0, 12),
+  )];
+}
+
+async function fetchAnthropicMetadata(input: string): Promise<string> {
+  const env = readProviderEnv();
+  if (!env.anthropicApiKey) {
+    throw new Error("ANTHROPIC_API_KEY is not configured");
+  }
+
+  const response = await fetch("https://api.anthropic.com/v1/messages", {
+    method: "POST",
+    headers: {
+      "x-api-key": env.anthropicApiKey,
+      "anthropic-version": "2023-06-01",
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      model: env.anthropicClassifierModel,
+      max_tokens: 1024,
+      temperature: 0.1,
+      system: CLASSIFIER_PROMPT,
+      messages: [
+        { role: "user", content: input },
+      ],
+    }),
+  });
+
+  if (!response.ok) {
+    throw new Error(`Anthropic classification failed (${response.status}): ${await response.text()}`);
+  }
+
+  const payload = await response.json();
+  return readAnthropicText(payload);
+}
+
+async function fetchOpenAIMetadata(input: string): Promise<string> {
+  const env = readProviderEnv();
+  if (!env.openAiApiKey) {
+    throw new Error("OPENAI_API_KEY is not configured");
+  }
+
+  const response = await fetch("https://api.openai.com/v1/chat/completions", {
+    method: "POST",
+    headers: openAIHeaders(env.openAiApiKey),
+    body: JSON.stringify({
+      model: "gpt-4o-mini",
+      temperature: 0.1,
+      response_format: { type: "json_object" },
+      messages: [
+        { role: "system", content: CLASSIFIER_PROMPT },
+        { role: "user", content: input },
+      ],
+    }),
+  });
+
+  if (!response.ok) {
+    throw new Error(`OpenAI classification failed (${response.status}): ${await response.text()}`);
+  }
+
+  const payload = await response.json();
+  return readChatCompletionText(payload);
+}
+
+function readAnthropicText(payload: unknown): string {
+  if (!isRecord(payload) || !Array.isArray(payload.content) || payload.content.length === 0) {
+    return "";
+  }
+
+  return payload.content
+    .map((block: unknown) => {
+      if (!isRecord(block) || asString(block.type, "") !== "text") {
+        return "";
+      }
+      return asString(block.text, "");
+    })
+    .join("");
+}
+
+function readChatCompletionText(payload: unknown): string {
+  if (!isRecord(payload) || !Array.isArray(payload.choices) || payload.choices.length === 0) {
+    return "";
+  }
+
+  const firstChoice = payload.choices[0];
+  if (!isRecord(firstChoice) || !isRecord(firstChoice.message)) {
+    return "";
+  }
+
+  const content = firstChoice.message.content;
+  if (typeof content === "string") {
+    return content;
+  }
+
+  if (!Array.isArray(content)) {
+    return "";
+  }
+
+  return content
+    .map((part) => {
+      if (!isRecord(part) || asString(part.type, "") !== "text") {
+        return "";
+      }
+
+      return asString(part.text, "");
+    })
+    .join("");
+}
+
+function openAIHeaders(apiKey: string): Record<string, string> {
+  return {
+    Authorization: `Bearer ${apiKey}`,
+    "Content-Type": "application/json",
+  };
+}
+
+// --- Sensitivity detection ---
+// Patterns loaded from shared config: config/sensitivity-patterns.json
+import { RESTRICTED_PATTERNS, PERSONAL_PATTERNS } from "./sensitivity-patterns.ts";
+
+export type SensitivityResult = {
+  tier: "standard" | "personal" | "restricted";
+  reasons: string[];
+};
+
+export function detectSensitivity(text: string): SensitivityResult {
+  const reasons: string[] = [];
+
+  for (const [pattern, reason] of RESTRICTED_PATTERNS) {
+    if (pattern.test(text)) {
+      reasons.push(reason);
+      return { tier: "restricted", reasons };
+    }
+  }
+
+  for (const [pattern, reason] of PERSONAL_PATTERNS) {
+    if (pattern.test(text)) {
+      reasons.push(reason);
+    }
+  }
+
+  if (reasons.length > 0) {
+    return { tier: "personal", reasons };
+  }
+
+  return { tier: "standard", reasons: [] };
+}
+
+// --- Structured capture parsing ---
+
+export type StructuredCapture = {
+  matched: boolean;
+  normalizedText: string;
+  typeHint: string | null;
+  topicHint: string | null;
+  nextStep: string | null;
+};
+
+export function parseStructuredCapture(content: string): StructuredCapture {
+  const trimmed = content.trim();
+  const match = /^\s*\[([^\]]+)\]\s*\[([^\]]+)\]\s*(.+?)(?:\s*\+\s*(.+))?$/i.exec(trimmed);
+  if (!match) {
+    return {
+      matched: false,
+      normalizedText: trimmed,
+      typeHint: null,
+      topicHint: null,
+      nextStep: null,
+    };
+  }
+
+  const typeHint = normalizeTypeHint(match[1] ?? "");
+  const topicHint = (match[2] ?? "").trim().slice(0, 80) || null;
+  const thoughtBody = (match[3] ?? "").trim();
+  const nextStep = (match[4] ?? "").trim().slice(0, 180) || null;
+  const normalizedText = nextStep
+    ? `${thoughtBody} Next step: ${nextStep}`
+    : thoughtBody;
+
+  return {
+    matched: true,
+    normalizedText,
+    typeHint,
+    topicHint,
+    nextStep,
+  };
+}
+
+export function normalizeTypeHint(value: string): string | null {
+  const key = value.trim().toLowerCase().replace(/\s+/g, "_");
+  if (!key) {
+    return null;
+  }
+
+  const aliases: Record<string, string> = {
+    idea: "idea",
+    task: "task",
+    person: "person_note",
+    person_note: "person_note",
+    reference: "reference",
+    ref: "reference",
+    note: "reference",
+    decision: "decision",
+    lesson: "lesson",
+    meeting: "meeting",
+    event: "meeting",
+    journal: "journal",
+    reflection: "journal",
+  };
+
+  return aliases[key] ?? null;
+}
+
+export function mergeUniqueStrings(base: unknown, extras: string[]): string[] {
+  return normalizeStringArray([
+    ...normalizeStringArray(base),
+    ...normalizeStringArray(extras),
+  ]);
+}
+
+// --- Generic helpers ---
+
+export function asString(value: unknown, fallback: string): string {
+  return typeof value === "string" ? value : fallback;
+}
+
+export function asNumber(value: unknown, fallback: number, min: number, max: number): number {
+  const parsed = Number(value);
+  if (!Number.isFinite(parsed)) {
+    return fallback;
+  }
+
+  return Math.min(max, Math.max(min, parsed));
+}
+
+export function asInteger(value: unknown, fallback: number, min: number, max: number): number {
+  return Math.round(asNumber(value, fallback, min, max));
+}
+
+export function asBoolean(value: unknown, fallback: boolean): boolean {
+  return typeof value === "boolean" ? value : fallback;
+}
+
+export function asOptionalInteger(value: unknown, min: number, max: number): number | null {
+  if (value === undefined || value === null || value === "") {
+    return null;
+  }
+
+  return asInteger(value, min, min, max);
+}
+
+export function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+// --- Content fingerprint ---
+
+/**
+ * Compute SHA-256 fingerprint matching the SQL `compute_thought_content_fingerprint()`.
+ * Algorithm: lowercase → collapse whitespace → trim → SHA-256 hex.
+ */
+export async function computeContentFingerprint(content: string): Promise<string> {
+  const normalized = content.trim().replace(/\s+/g, " ").toLowerCase();
+  if (!normalized) return "";
+  const encoder = new TextEncoder();
+  const data = encoder.encode(normalized);
+  const hashBuffer = await crypto.subtle.digest("SHA-256", data);
+  return Array.from(new Uint8Array(hashBuffer))
+    .map((b) => b.toString(16).padStart(2, "0"))
+    .join("");
+}
+
+// --- Sensitivity tier resolution ---
+
+/**
+ * Resolve sensitivity tier with escalation-only semantics.
+ * Can only escalate (standard → personal → restricted), never downgrade.
+ * Unrecognized values normalize to "personal".
+ */
+export function resolveSensitivityTier(
+  detected: typeof SENSITIVITY_TIERS[number],
+  override?: string,
+): typeof SENSITIVITY_TIERS[number] {
+  if (!override) return detected;
+
+  const normalized = override.trim().toLowerCase();
+  const validTiers: readonly string[] = SENSITIVITY_TIERS;
+  const overrideIndex = validTiers.indexOf(normalized);
+  const detectedIndex = validTiers.indexOf(detected);
+
+  if (overrideIndex < 0) {
+    // Unrecognized value → normalize to "personal" (safe default)
+    const personalIndex = validTiers.indexOf("personal");
+    return SENSITIVITY_TIERS[Math.max(detectedIndex, personalIndex)];
+  }
+
+  // Only escalate, never downgrade
+  return SENSITIVITY_TIERS[Math.max(detectedIndex, overrideIndex)];
+}
+
+// --- Canonical ingest pipeline ---
+
+export type PreparedPayload = {
+  content: string;
+  embedding: number[];
+  metadata: Record<string, unknown>;
+  type: string;
+  importance: number;
+  quality_score: number;
+  sensitivity_tier: string;
+  source_type: string;
+  content_fingerprint: string;
+  warnings: string[];
+};
+
+/** Ambient capture provenance fields — threaded through smart-ingest into thought metadata. */
+export type SourceMetadata = {
+  source_client?: string;     // "claude_code" | "claude_ai" | "chatgpt" | etc.
+  capture_mode?: string;      // "ambient_session_end" | "manual" | "bulk_import"
+  session_id?: string;        // External session UUID
+  source_title?: string;      // Human-readable session name
+  captured_at?: string;       // ISO 8601 timestamp
+  project_path?: string;      // Working directory from transcript
+  git_branch?: string;        // Branch name if available
+  import_key?: string;        // Idempotency key for session-level dedup
+};
+
+export type PrepareThoughtOpts = {
+  source?: string;
+  source_type?: string;
+  metadata?: Record<string, unknown>;
+  /** Skip embedding computation (for dry-run or when caller provides embedding) */
+  skip_embedding?: boolean;
+  /** Pre-computed embedding to use instead of calling embedText */
+  embedding?: number[];
+  /** Skip LLM metadata extraction (use only structured capture + defaults) */
+  skip_classification?: boolean;
+};
+
+/**
+ * Canonical thought preparation pipeline.
+ *
+ * Override precedence (highest to lowest):
+ *   1. Structured capture hint (from parseStructuredCapture)
+ *   2. Explicit caller override (opts.metadata.type, opts.metadata.importance, etc.)
+ *   3. Extracted metadata (from LLM classification via extractMetadata)
+ *   4. Defaults (type: 'idea', importance: 3, quality_score: 50, sensitivity: 'standard')
+ *
+ * All ingest paths (MCP capture_thought, REST /capture, smart-ingest) call this.
+ */
+export async function prepareThoughtPayload(
+  content: string,
+  opts?: PrepareThoughtOpts,
+): Promise<PreparedPayload> {
+  const source = opts?.source ?? "mcp";
+  const sourceType = opts?.source_type ?? source;
+  const extraMetadata = opts?.metadata ?? {};
+  const warnings: string[] = [];
+
+  // Step 1: Parse structured capture format
+  const structuredCapture = parseStructuredCapture(content);
+  const normalizedText = structuredCapture.normalizedText.trim();
+
+  if (!normalizedText) {
+    throw new Error("content is required");
+  }
+
+  // Step 2: Detect sensitivity
+  const sensitivity = detectSensitivity(normalizedText);
+
+  // Step 3: Resolve type (precedence: structured > caller > extracted > default)
+  const callerType = asString(extraMetadata.memory_type, asString(extraMetadata.type, ""));
+
+  // Step 4: Extract metadata via LLM (if not skipped)
+  let extracted: ThoughtMetadata | null = null;
+  if (!opts?.skip_classification) {
+    try {
+      extracted = await extractMetadata(normalizedText);
+    } catch (err) {
+      console.warn("Metadata extraction failed, using defaults", err);
+      warnings.push("metadata_fallback");
+    }
+  }
+
+  // Step 5: Apply precedence rules for type
+  const resolvedType = sanitizeType(
+    structuredCapture.typeHint || callerType || extracted?.type || DEFAULT_TYPE
+  );
+
+  // Step 6: Merge topics, tags, people, action_items
+  const baseTags = normalizeStringArray(extraMetadata.tags);
+  const baseTopics = normalizeStringArray(extraMetadata.topics);
+  const basePeople = normalizeStringArray(extraMetadata.people);
+  const baseActionItems = normalizeStringArray(extraMetadata.action_items);
+
+  const extractedTopics = extracted ? normalizeStringArray(extracted.topics) : [];
+  const extractedTags = extracted ? normalizeStringArray(extracted.tags) : [];
+  const extractedPeople = extracted ? normalizeStringArray(extracted.people) : [];
+  const extractedActionItems = extracted ? normalizeStringArray(extracted.action_items) : [];
+
+  let topics = mergeUniqueStrings(baseTopics.length > 0 ? baseTopics : extractedTopics, []);
+  let tags = mergeUniqueStrings(baseTags.length > 0 ? baseTags : extractedTags, []);
+  const people = mergeUniqueStrings(basePeople.length > 0 ? basePeople : extractedPeople, []);
+  let actionItems = mergeUniqueStrings(
+    baseActionItems.length > 0 ? baseActionItems : extractedActionItems, []
+  );
+
+  // Add structured capture hints
+  if (structuredCapture.topicHint) {
+    topics = mergeUniqueStrings(topics, [structuredCapture.topicHint]);
+    tags = mergeUniqueStrings(tags, [structuredCapture.topicHint]);
+  }
+  if (structuredCapture.nextStep) {
+    actionItems = mergeUniqueStrings(actionItems, [structuredCapture.nextStep]);
+  }
+
+  // Step 7: Resolve importance (precedence: caller > structured > extracted-confidence > default)
+  const callerImportance = extraMetadata.importance !== undefined
+    ? asInteger(extraMetadata.importance, DEFAULT_IMPORTANCE, 1, 5)
+    : null;
+  const structuredImportance = structuredCapture.matched ? STRUCTURED_CAPTURE_IMPORTANCE : null;
+  const importance = callerImportance ?? structuredImportance ?? DEFAULT_IMPORTANCE;
+
+  // Step 8: Resolve confidence
+  const callerConfidence = extraMetadata.confidence !== undefined
+    ? asNumber(extraMetadata.confidence, DEFAULT_CONFIDENCE, 0, 1)
+    : null;
+  const structuredConfidence = structuredCapture.matched ? STRUCTURED_CAPTURE_CONFIDENCE : null;
+  const confidence = callerConfidence ?? structuredConfidence ?? extracted?.confidence ?? DEFAULT_CONFIDENCE;
+
+  // Step 9: Resolve quality score
+  const callerQuality = extraMetadata.quality_score !== undefined
+    ? asNumber(extraMetadata.quality_score, DEFAULT_QUALITY_SCORE, 0, 100)
+    : null;
+  const quality_score = callerQuality ?? Math.round((confidence * 70) + 20);
+
+  // Step 10: Resolve summary
+  const callerSummary = asString(extraMetadata.summary, "");
+  const extractedSummary = extracted?.summary ?? "";
+  const summary = (callerSummary || extractedSummary || normalizedText).trim().slice(0, MAX_SUMMARY_LENGTH);
+
+  // Step 11: Resolve sensitivity tier (only escalates)
+  const callerSensitivity = asString(extraMetadata.sensitivity_tier, asString(extraMetadata.sensitivity, ""));
+  const sensitivity_tier = resolveSensitivityTier(sensitivity.tier, callerSensitivity || undefined);
+
+  // Step 12: Compute embedding
+  let embedding: number[] = [];
+  if (opts?.embedding) {
+    embedding = opts.embedding;
+  } else if (!opts?.skip_embedding) {
+    try {
+      embedding = await embedText(normalizedText);
+    } catch (err) {
+      console.warn("Embedding failed, will be null", err);
+      warnings.push("embedding_unavailable");
+    }
+  }
+
+  // Step 13: Compute content fingerprint
+  const content_fingerprint = await computeContentFingerprint(normalizedText);
+
+  // Step 14: Assemble metadata object
+  const metadata = applyEvergreenTag(normalizedText, {
+    ...extraMetadata,
+    type: resolvedType,
+    summary,
+    topics,
+    tags,
+    people,
+    action_items: actionItems,
+    confidence,
+    source,
+    source_type: asString(extraMetadata.source_type, sourceType),
+    capture_format: structuredCapture.matched ? "structured_v1" : "freeform",
+    structured_capture: structuredCapture.matched
+      ? {
+          type: structuredCapture.typeHint,
+          topic: structuredCapture.topicHint,
+          next_step: structuredCapture.nextStep,
+        }
+      : null,
+    captured_at: new Date().toISOString(),
+    sensitivity_reasons: sensitivity.reasons,
+    agent_name: asString(extraMetadata.agent_name, "mcp"),
+    provider: asString(extraMetadata.provider, "mcp"),
+  });
+
+  return {
+    content: normalizedText,
+    embedding,
+    metadata,
+    type: resolvedType,
+    importance,
+    quality_score,
+    sensitivity_tier,
+    source_type: asString(extraMetadata.source_type, sourceType),
+    content_fingerprint,
+    warnings,
+  };
+}
+
+function sanitizeType(value: string): string {
+  const normalized = value.trim().toLowerCase();
+  return ALLOWED_TYPES.has(normalized) ? normalized : DEFAULT_TYPE;
+}

--- a/integrations/open-brain-rest/function/utils/sensitivity-patterns.json
+++ b/integrations/open-brain-rest/function/utils/sensitivity-patterns.json
@@ -1,0 +1,19 @@
+{
+  "restricted": [
+    { "pattern": "\\b\\d{3}-?\\d{2}-?\\d{4}\\b", "flags": "", "label": "ssn_pattern" },
+    { "pattern": "\\b[A-Z]{1,2}\\d{6,9}\\b", "flags": "", "label": "passport_pattern" },
+    { "pattern": "\\b\\d{8,17}\\b.*\\b(account|routing|iban)\\b", "flags": "i", "label": "bank_account" },
+    { "pattern": "\\b(account|routing)\\b.*\\b\\d{8,17}\\b", "flags": "i", "label": "bank_account" },
+    { "pattern": "\\b(sk-|pk_live_|sk_live_|ghp_|gho_|AKIA)[A-Za-z0-9]{10,}", "flags": "i", "label": "api_key" },
+    { "pattern": "\\bpassword\\s*[:=]\\s*\\S+", "flags": "i", "label": "password_value" },
+    { "pattern": "\\b\\d{4}[\\s-]?\\d{4}[\\s-]?\\d{4}[\\s-]?\\d{4}\\b", "flags": "", "label": "credit_card" }
+  ],
+  "personal": [
+    { "pattern": "\\b\\d+\\s*mg\\b(?!\\s*\\/\\s*(dL|kg|L|ml))", "flags": "i", "label": "medication_dosage" },
+    { "pattern": "\\b(pregabalin|metoprolol|losartan|lisinopril|aspirin|atorvastatin|sertraline|metformin|gabapentin|prednisone|insulin|warfarin)\\b", "flags": "i", "label": "drug_name" },
+    { "pattern": "\\b(glucose|a1c|cholesterol|blood pressure|bp|hrv|bmi)\\b.*\\b\\d+", "flags": "i", "label": "health_measurement" },
+    { "pattern": "\\b(diagnosed|diagnosis|prediabetic|diabetic|arrhythmia|ablation)\\b", "flags": "i", "label": "medical_condition" },
+    { "pattern": "\\b(salary|income|net worth|401k|ira|portfolio)\\b.*\\b\\$?\\d", "flags": "i", "label": "financial_detail" },
+    { "pattern": "\\b\\$\\d{3,}[,\\d]*\\b", "flags": "i", "label": "financial_amount" }
+  ]
+}

--- a/integrations/open-brain-rest/function/utils/sensitivity-patterns.ts
+++ b/integrations/open-brain-rest/function/utils/sensitivity-patterns.ts
@@ -1,0 +1,19 @@
+/**
+ * Compile sensitivity patterns from the shared JSON config.
+ * Single source of truth: config/sensitivity-patterns.json
+ */
+
+import patternsJson from "./sensitivity-patterns.json" with { type: "json" };
+
+interface PatternDef {
+  pattern: string;
+  flags: string;
+  label: string;
+}
+
+function compile(defs: PatternDef[]): [RegExp, string][] {
+  return defs.map((d) => [new RegExp(d.pattern, d.flags), d.label]);
+}
+
+export const RESTRICTED_PATTERNS: [RegExp, string][] = compile(patternsJson.restricted);
+export const PERSONAL_PATTERNS: [RegExp, string][] = compile(patternsJson.personal);

--- a/integrations/open-brain-rest/metadata.json
+++ b/integrations/open-brain-rest/metadata.json
@@ -1,0 +1,25 @@
+{
+  "name": "Open Brain REST API",
+  "description": "REST API gateway providing search, capture, browse, CRUD, stats, reflections, duplicates, and ingest endpoints for the Open Brain thoughts database.",
+  "category": "integrations",
+  "author": {
+    "name": "Alan Shurafa",
+    "github": "alanshurafa"
+  },
+  "version": "1.0.0",
+  "requires": {
+    "open_brain": true,
+    "services": [
+      "OpenAI (embeddings + classification) or OpenRouter (embeddings only)",
+      "Anthropic (optional, preferred classifier)"
+    ],
+    "tools": [
+      "Supabase CLI"
+    ]
+  },
+  "tags": ["rest-api", "edge-function", "dashboard", "search", "capture", "ingest"],
+  "difficulty": "intermediate",
+  "estimated_time": "45 minutes",
+  "created": "2026-03-27",
+  "updated": "2026-03-27"
+}

--- a/integrations/open-brain-rest/sql/01-schema-extensions.sql
+++ b/integrations/open-brain-rest/sql/01-schema-extensions.sql
@@ -1,0 +1,78 @@
+-- 01-schema-extensions.sql
+-- Adds serial_id surrogate key and REST API columns to the thoughts table.
+-- Idempotent: safe to run multiple times on both UUID and BIGSERIAL id variants.
+
+-- Step 1: Add serial_id column if it doesn't exist
+ALTER TABLE thoughts ADD COLUMN IF NOT EXISTS serial_id BIGINT;
+
+-- Step 2: Backfill serial_id based on the type of thoughts.id
+DO $$
+DECLARE
+  v_data_type TEXT;
+  v_max BIGINT;
+BEGIN
+  -- Detect the data type of thoughts.id
+  SELECT data_type INTO v_data_type
+  FROM information_schema.columns
+  WHERE table_schema = 'public'
+    AND table_name = 'thoughts'
+    AND column_name = 'id';
+
+  IF v_data_type IN ('integer', 'bigint') THEN
+    -- Integer-based id: copy directly
+    UPDATE thoughts SET serial_id = id WHERE serial_id IS NULL;
+  ELSE
+    -- UUID-based id: assign deterministic sequential numbers
+    WITH numbered AS (
+      SELECT id, ROW_NUMBER() OVER (ORDER BY created_at, id) AS rn
+      FROM thoughts
+      WHERE serial_id IS NULL
+    )
+    UPDATE thoughts t
+    SET serial_id = (
+      SELECT n.rn + COALESCE((SELECT MAX(serial_id) FROM thoughts WHERE serial_id IS NOT NULL), 0)
+      FROM numbered n
+      WHERE n.id = t.id
+    )
+    WHERE t.serial_id IS NULL;
+  END IF;
+
+  -- Step 3: Create sequence and wire it up
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_class WHERE relname = 'thoughts_serial_id_seq' AND relkind = 'S'
+  ) THEN
+    CREATE SEQUENCE thoughts_serial_id_seq;
+  END IF;
+
+  SELECT COALESCE(MAX(serial_id), 0) INTO v_max FROM thoughts;
+  PERFORM setval('thoughts_serial_id_seq', GREATEST(v_max, 1));
+
+  -- Set column default to use the sequence
+  ALTER TABLE thoughts ALTER COLUMN serial_id SET DEFAULT nextval('thoughts_serial_id_seq');
+END $$;
+
+-- Step 4: Add UNIQUE constraint (idempotent via IF NOT EXISTS on the index)
+CREATE UNIQUE INDEX IF NOT EXISTS idx_thoughts_serial_id_unique ON thoughts (serial_id);
+
+-- Step 5: Ensure NOT NULL
+ALTER TABLE thoughts ALTER COLUMN serial_id SET NOT NULL;
+
+-- Step 6: Add additional columns
+ALTER TABLE thoughts ADD COLUMN IF NOT EXISTS type TEXT DEFAULT 'idea';
+ALTER TABLE thoughts ADD COLUMN IF NOT EXISTS importance SMALLINT DEFAULT 3;
+ALTER TABLE thoughts ADD COLUMN IF NOT EXISTS quality_score NUMERIC(5,2) DEFAULT 50;
+ALTER TABLE thoughts ADD COLUMN IF NOT EXISTS sensitivity_tier TEXT DEFAULT 'standard';
+ALTER TABLE thoughts ADD COLUMN IF NOT EXISTS source_type TEXT DEFAULT 'mcp';
+ALTER TABLE thoughts ADD COLUMN IF NOT EXISTS content_fingerprint TEXT;
+ALTER TABLE thoughts ADD COLUMN IF NOT EXISTS updated_at TIMESTAMPTZ DEFAULT now();
+
+-- Step 7: Add indexes
+CREATE INDEX IF NOT EXISTS idx_thoughts_type ON thoughts (type);
+CREATE INDEX IF NOT EXISTS idx_thoughts_importance ON thoughts (importance);
+CREATE INDEX IF NOT EXISTS idx_thoughts_sensitivity ON thoughts (sensitivity_tier);
+CREATE INDEX IF NOT EXISTS idx_thoughts_fingerprint ON thoughts (content_fingerprint);
+CREATE INDEX IF NOT EXISTS idx_thoughts_serial_id ON thoughts (serial_id);
+
+-- Step 8: Grant permissions
+GRANT SELECT, INSERT, UPDATE, DELETE ON TABLE public.thoughts TO service_role;
+GRANT USAGE, SELECT ON SEQUENCE thoughts_serial_id_seq TO service_role;

--- a/integrations/open-brain-rest/sql/02-reflections-table.sql
+++ b/integrations/open-brain-rest/sql/02-reflections-table.sql
@@ -1,0 +1,27 @@
+-- 02-reflections-table.sql
+-- Creates the reflections table for storing structured reasoning about thoughts.
+-- All foreign keys reference thoughts(serial_id), not thoughts(id).
+
+CREATE TABLE IF NOT EXISTS reflections (
+  id BIGSERIAL PRIMARY KEY,
+  thought_id BIGINT NOT NULL REFERENCES thoughts(serial_id) ON DELETE CASCADE,
+  trigger_context TEXT NOT NULL,
+  options JSONB NOT NULL DEFAULT '[]'::jsonb,
+  factors JSONB NOT NULL DEFAULT '[]'::jsonb,
+  conclusion TEXT NOT NULL DEFAULT '',
+  confidence NUMERIC(3,2) DEFAULT 0.5,
+  reflection_type TEXT NOT NULL DEFAULT 'general',
+  embedding vector(1536),
+  metadata JSONB NOT NULL DEFAULT '{}'::jsonb,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+-- Indexes
+CREATE INDEX IF NOT EXISTS idx_reflections_thought_id ON reflections (thought_id);
+CREATE INDEX IF NOT EXISTS idx_reflections_reflection_type ON reflections (reflection_type);
+CREATE INDEX IF NOT EXISTS idx_reflections_created_at ON reflections (created_at);
+
+-- Permissions
+GRANT SELECT, INSERT, UPDATE, DELETE ON TABLE public.reflections TO service_role;
+GRANT USAGE, SELECT ON SEQUENCE reflections_id_seq TO service_role;

--- a/integrations/open-brain-rest/sql/03-ingestion-tables.sql
+++ b/integrations/open-brain-rest/sql/03-ingestion-tables.sql
@@ -1,0 +1,79 @@
+-- 03-ingestion-tables.sql
+-- Creates the ingestion pipeline tables (jobs and items) and the
+-- append_thought_evidence RPC for the smart-ingest workflow.
+
+-- ── ingestion_jobs ──────────────────────────────────────────────────
+CREATE TABLE IF NOT EXISTS ingestion_jobs (
+  id BIGSERIAL PRIMARY KEY,
+  source_label TEXT NOT NULL,
+  raw_input TEXT,
+  status TEXT NOT NULL DEFAULT 'pending'
+    CHECK (status IN ('pending', 'extracting', 'extracted', 'executing', 'complete', 'failed')),
+  extracted_count INT DEFAULT 0,
+  added_count INT DEFAULT 0,
+  skipped_count INT DEFAULT 0,
+  appended_count INT DEFAULT 0,
+  revised_count INT DEFAULT 0,
+  metadata JSONB DEFAULT '{}'::jsonb,
+  created_at TIMESTAMPTZ DEFAULT now(),
+  completed_at TIMESTAMPTZ
+);
+
+CREATE INDEX IF NOT EXISTS idx_ingestion_jobs_status ON ingestion_jobs (status);
+CREATE INDEX IF NOT EXISTS idx_ingestion_jobs_created_at ON ingestion_jobs (created_at);
+
+GRANT SELECT, INSERT, UPDATE, DELETE ON TABLE public.ingestion_jobs TO service_role;
+GRANT USAGE, SELECT ON SEQUENCE ingestion_jobs_id_seq TO service_role;
+
+-- ── ingestion_items ─────────────────────────────────────────────────
+CREATE TABLE IF NOT EXISTS ingestion_items (
+  id BIGSERIAL PRIMARY KEY,
+  job_id BIGINT NOT NULL REFERENCES ingestion_jobs(id) ON DELETE CASCADE,
+  content TEXT NOT NULL,
+  type TEXT DEFAULT 'idea',
+  fingerprint TEXT,
+  action TEXT NOT NULL DEFAULT 'add'
+    CHECK (action IN ('add', 'skip', 'create_revision', 'append_evidence')),
+  reason TEXT,
+  similarity NUMERIC(5,4),
+  status TEXT NOT NULL DEFAULT 'pending',
+  matched_thought_id BIGINT REFERENCES thoughts(serial_id),
+  result_thought_id BIGINT REFERENCES thoughts(serial_id),
+  metadata JSONB DEFAULT '{}'::jsonb,
+  created_at TIMESTAMPTZ DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_ingestion_items_job_id ON ingestion_items (job_id);
+CREATE INDEX IF NOT EXISTS idx_ingestion_items_status ON ingestion_items (status);
+CREATE INDEX IF NOT EXISTS idx_ingestion_items_fingerprint ON ingestion_items (fingerprint);
+CREATE INDEX IF NOT EXISTS idx_ingestion_items_action ON ingestion_items (action);
+
+GRANT SELECT, INSERT, UPDATE, DELETE ON TABLE public.ingestion_items TO service_role;
+GRANT USAGE, SELECT ON SEQUENCE ingestion_items_id_seq TO service_role;
+
+-- ── append_thought_evidence RPC ─────────────────────────────────────
+CREATE OR REPLACE FUNCTION append_thought_evidence(
+  p_thought_id BIGINT,
+  p_new_content TEXT,
+  p_source_label TEXT DEFAULT 'smart-ingest'
+)
+RETURNS JSONB AS $$
+DECLARE
+  v_current TEXT;
+  v_updated TEXT;
+BEGIN
+  SELECT content INTO v_current FROM thoughts WHERE serial_id = p_thought_id;
+
+  IF v_current IS NULL THEN
+    RETURN jsonb_build_object('error', 'thought not found');
+  END IF;
+
+  v_updated := v_current || E'\n\n--- Evidence from ' || p_source_label || ' ---\n' || p_new_content;
+
+  UPDATE thoughts
+  SET content = v_updated, updated_at = now()
+  WHERE serial_id = p_thought_id;
+
+  RETURN jsonb_build_object('thought_id', p_thought_id, 'action', 'appended');
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER;

--- a/integrations/open-brain-rest/sql/04-rpcs.sql
+++ b/integrations/open-brain-rest/sql/04-rpcs.sql
@@ -1,0 +1,467 @@
+-- 04-rpcs.sql
+-- Eight RPC functions for the Open Brain REST API.
+-- All use serial_id as the numeric key and return it as "id" in results.
+
+-- ── 1. upsert_thought ──────────────────────────────────────────────
+CREATE OR REPLACE FUNCTION upsert_thought(
+  p_content TEXT,
+  p_payload JSONB DEFAULT '{}'::jsonb
+)
+RETURNS JSONB AS $$
+DECLARE
+  v_fingerprint TEXT;
+  v_existing_serial BIGINT;
+  v_serial BIGINT;
+  v_action TEXT;
+BEGIN
+  v_fingerprint := p_payload->>'content_fingerprint';
+
+  -- Check for existing thought by fingerprint
+  IF v_fingerprint IS NOT NULL THEN
+    SELECT serial_id INTO v_existing_serial
+    FROM thoughts
+    WHERE content_fingerprint = v_fingerprint
+    LIMIT 1;
+  END IF;
+
+  IF v_existing_serial IS NOT NULL THEN
+    -- Update existing thought
+    UPDATE thoughts SET
+      content = p_content,
+      embedding = CASE
+        WHEN p_payload ? 'embedding' THEN (p_payload->>'embedding')::vector
+        ELSE embedding
+      END,
+      metadata = CASE
+        WHEN p_payload ? 'metadata' THEN (p_payload->'metadata')
+        ELSE metadata
+      END,
+      type = COALESCE(p_payload->>'type', type),
+      importance = COALESCE((p_payload->>'importance')::SMALLINT, importance),
+      quality_score = COALESCE((p_payload->>'quality_score')::NUMERIC, quality_score),
+      sensitivity_tier = COALESCE(p_payload->>'sensitivity_tier', sensitivity_tier),
+      source_type = COALESCE(p_payload->>'source_type', source_type),
+      content_fingerprint = COALESCE(v_fingerprint, content_fingerprint),
+      updated_at = now()
+    WHERE serial_id = v_existing_serial;
+
+    v_serial := v_existing_serial;
+    v_action := 'updated';
+  ELSE
+    -- Insert new thought
+    INSERT INTO thoughts (
+      content, embedding, metadata, type, importance,
+      quality_score, sensitivity_tier, source_type, content_fingerprint
+    ) VALUES (
+      p_content,
+      CASE WHEN p_payload ? 'embedding' THEN (p_payload->>'embedding')::vector ELSE NULL END,
+      COALESCE(p_payload->'metadata', '{}'::jsonb),
+      COALESCE(p_payload->>'type', 'idea'),
+      COALESCE((p_payload->>'importance')::SMALLINT, 3),
+      COALESCE((p_payload->>'quality_score')::NUMERIC, 50),
+      COALESCE(p_payload->>'sensitivity_tier', 'standard'),
+      COALESCE(p_payload->>'source_type', 'mcp'),
+      v_fingerprint
+    )
+    RETURNING serial_id INTO v_serial;
+
+    v_action := 'created';
+  END IF;
+
+  RETURN jsonb_build_object(
+    'thought_id', v_serial,
+    'action', v_action,
+    'content_fingerprint', v_fingerprint
+  );
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER;
+
+
+-- ── 2. match_thoughts (enhanced semantic search) ────────────────────
+CREATE OR REPLACE FUNCTION match_thoughts(
+  query_embedding vector(1536),
+  match_count INT DEFAULT 10,
+  match_threshold FLOAT DEFAULT 0.5,
+  filter JSONB DEFAULT '{}'::jsonb
+)
+RETURNS TABLE (
+  id BIGINT,
+  content TEXT,
+  type TEXT,
+  source_type TEXT,
+  importance SMALLINT,
+  quality_score NUMERIC(5,2),
+  sensitivity_tier TEXT,
+  metadata JSONB,
+  created_at TIMESTAMPTZ,
+  similarity FLOAT
+) AS $$
+BEGIN
+  RETURN QUERY
+  SELECT
+    t.serial_id AS id,
+    t.content,
+    t.type,
+    t.source_type,
+    t.importance,
+    t.quality_score,
+    t.sensitivity_tier,
+    t.metadata,
+    t.created_at,
+    (1 - (t.embedding <=> query_embedding))::FLOAT AS similarity
+  FROM thoughts t
+  WHERE t.embedding IS NOT NULL
+    AND (1 - (t.embedding <=> query_embedding)) >= match_threshold
+    AND (
+      NOT COALESCE((filter->>'exclude_restricted')::BOOLEAN, FALSE)
+      OR t.sensitivity_tier IS DISTINCT FROM 'restricted'
+    )
+  ORDER BY t.embedding <=> query_embedding
+  LIMIT match_count;
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER;
+
+
+-- ── 3. search_thoughts_text ─────────────────────────────────────────
+CREATE OR REPLACE FUNCTION search_thoughts_text(
+  p_query TEXT,
+  p_limit INT DEFAULT 20,
+  p_filter JSONB DEFAULT '{}'::jsonb,
+  p_offset INT DEFAULT 0
+)
+RETURNS TABLE (
+  id BIGINT,
+  content TEXT,
+  type TEXT,
+  source_type TEXT,
+  importance SMALLINT,
+  quality_score NUMERIC(5,2),
+  sensitivity_tier TEXT,
+  metadata JSONB,
+  created_at TIMESTAMPTZ,
+  rank FLOAT,
+  total_count BIGINT
+) AS $$
+DECLARE
+  v_tsquery tsquery;
+  v_total BIGINT;
+BEGIN
+  v_tsquery := websearch_to_tsquery('english', p_query);
+
+  -- Count total matches for pagination
+  SELECT COUNT(*) INTO v_total
+  FROM thoughts t
+  WHERE t.tsv @@ v_tsquery
+    AND (
+      NOT COALESCE((p_filter->>'exclude_restricted')::BOOLEAN, FALSE)
+      OR t.sensitivity_tier IS DISTINCT FROM 'restricted'
+    );
+
+  RETURN QUERY
+  SELECT
+    t.serial_id AS id,
+    t.content,
+    t.type,
+    t.source_type,
+    t.importance,
+    t.quality_score,
+    t.sensitivity_tier,
+    t.metadata,
+    t.created_at,
+    ts_rank(t.tsv, v_tsquery)::FLOAT AS rank,
+    v_total AS total_count
+  FROM thoughts t
+  WHERE t.tsv @@ v_tsquery
+    AND (
+      NOT COALESCE((p_filter->>'exclude_restricted')::BOOLEAN, FALSE)
+      OR t.sensitivity_tier IS DISTINCT FROM 'restricted'
+    )
+  ORDER BY ts_rank(t.tsv, v_tsquery) DESC
+  LIMIT p_limit
+  OFFSET p_offset;
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER;
+
+
+-- ── 4. brain_stats_aggregate ────────────────────────────────────────
+CREATE OR REPLACE FUNCTION brain_stats_aggregate(
+  p_since_days INT DEFAULT 0,
+  p_exclude_restricted BOOL DEFAULT TRUE
+)
+RETURNS JSONB AS $$
+DECLARE
+  v_total BIGINT;
+  v_types JSONB;
+  v_topics JSONB;
+  v_cutoff TIMESTAMPTZ;
+BEGIN
+  -- Calculate cutoff date
+  IF p_since_days > 0 THEN
+    v_cutoff := now() - (p_since_days || ' days')::INTERVAL;
+  ELSE
+    v_cutoff := '-infinity'::TIMESTAMPTZ;
+  END IF;
+
+  -- Total count
+  SELECT COUNT(*) INTO v_total
+  FROM thoughts t
+  WHERE t.created_at >= v_cutoff
+    AND (NOT p_exclude_restricted OR t.sensitivity_tier IS DISTINCT FROM 'restricted');
+
+  -- Type breakdown
+  SELECT COALESCE(jsonb_agg(jsonb_build_object('type', sub.type, 'count', sub.cnt)), '[]'::jsonb)
+  INTO v_types
+  FROM (
+    SELECT t.type, COUNT(*) AS cnt
+    FROM thoughts t
+    WHERE t.created_at >= v_cutoff
+      AND (NOT p_exclude_restricted OR t.sensitivity_tier IS DISTINCT FROM 'restricted')
+    GROUP BY t.type
+    ORDER BY cnt DESC
+  ) sub;
+
+  -- Topic breakdown from metadata->'topics' array
+  SELECT COALESCE(jsonb_agg(jsonb_build_object('topic', sub.topic, 'count', sub.cnt)), '[]'::jsonb)
+  INTO v_topics
+  FROM (
+    SELECT topic.value #>> '{}' AS topic, COUNT(*) AS cnt
+    FROM thoughts t,
+         jsonb_array_elements(COALESCE(t.metadata->'topics', '[]'::jsonb)) AS topic(value)
+    WHERE t.created_at >= v_cutoff
+      AND (NOT p_exclude_restricted OR t.sensitivity_tier IS DISTINCT FROM 'restricted')
+    GROUP BY topic.value #>> '{}'
+    ORDER BY cnt DESC
+  ) sub;
+
+  RETURN jsonb_build_object(
+    'total_count', v_total,
+    'types', v_types,
+    'topics', v_topics
+  );
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER;
+
+
+-- ── 5. get_thought_connections ──────────────────────────────────────
+CREATE OR REPLACE FUNCTION get_thought_connections(
+  p_thought_id BIGINT,
+  p_limit INT DEFAULT 20,
+  p_exclude_restricted BOOL DEFAULT TRUE
+)
+RETURNS TABLE (
+  id BIGINT,
+  content TEXT,
+  type TEXT,
+  importance SMALLINT,
+  created_at TIMESTAMPTZ,
+  shared_topics JSONB,
+  shared_people JSONB,
+  overlap_count INT,
+  similarity FLOAT,
+  score FLOAT
+) AS $$
+DECLARE
+  v_embedding vector(1536);
+  v_topics JSONB;
+  v_people JSONB;
+BEGIN
+  -- Get the source thought's embedding and metadata
+  SELECT t.embedding, COALESCE(t.metadata->'topics', '[]'::jsonb), COALESCE(t.metadata->'people', '[]'::jsonb)
+  INTO v_embedding, v_topics, v_people
+  FROM thoughts t
+  WHERE t.serial_id = p_thought_id;
+
+  RETURN QUERY
+  WITH candidates AS (
+    SELECT
+      t.serial_id,
+      t.content,
+      t.type,
+      t.importance,
+      t.created_at,
+      -- Shared topics
+      (
+        SELECT COALESCE(jsonb_agg(at.value), '[]'::jsonb)
+        FROM jsonb_array_elements(COALESCE(t.metadata->'topics', '[]'::jsonb)) AS at(value)
+        WHERE at.value IN (SELECT jsonb_array_elements(v_topics))
+      ) AS shared_topics,
+      -- Shared people
+      (
+        SELECT COALESCE(jsonb_agg(ap.value), '[]'::jsonb)
+        FROM jsonb_array_elements(COALESCE(t.metadata->'people', '[]'::jsonb)) AS ap(value)
+        WHERE ap.value IN (SELECT jsonb_array_elements(v_people))
+      ) AS shared_people,
+      -- Embedding similarity
+      CASE
+        WHEN t.embedding IS NOT NULL AND v_embedding IS NOT NULL
+        THEN (1 - (t.embedding <=> v_embedding))::FLOAT
+        ELSE 0.0
+      END AS sim
+    FROM thoughts t
+    WHERE t.serial_id != p_thought_id
+      AND (NOT p_exclude_restricted OR t.sensitivity_tier IS DISTINCT FROM 'restricted')
+  )
+  SELECT
+    c.serial_id AS id,
+    LEFT(c.content, 200) AS content,
+    c.type,
+    c.importance,
+    c.created_at,
+    c.shared_topics,
+    c.shared_people,
+    (COALESCE(jsonb_array_length(c.shared_topics), 0) + COALESCE(jsonb_array_length(c.shared_people), 0))::INT AS overlap_count,
+    c.sim AS similarity,
+    (
+      0.6 * LEAST(
+        (COALESCE(jsonb_array_length(c.shared_topics), 0) + COALESCE(jsonb_array_length(c.shared_people), 0))::FLOAT
+        / GREATEST(COALESCE(jsonb_array_length(v_topics), 0) + COALESCE(jsonb_array_length(v_people), 0), 1)::FLOAT,
+        1.0
+      )
+      + 0.4 * c.sim
+    )::FLOAT AS score
+  FROM candidates c
+  WHERE (
+    COALESCE(jsonb_array_length(c.shared_topics), 0) + COALESCE(jsonb_array_length(c.shared_people), 0) > 0
+    OR c.sim > 0.3
+  )
+  ORDER BY score DESC
+  LIMIT p_limit;
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER;
+
+
+-- ── 6. find_near_duplicates ─────────────────────────────────────────
+CREATE OR REPLACE FUNCTION find_near_duplicates(
+  p_threshold FLOAT DEFAULT 0.95,
+  p_limit INT DEFAULT 50,
+  p_offset INT DEFAULT 0
+)
+RETURNS TABLE (
+  thought_id_a BIGINT,
+  thought_id_b BIGINT,
+  similarity FLOAT,
+  content_a TEXT,
+  content_b TEXT,
+  type_a TEXT,
+  type_b TEXT,
+  quality_a NUMERIC(5,2),
+  quality_b NUMERIC(5,2),
+  created_a TIMESTAMPTZ,
+  created_b TIMESTAMPTZ
+) AS $$
+BEGIN
+  RETURN QUERY
+  SELECT
+    a.serial_id AS thought_id_a,
+    b.serial_id AS thought_id_b,
+    (1 - (a.embedding <=> b.embedding))::FLOAT AS similarity,
+    a.content AS content_a,
+    b.content AS content_b,
+    a.type AS type_a,
+    b.type AS type_b,
+    a.quality_score AS quality_a,
+    b.quality_score AS quality_b,
+    a.created_at AS created_a,
+    b.created_at AS created_b
+  FROM thoughts a
+  JOIN thoughts b ON a.serial_id < b.serial_id
+  WHERE a.embedding IS NOT NULL
+    AND b.embedding IS NOT NULL
+    AND (1 - (a.embedding <=> b.embedding)) >= p_threshold
+  ORDER BY (1 - (a.embedding <=> b.embedding)) DESC
+  LIMIT p_limit
+  OFFSET p_offset;
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER;
+
+
+-- ── 7. upsert_reflection ───────────────────────────────────────────
+CREATE OR REPLACE FUNCTION upsert_reflection(
+  p_thought_id BIGINT,
+  p_trigger_context TEXT,
+  p_options JSONB DEFAULT '[]'::jsonb,
+  p_factors JSONB DEFAULT '[]'::jsonb,
+  p_conclusion TEXT DEFAULT '',
+  p_embedding vector(1536) DEFAULT NULL,
+  p_reflection_type TEXT DEFAULT 'general',
+  p_metadata JSONB DEFAULT '{}'::jsonb
+)
+RETURNS JSONB AS $$
+DECLARE
+  v_id BIGINT;
+  v_action TEXT;
+BEGIN
+  -- Try to find existing reflection for this thought + type
+  SELECT r.id INTO v_id
+  FROM reflections r
+  WHERE r.thought_id = p_thought_id
+    AND r.reflection_type = p_reflection_type
+  LIMIT 1;
+
+  IF v_id IS NOT NULL THEN
+    UPDATE reflections SET
+      trigger_context = p_trigger_context,
+      options = p_options,
+      factors = p_factors,
+      conclusion = p_conclusion,
+      embedding = COALESCE(p_embedding, embedding),
+      metadata = p_metadata,
+      updated_at = now()
+    WHERE reflections.id = v_id;
+
+    v_action := 'updated';
+  ELSE
+    INSERT INTO reflections (
+      thought_id, trigger_context, options, factors,
+      conclusion, embedding, reflection_type, metadata
+    ) VALUES (
+      p_thought_id, p_trigger_context, p_options, p_factors,
+      p_conclusion, p_embedding, p_reflection_type, p_metadata
+    )
+    RETURNING reflections.id INTO v_id;
+
+    v_action := 'created';
+  END IF;
+
+  RETURN jsonb_build_object(
+    'reflection_id', v_id,
+    'action', v_action
+  );
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER;
+
+
+-- ── 8. match_reflections ────────────────────────────────────────────
+CREATE OR REPLACE FUNCTION match_reflections(
+  query_embedding vector(1536),
+  match_threshold FLOAT DEFAULT 0.5,
+  match_count INT DEFAULT 10,
+  p_reflection_type TEXT DEFAULT NULL
+)
+RETURNS TABLE (
+  id BIGINT,
+  thought_id BIGINT,
+  trigger_context TEXT,
+  conclusion TEXT,
+  reflection_type TEXT,
+  similarity FLOAT,
+  created_at TIMESTAMPTZ
+) AS $$
+BEGIN
+  RETURN QUERY
+  SELECT
+    r.id,
+    r.thought_id,
+    r.trigger_context,
+    r.conclusion,
+    r.reflection_type,
+    (1 - (r.embedding <=> query_embedding))::FLOAT AS similarity,
+    r.created_at
+  FROM reflections r
+  WHERE r.embedding IS NOT NULL
+    AND (1 - (r.embedding <=> query_embedding)) >= match_threshold
+    AND (p_reflection_type IS NULL OR r.reflection_type = p_reflection_type)
+  ORDER BY r.embedding <=> query_embedding
+  LIMIT match_count;
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER;

--- a/integrations/open-brain-rest/sql/05-text-search-index.sql
+++ b/integrations/open-brain-rest/sql/05-text-search-index.sql
@@ -1,0 +1,25 @@
+-- 05-text-search-index.sql
+-- Adds full-text search support to thoughts via a tsvector column,
+-- GIN index, and auto-update trigger.
+
+-- Step 1: Add tsv column if it doesn't exist
+ALTER TABLE thoughts ADD COLUMN IF NOT EXISTS tsv tsvector;
+
+-- Step 2: Backfill existing rows that have no tsvector yet
+UPDATE thoughts SET tsv = to_tsvector('english', content) WHERE tsv IS NULL;
+
+-- Step 3: Create GIN index for fast full-text queries
+CREATE INDEX IF NOT EXISTS idx_thoughts_tsv ON thoughts USING GIN (tsv);
+
+-- Step 4: Auto-update trigger on content changes
+CREATE OR REPLACE FUNCTION thoughts_tsv_trigger() RETURNS trigger AS $$
+BEGIN
+  NEW.tsv := to_tsvector('english', COALESCE(NEW.content, ''));
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS trg_thoughts_tsv ON thoughts;
+CREATE TRIGGER trg_thoughts_tsv
+  BEFORE INSERT OR UPDATE OF content ON thoughts
+  FOR EACH ROW EXECUTE FUNCTION thoughts_tsv_trigger();


### PR DESCRIPTION
## Contribution Type

- [ ] Recipe (`/recipes`)
- [ ] Schema (`/schemas`)
- [x] Dashboard (`/dashboards`)
- [ ] Integration (`/integrations`)
- [ ] Repo improvement (docs, CI, templates)

## What does this do?

Updates the Next.js dashboard to explicitly reference the new `open-brain-rest` integration as its required backend:

- Adds a cross-reference link to `../../integrations/open-brain-rest/README.md` in prerequisites
- Fixes a path typo in Step 1 (`open-brain-dashboard` → `open-brain-dashboard-next`)
- Declares `open-brain-rest Edge Function` in `metadata.json` services

> **Dependency:** This PR depends on #129 (`[integrations] Add open-brain-rest Edge Function`). Merge #129 first — this PR's cross-reference link (`../../integrations/open-brain-rest/README.md`) only resolves after the integration exists in the repo.

## Requirements

No additional requirements — this is a docs-only update to an existing dashboard contribution.

## Checklist

- [x] I've read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] My contribution has a `README.md` with prerequisites, step-by-step instructions, and expected outcome
- [x] My `metadata.json` has all required fields
- [x] I tested this on my own Open Brain instance
- [x] No credentials, API keys, or secrets are included

Companion to #129. Together they close #124.