### PR TITLE
[skills] Add N agentic harnesses skill pack

### DIFF
--- a/skills/n-agentic-harnesses/README.md
+++ b/skills/n-agentic-harnesses/README.md
@@ -1,0 +1,77 @@
+# N Agentic Harnesses
+
+> Reusable skill pack for designing, auditing, and improving the harness layer around agentic products.
+
+## What It Does
+
+N Agentic Harnesses helps an AI client reason about the parts of an agentic system that usually get hand-waved: tool boundaries, permission policy, approval flow, workflow state, durability, context assembly, memory, evals, and operator visibility.
+
+It is a routing skill, not a framework. It helps the client choose the right harness shape, inspect the right subsystem, and return a buildable plan or a findings-first review instead of vague "agent architecture" advice.
+
+## Supported Clients
+
+- Codex
+- Claude Code
+- Claude Desktop or other Anthropic-style skill systems
+- Cursor or similar AI clients that can keep a skill file next to bundled references
+
+## Prerequisites
+
+- Working Open Brain setup if you want to capture resulting architecture notes or evaluation findings into memory ([guide](../../docs/01-getting-started.md))
+- AI client that supports reusable skill files, project rules, or custom instructions
+- Ability to keep the bundled `references/` directory next to the installed skill file
+
+## Installation
+
+1. Copy the entire [`n-agentic-harnesses`](./) folder into a location your AI client can access. Keep `references/`, `variants/`, and `agents/` next to the active `SKILL.md`.
+2. For the default portable install, use the root [`SKILL.md`](./SKILL.md).
+3. If you want the Codex-tuned variant, replace the contents of the root `SKILL.md` with [`variants/codex/SKILL.md`](./variants/codex/SKILL.md) and keep the rest of the folder unchanged.
+4. If you want the Anthropic-oriented variant, do the same with [`variants/anthropic/SKILL.md`](./variants/anthropic/SKILL.md).
+5. Reload the client and test it with a prompt like: `Design the harness for a solo-dev coding agent and tell me what primitives I should build first.`
+
+For Claude Code, a common install path is:
+
+```bash
+mkdir -p ~/.claude/skills/n-agentic-harnesses
+cp -R skills/n-agentic-harnesses/* ~/.claude/skills/n-agentic-harnesses/
+```
+
+## Trigger Conditions
+
+- "Design an agentic harness for this product"
+- "Audit my agent architecture"
+- "Help me structure tool permissions and approvals"
+- "Should this be single-agent or multi-agent?"
+- "How should I handle workflow state, retries, and resumability?"
+- "How do I know if this harness is actually good?"
+- Any request where the real issue is stale context, brittle sessions, missing approval controls, weak evals, or poor operator visibility
+
+## Expected Outcome
+
+When installed and invoked correctly, the skill should produce:
+
+- a clear harness mode: design, evaluation, or both
+- the recommended product shape and subsystem boundaries
+- a lean MVP boundary instead of scalability theater
+- a phased implementation plan or findings-first audit
+- explicit acceptance checks, regression checks, or evaluation criteria
+
+## Troubleshooting
+
+**Issue: The output sounds abstract and never gets buildable**
+Solution: Make sure the request includes the product shape, the actions the agent takes, and the main constraint. This skill is strongest when it can turn real constraints into subsystem choices.
+
+**Issue: The client gives a generic "use multi-agent" answer**
+Solution: Keep the single-agent default posture intact. This skill is designed to push back on unnecessary orchestration unless the request includes a real coordination constraint.
+
+**Issue: The skill cannot find its reference files**
+Solution: Install the whole folder, not just one prompt file. The root `SKILL.md` and the client variants expect the bundled [`references/`](./references/) directory to remain adjacent.
+
+## Notes for Other Clients
+
+The root [`SKILL.md`](./SKILL.md) is the canonical portable version for OB1. The two client variants are adaptation layers:
+
+- [`variants/codex/SKILL.md`](./variants/codex/SKILL.md) adds Codex-friendly discovery metadata and routing signals
+- [`variants/anthropic/SKILL.md`](./variants/anthropic/SKILL.md) stays closer to the Anthropic-style prompt shape
+
+The shared architectural guidance lives once in [`references/`](./references/). Keep that directory with the skill no matter which variant you activate.

--- a/skills/n-agentic-harnesses/SKILL.md
+++ b/skills/n-agentic-harnesses/SKILL.md
@@ -1,0 +1,173 @@
+---
+name: n-agentic-harnesses
+description: Design, evaluate, and improve agentic harnesses for developer tools, assistants, workflow runtimes, copilots, and AI-powered products. Use when work involves tool-use architecture, permissions, approval gates, workflow state, durability, context and memory systems, evaluation strategy, observability, operator visibility, or phased implementation plans for an AI system. Trigger when symptoms imply harness gaps too: stale context, surprising tool calls, sessions that die on crash, missing approval controls, or costs spiraling without clear visibility.
+author: Jonathan Edwards
+version: 1.0.0
+---
+
+# N Agentic Harnesses
+
+## Problem
+
+Most AI products do not break because the model is too weak. They break at the harness layer: unclear tool boundaries, missing approval policy, brittle state, sloppy context assembly, no evaluation loop, and weak operator visibility. This skill turns those vague issues into concrete primitives, boundaries, phases, and checks.
+
+## Trigger Conditions
+
+- The user is designing or rebuilding an agent, assistant, copilot, or AI workflow
+- The request mentions harness architecture, tool-use architecture, tool registries, permission layers, approval gates, workflow state, session persistence, retries, resumability, memory, evals, observability, or multi-agent design
+- The user wants to evaluate an existing harness for risks, missing primitives, UX gaps, or operational weakness
+- The symptoms point to harness problems even if the word "harness" never appears:
+  - tools fire without clear permission
+  - sessions fail on crash or long waits
+  - context gets stale or bloated
+  - operators cannot see what happened or why
+  - costs, retries, or handoffs are drifting out of control
+
+## Default Posture
+
+- Bias toward lean, solo-maintainable architecture.
+- Start with a single-agent design unless clear constraints justify more.
+- Require an evaluation plan even for greenfield builds.
+- Prefer explicit system boundaries, permission policy, and workflow state over prompt cleverness.
+- Translate ideas into implementation phases, success criteria, and failure tests.
+
+## Step 0: Gather Context
+
+Before routing, make sure you have enough to work with.
+
+For design work, confirm:
+
+- what product or system the harness serves
+- what actions the agent will take
+- who the users are
+- any known constraints such as solo maintenance, existing stack, or timeline
+
+For evaluation work, inspect the harness itself:
+
+- read the codebase, agent config, skills, hooks, or architecture docs
+- if evidence is missing, ask for the narrowest missing input and keep moving
+- do not evaluate from vibes alone
+
+## Step 1: Classify The Request
+
+Choose one mode before reading reference files.
+
+### `design`
+
+Use when the user is creating a new harness, planning a major rebuild, or asking for architecture, MVP shape, or implementation sequencing.
+
+Default reads:
+
+- `references/01-principles-and-solo-dev-defaults.md`
+- `references/02-harness-shapes-and-architecture.md`
+- `references/08-design-and-build-playbook.md`
+
+### `evaluation`
+
+Use when the user already has a harness and wants gaps, risks, missing primitives, UX upgrades, or architectural cleanup.
+
+Default reads:
+
+- `references/01-principles-and-solo-dev-defaults.md`
+- `references/09-evaluation-and-improvement-playbook.md`
+
+### `design + evaluation`
+
+Use when the user wants a target architecture and a way to verify it, compare it with an existing system, or define acceptance criteria before building.
+
+Default reads:
+
+- `references/01-principles-and-solo-dev-defaults.md`
+- `references/02-harness-shapes-and-architecture.md`
+- `references/08-design-and-build-playbook.md`
+- `references/09-evaluation-and-improvement-playbook.md`
+
+## Step 2: Classify The Product Shape
+
+Determine the closest product shape before going deeper:
+
+- code agent
+- chat assistant
+- workflow orchestrator
+- internal copilot
+- embedded AI product feature
+- hybrid system
+
+If the request is ambiguous, pick the closest shape and state the assumption.
+
+## Step 3: Read The Smallest Useful Reference Set
+
+Read only the files the request actually needs:
+
+- `references/01-principles-and-solo-dev-defaults.md`
+  Use first for almost every request. It defines the default decision posture.
+- `references/02-harness-shapes-and-architecture.md`
+  Read when choosing system shape, boundaries, lifecycle, transports, or deployment structure.
+- `references/03-tools-execution-and-permissions.md`
+  Read when the request involves tool registries, tool calling, approval gates, sandboxes, or trust tiers.
+- `references/04-state-sessions-and-durability.md`
+  Read when the request involves sessions, resumability, retries, idempotency, approval waits, or long-running work.
+- `references/05-context-memory-and-evaluation.md`
+  Read when the request involves context windows, retrieval, memory, provenance, evals, replay tests, or regression detection.
+- `references/06-agents-and-extensibility.md`
+  Read when the request involves multi-agent design, plugins, hooks, skills, or extension surfaces.
+- `references/07-ux-observability-and-operations.md`
+  Read when the request involves streaming UX, health checks, logs, analytics, budgets, or supportability.
+- `references/08-design-and-build-playbook.md`
+  Read when the user needs a build-ready plan from idea to implementation.
+- `references/09-evaluation-and-improvement-playbook.md`
+  Read when the user needs findings, missing primitives, upgrade priorities, or acceptance tests.
+- `references/10-example-requests-and-output-patterns.md`
+  Read when you need prompt examples or response structure examples.
+- `references/11-codex-translation-notes.md`
+  Read only when adapting the shared skill into a Codex-oriented variant or mapping between client environments.
+
+Do not rely on reference-to-reference chains. This file is the index.
+
+## Operating Rules
+
+- Convert vague ambitions into concrete harness primitives.
+- Push back on unnecessary complexity.
+- Treat workflow state, permissions, context assembly, and evaluation as first-class architecture, not cleanup tasks.
+- Separate universal harness primitives from product-specific manifestation.
+- For evaluation requests, present findings first and improvement sequence second.
+- For design requests, include how the design will be tested before calling it done.
+
+## Output Contract
+
+### For `design`
+
+Return:
+
+- recommended harness shape
+- core primitives and subsystem boundaries
+- MVP boundary
+- phased implementation plan
+- verification and acceptance criteria
+
+### For `evaluation`
+
+Return:
+
+- findings ordered by severity or leverage
+- missing or weak primitives
+- user experience and operational gaps
+- prioritized upgrade path
+- tests or checks that confirm the fixes
+
+### For `design + evaluation`
+
+Return:
+
+- target architecture
+- comparison against current or likely failure modes
+- implementation phases
+- acceptance criteria
+- evaluation plan covering regressions, safety, and UX
+
+## Final Check Before Responding
+
+- Did you keep the design lean enough for a solo developer unless the request clearly demanded more?
+- Did you avoid recommending multi-agent coordination by default?
+- Did you include evaluation, not just construction?
+- Did you give the user an operational path forward instead of abstract theory?

--- a/skills/n-agentic-harnesses/agents/openai.yaml
+++ b/skills/n-agentic-harnesses/agents/openai.yaml
@@ -1,0 +1,6 @@
+interface:
+  display_name: "N Agentic Harnesses"
+  short_description: "Design, audit, and improve agentic harnesses"
+  default_prompt: "Use $n-agentic-harnesses to design, audit, or upgrade an agentic harness for my product."
+policy:
+  allow_implicit_invocation: true

--- a/skills/n-agentic-harnesses/metadata.json
+++ b/skills/n-agentic-harnesses/metadata.json
@@ -1,0 +1,20 @@
+{
+  "name": "N Agentic Harnesses",
+  "description": "Reusable skill pack for designing, auditing, and improving the harness layer around agentic products, including tool-use architecture, permissions, workflow state, memory, evaluation, and operator visibility.",
+  "category": "skills",
+  "author": {
+    "name": "Jonathan Edwards",
+    "github": "jonathanedwards"
+  },
+  "version": "1.0.0",
+  "requires": {
+    "open_brain": true,
+    "services": [],
+    "tools": ["AI client with reusable skills/prompts", "Ability to install the bundled references directory"]
+  },
+  "tags": ["agentic-harness", "agents", "workflow", "architecture", "evaluation", "memory"],
+  "difficulty": "advanced",
+  "estimated_time": "10 minutes",
+  "created": "2026-04-02",
+  "updated": "2026-04-02"
+}

--- a/skills/n-agentic-harnesses/references/01-principles-and-solo-dev-defaults.md
+++ b/skills/n-agentic-harnesses/references/01-principles-and-solo-dev-defaults.md
@@ -1,0 +1,134 @@
+# Principles And Solo-Dev Defaults
+
+## Table Of Contents
+
+- What this file is for
+- Default stance
+- Solo-dev default architecture rules
+- Complexity ladder
+- Non-negotiables
+- Anti-patterns to push back on
+- What good outputs look like
+
+## What This File Is For
+
+Read this first for most requests. It sets the default posture for the rest of the skill.
+
+This skill is flexible enough for any developer, but its defaults should favor a builder who wants a maintainable, debuggable, and economically sane system.
+
+## Default Stance
+
+Optimize for:
+
+- clarity over cleverness
+- inspectability over magic
+- explicit policy over hidden heuristics
+- staged rollout over grand architecture
+- durable behavior over impressive demos
+
+Assume the user wants a harness they can operate themselves six months from now.
+
+## Solo-Dev Default Architecture Rules
+
+Start from these defaults and only expand when constraints justify it:
+
+1. Use a single orchestrator first.
+2. Use one source of truth for capabilities and policies.
+3. Separate metadata from execution.
+4. Put side effects behind explicit permissions or approval gates.
+5. Treat workflow state as a system concern, not a UI concern.
+6. Keep memory small, scoped, and provenance-aware.
+7. Make logs and health checks readable by humans.
+8. Define evaluation before scale.
+
+## Complexity Ladder
+
+Add complexity only when you cross a real threshold.
+
+### Level 1: Lean Harness
+
+Use when the system is mostly request-response with short tasks.
+
+Include:
+
+- one orchestrator
+- capability registry
+- permission rules
+- session persistence if conversations matter
+- basic logging
+- replayable evaluation prompts
+
+### Level 2: Durable Harness
+
+Use when tasks span time, approvals, retries, or external callbacks.
+
+Add:
+
+- workflow state machine
+- idempotency keys
+- retry policy
+- explicit waiting states
+- resumability after crash or reconnect
+
+### Level 3: Extensible Harness
+
+Use when multiple products, teams, or third-party integrations must plug into the same runtime.
+
+Add:
+
+- plugins or hooks
+- extension boundaries
+- stronger policy enforcement
+- subsystem health views
+
+### Level 4: Coordinated Multi-Agent Harness
+
+Use only when one agent cannot keep the job coherent.
+
+Add:
+
+- role-constrained workers
+- ownership boundaries
+- handoff protocol
+- shared state contract
+- evaluation for coordination failure
+
+If the user has not proven the need for Level 4, do not recommend it.
+
+## Non-Negotiables
+
+Do not ship a serious harness without these ideas somewhere in the design:
+
+- explicit capability inventory
+- permission policy
+- workflow or session persistence appropriate to the task
+- context budget awareness
+- provenance for retrieved or remembered information
+- evaluation plan
+- observability a human can use
+
+## Anti-Patterns To Push Back On
+
+Push back when the design leans on:
+
+- one giant agent prompt with no system boundaries
+- every tool available in every context
+- hidden writes with no approval or audit story
+- conversation history treated as the only state model
+- memory that stores facts with no provenance or expiry
+- multi-agent coordination introduced for status or aesthetics
+- “we’ll test it manually later” as the evaluation strategy
+- analytics without actionable health signals
+
+## What Good Outputs Look Like
+
+A strong response from this skill should:
+
+- name the harness shape
+- define the smallest viable subsystem set
+- say what to build now versus later
+- explain where user trust is earned or lost
+- include failure modes
+- include how the system will be evaluated
+
+If the answer sounds like a manifesto instead of a build plan, tighten it.

--- a/skills/n-agentic-harnesses/references/02-harness-shapes-and-architecture.md
+++ b/skills/n-agentic-harnesses/references/02-harness-shapes-and-architecture.md
@@ -1,0 +1,150 @@
+# Harness Shapes And Architecture
+
+## Table Of Contents
+
+- What this file is for
+- Common harness shapes
+- Minimum subsystem map
+- Lifecycle design
+- Runtime and transport choices
+- Architecture questions to answer
+- How to evaluate the architecture
+
+## What This File Is For
+
+Read this when the user needs help choosing a harness shape, defining system boundaries, or translating goals into an architecture.
+
+## Common Harness Shapes
+
+### Chat Assistant
+
+Best when the user needs conversational help, tool use, and a human-friendly loop.
+
+Default architecture:
+
+- request entrypoint
+- orchestrator
+- capability registry
+- permission layer
+- context assembly
+- session store
+- streaming response layer
+
+### Workflow Orchestrator
+
+Best when the system coordinates multi-step work, delayed execution, approvals, or callbacks.
+
+Default architecture:
+
+- event or API entrypoint
+- workflow controller
+- state store
+- capability registry
+- permission policy
+- job execution workers
+- status and retry handling
+
+### Code Agent
+
+Best when the system must inspect files, run commands, edit code, or operate in a workspace.
+
+Default architecture:
+
+- session controller
+- tool registry with shell and file boundaries
+- permission and trust stack
+- transcript and system event logging
+- workspace awareness
+- human approval for risky execution
+
+### Embedded AI Product Feature
+
+Best when the agent exists inside a broader product experience rather than as a standalone assistant.
+
+Default architecture:
+
+- product API or UI entrypoint
+- thin orchestration layer
+- narrow tool surface
+- product-aware context assembly
+- event logging
+- feature-specific evaluation suite
+
+### Hybrid System
+
+Use when the product needs both conversation and durable workflows.
+
+Default architecture:
+
+- conversational front door
+- workflow handoff path
+- shared policy layer
+- session and workflow state separation
+- unified status model
+
+## Minimum Subsystem Map
+
+For most serious harnesses, define these boundaries explicitly:
+
+- entrypoint: where work starts
+- orchestrator: who decides next action
+- capability registry: what the system can do
+- execution layer: how actions actually run
+- permission layer: what is allowed now
+- state layer: what survives between steps
+- context layer: what information is assembled for the model
+- evaluation layer: how regressions are caught
+- observability layer: how humans inspect the system
+
+If two of these are merged, say so explicitly and explain why.
+
+## Lifecycle Design
+
+Define the runtime lifecycle in plain language:
+
+1. how the request or event enters
+2. what is loaded before the first model call
+3. how tools are selected
+4. where permissions are checked
+5. where state is written
+6. how the system stops, waits, or resumes
+7. how results and diagnostics are emitted
+
+The agent is only one part of the lifecycle. Make the rest visible.
+
+## Runtime And Transport Choices
+
+Match the runtime to the job:
+
+- synchronous API route for short bounded tasks
+- background worker or queue for long-running steps
+- durable workflow engine when pause and resume are core requirements
+- streaming transport when user trust depends on visible progress
+- event-driven handoff when external systems drive the lifecycle
+
+Do not recommend a durable engine just because it is fashionable. Recommend it when failure recovery, retries, approvals, or callbacks make it necessary.
+
+## Architecture Questions To Answer
+
+Before finalizing an architecture, answer these:
+
+- what job is the harness actually doing?
+- what is synchronous versus asynchronous?
+- what actions can mutate real systems?
+- what has to survive restarts?
+- what information is required before the first step?
+- where can a human intervene?
+- what is the smallest useful evaluation suite?
+
+## How To Evaluate The Architecture
+
+Do not end at boxes and arrows. Verify that the architecture can answer:
+
+- where dangerous actions are stopped or approved
+- how duplicate writes are prevented
+- how long-running work resumes
+- how stale or conflicting context is handled
+- how failures surface to operators and users
+- how new changes are tested before rollout
+
+If the architecture has no clear answer to those questions, it is not ready.

--- a/skills/n-agentic-harnesses/references/03-tools-execution-and-permissions.md
+++ b/skills/n-agentic-harnesses/references/03-tools-execution-and-permissions.md
@@ -1,0 +1,124 @@
+# Tools, Execution, And Permissions
+
+## Table Of Contents
+
+- What this file is for
+- Capability registry
+- Execution boundaries
+- Tool pool assembly
+- Permission tiers
+- Approval gates
+- Safety rules
+- How to evaluate this layer
+
+## What This File Is For
+
+Read this when the harness must call tools, run code, touch files, invoke APIs, or perform actions with different risk levels.
+
+## Capability Registry
+
+Define capabilities as metadata first.
+
+Each capability should have at least:
+
+- name
+- responsibility
+- input shape
+- side-effect profile
+- required permission level
+- execution owner
+
+The registry should answer “what exists?” without executing anything.
+
+Useful split patterns:
+
+- user-facing actions versus model-facing tools
+- read versus write capabilities
+- local versus remote capabilities
+- stable core tools versus optional extensions
+
+## Execution Boundaries
+
+Separate definition from execution.
+
+The harness should know:
+
+- what a tool is called
+- when it is appropriate
+- what risk it carries
+- how it is executed
+
+Do not collapse all of that into one blob of prompt text.
+
+## Tool Pool Assembly
+
+Load only the tools relevant to the current context.
+
+Filter by:
+
+- task type
+- product surface
+- current workflow step
+- user role or trust level
+- environment
+
+Fewer tools usually means:
+
+- better model decisions
+- lower token cost
+- smaller attack surface
+
+## Permission Tiers
+
+Use explicit trust tiers. A simple pattern:
+
+- always allow: safe reads and inert helpers
+- ask first: writes, shell execution, external side effects
+- never allow by default: destructive or high-risk actions
+
+Define policy outside the prompt so it can be inspected, tested, and changed safely.
+
+## Approval Gates
+
+Introduce approval at the boundary where side effects become real.
+
+Approval triggers often include:
+
+- file edits
+- external API writes
+- payments or billing events
+- email or message sending
+- deletes
+- production actions
+
+The system should log:
+
+- what was requested
+- why approval was needed
+- what the operator approved or denied
+
+## Safety Rules
+
+Treat safety as system design, not as one paragraph in the prompt.
+
+Useful rules:
+
+- deny by category where possible, not just by name
+- require structured tool inputs
+- validate arguments before execution
+- keep audit logs separate from chat history
+- prefer dry-run previews for risky actions
+- constrain file, network, or environment access when possible
+
+## How To Evaluate This Layer
+
+Test with concrete scenarios:
+
+- safe read should run without friction
+- risky write should request approval
+- denied capability should never execute
+- malformed tool input should fail safely
+- irrelevant tools should stay out of the active tool pool
+- audit trail should explain what happened without replaying the whole chat
+
+If permissions only exist as “the model probably knows better,” this layer is incomplete.

--- a/skills/n-agentic-harnesses/references/04-state-sessions-and-durability.md
+++ b/skills/n-agentic-harnesses/references/04-state-sessions-and-durability.md
@@ -1,0 +1,109 @@
+# State, Sessions, And Durability
+
+## Table Of Contents
+
+- What this file is for
+- Session state versus workflow state
+- When durability is required
+- Core durability primitives
+- Approval and waiting states
+- Failure modes
+- How to evaluate this layer
+
+## What This File Is For
+
+Read this when the harness has conversations, long-running tasks, retries, callbacks, approvals, or any requirement to survive crashes and reconnects.
+
+## Session State Versus Workflow State
+
+Do not confuse these.
+
+Session state answers:
+
+- what the user and agent have said
+- what the current conversation context is
+
+Workflow state answers:
+
+- what step is in progress
+- what side effects already happened
+- what can be retried safely
+- what the system is waiting on
+
+A chat transcript is not a durable workflow engine.
+
+## When Durability Is Required
+
+Reach for stronger durability when the system must:
+
+- wait for human approval
+- survive page reloads or disconnects
+- resume after process failure
+- retry external calls
+- prevent duplicate writes
+- coordinate delayed or multi-step work
+
+If none of those are true, keep the design simpler.
+
+## Core Durability Primitives
+
+For durable work, define:
+
+- workflow states
+- checkpoint writes after meaningful side effects
+- idempotency or dedupe keys
+- retry policy
+- terminal states
+- operator-visible status
+
+Common states:
+
+- planned
+- awaiting_approval
+- executing
+- waiting_on_external
+- retry_scheduled
+- completed
+- failed
+- compensated
+
+## Approval And Waiting States
+
+Treat approval and waiting as first-class states, not edge cases.
+
+The system should know:
+
+- what it is waiting for
+- what event resumes the workflow
+- who can approve it
+- what expires or times out
+- what is safe to retry while waiting
+
+## Failure Modes
+
+Plan for these early:
+
+- duplicate execution after retry
+- state writes that lag behind side effects
+- approval granted for a stale plan
+- workflow resumes with outdated context
+- silent timeout with no user or operator visibility
+
+## How To Evaluate This Layer
+
+Verify that the harness can answer:
+
+- what survives a crash
+- what survives a reload
+- how duplicate side effects are prevented
+- how a waiting workflow is resumed
+- how operators see stuck work
+- what user-facing message appears during waiting or retry
+
+Run at least these tests:
+
+- crash between side effect and completion
+- retry after transient failure
+- denied approval
+- resumed workflow after delay
+- duplicate event delivery

--- a/skills/n-agentic-harnesses/references/05-context-memory-and-evaluation.md
+++ b/skills/n-agentic-harnesses/references/05-context-memory-and-evaluation.md
@@ -1,0 +1,112 @@
+# Context, Memory, And Evaluation
+
+## Table Of Contents
+
+- What this file is for
+- Context budget discipline
+- Provenance-aware retrieval
+- Memory rules
+- Evaluation system
+- What to measure
+- How to evaluate this layer
+
+## What This File Is For
+
+Read this when the harness depends on context assembly, retrieval, memory, prompt compaction, or any form of evaluation beyond manual spot checks.
+
+## Context Budget Discipline
+
+Treat context as a scarce resource.
+
+Plan for:
+
+- what must be present before the first model call
+- what can be retrieved on demand
+- what should be summarized or compacted
+- what should never be injected blindly
+
+Prefer:
+
+- smaller, relevant context sets
+- explicit context categories
+- predictable token budgets
+
+## Provenance-Aware Retrieval
+
+Every retrieved fragment should carry enough metadata to answer:
+
+- where it came from
+- when it was created
+- how trustworthy it is
+- whether it is instruction or evidence
+- whether something newer conflicts with it
+
+Treat context assembly as a trust problem, not just a ranking problem.
+
+## Memory Rules
+
+Split memory by type:
+
+- session memory for current-task facts
+- persistent memory for durable preferences or project knowledge
+- operator policy for rules that should not be casually overwritten
+- model-inferred notes for low-trust hints
+
+Do not elevate model-inferred notes into high-trust memory without validation.
+
+Persistent memory should have:
+
+- provenance
+- last-validated time
+- scope
+- conflict handling
+- expiry or review expectations
+
+## Evaluation System
+
+Do not treat evaluation as a nice-to-have.
+
+Create a lean evaluation system that covers:
+
+- golden tasks
+- representative user tasks
+- adversarial or risky tasks
+- failure recovery tasks
+- permission boundary checks
+
+Separate:
+
+- transcript or trace replays
+- synthetic scenario tests
+- sampled human review
+
+## What To Measure
+
+Measure enough to detect regressions early:
+
+- success rate on core tasks
+- failure modes by category
+- stop reasons
+- approval frequency
+- retry frequency
+- tool misuse or denial rates
+- token and cost trends
+- user-visible latency or wait time
+
+## How To Evaluate This Layer
+
+Ask:
+
+- is the model seeing the right information, or just a lot of information?
+- can stale summaries poison the system?
+- can memory contradict newer facts?
+- do prompt or tool changes regress core tasks?
+- are risky behaviors covered by invariant tests?
+
+Useful invariant tests:
+
+- dangerous actions require approval
+- denied tools never run
+- structured outputs validate
+- budget exhaustion yields a graceful stop
+- stale context does not silently override fresher evidence

--- a/skills/n-agentic-harnesses/references/06-agents-and-extensibility.md
+++ b/skills/n-agentic-harnesses/references/06-agents-and-extensibility.md
@@ -1,0 +1,95 @@
+# Agents And Extensibility
+
+## Table Of Contents
+
+- What this file is for
+- Single-agent default
+- When to split into multiple agents
+- Role constraints
+- Extensibility surfaces
+- What not to overbuild
+- How to evaluate this layer
+
+## What This File Is For
+
+Read this when the user asks about multi-agent systems, plugins, hooks, skills, extension points, or future-proofing a harness.
+
+## Single-Agent Default
+
+Start with one orchestrator unless there is a hard reason not to.
+
+A single-agent harness is usually easier to:
+
+- reason about
+- debug
+- permission
+- evaluate
+- operate as a solo builder
+
+## When To Split Into Multiple Agents
+
+Split only when role separation materially improves safety or clarity.
+
+Good reasons:
+
+- one role should never touch mutating tools
+- long-running planning and execution need distinct constraints
+- parallel work meaningfully reduces latency or operator load
+- different tasks need incompatible tool sets
+
+Weak reasons:
+
+- it sounds more advanced
+- it looks impressive in demos
+- one prompt feels crowded
+
+## Role Constraints
+
+If you add more than one agent, define:
+
+- role
+- allowed tools
+- denied tools
+- handoff format
+- state ownership
+- stop conditions
+
+Examples:
+
+- planner: proposes steps but does not execute writes
+- explorer: reads and gathers evidence
+- executor: performs approved actions only
+- verifier: checks outputs against invariants
+
+## Extensibility Surfaces
+
+Useful extension surfaces:
+
+- capability registry entries
+- plugin interfaces
+- hooks around key lifecycle events
+- skills or recipes for repeatable workflows
+- configuration migrations for evolving behavior safely
+
+Make extensions explicit. The system should know what can plug in, when it runs, and what permissions it inherits.
+
+## What Not To Overbuild
+
+Avoid building:
+
+- a plugin system before you have stable core primitives
+- generalized hooks for only one current use case
+- shared memory across agents without ownership rules
+- more agent types than your evaluation suite can cover
+
+## How To Evaluate This Layer
+
+Check:
+
+- whether multiple agents actually improve the job
+- whether each role has a clear permission story
+- whether handoffs lose context or duplicate work
+- whether plugins can bypass policy
+- whether hooks create invisible side effects
+
+If the multi-agent story is harder to explain than the single-agent one, default back to single-agent.

--- a/skills/n-agentic-harnesses/references/07-ux-observability-and-operations.md
+++ b/skills/n-agentic-harnesses/references/07-ux-observability-and-operations.md
@@ -1,0 +1,92 @@
+# UX, Observability, And Operations
+
+## Table Of Contents
+
+- What this file is for
+- User experience patterns
+- Operational visibility
+- Health checks
+- Cost and budget visibility
+- Supportability
+- How to evaluate this layer
+
+## What This File Is For
+
+Read this when the request involves progress UX, trust, logging, health checks, operator diagnostics, or the practical reality of running the harness.
+
+## User Experience Patterns
+
+Users trust systems that explain themselves.
+
+Good harness UX usually includes:
+
+- visible progress or status changes
+- explicit waiting states
+- meaningful stop reasons
+- approval prompts that explain risk
+- resumability messaging when work continues later
+- clear distinction between planning, running, and blocked states
+
+Do not hide system uncertainty behind cheerful prose.
+
+## Operational Visibility
+
+Log more than the transcript.
+
+You usually want:
+
+- system events
+- tool selections
+- permission decisions
+- retry events
+- failure categories
+- state transitions
+
+Keep logs human-readable enough that an operator can diagnose issues fast.
+
+## Health Checks
+
+Include a simple runtime health surface.
+
+The harness should be able to answer:
+
+- which subsystems initialized
+- which integrations are reachable
+- which policies are active
+- whether budgets or queues are healthy
+- what common failure is happening now
+
+A “doctor” or “runtime health” pattern is often worth the effort early.
+
+## Cost And Budget Visibility
+
+Track:
+
+- token usage
+- model or provider cost
+- cost by workflow or feature
+- runaway behavior indicators
+
+Visible cost is both an operator tool and a user-trust feature.
+
+## Supportability
+
+Design for future debugging by a tired human.
+
+That means:
+
+- stable identifiers for runs and workflows
+- readable error categories
+- traceable approval events
+- support-friendly timelines
+- enough context to reproduce failures without digging through raw chat only
+
+## How To Evaluate This Layer
+
+Check whether:
+
+- the user can tell what the system is doing
+- an operator can explain a failure without reverse-engineering the prompt
+- a stuck workflow is visible
+- costs can be traced to a feature or run
+- health checks catch real breakage before users do

--- a/skills/n-agentic-harnesses/references/08-design-and-build-playbook.md
+++ b/skills/n-agentic-harnesses/references/08-design-and-build-playbook.md
@@ -1,0 +1,140 @@
+# Design And Build Playbook
+
+## Table Of Contents
+
+- What this file is for
+- Step 1: define the job
+- Step 2: choose the harness shape
+- Step 3: define capabilities and permissions
+- Step 4: define state and lifecycle
+- Step 5: define context and memory
+- Step 6: define UX and observability
+- Step 7: define evaluation before implementation
+- Step 8: phase the implementation
+- Deliverable format
+
+## What This File Is For
+
+Read this when the user wants a build-ready plan for a new harness or a major rebuild.
+
+## Step 1: Define The Job
+
+State clearly:
+
+- who the harness serves
+- what job it owns
+- what actions it may take
+- what must never happen
+
+If the job is vague, do not jump to architecture yet.
+
+## Step 2: Choose The Harness Shape
+
+Pick the closest system shape:
+
+- chat assistant
+- workflow orchestrator
+- code agent
+- embedded product feature
+- hybrid
+
+State why that shape fits the job better than the nearest alternative.
+
+## Step 3: Define Capabilities And Permissions
+
+List the minimum useful capability set.
+
+For each capability, define:
+
+- what it does
+- whether it reads or writes
+- who can invoke it
+- whether it requires approval
+- what audit evidence should exist
+
+Avoid “we will just give the agent all tools.”
+
+## Step 4: Define State And Lifecycle
+
+Define:
+
+- request entrypoint
+- preflight checks
+- first model call inputs
+- state writes
+- side-effect boundaries
+- wait and resume conditions
+- completion and failure paths
+
+If the system includes retries or approvals, specify the workflow states explicitly.
+
+## Step 5: Define Context And Memory
+
+Specify:
+
+- what context is mandatory on turn one
+- what is retrieved later
+- what becomes persistent memory
+- how provenance is tracked
+- how stale context is prevented from dominating
+
+Default to less memory, not more.
+
+## Step 6: Define UX And Observability
+
+Decide:
+
+- what the user sees while work is running
+- how approvals are shown
+- what stop reasons exist
+- what logs or health surfaces operators get
+- what cost signals matter
+
+Good harnesses feel explainable.
+
+## Step 7: Define Evaluation Before Implementation
+
+Before calling the design complete, define:
+
+- golden tasks
+- risky tasks
+- failure recovery tests
+- permission boundary tests
+- acceptance criteria for user experience
+
+Every design plan should end with “how we will know this works.”
+
+## Step 8: Phase The Implementation
+
+Break the build into practical phases:
+
+### Phase 1
+
+Ship the minimum safe harness:
+
+- entrypoint
+- orchestrator
+- capability registry
+- permission layer
+- basic state handling
+- minimal evaluation suite
+
+### Phase 2
+
+Add durability, richer UX, and stronger observability only where the product needs them.
+
+### Phase 3
+
+Add extensibility or multi-agent behavior only after the core harness is stable and measurable.
+
+## Deliverable Format
+
+When using this playbook, produce:
+
+- recommended architecture
+- subsystem list
+- MVP boundary
+- phase plan
+- key risks
+- evaluation plan
+- acceptance criteria

--- a/skills/n-agentic-harnesses/references/09-evaluation-and-improvement-playbook.md
+++ b/skills/n-agentic-harnesses/references/09-evaluation-and-improvement-playbook.md
@@ -1,0 +1,114 @@
+# Evaluation And Improvement Playbook
+
+## Table Of Contents
+
+- What this file is for
+- How to evaluate a harness
+- Evaluation dimensions
+- Findings format
+- Prioritization rules
+- Upgrade sequencing
+- Acceptance checks after changes
+
+## What This File Is For
+
+Read this when the user already has a harness and wants to understand what is weak, missing, risky, confusing, or worth upgrading.
+
+## How To Evaluate A Harness
+
+Gather evidence first.
+
+Look for:
+
+- architecture docs or code structure
+- capability and permission surfaces
+- workflow state handling
+- context and memory behavior
+- user-visible status patterns
+- logs, health views, or analytics
+- existing evaluation coverage
+
+Do not judge the harness only by prompt quality.
+
+## Evaluation Dimensions
+
+Evaluate along these dimensions:
+
+### Architecture
+
+- Is the harness shape clear?
+- Are subsystem boundaries explicit?
+- Is there a single source of truth for capabilities and policy?
+
+### Safety And Permissions
+
+- Are risky actions gated?
+- Is there an audit trail?
+- Can dangerous behavior happen silently?
+
+### State And Durability
+
+- Can the system resume or retry safely?
+- Is conversation state being mistaken for workflow state?
+- Are duplicate side effects possible?
+
+### Context, Memory, And Evals
+
+- Is context assembled intentionally?
+- Is memory scoped and trustworthy?
+- Are regressions tested before users discover them?
+
+### UX And Operations
+
+- Can users see what is happening?
+- Can operators diagnose failures?
+- Is cost visible enough to control?
+
+## Findings Format
+
+Present findings first.
+
+For each finding, include:
+
+- severity or leverage
+- what is missing or weak
+- why it matters
+- likely user or operator impact
+- recommended fix direction
+
+After findings, summarize strengths briefly.
+
+## Prioritization Rules
+
+Prioritize in this order:
+
+1. silent risk or safety gaps
+2. durability and duplicate-write risks
+3. missing evaluation coverage
+4. severe UX trust failures
+5. maintainability and extensibility cleanup
+
+Favor fixes that improve both user experience and operator control.
+
+## Upgrade Sequencing
+
+Most retrofit paths should look like this:
+
+1. stabilize capability and permission boundaries
+2. make state and resumability explicit
+3. add or repair evaluation coverage
+4. improve UX and observability
+5. add extensibility only if still needed
+
+Do not recommend a full rewrite when a subsystem correction will do.
+
+## Acceptance Checks After Changes
+
+After major improvements, verify:
+
+- risky operations are gated and logged
+- retries do not double-write
+- waiting or blocked states are visible
+- core tasks pass representative evals
+- operators can explain recent failures quickly
+- the harness is simpler or clearer than before, not just more powerful

--- a/skills/n-agentic-harnesses/references/10-example-requests-and-output-patterns.md
+++ b/skills/n-agentic-harnesses/references/10-example-requests-and-output-patterns.md
@@ -1,0 +1,243 @@
+# Example Requests And Output Patterns
+
+## Table Of Contents
+
+- What this file is for
+- Design examples
+- Evaluation examples
+- Mixed-mode examples
+- Output patterns
+- Worked example: design mode
+- Worked example: evaluation mode
+
+## What This File Is For
+
+Read this when you need prompt examples, response structure examples, or calibration on the depth and tone of a strong response.
+
+## Design Examples
+
+Example request:
+
+> Design a lean agentic harness for my SaaS app that can answer questions, call a few internal APIs, and ask before taking risky actions.
+
+Expected response shape:
+
+- recommended harness shape
+- minimum subsystem map
+- capability and permission plan
+- phased implementation
+- evaluation plan
+
+Example request:
+
+> I want an agent that can handle multi-step onboarding flows and resume after approvals or time delays.
+
+Expected response shape:
+
+- workflow-oriented architecture
+- state and resumability design
+- approval model
+- failure tests
+
+## Evaluation Examples
+
+Example request:
+
+> Review my current AI harness and tell me what I am overlooking.
+
+Expected response shape:
+
+- findings first
+- missing primitives
+- improvement priorities
+- acceptance checks after fixes
+
+Example request:
+
+> My agent works in demos but feels fragile in production. What should I inspect?
+
+Expected response shape:
+
+- likely failure categories
+- subsystem-by-subsystem review targets
+- highest-leverage fixes
+
+## Mixed-Mode Examples
+
+Example request:
+
+> Design the harness I should move toward and tell me how I would know it is better than what I have now.
+
+Expected response shape:
+
+- target architecture
+- comparison against current gaps
+- phased migration
+- evaluation and acceptance criteria
+
+## Output Patterns
+
+### Design Pattern
+
+Use a compact structure:
+
+- architecture
+- MVP
+- phases
+- tests
+
+### Evaluation Pattern
+
+Use a findings-first structure:
+
+- findings
+- open assumptions
+- upgrade path
+
+### Mixed Pattern
+
+Use:
+
+- target design
+- delta from current system
+- implementation order
+- validation plan
+
+If the answer starts drifting into theory, bring it back to decisions, risks, and next moves.
+
+## Worked Example: Design Mode
+
+Request:
+
+> I'm building a customer support assistant for a B2B SaaS product. It needs to answer questions from our docs, look up customer account info via our API, and sometimes create support tickets. It should ask before doing anything that changes data. Solo dev, Next.js frontend, Supabase backend.
+
+Response:
+
+### Harness Shape
+
+Chat assistant with approval gates. The core job is conversational help with controlled side effects — not a workflow engine or code agent.
+
+### Subsystem Map
+
+- **Entrypoint:** Next.js API route accepting user messages, streaming responses via SSE
+- **Orchestrator:** Single LLM call per turn with tool use. No multi-agent needed.
+- **Capability registry:** Three tools:
+  - `search_docs` (read-only, always allowed)
+  - `lookup_account` (read-only, always allowed)
+  - `create_ticket` (write, requires approval)
+- **Permission layer:** Binary trust tiers — reads auto-approve, writes require user confirmation before execution
+- **Context assembly:** System prompt + last N messages + retrieved doc chunks. Budget: reserve 40% of context for docs retrieval, 40% for conversation, 20% for system prompt and tool definitions.
+- **Session store:** Supabase table keyed by session ID, persisted after every turn
+- **Observability:** Log tool invocations, approval decisions, and stop reasons to a `harness_events` table
+
+### MVP Boundary
+
+Phase 1 ships with:
+
+- `search_docs` and `lookup_account` only
+- Session persistence
+- Basic event logging
+- 5 golden task evals
+
+Phase 2 adds:
+
+- `create_ticket` with approval gate
+- Approval audit trail
+- Richer eval suite covering permission boundaries
+
+Phase 3 (only if needed):
+
+- Conversation compaction for long sessions
+- Cost tracking per session
+- Health check endpoint
+
+### Evaluation Plan
+
+Golden tasks:
+
+1. User asks a question answerable from docs — agent answers correctly using `search_docs`
+2. User asks about their account — agent calls `lookup_account` with correct parameters
+3. User asks to create a ticket — agent requests approval before calling `create_ticket`
+4. User asks to delete an account — agent refuses (no such tool exists)
+5. Malformed tool input — agent handles gracefully without crashing
+
+Acceptance criteria:
+
+- All 5 golden tasks pass
+- Write tools never execute without prior approval
+- Sessions survive a page reload
+- An operator can trace any tool invocation from the event log
+
+### Key Risks
+
+- Doc retrieval returning irrelevant chunks, causing bad answers. Mitigate with retrieval quality evals.
+- Session state growing unbounded for long conversations. Monitor and add compaction in Phase 3 if needed.
+- Approval fatigue if too many actions require confirmation. Start strict, loosen based on usage data.
+
+---
+
+## Worked Example: Evaluation Mode
+
+Request:
+
+> Here's my AI agent setup. It's a coding assistant that can read files, edit files, and run shell commands. It works but sometimes it does things I don't expect — edits the wrong file, runs commands I didn't ask for. Can you evaluate what I'm missing?
+
+After reading the user's codebase and configuration:
+
+Response:
+
+### Findings
+
+**1. No permission differentiation between tools (High severity)**
+
+All three tools — file read, file edit, shell execution — are treated identically. There is no approval gate on writes or shell commands. The agent can edit any file or run any command without asking.
+
+Why it matters: This is the direct cause of the "does things I didn't expect" problem. Shell execution and file edits are fundamentally different risk levels from file reads, and the harness treats them the same.
+
+Fix direction: Introduce trust tiers. File reads auto-approve. File edits require confirmation for files outside the current working directory. Shell commands require confirmation unless they match a pre-approved pattern list (e.g., `ls`, `git status`, `cat`).
+
+**2. No tool pool filtering (Medium severity)**
+
+All tools are available in every context. When the user asks "explain this function," the agent has access to shell execution and file editing tools it doesn't need.
+
+Why it matters: More tools means more ways the model can go wrong. If the active tool set included only file read for explanation tasks, the agent couldn't accidentally edit or execute.
+
+Fix direction: Add context-based tool pool assembly. For read-only tasks, load only read-only tools.
+
+**3. No system event logging (Medium severity)**
+
+The only record of what happened is the conversation transcript. There is no separate log of which tools were called, what arguments were passed, or whether any permission checks occurred.
+
+Why it matters: When the agent "edits the wrong file," there is no quick way to see what tool call was made, what arguments it received, or whether the file path was hallucinated versus retrieved from context.
+
+Fix direction: Add a structured event log that records every tool invocation with timestamp, tool name, arguments, and result status.
+
+**4. Conversation history is unbounded (Low severity)**
+
+The full conversation is sent to the model on every turn with no compaction.
+
+Why it matters: Long sessions will eventually exceed the context window and fail. Before that, they'll get expensive and slow.
+
+Fix direction: Add transcript compaction after a configurable turn threshold. Summarize older turns, keep recent ones verbatim.
+
+### Strengths
+
+- Clean tool definitions with clear input schemas
+- Session persistence works correctly
+- The agent's system prompt is well-structured and task-focused
+
+### Prioritized Upgrade Path
+
+1. **Add permission tiers and approval gates for writes and shell** — this directly addresses the core complaint
+2. **Add tool invocation logging** — enables debugging when unexpected behavior occurs
+3. **Add tool pool filtering** — reduces the attack surface for each turn
+4. **Add transcript compaction** — prevents long-session failures
+
+### Acceptance Checks After Fixes
+
+- File edit outside working directory triggers approval prompt
+- Shell command not on pre-approved list triggers approval prompt
+- Pre-approved commands (ls, git status) execute without friction
+- Every tool invocation appears in the event log with arguments
+- Explanation-only tasks load only read tools
+- A 50-turn conversation does not exceed context limits

--- a/skills/n-agentic-harnesses/references/11-codex-translation-notes.md
+++ b/skills/n-agentic-harnesses/references/11-codex-translation-notes.md
@@ -1,0 +1,53 @@
+# Codex Translation Notes
+
+## Table Of Contents
+
+- What this file is for
+- Baseline rule
+- Likely Codex-specific additions
+- What should stay the same
+- Migration approach
+
+## What This File Is For
+
+Read this only when adapting the Anthropic-first skill into a Codex-oriented variant.
+
+## Baseline Rule
+
+Keep the Anthropic-style skill as the source version.
+
+Treat any Codex-oriented version as an adaptation layer, not the canonical design.
+
+## Likely Codex-Specific Additions
+
+Possible additions in a Codex version:
+
+- `agents/openai.yaml` metadata
+- path or prompt trigger metadata
+- validation scripts
+- repo- or plugin-specific routing hints
+- additional instructions for developer tools and MCP usage
+
+Those additions should not rewrite the core skill logic. They should only help Codex discover and render the same skill more effectively.
+
+## What Should Stay The Same
+
+Preserve:
+
+- the skill slug and identity
+- progressive disclosure design
+- router behavior in `SKILL.md`
+- reference file boundaries
+- design plus evaluation as equal first-class jobs
+- solo-dev default posture
+
+## Migration Approach
+
+When building the Codex version later:
+
+1. copy the Anthropic-first directory
+2. add Codex metadata and only the minimum extra files needed
+3. validate that the router still points to the same reference files
+4. avoid turning the skill into a Codex-only internal document
+
+If the Codex version starts changing the actual architectural guidance, you are no longer translating it. You are forking it.

--- a/skills/n-agentic-harnesses/variants/anthropic/SKILL.md
+++ b/skills/n-agentic-harnesses/variants/anthropic/SKILL.md
@@ -1,0 +1,178 @@
+---
+name: n-agentic-harnesses-anthropic
+description: >-
+  Design, evaluate, and improve agentic harnesses — the orchestration layer
+  around LLM-powered tools, agents, assistants, copilots, workflow runtimes,
+  and AI-driven product features. Use this skill whenever the user mentions
+  building an agentic system, structuring tool use, adding permissions or
+  approval gates, designing multi-step AI workflows, managing context windows
+  or memory, making agents durable or resumable, evaluating or pressure-testing
+  an existing harness, planning phased implementation for an AI product,
+  reviewing agent architecture, improving agent UX or observability, or asking
+  how to know if their harness is actually good. Also use when the user
+  describes problems that imply harness gaps — like agents doing unexpected
+  things, context getting stale, sessions not surviving crashes, tools running
+  without permission, or costs spiraling — even if they do not use the word
+  "harness."
+---
+
+# N Agentic Harnesses For Anthropic
+
+Use this skill as a router for designing, building, and evaluating agentic harnesses.
+
+Read only the files you need. Do not load the entire reference set unless the request genuinely spans multiple subsystems.
+
+Default posture:
+
+- Bias toward lean, solo-maintainable architecture.
+- Start with a single-agent design unless clear constraints justify more.
+- Require an evaluation plan even for greenfield builds.
+- Prefer explicit system boundaries, permission policy, and workflow state over prompt cleverness.
+- Translate ideas into implementation phases, success criteria, and failure tests.
+
+## Step 0: Gather Context
+
+Before routing, make sure you have enough to work with.
+
+If the user is asking for a **design**, confirm you understand:
+
+- what product or system the harness serves
+- what actions the agent will take
+- who the users are
+- any known constraints (solo dev, team, existing stack, timeline)
+
+If the user is asking for an **evaluation**, you need access to the harness itself:
+
+- read their codebase, CLAUDE.md, settings, skills, hooks, or architecture docs
+- if none of that is available, ask what they have and where it lives
+- do not evaluate from vibes alone — gather evidence first
+
+If the request is vague ("help me build an agent" or "is my harness any good"), ask one or two clarifying questions before proceeding. Do not stall the conversation with an interview — get enough to pick a mode and start.
+
+## Step 1: Classify The Request
+
+Choose one mode before reading reference files.
+
+### `design`
+
+Use when the user is creating a new harness, planning a major rebuild, or asking for architecture, MVP, or implementation sequencing.
+
+Default reads:
+
+- `references/01-principles-and-solo-dev-defaults.md`
+- `references/02-harness-shapes-and-architecture.md`
+- `references/08-design-and-build-playbook.md`
+
+Add subsystem files only as needed.
+
+### `evaluation`
+
+Use when the user already has a harness and wants gaps, risks, missing primitives, UX upgrades, or architectural cleanup.
+
+Default reads:
+
+- `references/01-principles-and-solo-dev-defaults.md`
+- `references/09-evaluation-and-improvement-playbook.md`
+
+Add subsystem files only for the parts under review.
+
+### `design + evaluation`
+
+Use when the user wants a target architecture and a way to verify it, compare it with an existing system, or define acceptance criteria before building.
+
+Default reads:
+
+- `references/01-principles-and-solo-dev-defaults.md`
+- `references/02-harness-shapes-and-architecture.md`
+- `references/08-design-and-build-playbook.md`
+- `references/09-evaluation-and-improvement-playbook.md`
+
+## Step 2: Classify The Product Shape
+
+Determine the closest product shape before going deeper:
+
+- code agent
+- chat assistant
+- workflow orchestrator
+- internal copilot
+- embedded AI product feature
+- hybrid system
+
+If the request is ambiguous, pick the closest shape and state the assumption.
+
+## Step 3: Read The Smallest Useful Reference Set
+
+Read these only when the request needs them:
+
+- `references/01-principles-and-solo-dev-defaults.md`
+  Use first for almost every request. It defines the default decision posture.
+- `references/02-harness-shapes-and-architecture.md`
+  Read when choosing system shape, boundaries, lifecycle, transports, or deployment structure.
+- `references/03-tools-execution-and-permissions.md`
+  Read when the request involves tool registries, tool calling, approval gates, sandboxes, or trust tiers.
+- `references/04-state-sessions-and-durability.md`
+  Read when the request involves sessions, resumability, retries, idempotency, approval waits, or long-running work.
+- `references/05-context-memory-and-evaluation.md`
+  Read when the request involves context windows, retrieval, memory, provenance, evals, replay tests, or regression detection.
+- `references/06-agents-and-extensibility.md`
+  Read when the request involves multi-agent design, plugins, hooks, skills, or extension surfaces.
+- `references/07-ux-observability-and-operations.md`
+  Read when the request involves streaming UX, health checks, logs, analytics, budgets, or supportability.
+- `references/08-design-and-build-playbook.md`
+  Read when the user needs a build-ready plan from idea to implementation.
+- `references/09-evaluation-and-improvement-playbook.md`
+  Read when the user needs findings, missing primitives, upgrade priorities, or acceptance tests.
+- `references/10-example-requests-and-output-patterns.md`
+  Read when you need prompt examples or response structure examples.
+- `references/11-codex-translation-notes.md`
+  Read only when adapting this Anthropic-style skill into a Codex-oriented version or when mapping concepts between the two environments.
+
+Do not rely on reference-to-reference chains. This file is the index.
+
+## Operating Rules
+
+- Convert vague ambitions into concrete harness primitives.
+- Push back on unnecessary complexity.
+- Treat workflow state, permissions, context assembly, and evaluation as first-class architecture, not cleanup tasks.
+- Separate universal harness primitives from product-specific manifestation.
+- For evaluation requests, present findings first and improvement sequence second.
+- For design requests, include how the design will be tested before calling it done.
+
+## Output Contract
+
+### For `design`
+
+Return:
+
+- recommended harness shape
+- core primitives and subsystem boundaries
+- MVP boundary
+- phased implementation plan
+- verification and acceptance criteria
+
+### For `evaluation`
+
+Return:
+
+- findings ordered by severity or leverage
+- missing or weak primitives
+- user experience and operational gaps
+- prioritized upgrade path
+- tests or checks that confirm the fixes
+
+### For `design + evaluation`
+
+Return:
+
+- target architecture
+- comparison against current or likely failure modes
+- implementation phases
+- acceptance criteria
+- evaluation plan covering regressions, safety, and UX
+
+## Final Check Before Responding
+
+- Did you keep the design lean enough for a solo developer unless the request clearly demanded more?
+- Did you avoid recommending multi-agent coordination by default?
+- Did you include evaluation, not just construction?
+- Did you give the user an operational path forward instead of abstract theory?

--- a/skills/n-agentic-harnesses/variants/codex/SKILL.md
+++ b/skills/n-agentic-harnesses/variants/codex/SKILL.md
@@ -1,0 +1,228 @@
+---
+name: n-agentic-harnesses-codex
+description: Designs, evaluates, and improves agentic harnesses for developer tools, assistants, workflow runtimes, copilots, and AI-powered products. Applies when work involves defining or reviewing tool-use architecture, permissions, workflow state, durability, context and memory systems, evaluation strategy, observability, user experience, or phased implementation plans for an agentic system.
+metadata:
+  priority: 6
+  pathPatterns:
+    - '**/*harness*'
+    - '**/*agent-runtime*'
+    - '**/*agent_runtime*'
+    - '**/*orchestrat*'
+    - '**/*workflow*'
+    - '**/*tool-registry*'
+    - '**/*tool_registry*'
+    - '**/*permission*'
+    - '**/*approval*'
+    - '**/*state-machine*'
+    - '**/*state_machine*'
+    - '**/*session*'
+    - '**/*memory*'
+    - '**/*eval*'
+    - '**/*retry*'
+  importPatterns:
+    - '@modelcontextprotocol/*'
+    - 'langgraph'
+    - '@langchain/*'
+    - 'langchain'
+    - '@vercel/workflow'
+  bashPatterns:
+    - '\bnpm\s+(install|i|add)\s+[^\n]*(langgraph|langchain|@vercel/workflow|@modelcontextprotocol)\b'
+    - '\bpnpm\s+(install|i|add)\s+[^\n]*(langgraph|langchain|@vercel/workflow|@modelcontextprotocol)\b'
+    - '\bbun\s+(install|i|add)\s+[^\n]*(langgraph|langchain|@vercel/workflow|@modelcontextprotocol)\b'
+    - '\byarn\s+add\s+[^\n]*(langgraph|langchain|@vercel/workflow|@modelcontextprotocol)\b'
+  promptSignals:
+    phrases:
+      - "agentic harness"
+      - "agent harness"
+      - "ai harness"
+      - "harness architecture"
+      - "agent architecture"
+      - "agent runtime"
+      - "agent workflow runtime"
+      - "tool-use architecture"
+      - "tool use architecture"
+      - "tool calling system"
+      - "tool registry"
+      - "capability registry"
+      - "permission layer"
+      - "approval gate"
+      - "human-in-the-loop"
+      - "workflow state"
+      - "session persistence"
+      - "durable agent"
+      - "durable workflow"
+      - "resume after crash"
+      - "crash-safe agent"
+      - "retry and idempotency"
+      - "context assembly"
+      - "memory system"
+      - "evaluation harness"
+      - "replay evals"
+      - "agent observability"
+      - "operator visibility"
+      - "multi-agent architecture"
+      - "single agent vs multi-agent"
+      - "stop reasons"
+    allOf:
+      - [agent, harness]
+      - [tool, registry]
+      - [permission, approval]
+      - [workflow, state]
+      - [resume, retry]
+      - [context, memory]
+      - [evaluation, harness]
+      - [multi-agent, architecture]
+      - [durable, agent]
+      - [operator, visibility]
+    anyOf:
+      - "agent orchestration"
+      - "approval workflow"
+      - "tool-calling runtime"
+      - "tool calling runtime"
+      - "state machine"
+      - "retry policy"
+    noneOf: []
+    minScore: 6
+---
+
+# N Agentic Harnesses For Codex
+
+Use this skill as a router for designing, building, and evaluating agentic harnesses.
+
+Read only the files you need. Do not load the entire reference set unless the request genuinely spans multiple subsystems.
+
+Default posture:
+
+- Bias toward lean, solo-maintainable architecture.
+- Start with a single-agent design unless clear constraints justify more.
+- Require an evaluation plan even for greenfield builds.
+- Prefer explicit system boundaries, permission policy, and workflow state over prompt cleverness.
+- Translate ideas into implementation phases, success criteria, and failure tests.
+
+## Step 1: Classify The Request
+
+Choose one mode before reading reference files.
+
+### `design`
+
+Use when the user is creating a new harness, planning a major rebuild, or asking for architecture, MVP, or implementation sequencing.
+
+Default reads:
+
+- `references/01-principles-and-solo-dev-defaults.md`
+- `references/02-harness-shapes-and-architecture.md`
+- `references/08-design-and-build-playbook.md`
+
+Add subsystem files only as needed.
+
+### `evaluation`
+
+Use when the user already has a harness and wants gaps, risks, missing primitives, UX upgrades, or architectural cleanup.
+
+Default reads:
+
+- `references/01-principles-and-solo-dev-defaults.md`
+- `references/09-evaluation-and-improvement-playbook.md`
+
+Add subsystem files only for the parts under review.
+
+### `design + evaluation`
+
+Use when the user wants a target architecture and a way to verify it, compare it with an existing system, or define acceptance criteria before building.
+
+Default reads:
+
+- `references/01-principles-and-solo-dev-defaults.md`
+- `references/02-harness-shapes-and-architecture.md`
+- `references/08-design-and-build-playbook.md`
+- `references/09-evaluation-and-improvement-playbook.md`
+
+## Step 2: Classify The Product Shape
+
+Determine the closest product shape before going deeper:
+
+- code agent
+- chat assistant
+- workflow orchestrator
+- internal copilot
+- embedded AI product feature
+- hybrid system
+
+If the request is ambiguous, pick the closest shape and state the assumption.
+
+## Step 3: Read The Smallest Useful Reference Set
+
+Read these only when the request needs them:
+
+- `references/01-principles-and-solo-dev-defaults.md`
+  Use first for almost every request. It defines the default decision posture.
+- `references/02-harness-shapes-and-architecture.md`
+  Read when choosing system shape, boundaries, lifecycle, transports, or deployment structure.
+- `references/03-tools-execution-and-permissions.md`
+  Read when the request involves tool registries, tool calling, approval gates, sandboxes, or trust tiers.
+- `references/04-state-sessions-and-durability.md`
+  Read when the request involves sessions, resumability, retries, idempotency, approval waits, or long-running work.
+- `references/05-context-memory-and-evaluation.md`
+  Read when the request involves context windows, retrieval, memory, provenance, evals, replay tests, or regression detection.
+- `references/06-agents-and-extensibility.md`
+  Read when the request involves multi-agent design, plugins, hooks, skills, or extension surfaces.
+- `references/07-ux-observability-and-operations.md`
+  Read when the request involves streaming UX, health checks, logs, analytics, budgets, or supportability.
+- `references/08-design-and-build-playbook.md`
+  Read when the user needs a build-ready plan from idea to implementation.
+- `references/09-evaluation-and-improvement-playbook.md`
+  Read when the user needs findings, missing primitives, upgrade priorities, or acceptance tests.
+- `references/10-example-requests-and-output-patterns.md`
+  Read when you need prompt examples or response structure examples.
+- `references/11-codex-translation-notes.md`
+  Read only when adapting this Anthropic-style skill into a Codex-oriented version or when mapping concepts between the two environments.
+
+Do not rely on reference-to-reference chains. This file is the index.
+
+## Operating Rules
+
+- Convert vague ambitions into concrete harness primitives.
+- Push back on unnecessary complexity.
+- Treat workflow state, permissions, context assembly, and evaluation as first-class architecture, not cleanup tasks.
+- Separate universal harness primitives from product-specific manifestation.
+- For evaluation requests, present findings first and improvement sequence second.
+- For design requests, include how the design will be tested before calling it done.
+
+## Output Contract
+
+### For `design`
+
+Return:
+
+- recommended harness shape
+- core primitives and subsystem boundaries
+- MVP boundary
+- phased implementation plan
+- verification and acceptance criteria
+
+### For `evaluation`
+
+Return:
+
+- findings ordered by severity or leverage
+- missing or weak primitives
+- user experience and operational gaps
+- prioritized upgrade path
+- tests or checks that confirm the fixes
+
+### For `design + evaluation`
+
+Return:
+
+- target architecture
+- comparison against current or likely failure modes
+- implementation phases
+- acceptance criteria
+- evaluation plan covering regressions, safety, and UX
+
+## Final Check Before Responding
+
+- Did you keep the design lean enough for a solo developer unless the request clearly demanded more?
+- Did you avoid recommending multi-agent coordination by default?
+- Did you include evaluation, not just construction?
+- Did you give the user an operational path forward instead of abstract theory?


### PR DESCRIPTION
## Summary
- add `skills/n-agentic-harnesses/` as a new OB1 skill contribution
- rename the imported skill pack from `lej-agentic-harnesses` to `n-agentic-harnesses` across the canonical skill and client variants
- include shared reference docs, a portable root `SKILL.md`, Codex and Anthropic variants, and OB1-compliant `README.md` and `metadata.json`

## Validation
- validated `skills/n-agentic-harnesses/metadata.json` against `.github/metadata.schema.json` with `uvx check-jsonschema`
- checked README links, secret/local-MCP patterns, file size constraints, and staged diff whitespace
- kept the diff scoped to the new contribution folder so it aligns with the OB1 PR gate
