### PR TITLE
[recipes] Fix claudeception: single-line YAML descriptions

### DIFF
--- a/docs/01-getting-started.md
+++ b/docs/01-getting-started.md
@@ -585,7 +585,6 @@ Get-Content supabase\functions\open-brain-mcp\index.ts -Head 1
 
 > [!CAUTION]
 > ❌ If you see `console.log("Hello from Functions!")` — the download didn't overwrite the starter file. Delete the folder, re-create it, and retry the download commands.
->
 > ✅ If you see `import "jsr:@supabase/functions-js/edge-runtime.d.ts";` — you're good.
 
 ![6.7](https://img.shields.io/badge/6.7-Deploy-555?style=for-the-badge&labelColor=1E88E5)

--- a/docs/01-getting-started.md
+++ b/docs/01-getting-started.md
@@ -242,7 +242,7 @@ Copy the output — it'll look something like `a3f8b2c1d4e5...` (64 characters).
 
 > [!WARNING]
 > Copy and paste the command for **your operating system only**. The Mac command won't work on Windows and vice versa.
-
+>
 > [!IMPORTANT]
 > This is your **one access key for all of Open Brain** — core setup and every extension you add later. Save it somewhere permanent. Never generate a new one unless you want to replace it for ALL deployed functions.
 

--- a/recipes/claudeception/claudeception.skill.md
+++ b/recipes/claudeception/claudeception.skill.md
@@ -1,12 +1,6 @@
 ---
 name: claudeception
-description: |
-  Continuous learning system that extracts reusable knowledge from work sessions.
-  Triggers: (1) /claudeception command to review session learnings, (2) "save this as a skill"
-  or "extract a skill from this", (3) "what did we learn?", (4) After any task involving
-  non-obvious debugging, workarounds, or trial-and-error discovery. Creates new skills
-  when valuable, reusable knowledge is identified. Integrates with Open Brain to prevent
-  duplicates and share knowledge across sessions.
+description: Continuous learning system that extracts reusable knowledge from work sessions. Triggers: (1) /claudeception command, (2) "save this as a skill" or "extract a skill", (3) "what did we learn?", (4) After non-obvious debugging or trial-and-error discovery. Creates new skills when valuable, reusable knowledge is identified. Integrates with Open Brain to prevent duplicates.
 author: Jared Irish
 version: 2.0.0
 ---
@@ -88,9 +82,7 @@ were consulted. Skip this for project-specific internal patterns.
 ```markdown
 ---
 name: [descriptive-kebab-case-name]
-description: |
-  [Precise description with: (1) exact use cases, (2) trigger conditions like
-  specific error messages, (3) what problem this solves.]
+description: [SINGLE LINE, max 1024 chars. Include trigger phrases, output type, use cases. NEVER use pipe (|) or multi-line. Multi-line descriptions break agent routing silently.]
 author: [your name]
 version: 1.0.0
 ---
@@ -186,11 +178,7 @@ Found `n8n-docker-troubleshooting` but it covers different issues (Code node san
 ```markdown
 ---
 name: n8n-workflow-api-quirks
-description: |
-  Fix n8n REST API issues when importing/updating workflows. Use when:
-  (1) POST /api/v1/workflows returns "tags is read-only",
-  (2) API key from .env returns 401 but MCP config key works,
-  (3) PATCH doesn't update workflow code (need delete + recreate).
+description: Fix n8n REST API issues when importing/updating workflows. Use when: (1) POST /api/v1/workflows returns "tags is read-only", (2) API key from .env returns 401 but MCP config key works, (3) PATCH doesn't update workflow code (need delete + recreate).
 author: Jared Irish
 version: 1.0.0
 ---


### PR DESCRIPTION
## Summary
- Convert 3 multi-line `description: |` instances to single-line YAML
- Nate's March 2026 Skills Standard: multi-line descriptions break agent routing silently
- Fixed: recipe's own description + 2 template examples that teach the wrong pattern

## Context
Skills audit found 46% of skills had broken multi-line descriptions. Root cause traced to claudeception's template teaching `description: |` as the correct format. This fix prevents new skills from being created with the broken pattern.

Generated with [Claude Code](https://claude.com/claude-code)