### PR TITLE
[recipes] Fix UUID cursor in fingerprint dedup backfill

### DIFF
--- a/recipes/fingerprint-dedup-backfill/backfill-fingerprints.mjs
+++ b/recipes/fingerprint-dedup-backfill/backfill-fingerprints.mjs
@@ -94,14 +94,14 @@ function buildContentFingerprint(text) {
 
 // ── REST helpers ────────────────────────────────────────────────────────────
 
-async function fetchBatch(cursorId, batchSize) {
+async function fetchBatch(cursorCreatedAt, batchSize) {
   const url =
     `${REST_BASE}/thoughts` +
     `?content_fingerprint=is.null` +
-    `&id=gt.${cursorId}` +
-    `&select=id,content` +
+    `&created_at=gt.${encodeURIComponent(cursorCreatedAt)}` +
+    `&select=id,content,created_at` +
     `&limit=${batchSize}` +
-    `&order=id.asc`;
+    `&order=created_at.asc`;
   const res = await fetch(url, { headers: HEADERS });
   if (!res.ok) {
     const body = await res.text().catch(() => "");
@@ -162,7 +162,7 @@ function loadState() {
     return JSON.parse(fs.readFileSync(STATE_FILE, "utf8"));
   } catch {
     return {
-      cursorId: 0,
+      cursorCreatedAt: "1970-01-01T00:00:00Z",
       totalDone: 0,
       totalDuplicates: 0,
       totalErrors: 0,
@@ -183,7 +183,7 @@ async function main() {
   const state = loadState();
   console.log("=== Backfill content_fingerprint ===");
   console.log(
-    `Resuming from cursor id=${state.cursorId} (${state.totalDone} already done)`
+    `Resuming from cursor created_at=${state.cursorCreatedAt} (${state.totalDone} already done)`
   );
   console.log(`Batch size: ${BATCH_SIZE}`);
   console.log();
@@ -191,12 +191,12 @@ async function main() {
   while (true) {
     state.batches++;
     process.stdout.write(
-      `Batch ${state.batches}: fetching from id>${state.cursorId}… `
+      `Batch ${state.batches}: fetching from created_at>${state.cursorCreatedAt}… `
     );
 
     let rows;
     try {
-      rows = await fetchBatch(state.cursorId, BATCH_SIZE);
+      rows = await fetchBatch(state.cursorCreatedAt, BATCH_SIZE);
     } catch (err) {
       console.error("\n  Fetch error:", err.message, "— retrying in 5s…");
       await new Promise((r) => setTimeout(r, 5000));
@@ -221,8 +221,8 @@ async function main() {
     state.totalDuplicates += duplicates;
     state.totalErrors += errors;
 
-    const maxId = rows[rows.length - 1].id;
-    state.cursorId = typeof maxId === "number" ? maxId : maxId;
+    const lastCreatedAt = rows[rows.length - 1].created_at;
+    state.cursorCreatedAt = lastCreatedAt;
     saveState(state);
 
     const dupeStr =
@@ -231,7 +231,7 @@ async function main() {
     console.log(
       `  → ${done} patched${dupeStr}${errStr}. ` +
         `Total: ${state.totalDone} patched, ${state.totalDuplicates} duplicates, ${state.totalErrors} errors. ` +
-        `Cursor: ${state.cursorId}`
+        `Cursor: ${state.cursorCreatedAt}`
     );
 
     await new Promise((r) => setTimeout(r, 150));

--- a/recipes/fingerprint-dedup-backfill/delete-duplicates.mjs
+++ b/recipes/fingerprint-dedup-backfill/delete-duplicates.mjs
@@ -93,14 +93,14 @@ function buildFingerprint(text) {
 
 // ── REST helpers ────────────────────────────────────────────────────────────
 
-async function fetchBatch(cursorId, batchSize) {
+async function fetchBatch(cursorCreatedAt, batchSize) {
   const url =
     `${REST_BASE}/thoughts` +
     `?content_fingerprint=is.null` +
-    `&id=gt.${cursorId}` +
-    `&select=id,content` +
+    `&created_at=gt.${encodeURIComponent(cursorCreatedAt)}` +
+    `&select=id,content,created_at` +
     `&limit=${batchSize}` +
-    `&order=id.asc`;
+    `&order=created_at.asc`;
   const res = await fetch(url, { headers: HEADERS });
   if (!res.ok) {
     const body = await res.text().catch(() => "");
@@ -173,7 +173,7 @@ function loadState() {
     return JSON.parse(fs.readFileSync(STATE_FILE, "utf8"));
   } catch {
     return {
-      cursorId: 0,
+      cursorCreatedAt: "1970-01-01T00:00:00Z",
       totalDeleted: 0,
       totalPatched: 0,
       totalWouldDelete: 0,
@@ -205,19 +205,19 @@ async function main() {
   }
 
   console.log(
-    `Resuming from cursor id=${state.cursorId} (deleted: ${state.totalDeleted}, patched: ${state.totalPatched})`
+    `Resuming from cursor created_at=${state.cursorCreatedAt} (deleted: ${state.totalDeleted}, patched: ${state.totalPatched})`
   );
   console.log(`Batch size: ${BATCH_SIZE}\n`);
 
   while (true) {
     state.batches++;
     process.stdout.write(
-      `Batch ${state.batches}: fetching from id>${state.cursorId}… `
+      `Batch ${state.batches}: fetching from created_at>${state.cursorCreatedAt}… `
     );
 
     let rows;
     try {
-      rows = await fetchBatch(state.cursorId, BATCH_SIZE);
+      rows = await fetchBatch(state.cursorCreatedAt, BATCH_SIZE);
     } catch (err) {
       console.error("\n  Fetch error:", err.message, "— retrying in 5s…");
       await new Promise((r) => setTimeout(r, 5000));
@@ -303,14 +303,14 @@ async function main() {
     }
 
     // Advance cursor
-    const maxId = rows[rows.length - 1].id;
-    state.cursorId = maxId;
+    const lastCreatedAt = rows[rows.length - 1].created_at;
+    state.cursorCreatedAt = lastCreatedAt;
     saveState(state);
 
     console.log(
       `  Totals: deleted=${state.totalDeleted}, patched=${state.totalPatched}, ` +
         `would-delete=${state.totalWouldDelete}, errors=${state.totalErrors}. ` +
-        `Cursor: ${state.cursorId}`
+        `Cursor: ${state.cursorCreatedAt}`
     );
 
     await new Promise((r) => setTimeout(r, 200));

--- a/recipes/fingerprint-dedup-backfill/metadata.json
+++ b/recipes/fingerprint-dedup-backfill/metadata.json
@@ -16,5 +16,5 @@
   "difficulty": "beginner",
   "estimated_time": "15 minutes",
   "created": "2026-03-22",
-  "updated": "2026-03-22"
+  "updated": "2026-04-03"
 }


### PR DESCRIPTION
**Contribution Type**

<!-- Check one -->
- [x] Recipe (`/recipes`)
- [ ] Schema (`/schemas`)
- [ ] Dashboard (`/dashboards`)
- [ ] Integration (`/integrations`)
- [ ] Skill (`/skills`)
- [ ] Repo improvement (docs, CI, templates)

## What does this do?

Fixes the fingerprint dedup backfill scripts to work with UUID primary keys on the thoughts table. Changed cursor pagination from `id` (integer) to `created_at` (timestamp), which works for any ID type and resolves the error `invalid input syntax for type uuid: "0"`.

## Requirements

- Node.js 18+
- [Content Fingerprint Dedup primitive](../../primitives/content-fingerprint-dedup/) applied (so `content_fingerprint` column exists on thoughts table)

## Checklist

- [x] I've read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] My contribution has a `README.md` with prerequisites, step-by-step instructions, and expected outcome
- [x] My `metadata.json` has all required fields
- [x] If my contribution depends on a skill or primitive, I declared it in metadata.json and linked it in the README — depends on `content-fingerprint-dedup` primitive (declared in existing README)
- [x] I tested this on my own Open Brain instance — 1815 rows backfilled successfully, 10 duplicates skipped, 0 errors
- [x] No credentials, API keys, or secrets are included


## Test Results

```
$ node backfill-fingerprints.mjs

=== Backfill content_fingerprint ===
Resuming from cursor created_at=1970-01-01T00:00:00Z (0 already done)
Batch size: 1000

Batch 1: fetching from created_at>1970-01-01T00:00:00Z… 1000 rows. Patching…
  → 1000 patched. Total: 1000 patched, 0 duplicates, 0 errors. Cursor: 2025-04-12T13:52:40+00:00
Batch 2: fetching from created_at>2025-04-12T13:52:40+00:00… 825 rows. Patching…
  → 815 patched, 10 duplicates (skipped). Total: 1815 patched, 10 duplicates, 0 errors. Cursor: 2026-04-03T07:41:36.188656+00:00
Batch 3: fetching from created_at>2026-04-03T07:41:36.188656+00:00… (no rows) — Done.

=== COMPLETE ===
Total rows backfilled   : 1815
Total duplicate skipped : 10
Total other errors      : 0
State file cleaned up.
```

**Outcome:** ✅ Fix verified working on real Open Brain database with UUID primary key.