### PR TITLE
Add optional local Ollama MCP setup and publish-safe docs

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -1,0 +1,11 @@
+# Copy this file to .env.local and fill in your own values.
+# Do not commit .env.local.
+
+SUPABASE_URL=https://your-project-ref.supabase.co
+SUPABASE_SERVICE_ROLE_KEY=your_service_role_key
+MCP_ACCESS_KEY=generate_a_long_random_access_key
+
+# Local Ollama defaults
+OLLAMA_BASE_URL=http://127.0.0.1:11434
+OLLAMA_EMBED_MODEL=nomic-embed-text
+OLLAMA_CHAT_MODEL=qwen3.5:2b-q4_K_M

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@ node_modules/
 .DS_Store
 .planning/
 supabase/
+.vscode/
 
 # Credentials & runtime state
 .env
@@ -11,6 +12,7 @@ credentials.json
 token.json
 gmail-sync-log.json
 sync-log.json
+run-local-open-brain-mcp.sh
 
 # Build artifacts
 deno.lock

--- a/README.md
+++ b/README.md
@@ -14,6 +14,69 @@ https://github.com/user-attachments/assets/80a79b09-f323-42c6-b11b-de10bb6fa36f
 
 ## Getting Started
 
+## Local Ollama MCP setup
+
+This repo now supports a fully local MCP path for capture and search, with Supabase as storage and Ollama for embeddings plus lightweight metadata extraction.
+
+### What this gives you
+
+- Supabase stores thoughts and vectors
+- a local MCP server exposes `capture_thought`, `search_thoughts`, `list_thoughts`, and `thought_stats`
+- Ollama runs locally for embeddings and metadata extraction
+- OpenClaw, Claude Desktop, or any MCP client can point at the same local endpoint
+
+### Quick start
+
+1. Install and run Ollama.
+2. Pull the recommended local models:
+   - `ollama pull nomic-embed-text`
+   - `ollama pull qwen3.5:2b-q4_K_M`
+3. Create your local env file:
+   - `cp .env.local.example .env.local`
+4. Fill in these values in `.env.local`:
+   - `SUPABASE_URL`
+   - `SUPABASE_SERVICE_ROLE_KEY`
+   - `MCP_ACCESS_KEY`
+5. Start the local MCP server:
+   - `cp run-local-open-brain-mcp.sh.example run-local-open-brain-mcp.sh`
+   - `chmod +x run-local-open-brain-mcp.sh`
+   - `./run-local-open-brain-mcp.sh`
+6. Point your MCP client to:
+   - `http://127.0.0.1:8000/?key=YOUR_MCP_ACCESS_KEY`
+
+### Recommended local defaults
+
+These defaults are used unless you override them in `.env.local`:
+
+- `OLLAMA_BASE_URL=http://127.0.0.1:11434`
+- `OLLAMA_EMBED_MODEL=nomic-embed-text`
+- `OLLAMA_CHAT_MODEL=qwen3.5:2b-q4_K_M`
+
+### Database note
+
+If you use `nomic-embed-text`, your `thoughts.embedding` column must be `vector(768)`.
+If your database was originally built for OpenAI or OpenRouter embeddings, it may still be `vector(1536)` and must be migrated before local capture works.
+
+The included `setup-complete.sql` is now aligned to the local Ollama path in this repo and creates a `vector(768)` schema by default.
+If you choose a different embedding model, update both the database schema and the MCP server configuration together.
+
+### Files added for local setup
+
+- `local-open-brain-mcp.ts` — local Deno MCP server for Ollama-backed capture and search
+- `.env.local.example` — example local environment variables
+- `run-local-open-brain-mcp.sh.example` — safe launcher template with no secrets committed
+- `setup-complete.sql` and `setup-sql/` — SQL helpers for creating the core schema
+
+### Notes for agent users
+
+If you are wiring this into OpenClaw, Claude Desktop, Codex, or another agent client:
+
+- never commit real values in `.env.local` or `run-local-open-brain-mcp.sh`
+- prefer a local MCP URL for Ollama-backed capture, because hosted Supabase Edge functions cannot reliably reach your local Ollama instance
+- keep the MCP access key separate from your Supabase service role key
+- use the service role key only on trusted local machines or private servers
+
+
 https://github.com/user-attachments/assets/85208d73-112b-4204-82fd-d03b6c397a8b
 
 Never built an Open Brain? Start here:

--- a/deno.json
+++ b/deno.json
@@ -1,0 +1,6 @@
+{
+  "nodeModulesDir": "auto",
+  "imports": {
+    "@supabase/supabase-js": "npm:@supabase/supabase-js@2.47.10"
+  }
+}

--- a/local-open-brain-mcp.ts
+++ b/local-open-brain-mcp.ts
@@ -1,0 +1,156 @@
+import { serve } from "https://deno.land/std@0.224.0/http/server.ts";
+import { createClient } from "npm:@supabase/supabase-js@2.47.10";
+
+const SUPABASE_URL = Deno.env.get("SUPABASE_URL")!;
+const SUPABASE_SERVICE_ROLE_KEY = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY")!;
+const MCP_ACCESS_KEY = Deno.env.get("MCP_ACCESS_KEY")!;
+const OLLAMA_BASE_URL = Deno.env.get("OLLAMA_BASE_URL") ?? "http://127.0.0.1:11434";
+const OLLAMA_EMBED_MODEL = Deno.env.get("OLLAMA_EMBED_MODEL") ?? "nomic-embed-text";
+const OLLAMA_CHAT_MODEL = Deno.env.get("OLLAMA_CHAT_MODEL") ?? "qwen3.5:2b-q4_K_M";
+
+const supabase = createClient(SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY);
+
+const corsHeaders = {
+  "Access-Control-Allow-Origin": "*",
+  "Access-Control-Allow-Headers": "authorization, x-client-info, apikey, content-type, x-brain-key, accept, mcp-session-id",
+  "Access-Control-Allow-Methods": "GET, POST, OPTIONS, DELETE",
+};
+
+async function getEmbedding(text: string): Promise<number[]> {
+  const r = await fetch(`${OLLAMA_BASE_URL}/api/embeddings`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ model: OLLAMA_EMBED_MODEL, prompt: text }),
+  });
+  if (!r.ok) throw new Error(`Ollama embeddings failed: ${r.status} ${await r.text()}`);
+  const d = await r.json();
+  if (!Array.isArray(d.embedding)) throw new Error("Missing embedding array");
+  return d.embedding;
+}
+
+async function extractMetadata(text: string): Promise<Record<string, unknown>> {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), 12000);
+  try {
+    const r = await fetch(`${OLLAMA_BASE_URL}/api/chat`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      signal: controller.signal,
+      body: JSON.stringify({
+        model: OLLAMA_CHAT_MODEL,
+        format: "json",
+        stream: false,
+        options: { num_predict: 120, temperature: 0 },
+        messages: [
+          {
+            role: "system",
+            content:
+              `Return valid JSON only with keys people, action_items, dates_mentioned, topics, type. Keep it minimal and only use explicitly present information.`,
+          },
+          { role: "user", content: text },
+        ],
+      }),
+    });
+    if (!r.ok) throw new Error(`Ollama metadata extraction failed: ${r.status} ${await r.text()}`);
+    const d = await r.json();
+    try {
+      return JSON.parse(d.message.content);
+    } catch {
+      return { topics: ["uncategorized"], type: "observation" };
+    }
+  } catch {
+    return { topics: ["uncategorized"], type: "observation" };
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+function sse(data: unknown) {
+  return `event: message\ndata: ${JSON.stringify(data)}\n\n`;
+}
+
+serve(async (req) => {
+  if (req.method === "OPTIONS") return new Response("ok", { headers: corsHeaders });
+
+  const url = new URL(req.url);
+  const key = req.headers.get("x-brain-key") || url.searchParams.get("key");
+  if (!key || key !== MCP_ACCESS_KEY) {
+    return Response.json({ error: "Invalid or missing access key" }, { status: 401, headers: corsHeaders });
+  }
+
+  if (req.method === "POST") {
+    const body = await req.json().catch(() => ({}));
+    if (body?.method === "tools/list") {
+      const payload = {
+        jsonrpc: "2.0",
+        id: body.id,
+        result: {
+          tools: [
+            { name: "search_thoughts", description: "Search captured thoughts by meaning.", inputSchema: { type: "object", properties: { query: { type: "string" }, limit: { type: "number", default: 10 }, threshold: { type: "number", default: 0.5 } }, required: ["query"] } },
+            { name: "list_thoughts", description: "List recently captured thoughts.", inputSchema: { type: "object", properties: { limit: { type: "number", default: 10 }, type: { type: "string" }, topic: { type: "string" }, person: { type: "string" }, days: { type: "number" } } } },
+            { name: "thought_stats", description: "Get summary statistics for thoughts.", inputSchema: { type: "object", properties: {} } },
+            { name: "capture_thought", description: "Save a new thought.", inputSchema: { type: "object", properties: { content: { type: "string" } }, required: ["content"] } },
+          ],
+        },
+      };
+      return new Response(sse(payload), { headers: { ...corsHeaders, "content-type": "text/event-stream" } });
+    }
+
+    if (body?.method === "tools/call") {
+      const name = body?.params?.name;
+      const args = body?.params?.arguments ?? {};
+      try {
+        let text = "";
+        if (name === "capture_thought") {
+          const content = String(args.content ?? "");
+          const [embedding, metadata] = await Promise.all([getEmbedding(content), extractMetadata(content)]);
+          const { data: upsertResult, error: upsertError } = await supabase.rpc("upsert_thought", {
+            p_content: content,
+            p_payload: { metadata: { ...metadata, source: "local-mcp" } },
+          });
+          if (upsertError) throw new Error(upsertError.message);
+          const thoughtId = upsertResult?.id;
+          const { error: embError } = await supabase.from("thoughts").update({ embedding }).eq("id", thoughtId);
+          if (embError) throw new Error(embError.message);
+          text = `Captured thought ${thoughtId}`;
+        } else if (name === "search_thoughts") {
+          const qEmb = await getEmbedding(String(args.query ?? ""));
+          const { data, error } = await supabase.rpc("match_thoughts", {
+            query_embedding: qEmb,
+            match_threshold: Number(args.threshold ?? 0.5),
+            match_count: Number(args.limit ?? 10),
+            filter: {},
+          });
+          if (error) throw new Error(error.message);
+          text = JSON.stringify(data ?? [], null, 2);
+        } else if (name === "list_thoughts") {
+          let q = supabase.from("thoughts").select("content, metadata, created_at").order("created_at", { ascending: false }).limit(Number(args.limit ?? 10));
+          if (args.type) q = q.contains("metadata", { type: args.type });
+          if (args.topic) q = q.contains("metadata", { topics: [args.topic] });
+          if (args.person) q = q.contains("metadata", { people: [args.person] });
+          if (args.days) {
+            const since = new Date();
+            since.setDate(since.getDate() - Number(args.days));
+            q = q.gte("created_at", since.toISOString());
+          }
+          const { data, error } = await q;
+          if (error) throw new Error(error.message);
+          text = JSON.stringify(data ?? [], null, 2);
+        } else if (name === "thought_stats") {
+          const { count } = await supabase.from("thoughts").select("*", { count: "exact", head: true });
+          text = JSON.stringify({ total: count ?? 0 });
+        } else {
+          throw new Error(`Unknown tool: ${name}`);
+        }
+
+        const payload = { jsonrpc: "2.0", id: body.id, result: { content: [{ type: "text", text }] } };
+        return new Response(sse(payload), { headers: { ...corsHeaders, "content-type": "text/event-stream" } });
+      } catch (err) {
+        const payload = { jsonrpc: "2.0", id: body.id, error: { code: -32000, message: err instanceof Error ? err.message : String(err) } };
+        return new Response(sse(payload), { status: 200, headers: { ...corsHeaders, "content-type": "text/event-stream" } });
+      }
+    }
+  }
+
+  return Response.json({ ok: true, service: "local-open-brain-mcp" }, { headers: corsHeaders });
+});

--- a/run-local-open-brain-mcp.sh.example
+++ b/run-local-open-brain-mcp.sh.example
@@ -1,0 +1,20 @@
+#!/bin/zsh
+set -euo pipefail
+
+cd "$(dirname "$0")"
+
+if [[ -f .env.local ]]; then
+  set -a
+  source ./.env.local
+  set +a
+fi
+
+: "${SUPABASE_URL:?Set SUPABASE_URL in .env.local or your shell}"
+: "${SUPABASE_SERVICE_ROLE_KEY:?Set SUPABASE_SERVICE_ROLE_KEY in .env.local or your shell}"
+: "${MCP_ACCESS_KEY:?Set MCP_ACCESS_KEY in .env.local or your shell}"
+
+export OLLAMA_BASE_URL="${OLLAMA_BASE_URL:-http://127.0.0.1:11434}"
+export OLLAMA_EMBED_MODEL="${OLLAMA_EMBED_MODEL:-nomic-embed-text}"
+export OLLAMA_CHAT_MODEL="${OLLAMA_CHAT_MODEL:-qwen3.5:2b-q4_K_M}"
+
+exec deno run --allow-net --allow-env local-open-brain-mcp.ts

--- a/server/index.ts
+++ b/server/index.ts
@@ -8,62 +8,71 @@ import { createClient } from "@supabase/supabase-js";
 
 const SUPABASE_URL = Deno.env.get("SUPABASE_URL")!;
 const SUPABASE_SERVICE_ROLE_KEY = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY")!;
-const OPENROUTER_API_KEY = Deno.env.get("OPENROUTER_API_KEY")!;
 const MCP_ACCESS_KEY = Deno.env.get("MCP_ACCESS_KEY")!;
+const OLLAMA_BASE_URL = Deno.env.get("OLLAMA_BASE_URL") ?? "http://host.docker.internal:11434";
+const OLLAMA_EMBED_MODEL = Deno.env.get("OLLAMA_EMBED_MODEL") ?? "nomic-embed-text";
+const OLLAMA_CHAT_MODEL = Deno.env.get("OLLAMA_CHAT_MODEL") ?? "qwen3.5:2b-q4_K_M";
 
-const OPENROUTER_BASE = "https://openrouter.ai/api/v1";
 const supabase = createClient(SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY);
 
 async function getEmbedding(text: string): Promise<number[]> {
-  const r = await fetch(`${OPENROUTER_BASE}/embeddings`, {
+  const r = await fetch(`${OLLAMA_BASE_URL}/api/embeddings`, {
     method: "POST",
     headers: {
-      Authorization: `Bearer ${OPENROUTER_API_KEY}`,
       "Content-Type": "application/json",
     },
     body: JSON.stringify({
-      model: "openai/text-embedding-3-small",
-      input: text,
+      model: OLLAMA_EMBED_MODEL,
+      prompt: text,
     }),
   });
   if (!r.ok) {
     const msg = await r.text().catch(() => "");
-    throw new Error(`OpenRouter embeddings failed: ${r.status} ${msg}`);
+    throw new Error(`Ollama embeddings failed: ${r.status} ${msg}`);
   }
   const d = await r.json();
-  return d.data[0].embedding;
+  if (!Array.isArray(d.embedding)) throw new Error("Ollama embeddings response missing embedding array");
+  return d.embedding;
 }
 
 async function extractMetadata(text: string): Promise<Record<string, unknown>> {
-  const r = await fetch(`${OPENROUTER_BASE}/chat/completions`, {
-    method: "POST",
-    headers: {
-      Authorization: `Bearer ${OPENROUTER_API_KEY}`,
-      "Content-Type": "application/json",
-    },
-    body: JSON.stringify({
-      model: "openai/gpt-4o-mini",
-      response_format: { type: "json_object" },
-      messages: [
-        {
-          role: "system",
-          content: `Extract metadata from the user's captured thought. Return JSON with:
-- "people": array of people mentioned (empty if none)
-- "action_items": array of implied to-dos (empty if none)
-- "dates_mentioned": array of dates YYYY-MM-DD (empty if none)
-- "topics": array of 1-3 short topic tags (always at least one)
-- "type": one of "observation", "task", "idea", "reference", "person_note"
-Only extract what's explicitly there.`,
-        },
-        { role: "user", content: text },
-      ],
-    }),
-  });
-  const d = await r.json();
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), 12000);
   try {
-    return JSON.parse(d.choices[0].message.content);
+    const r = await fetch(`${OLLAMA_BASE_URL}/api/chat`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      signal: controller.signal,
+      body: JSON.stringify({
+        model: OLLAMA_CHAT_MODEL,
+        format: "json",
+        stream: false,
+        options: { num_predict: 120, temperature: 0 },
+        messages: [
+          {
+            role: "system",
+            content: `Return valid JSON only with keys people, action_items, dates_mentioned, topics, type. Keep it minimal and only use explicitly present information.`,
+          },
+          { role: "user", content: text },
+        ],
+      }),
+    });
+    if (!r.ok) {
+      const msg = await r.text().catch(() => "");
+      throw new Error(`Ollama metadata extraction failed: ${r.status} ${msg}`);
+    }
+    const d = await r.json();
+    try {
+      return JSON.parse(d.message.content);
+    } catch {
+      return { topics: ["uncategorized"], type: "observation" };
+    }
   } catch {
     return { topics: ["uncategorized"], type: "observation" };
+  } finally {
+    clearTimeout(timeout);
   }
 }
 

--- a/setup-complete.sql
+++ b/setup-complete.sql
@@ -1,0 +1,105 @@
+-- SQL Setup for Open Brain
+-- Run this in the Supabase SQL Editor for your own project.
+-- Recommended for the local Ollama path in this repo: use vector(768) with nomic-embed-text.
+
+CREATE EXTENSION IF NOT EXISTS vector;
+
+CREATE TABLE IF NOT EXISTS thoughts (
+  id uuid DEFAULT gen_random_uuid() PRIMARY KEY,
+  content text NOT NULL,
+  embedding vector(768),
+  metadata jsonb DEFAULT '{}'::jsonb,
+  created_at timestamptz DEFAULT now(),
+  updated_at timestamptz DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_thoughts_embedding ON thoughts
+  USING hnsw (embedding vector_cosine_ops);
+CREATE INDEX IF NOT EXISTS idx_thoughts_metadata ON thoughts USING gin (metadata);
+CREATE INDEX IF NOT EXISTS idx_thoughts_created_at ON thoughts (created_at DESC);
+
+CREATE OR REPLACE FUNCTION update_updated_at()
+RETURNS TRIGGER AS $$
+BEGIN
+  NEW.updated_at = now();
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS thoughts_updated_at ON thoughts;
+CREATE TRIGGER thoughts_updated_at
+  BEFORE UPDATE ON thoughts
+  FOR EACH ROW
+  EXECUTE FUNCTION update_updated_at();
+
+CREATE OR REPLACE FUNCTION match_thoughts(
+  query_embedding vector(768),
+  match_threshold float DEFAULT 0.7,
+  match_count int DEFAULT 10,
+  filter jsonb DEFAULT '{}'::jsonb
+)
+RETURNS TABLE (
+  id uuid,
+  content text,
+  metadata jsonb,
+  similarity float,
+  created_at timestamptz
+)
+LANGUAGE plpgsql
+AS $$
+BEGIN
+  RETURN QUERY
+  SELECT
+    t.id,
+    t.content,
+    t.metadata,
+    1 - (t.embedding <=> query_embedding) AS similarity,
+    t.created_at
+  FROM thoughts t
+  WHERE 1 - (t.embedding <=> query_embedding) > match_threshold
+    AND (filter = '{}'::jsonb OR t.metadata @> filter)
+  ORDER BY t.embedding <=> query_embedding
+  LIMIT match_count;
+END;
+$$;
+
+ALTER TABLE thoughts ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS "Service role full access" ON thoughts;
+CREATE POLICY "Service role full access"
+  ON thoughts
+  FOR ALL
+  USING (auth.role() = 'service_role');
+
+GRANT SELECT, INSERT, UPDATE, DELETE ON TABLE public.thoughts TO service_role;
+
+ALTER TABLE thoughts ADD COLUMN IF NOT EXISTS content_fingerprint TEXT;
+
+DROP INDEX IF EXISTS idx_thoughts_fingerprint;
+CREATE UNIQUE INDEX idx_thoughts_fingerprint
+  ON thoughts (content_fingerprint)
+  WHERE content_fingerprint IS NOT NULL;
+
+CREATE OR REPLACE FUNCTION upsert_thought(p_content TEXT, p_payload JSONB DEFAULT '{}')
+RETURNS JSONB AS $$
+DECLARE
+  v_fingerprint TEXT;
+  v_result JSONB;
+  v_id UUID;
+BEGIN
+  v_fingerprint := encode(sha256(convert_to(
+    lower(trim(regexp_replace(p_content, '\s+', ' ', 'g'))),
+    'UTF8'
+  )), 'hex');
+
+  INSERT INTO thoughts (content, content_fingerprint, metadata)
+  VALUES (p_content, v_fingerprint, COALESCE(p_payload->'metadata', '{}'::jsonb))
+  ON CONFLICT (content_fingerprint) WHERE content_fingerprint IS NOT NULL DO UPDATE
+  SET updated_at = now(),
+      metadata = thoughts.metadata || COALESCE(EXCLUDED.metadata, '{}'::jsonb)
+  RETURNING id INTO v_id;
+
+  v_result := jsonb_build_object('id', v_id, 'fingerprint', v_fingerprint);
+  RETURN v_result;
+END;
+$$ LANGUAGE plpgsql;

--- a/setup-sql/01_enable_vector.sql
+++ b/setup-sql/01_enable_vector.sql
@@ -1,0 +1,2 @@
+-- Enable pgvector extension
+create extension if not exists vector;

--- a/setup-sql/02_create_thoughts.sql
+++ b/setup-sql/02_create_thoughts.sql
@@ -1,0 +1,33 @@
+-- Create the thoughts table
+create table thoughts (
+  id uuid default gen_random_uuid() primary key,
+  content text not null,
+  embedding vector(1536),
+  metadata jsonb default '{}'::jsonb,
+  created_at timestamptz default now(),
+  updated_at timestamptz default now()
+);
+
+-- Index for fast vector similarity search
+create index on thoughts
+  using hnsw (embedding vector_cosine_ops);
+
+-- Index for filtering by metadata fields
+create index on thoughts using gin (metadata);
+
+-- Index for date range queries
+create index on thoughts (created_at desc);
+
+-- Auto-update the updated_at timestamp
+create or replace function update_updated_at()
+returns trigger as $$
+begin
+  new.updated_at = now();
+  return new;
+end;
+$$ language plpgsql;
+
+create trigger thoughts_updated_at
+  before update on thoughts
+  for each row
+  execute function update_updated_at();

--- a/setup-sql/03_create_search_function.sql
+++ b/setup-sql/03_create_search_function.sql
@@ -1,0 +1,30 @@
+create or replace function match_thoughts(
+  query_embedding vector(1536),
+  match_threshold float default 0.7,
+  match_count int default 10,
+  filter jsonb default '{}'::jsonb
+)
+returns table (
+  id uuid,
+  content text,
+  metadata jsonb,
+  similarity float,
+  created_at timestamptz
+)
+language plpgsql
+as $$
+begin
+  return query
+  select
+    t.id,
+    t.content,
+    t.metadata,
+    1 - (t.embedding <=> query_embedding) as similarity,
+    t.created_at
+  from thoughts t
+  where 1 - (t.embedding <=> query_embedding) > match_threshold
+    and (filter = '{}'::jsonb or t.metadata @> filter)
+  order by t.embedding <=> query_embedding
+  limit match_count;
+end;
+$$;

--- a/setup-sql/04_security.sql
+++ b/setup-sql/04_security.sql
@@ -1,0 +1,10 @@
+-- Lock down security
+alter table thoughts enable row level security;
+
+create policy "Service role full access"
+  on thoughts
+  for all
+  using (auth.role() = 'service_role');
+  
+-- Grant permissions to service_role
+grant select, insert, update, delete on table public.thoughts to service_role;

--- a/setup-sql/05_deduplication.sql
+++ b/setup-sql/05_deduplication.sql
@@ -1,0 +1,32 @@
+-- Add fingerprint column for deduplication
+alter table thoughts add column if not exists content_fingerprint text;
+
+-- Unique index so duplicate content is detected
+create unique index if not exists idx_thoughts_fingerprint
+  on thoughts (content_fingerprint)
+  where content_fingerprint is not null;
+
+-- Upsert function: inserts new thoughts, merges metadata on duplicates
+create or replace function upsert_thought(p_content text, p_payload jsonb default '{}')
+returns jsonb as $$
+declare
+  v_fingerprint text;
+  v_result jsonb;
+  v_id uuid;
+begin
+  v_fingerprint := encode(sha256(convert_to(
+    lower(trim(regexp_replace(p_content, '\s+', ' ', 'g'))),
+    'UTF8'
+  )), 'hex');
+
+  insert into thoughts (content, content_fingerprint, metadata)
+  values (p_content, v_fingerprint, coalesce(p_payload->'metadata', '{}'::jsonb))
+  on conflict (content_fingerprint) where content_fingerprint is not null do update
+  set updated_at = now(),
+      metadata = thoughts.metadata || coalesce(excluded.metadata, '{}'::jsonb)
+  returning id into v_id;
+
+  v_result := jsonb_build_object('id', v_id, 'fingerprint', v_fingerprint);
+  return v_result;
+end;
+$$ language plpgsql;


### PR DESCRIPTION
This PR adds an optional local deployment path for Open Brain users who want to run embeddings and lightweight metadata extraction through local Ollama instead of a paid hosted model provider.

What's included:
- a local MCP server for capture/search against Supabase
- env-based local launcher templates, with secrets removed from the repo
- setup docs for humans
- notes for agent users
- SQL setup files aligned to the local `nomic-embed-text` path (`vector(768)`)
- safer metadata extraction fallback behavior

Why this may help:
- reduces dependency on paid inference providers for some users
- makes local/self-hosted setups easier to understand and reproduce
- keeps the existing Supabase storage model while allowing local inference
- improves publish safety by moving local credentials to env-based templates

Important note:
- this is an optional path, not a replacement for the existing hosted approach
- for users who want even more control, this could also be a stepping stone toward a fully local deployment path in the future