### PR TITLE
[integrations] Perplexity Pro MCP compatibility

### DIFF
--- a/extensions/_template/AGENT_SPEC.md
+++ b/extensions/_template/AGENT_SPEC.md
@@ -148,7 +148,11 @@ const server = new McpServer({
 const app = new Hono();
 
 app.all("*", async (c) => {
-  const provided = c.req.header("x-brain-key") || new URL(c.req.url).searchParams.get("key");
+  // Accept access key via Authorization: Bearer header, x-brain-key header, or URL query parameter
+  const authHeader = c.req.header("Authorization");
+  const provided = (authHeader?.startsWith("Bearer ") && authHeader.split(" ")[1])
+    || c.req.header("x-brain-key")
+    || new URL(c.req.url).searchParams.get("key");
   if (!provided || provided !== MCP_ACCESS_KEY) {
     return c.json({ error: "Invalid or missing access key" }, 401);
   }

--- a/integrations/kubernetes-deployment/index.ts
+++ b/integrations/kubernetes-deployment/index.ts
@@ -415,7 +415,11 @@ server.registerTool(
 const app = new Hono();
 
 app.all("*", async (c) => {
-  const provided = c.req.header("x-brain-key") || new URL(c.req.url).searchParams.get("key");
+  // Accept access key via Authorization: Bearer header, x-brain-key header, or URL query parameter
+  const authHeader = c.req.header("Authorization");
+  const provided = (authHeader?.startsWith("Bearer ") && authHeader.split(" ")[1])
+    || c.req.header("x-brain-key")
+    || new URL(c.req.url).searchParams.get("key");
   if (!provided || provided !== MCP_ACCESS_KEY) {
     return c.json({ error: "Invalid or missing access key" }, 401);
   }

--- a/integrations/perplexity-pro/README.md
+++ b/integrations/perplexity-pro/README.md
@@ -1,0 +1,61 @@
+# Perplexity Pro MCP
+
+> Connect Perplexity Pro as an MCP client to your Open Brain — enables AI-powered search across your captured thoughts.
+
+## What It Does
+
+Perplexity Pro can connect to remote MCP servers. Once connected, you can search your Open Brain directly from Perplexity using natural language. Your thoughts become part of Perplexity's contextual awareness.
+
+## Prerequisites
+
+- Working Open Brain setup ([guide](../../docs/01-getting-started.md))
+- Perplexity Pro subscription
+- Updated Open Brain MCP server (with Bearer auth support)
+
+## Steps
+
+### 1. Update Your MCP Server
+
+If you deployed Open Brain before April 2026, update the edge function:
+
+```bash
+cd your-supabase-project
+supabase functions deploy open-brain-mcp --no-verify-jwt
+```
+
+### 2. Get Your Connection Details
+
+- **MCP URL:** `https://YOUR_PROJECT_REF.supabase.co/functions/v1/open-brain-mcp`
+- **Access Key:** Your MCP_ACCESS_KEY from Step 5 of the setup guide
+
+### 3. Connect Perplexity
+
+1. Open Perplexity Pro > Your user profile > settings
+2. Navigate to MCP / Connectors
+3. Add new connector:
+   - **Name:** MyOpenBrain
+   - **URL:** `https://YOUR_PROJECT_REF.supabase.co/functions/v1/open-brain-mcp`
+   - **Authentication:** Choose API `Authorization: Bearer YOUR_ACCESS_KEY`
+4. Save and enable it
+
+### 4. Verify Connection
+
+From Perplexity input field, click "+" and choose the MyOpenBrain connector.
+
+Ask Perplexity: "What thoughts do I have about [topic]?"
+
+## Expected Outcome
+
+Perplexity returns relevant thoughts from your Open Brain with citations. The four MCP tools (search_thoughts, list_thoughts, thought_stats, capture_thought) are available.
+
+## Troubleshooting
+
+**Issue: "Couldn't connect to MCP server"**
+Solution: Ensure your MCP server is deployed and supports Bearer auth. Re-deploy if needed.
+
+**Issue: "Invalid access key"**
+Solution: Verify the key matches your MCP_ACCESS_KEY exactly. Re-check in Supabase secrets.
+
+## Tool Surface Area
+
+This integration adds 4 MCP tools to your Perplexity context. See the [MCP Tool Audit & Optimization Guide](../../docs/05-tool-audit.md).

--- a/integrations/perplexity-pro/metadata.json
+++ b/integrations/perplexity-pro/metadata.json
@@ -1,0 +1,20 @@
+{
+  "name": "Perplexity Pro MCP",
+  "description": "Connect Perplexity Pro as an MCP client to search and capture thoughts in Open Brain.",
+  "category": "integrations",
+  "author": {
+    "name": "Antonio De Marinis",
+    "github": "demarant"
+  },
+  "version": "1.0.0",
+  "requires": {
+    "open_brain": true,
+    "services": ["Perplexity Pro"],
+    "tools": []
+  },
+  "tags": ["perplexity", "mcp", "client", "search"],
+  "difficulty": "beginner",
+  "estimated_time": "10 minutes",
+  "created": "2026-04-04",
+  "updated": "2026-04-04"
+}

--- a/recipes/fingerprint-dedup-backfill/backfill-fingerprints.mjs
+++ b/recipes/fingerprint-dedup-backfill/backfill-fingerprints.mjs
@@ -94,14 +94,14 @@ function buildContentFingerprint(text) {
 
 // ── REST helpers ────────────────────────────────────────────────────────────
 
-async function fetchBatch(cursorId, batchSize) {
+async function fetchBatch(cursorCreatedAt, batchSize) {
   const url =
     `${REST_BASE}/thoughts` +
     `?content_fingerprint=is.null` +
-    `&id=gt.${cursorId}` +
-    `&select=id,content` +
+    `&created_at=gt.${encodeURIComponent(cursorCreatedAt)}` +
+    `&select=id,content,created_at` +
     `&limit=${batchSize}` +
-    `&order=id.asc`;
+    `&order=created_at.asc`;
   const res = await fetch(url, { headers: HEADERS });
   if (!res.ok) {
     const body = await res.text().catch(() => "");
@@ -162,7 +162,7 @@ function loadState() {
     return JSON.parse(fs.readFileSync(STATE_FILE, "utf8"));
   } catch {
     return {
-      cursorId: 0,
+      cursorCreatedAt: "1970-01-01T00:00:00Z",
       totalDone: 0,
       totalDuplicates: 0,
       totalErrors: 0,
@@ -183,7 +183,7 @@ async function main() {
   const state = loadState();
   console.log("=== Backfill content_fingerprint ===");
   console.log(
-    `Resuming from cursor id=${state.cursorId} (${state.totalDone} already done)`
+    `Resuming from cursor created_at=${state.cursorCreatedAt} (${state.totalDone} already done)`
   );
   console.log(`Batch size: ${BATCH_SIZE}`);
   console.log();
@@ -191,12 +191,12 @@ async function main() {
   while (true) {
     state.batches++;
     process.stdout.write(
-      `Batch ${state.batches}: fetching from id>${state.cursorId}… `
+      `Batch ${state.batches}: fetching from created_at>${state.cursorCreatedAt}… `
     );
 
     let rows;
     try {
-      rows = await fetchBatch(state.cursorId, BATCH_SIZE);
+      rows = await fetchBatch(state.cursorCreatedAt, BATCH_SIZE);
     } catch (err) {
       console.error("\n  Fetch error:", err.message, "— retrying in 5s…");
       await new Promise((r) => setTimeout(r, 5000));
@@ -221,8 +221,8 @@ async function main() {
     state.totalDuplicates += duplicates;
     state.totalErrors += errors;
 
-    const maxId = rows[rows.length - 1].id;
-    state.cursorId = typeof maxId === "number" ? maxId : maxId;
+    const lastCreatedAt = rows[rows.length - 1].created_at;
+    state.cursorCreatedAt = lastCreatedAt;
     saveState(state);
 
     const dupeStr =
@@ -231,7 +231,7 @@ async function main() {
     console.log(
       `  → ${done} patched${dupeStr}${errStr}. ` +
         `Total: ${state.totalDone} patched, ${state.totalDuplicates} duplicates, ${state.totalErrors} errors. ` +
-        `Cursor: ${state.cursorId}`
+        `Cursor: ${state.cursorCreatedAt}`
     );
 
     await new Promise((r) => setTimeout(r, 150));

--- a/recipes/fingerprint-dedup-backfill/delete-duplicates.mjs
+++ b/recipes/fingerprint-dedup-backfill/delete-duplicates.mjs
@@ -93,14 +93,14 @@ function buildFingerprint(text) {
 
 // ── REST helpers ────────────────────────────────────────────────────────────
 
-async function fetchBatch(cursorId, batchSize) {
+async function fetchBatch(cursorCreatedAt, batchSize) {
   const url =
     `${REST_BASE}/thoughts` +
     `?content_fingerprint=is.null` +
-    `&id=gt.${cursorId}` +
-    `&select=id,content` +
+    `&created_at=gt.${encodeURIComponent(cursorCreatedAt)}` +
+    `&select=id,content,created_at` +
     `&limit=${batchSize}` +
-    `&order=id.asc`;
+    `&order=created_at.asc`;
   const res = await fetch(url, { headers: HEADERS });
   if (!res.ok) {
     const body = await res.text().catch(() => "");
@@ -173,7 +173,7 @@ function loadState() {
     return JSON.parse(fs.readFileSync(STATE_FILE, "utf8"));
   } catch {
     return {
-      cursorId: 0,
+      cursorCreatedAt: "1970-01-01T00:00:00Z",
       totalDeleted: 0,
       totalPatched: 0,
       totalWouldDelete: 0,
@@ -205,19 +205,19 @@ async function main() {
   }
 
   console.log(
-    `Resuming from cursor id=${state.cursorId} (deleted: ${state.totalDeleted}, patched: ${state.totalPatched})`
+    `Resuming from cursor created_at=${state.cursorCreatedAt} (deleted: ${state.totalDeleted}, patched: ${state.totalPatched})`
   );
   console.log(`Batch size: ${BATCH_SIZE}\n`);
 
   while (true) {
     state.batches++;
     process.stdout.write(
-      `Batch ${state.batches}: fetching from id>${state.cursorId}… `
+      `Batch ${state.batches}: fetching from created_at>${state.cursorCreatedAt}… `
     );
 
     let rows;
     try {
-      rows = await fetchBatch(state.cursorId, BATCH_SIZE);
+      rows = await fetchBatch(state.cursorCreatedAt, BATCH_SIZE);
     } catch (err) {
       console.error("\n  Fetch error:", err.message, "— retrying in 5s…");
       await new Promise((r) => setTimeout(r, 5000));
@@ -303,14 +303,14 @@ async function main() {
     }
 
     // Advance cursor
-    const maxId = rows[rows.length - 1].id;
-    state.cursorId = maxId;
+    const lastCreatedAt = rows[rows.length - 1].created_at;
+    state.cursorCreatedAt = lastCreatedAt;
     saveState(state);
 
     console.log(
       `  Totals: deleted=${state.totalDeleted}, patched=${state.totalPatched}, ` +
         `would-delete=${state.totalWouldDelete}, errors=${state.totalErrors}. ` +
-        `Cursor: ${state.cursorId}`
+        `Cursor: ${state.cursorCreatedAt}`
     );
 
     await new Promise((r) => setTimeout(r, 200));

--- a/recipes/fingerprint-dedup-backfill/metadata.json
+++ b/recipes/fingerprint-dedup-backfill/metadata.json
@@ -16,5 +16,5 @@
   "difficulty": "beginner",
   "estimated_time": "15 minutes",
   "created": "2026-03-22",
-  "updated": "2026-03-22"
+  "updated": "2026-04-03"
 }

--- a/server/index.ts
+++ b/server/index.ts
@@ -378,8 +378,11 @@ app.options("*", (c) => {
 });
 
 app.all("*", async (c) => {
-  // Accept access key via header OR URL query parameter
-  const provided = c.req.header("x-brain-key") || new URL(c.req.url).searchParams.get("key");
+  // Accept access key via Authorization: Bearer header, x-brain-key header, or URL query parameter
+  const authHeader = c.req.header("Authorization");
+  const provided = (authHeader?.startsWith("Bearer ") && authHeader.split(" ")[1])
+    || c.req.header("x-brain-key")
+    || new URL(c.req.url).searchParams.get("key");
   if (!provided || provided !== MCP_ACCESS_KEY) {
     return c.json({ error: "Invalid or missing access key" }, 401, corsHeaders);
   }


### PR DESCRIPTION
## Contribution Type

<!-- Check one -->
- [ ] Recipe (`/recipes`)
- [ ] Schema (`/schemas`)
- [ ] Dashboard (`/dashboards`)
- [x] Integration (`/integrations`)
- [ ] Skill (`/skills`)
- [ ] Repo improvement (docs, CI, templates)

## What does this do?

Adds integration documentation for connecting Perplexity Pro as an MCP client to Open Brain. Provides step-by-step instructions for configuring the Bearer auth connection (introduced in the companion server PR), enabling Perplexity to search and capture thoughts directly. The four MCP tools (search_thoughts, list_thoughts, thought_stats, capture_thought) become available in Perplexity. 

See screenshot below from Perplexity chat:
<img width="998" height="783" alt="image" src="https://github.com/user-attachments/assets/008e426b-6fa1-4dad-a8a8-b269abd341ee" />

Documents integration for:
https://github.com/NateBJones-Projects/OB1/issues/73

## Requirements

- Working Open Brain setup with updated MCP server (Bearer auth support — see PR #154)
- Perplexity Pro subscription
- No additional tools or services required

## Checklist

- [x] I've read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] My contribution has a `README.md` with prerequisites, step-by-step instructions, and expected outcome
- [x] My `metadata.json` has all required fields
- [x] If my contribution depends on a skill or primitive, I declared it in metadata.json and linked it in the README — N/A (no dependencies)
- [x] I tested this on my own Open Brain instance — Tested on Perplexity web and mobile app; verified both retrieval and storage of thoughts
- [x] No credentials, API keys, or secrets are included