### PR TITLE
[server] Add Authorization Bearer support for MCP clients

### DIFF
--- a/extensions/_template/AGENT_SPEC.md
+++ b/extensions/_template/AGENT_SPEC.md
@@ -148,7 +148,11 @@ const server = new McpServer({
 const app = new Hono();
 
 app.all("*", async (c) => {
-  const provided = c.req.header("x-brain-key") || new URL(c.req.url).searchParams.get("key");
+  // Accept access key via Authorization: Bearer header, x-brain-key header, or URL query parameter
+  const authHeader = c.req.header("Authorization");
+  const provided = (authHeader?.startsWith("Bearer ") && authHeader.split(" ")[1])
+    || c.req.header("x-brain-key")
+    || new URL(c.req.url).searchParams.get("key");
   if (!provided || provided !== MCP_ACCESS_KEY) {
     return c.json({ error: "Invalid or missing access key" }, 401);
   }

--- a/integrations/kubernetes-deployment/index.ts
+++ b/integrations/kubernetes-deployment/index.ts
@@ -415,7 +415,11 @@ server.registerTool(
 const app = new Hono();
 
 app.all("*", async (c) => {
-  const provided = c.req.header("x-brain-key") || new URL(c.req.url).searchParams.get("key");
+  // Accept access key via Authorization: Bearer header, x-brain-key header, or URL query parameter
+  const authHeader = c.req.header("Authorization");
+  const provided = (authHeader?.startsWith("Bearer ") && authHeader.split(" ")[1])
+    || c.req.header("x-brain-key")
+    || new URL(c.req.url).searchParams.get("key");
   if (!provided || provided !== MCP_ACCESS_KEY) {
     return c.json({ error: "Invalid or missing access key" }, 401);
   }

--- a/recipes/fingerprint-dedup-backfill/backfill-fingerprints.mjs
+++ b/recipes/fingerprint-dedup-backfill/backfill-fingerprints.mjs
@@ -94,14 +94,14 @@ function buildContentFingerprint(text) {
 
 // ── REST helpers ────────────────────────────────────────────────────────────
 
-async function fetchBatch(cursorId, batchSize) {
+async function fetchBatch(cursorCreatedAt, batchSize) {
   const url =
     `${REST_BASE}/thoughts` +
     `?content_fingerprint=is.null` +
-    `&id=gt.${cursorId}` +
-    `&select=id,content` +
+    `&created_at=gt.${encodeURIComponent(cursorCreatedAt)}` +
+    `&select=id,content,created_at` +
     `&limit=${batchSize}` +
-    `&order=id.asc`;
+    `&order=created_at.asc`;
   const res = await fetch(url, { headers: HEADERS });
   if (!res.ok) {
     const body = await res.text().catch(() => "");
@@ -162,7 +162,7 @@ function loadState() {
     return JSON.parse(fs.readFileSync(STATE_FILE, "utf8"));
   } catch {
     return {
-      cursorId: 0,
+      cursorCreatedAt: "1970-01-01T00:00:00Z",
       totalDone: 0,
       totalDuplicates: 0,
       totalErrors: 0,
@@ -183,7 +183,7 @@ async function main() {
   const state = loadState();
   console.log("=== Backfill content_fingerprint ===");
   console.log(
-    `Resuming from cursor id=${state.cursorId} (${state.totalDone} already done)`
+    `Resuming from cursor created_at=${state.cursorCreatedAt} (${state.totalDone} already done)`
   );
   console.log(`Batch size: ${BATCH_SIZE}`);
   console.log();
@@ -191,12 +191,12 @@ async function main() {
   while (true) {
     state.batches++;
     process.stdout.write(
-      `Batch ${state.batches}: fetching from id>${state.cursorId}… `
+      `Batch ${state.batches}: fetching from created_at>${state.cursorCreatedAt}… `
     );
 
     let rows;
     try {
-      rows = await fetchBatch(state.cursorId, BATCH_SIZE);
+      rows = await fetchBatch(state.cursorCreatedAt, BATCH_SIZE);
     } catch (err) {
       console.error("\n  Fetch error:", err.message, "— retrying in 5s…");
       await new Promise((r) => setTimeout(r, 5000));
@@ -221,8 +221,8 @@ async function main() {
     state.totalDuplicates += duplicates;
     state.totalErrors += errors;
 
-    const maxId = rows[rows.length - 1].id;
-    state.cursorId = typeof maxId === "number" ? maxId : maxId;
+    const lastCreatedAt = rows[rows.length - 1].created_at;
+    state.cursorCreatedAt = lastCreatedAt;
     saveState(state);
 
     const dupeStr =
@@ -231,7 +231,7 @@ async function main() {
     console.log(
       `  → ${done} patched${dupeStr}${errStr}. ` +
         `Total: ${state.totalDone} patched, ${state.totalDuplicates} duplicates, ${state.totalErrors} errors. ` +
-        `Cursor: ${state.cursorId}`
+        `Cursor: ${state.cursorCreatedAt}`
     );
 
     await new Promise((r) => setTimeout(r, 150));

--- a/recipes/fingerprint-dedup-backfill/delete-duplicates.mjs
+++ b/recipes/fingerprint-dedup-backfill/delete-duplicates.mjs
@@ -93,14 +93,14 @@ function buildFingerprint(text) {
 
 // ── REST helpers ────────────────────────────────────────────────────────────
 
-async function fetchBatch(cursorId, batchSize) {
+async function fetchBatch(cursorCreatedAt, batchSize) {
   const url =
     `${REST_BASE}/thoughts` +
     `?content_fingerprint=is.null` +
-    `&id=gt.${cursorId}` +
-    `&select=id,content` +
+    `&created_at=gt.${encodeURIComponent(cursorCreatedAt)}` +
+    `&select=id,content,created_at` +
     `&limit=${batchSize}` +
-    `&order=id.asc`;
+    `&order=created_at.asc`;
   const res = await fetch(url, { headers: HEADERS });
   if (!res.ok) {
     const body = await res.text().catch(() => "");
@@ -173,7 +173,7 @@ function loadState() {
     return JSON.parse(fs.readFileSync(STATE_FILE, "utf8"));
   } catch {
     return {
-      cursorId: 0,
+      cursorCreatedAt: "1970-01-01T00:00:00Z",
       totalDeleted: 0,
       totalPatched: 0,
       totalWouldDelete: 0,
@@ -205,19 +205,19 @@ async function main() {
   }
 
   console.log(
-    `Resuming from cursor id=${state.cursorId} (deleted: ${state.totalDeleted}, patched: ${state.totalPatched})`
+    `Resuming from cursor created_at=${state.cursorCreatedAt} (deleted: ${state.totalDeleted}, patched: ${state.totalPatched})`
   );
   console.log(`Batch size: ${BATCH_SIZE}\n`);
 
   while (true) {
     state.batches++;
     process.stdout.write(
-      `Batch ${state.batches}: fetching from id>${state.cursorId}… `
+      `Batch ${state.batches}: fetching from created_at>${state.cursorCreatedAt}… `
     );
 
     let rows;
     try {
-      rows = await fetchBatch(state.cursorId, BATCH_SIZE);
+      rows = await fetchBatch(state.cursorCreatedAt, BATCH_SIZE);
     } catch (err) {
       console.error("\n  Fetch error:", err.message, "— retrying in 5s…");
       await new Promise((r) => setTimeout(r, 5000));
@@ -303,14 +303,14 @@ async function main() {
     }
 
     // Advance cursor
-    const maxId = rows[rows.length - 1].id;
-    state.cursorId = maxId;
+    const lastCreatedAt = rows[rows.length - 1].created_at;
+    state.cursorCreatedAt = lastCreatedAt;
     saveState(state);
 
     console.log(
       `  Totals: deleted=${state.totalDeleted}, patched=${state.totalPatched}, ` +
         `would-delete=${state.totalWouldDelete}, errors=${state.totalErrors}. ` +
-        `Cursor: ${state.cursorId}`
+        `Cursor: ${state.cursorCreatedAt}`
     );
 
     await new Promise((r) => setTimeout(r, 200));

--- a/recipes/fingerprint-dedup-backfill/metadata.json
+++ b/recipes/fingerprint-dedup-backfill/metadata.json
@@ -16,5 +16,5 @@
   "difficulty": "beginner",
   "estimated_time": "15 minutes",
   "created": "2026-03-22",
-  "updated": "2026-03-22"
+  "updated": "2026-04-03"
 }

--- a/server/index.ts
+++ b/server/index.ts
@@ -378,8 +378,11 @@ app.options("*", (c) => {
 });
 
 app.all("*", async (c) => {
-  // Accept access key via header OR URL query parameter
-  const provided = c.req.header("x-brain-key") || new URL(c.req.url).searchParams.get("key");
+  // Accept access key via Authorization: Bearer header, x-brain-key header, or URL query parameter
+  const authHeader = c.req.header("Authorization");
+  const provided = (authHeader?.startsWith("Bearer ") && authHeader.split(" ")[1])
+    || c.req.header("x-brain-key")
+    || new URL(c.req.url).searchParams.get("key");
   if (!provided || provided !== MCP_ACCESS_KEY) {
     return c.json({ error: "Invalid or missing access key" }, 401, corsHeaders);
   }


### PR DESCRIPTION
**Contribution Type**

<!-- Check one -->
- [ ] Recipe (`/recipes`)
- [ ] Schema (`/schemas`)
- [ ] Dashboard (`/dashboards`)
- [ ] Integration (`/integrations`)
- [ ] Skill (`/skills`)
- [x] Repo improvement (docs, CI, templates)

## What does this do?

Adds standard HTTP `Authorization: Bearer` authentication support to the Open Brain MCP server. Enables Perplexity Pro and other MCP clients that only support standard auth headers to connect directly without needing a proxy. Maintains backward compatibility with the existing `x-brain-key` header and `?key=` query parameter.

## Fixes
- https://github.com/NateBJones-Projects/OB1/issues/73

## Testing
- Tested on Perplexity web and mobile app
- Successfully retrieved and stored thoughts via MCP tools

## Requirements

- Working Open Brain setup with deployed MCP server
- Perplexity Pro or other MCP client requiring standard Bearer auth
- No additional external services or tools required

## Checklist

- [x] I've read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] This is a core server change, not a new contribution with README — no additional documentation required
- [x] My `metadata.json` has all required fields — N/A (server code change, not a contribution folder)
- [x] If my contribution depends on a skill or primitive, I declared it in metadata.json and linked it in the README — N/A
- [x] I tested this on my own Open Brain instance — Tested on Perplexity web and mobile app
- [x] No credentials, API keys, or secrets are included

---

**Note:** This is a core infrastructure change (server code), not a new recipe/integration. The PR includes:
- `server/index.ts` — Core MCP server with Bearer auth
- `integrations/kubernetes-deployment/index.ts` — Self-hosted variant
- `extensions/_template/AGENT_SPEC.md` — Updated canonical template