### PR TITLE
[extensions] Fix professional-crm Accept handling for Streamable HTTP

### DIFF
--- a/extensions/professional-crm/index.ts
+++ b/extensions/professional-crm/index.ts
@@ -19,6 +19,23 @@ const app = new Hono();
 
 // POST /mcp - Main MCP endpoint
 app.post("*", async (c) => {
+  // Force JSON-only responses. SSE causes a reconnect loop on stateless edge functions:
+  // the client sends Accept: text/event-stream (per MCP spec), the transport opens an SSE
+  // stream, the function terminates, client reconnects in ~1-2s -- ~43k idle invocations/day.
+  // Stripping text/event-stream forces plain JSON responses and breaks the loop.
+  {
+    const headers = new Headers(c.req.raw.headers);
+    headers.set("Accept", "application/json");
+    const patched = new Request(c.req.raw.url, {
+      method: c.req.raw.method,
+      headers,
+      body: c.req.raw.body,
+      // @ts-ignore -- duplex required for streaming body in Deno
+      duplex: "half",
+    });
+    Object.defineProperty(c.req, "raw", { value: patched, writable: true });
+  }
+
 
   // Auth check
   const key = c.req.query("key") || c.req.header("x-access-key");

--- a/extensions/professional-crm/index.ts
+++ b/extensions/professional-crm/index.ts
@@ -19,21 +19,6 @@ const app = new Hono();
 
 // POST /mcp - Main MCP endpoint
 app.post("*", async (c) => {
-  // Fix: Claude Desktop connectors don't send the Accept header that
-  // StreamableHTTPTransport requires. Build a patched request if missing.
-  if (!c.req.header("accept")?.includes("text/event-stream")) {
-    const headers = new Headers(c.req.raw.headers);
-    headers.set("Accept", "application/json, text/event-stream");
-    const patched = new Request(c.req.raw.url, {
-      method: c.req.raw.method,
-      headers,
-      body: c.req.raw.body,
-      // @ts-ignore -- duplex required for streaming body in Deno
-      duplex: "half",
-    });
-    Object.defineProperty(c.req, "raw", { value: patched, writable: true });
-  }
-
 
   // Auth check
   const key = c.req.query("key") || c.req.header("x-access-key");


### PR DESCRIPTION
## Problem

The `POST /mcp` handler currently rewrites incoming `Accept` headers in a way that can still trigger reconnect-heavy behavior on stateless edge functions.

## Fix

Force JSON-only responses for this extension’s MCP endpoint by rewriting the request header to `Accept: application/json` before it reaches `StreamableHTTPTransport`.

This keeps the endpoint in plain request/response mode and avoids the idle reconnect loop.

## Impact

- Prevents the repeated reconnect behavior on stateless edge functions
- Keeps invocation volume under control
- Does not change the extension’s tool behavior