### PR TITLE
[extensions] Add update_professional_contact tool to CRM extension

### DIFF
--- a/extensions/professional-crm/README.md
+++ b/extensions/professional-crm/README.md
@@ -160,7 +160,8 @@ If you build Extension 6, the `link_contact_to_professional_crm` tool works in r
 4. **`get_contact_history`** — Get a contact's full profile + all interactions ordered by date
 5. **`create_opportunity`** — Create an opportunity/deal linked to a contact (title, description, stage, value, expected_close_date)
 6. **`get_follow_ups_due`** — List contacts with follow_up_date in the past or next N days
-7. **`link_thought_to_contact`** — **CROSS-EXTENSION BRIDGE** — Takes a thought_id and contact_id, retrieves the thought from your core Open Brain, and links it to the contact record
+7. **`update_professional_contact`** — Update only the fields you provide on an existing contact, including setting or clearing `follow_up_date`
+8. **`link_thought_to_contact`** — **CROSS-EXTENSION BRIDGE** — Takes a thought_id and contact_id, retrieves the thought from your core Open Brain, and links it to the contact record
 
 ## Expected Outcome
 

--- a/extensions/professional-crm/index.ts
+++ b/extensions/professional-crm/index.ts
@@ -378,12 +378,16 @@ app.post("*", async (c) => {
       how_we_met: z.string().optional().describe("Updated context for how you met"),
       tags: z.array(z.string()).optional().describe("Replace tags (e.g., ['ai', 'consulting'])"),
       notes: z.string().optional().describe("Replace notes with new content"),
-      follow_up_date: z.string().optional().describe("Set or update follow-up date (YYYY-MM-DD)"),
+      follow_up_date: z.string().nullable().optional().describe("Set or update follow-up date (YYYY-MM-DD), or null/empty string to clear"),
     },
     async ({ contact_id, ...fields }) => {
       const updates: Record<string, unknown> = {};
       for (const [key, value] of Object.entries(fields)) {
-        if (value !== undefined) updates[key] = value;
+        if (key === "follow_up_date" && (value === null || value === "")) {
+          updates[key] = null;
+        } else if (value !== undefined) {
+          updates[key] = value;
+        }
       }
 
       if (Object.keys(updates).length === 0) {

--- a/extensions/professional-crm/index.ts
+++ b/extensions/professional-crm/index.ts
@@ -2,7 +2,7 @@
  * Extension 5: Professional CRM MCP Server (Remote Edge Function)
  *
  * Provides tools for managing professional contacts, interactions, and opportunities:
- * - Contact management with rich metadata
+ * - Contact management with rich metadata (add, update, search)
  * - Interaction logging with auto-updating last_contacted
  * - Opportunity/pipeline tracking
  * - Follow-up reminders
@@ -363,7 +363,61 @@ app.post("*", async (c) => {
     },
   );
 
-  // Tool 7: link_thought_to_contact (CROSS-EXTENSION BRIDGE)
+  // Tool 7: update_professional_contact
+  server.tool(
+    "update_professional_contact",
+    "Update an existing professional contact's details (name, title, company, email, etc.)",
+    {
+      contact_id: z.string().describe("Contact ID (UUID)"),
+      name: z.string().optional().describe("Updated full name"),
+      company: z.string().optional().describe("Updated company name"),
+      title: z.string().optional().describe("Updated job title"),
+      email: z.string().optional().describe("Updated email address"),
+      phone: z.string().optional().describe("Updated phone number"),
+      linkedin_url: z.string().optional().describe("Updated LinkedIn profile URL"),
+      how_we_met: z.string().optional().describe("Updated context for how you met"),
+      tags: z.array(z.string()).optional().describe("Replace tags (e.g., ['ai', 'consulting'])"),
+      notes: z.string().optional().describe("Replace notes with new content"),
+      follow_up_date: z.string().optional().describe("Set or update follow-up date (YYYY-MM-DD)"),
+    },
+    async ({ contact_id, ...fields }) => {
+      const updates: Record<string, unknown> = {};
+      for (const [key, value] of Object.entries(fields)) {
+        if (value !== undefined) updates[key] = value;
+      }
+
+      if (Object.keys(updates).length === 0) {
+        throw new Error("No fields provided to update");
+      }
+
+      const { data, error } = await supabase
+        .from("professional_contacts")
+        .update(updates)
+        .eq("id", contact_id)
+        .eq("user_id", userId)
+        .select()
+        .single();
+
+      if (error) {
+        throw new Error(`Failed to update contact: ${error.message}`);
+      }
+
+      return {
+        content: [
+          {
+            type: "text",
+            text: JSON.stringify({
+              success: true,
+              message: `Updated contact: ${data.name}`,
+              contact: data,
+            }, null, 2),
+          },
+        ],
+      };
+    },
+  );
+
+  // Tool 8: link_thought_to_contact (CROSS-EXTENSION BRIDGE)
   server.tool(
     "link_thought_to_contact",
     "CROSS-EXTENSION: Link a thought from your core Open Brain to a professional contact",


### PR DESCRIPTION
## Contribution Type

- [x] Repo improvement (docs, CI, templates)

## What does this do?

Adds the missing `update_professional_contact` tool to Extension 5 (Professional CRM), as proposed in #93 but never implemented. Accepts `contact_id` plus any combination of optional fields (`name`, `company`, `title`, `email`, `phone`, `linkedin_url`, `how_we_met`, `tags`, `notes`, `follow_up_date`). Only provided fields are updated. Also fixes `follow_up_date` being unwritable despite `get_follow_ups_due` querying it.

## Requirements

Nothing new.

## Checklist

- [x] I've read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] My contribution has a `README.md` with prerequisites, step-by-step instructions, and expected outcome
- [x] My `metadata.json` has all required fields
- [x] I tested this on my own Open Brain instance
- [x] No credentials, API keys, or secrets are included