### PR TITLE
[skills] Add autodream-brain-sync for cross-client memory sharing

### DIFF
--- a/skills/autodream-brain-sync/README.md
+++ b/skills/autodream-brain-sync/README.md
@@ -1,0 +1,53 @@
+# Autodream Brain Sync
+
+> Syncs Claude Code's local memory saves to Open Brain so memories are accessible from all AI clients and devices.
+
+## What It Does
+
+Whenever Claude Code saves a memory (via dreaming, autodream, or explicit requests), this skill also captures it to Open Brain via `mcp__open-brain__capture_thought`. This ensures memories aren't siloed in one machine's local files — they're available from ChatGPT, Claude Desktop, Codex, and any other MCP-connected client.
+
+## Supported Clients
+
+- Claude Code
+
+## Prerequisites
+
+- Working Open Brain setup with `capture_thought` tool available ([guide](../../docs/01-getting-started.md))
+- Claude Code with auto-memory enabled
+
+## Installation
+
+1. Copy `SKILL.md` into your project's `.claude/` directory, or add its contents to your `CLAUDE.md` under a skills section
+2. Restart Claude Code so it picks up the new instructions
+3. Verify by saving a memory ("remember that I prefer TypeScript over JavaScript") and checking that both a local memory file and an Open Brain capture are created
+
+## Trigger Conditions
+
+- Any memory file write to `.claude/projects/*/memory/`
+- User says "remember this", "save to memory", "dream", "autodream"
+- End-of-session auto-dreaming
+- Explicit `/memory` command usage
+
+## Expected Outcome
+
+Each memory save produces three things:
+1. A local `.md` file in the memory directory (standard Claude Code behavior)
+2. An updated `MEMORY.md` index (standard Claude Code behavior)
+3. A corresponding Open Brain thought capture (added by this skill)
+
+The Open Brain capture is prefixed with the memory type (e.g., `[feedback]`, `[user]`, `[project]`) for context when retrieved from other clients.
+
+## Troubleshooting
+
+**Issue: Open Brain capture fails but local memory saves fine**
+Solution: Check that your MCP server is running (`supabase functions list` should show `open-brain-mcp` as ACTIVE). The skill is designed to not block local saves if the capture fails.
+
+**Issue: Duplicate thoughts in Open Brain**
+Solution: Open Brain uses embedding-based dedup. If you update an existing memory, the new capture may coexist with the old one. This is expected — semantic search will surface the most relevant version.
+
+**Issue: Memories not appearing in ChatGPT/Claude Desktop**
+Solution: Other clients need to explicitly search Open Brain — memories aren't pushed to them automatically. Ask "search my brain for [topic]" to retrieve synced memories.
+
+## Notes for Other Clients
+
+This skill is specific to Claude Code's auto-memory system. Other clients (ChatGPT, Claude Desktop, Codex) capture directly to Open Brain without needing a sync step — they don't have local memory files. The skill ensures Claude Code's local memories don't become an isolated silo.

--- a/skills/autodream-brain-sync/SKILL.md
+++ b/skills/autodream-brain-sync/SKILL.md
@@ -1,0 +1,52 @@
+---
+name: autodream-brain-sync
+description: |
+  Syncs Claude Code's local memory system to Open Brain. Triggers whenever memories are
+  saved via dreaming, autodream, or explicit "remember this" requests. After every local
+  memory file write, captures the same content to Open Brain via mcp__open-brain__capture_thought
+  so that memories are accessible from all connected AI clients (ChatGPT, Claude Desktop,
+  Codex) and across all devices. Trigger on: memory saves, autodream, dreaming, "remember",
+  "save to memory", or any write to the .claude/projects/*/memory/ directory.
+author: rumbitopi
+version: 1.0.0
+---
+
+# Autodream Brain Sync
+
+## Problem
+
+Claude Code's auto-memory system (dreaming/autodream) saves memories to local files under `.claude/projects/*/memory/`. These files are only accessible to Claude Code on the same machine. If you use multiple AI clients (ChatGPT, Claude Desktop, Codex) or multiple devices, those memories are invisible to your other sessions.
+
+## Trigger Conditions
+
+- Any write to a memory file in `.claude/projects/*/memory/` (excluding `MEMORY.md` index)
+- User says "remember this", "save to memory", "dream", "autodream"
+- End-of-session memory saves (auto-dreaming)
+- Explicit `/memory` command usage
+
+## Process
+
+1. Write the memory to its local file as normal (following the standard memory system format with frontmatter)
+2. Update `MEMORY.md` index as normal
+3. **Immediately after each memory file write**, call `mcp__open-brain__capture_thought` with the memory content
+   - Use the memory content (not the frontmatter) as the thought
+   - Prefix with the memory type in brackets for context, e.g. `[feedback] Don't mock the database in integration tests`
+   - If the memory references a specific project, include the project name
+
+## Output
+
+Each memory save produces:
+- A local `.md` file in the memory directory (standard behavior)
+- An updated `MEMORY.md` index (standard behavior)
+- A corresponding Open Brain thought capture (added by this skill)
+
+## Guard Rails
+
+- **Do not capture the MEMORY.md index file itself** — it's just pointers, not content
+- **Do not duplicate** — if updating an existing memory file, capture the updated version (Open Brain handles dedup via embeddings)
+- **Do not block on failure** — if `mcp__open-brain__capture_thought` fails (MCP server down, network error), complete the local memory save anyway and note the sync failure
+- **Respect memory exclusions** — if the standard memory system says "don't save this", don't capture to Open Brain either
+
+## Notes for Other Clients
+
+This skill is specific to Claude Code's auto-memory system. Other clients don't have local memory files, so they capture directly to Open Brain without needing this sync step. The skill ensures Claude Code's local memories don't become an isolated silo.

--- a/skills/autodream-brain-sync/metadata.json
+++ b/skills/autodream-brain-sync/metadata.json
@@ -1,0 +1,20 @@
+{
+  "name": "Autodream Brain Sync",
+  "description": "Syncs Claude Code's local memory saves to Open Brain so memories are accessible from all AI clients and devices.",
+  "category": "skills",
+  "author": {
+    "name": "rumbitopi",
+    "github": "rumbitopi"
+  },
+  "version": "1.0.0",
+  "requires": {
+    "open_brain": true,
+    "services": [],
+    "tools": ["mcp__open-brain__capture_thought"]
+  },
+  "tags": ["memory", "autodream", "sync", "multi-client"],
+  "difficulty": "beginner",
+  "estimated_time": "5 minutes",
+  "created": "2026-03-31",
+  "updated": "2026-03-31"
+}


### PR DESCRIPTION
## Summary
- Adds a skill that syncs Claude Code's local memory saves (dreaming/autodream) to Open Brain via `mcp__open-brain__capture_thought`
- Ensures memories aren't siloed on one machine — they become accessible from ChatGPT, Claude Desktop, Codex, and any MCP-connected client across all devices
- Resubmission of #114, restructured as a proper `skills/` contribution per reviewer feedback

## Files
- `skills/autodream-brain-sync/SKILL.md` — The installable skill with trigger conditions, process, and guard rails
- `skills/autodream-brain-sync/README.md` — What it does, installation, troubleshooting
- `skills/autodream-brain-sync/metadata.json` — Structured metadata

## Test plan
- [x] Tested locally: saved a memory via autodream, confirmed both local file write and Open Brain capture
- [x] Verified captured thought is retrievable via `search_thoughts` from other sessions
- [x] Reviewer confirms skill file follows the `skills/_template` structure

🤖 Generated with [Claude Code](https://claude.com/claude-code)