### PR TITLE
[recipes] ChatGPT import v2: multi-thought knowledge extraction

### DIFF
--- a/recipes/chatgpt-conversation-import/.env.example
+++ b/recipes/chatgpt-conversation-import/.env.example
@@ -14,3 +14,12 @@ OPENROUTER_API_KEY=sk-or-v1-your-key-here
 # Optional: Custom ingest endpoint (use with --ingest-endpoint flag)
 # INGEST_URL=https://YOUR_PROJECT_REF.supabase.co/functions/v1/ingest-thought
 # INGEST_KEY=your-ingest-key-here
+
+# Optional: User ID for multi-tenant RLS (required for --store-conversations)
+# Find your user UUID in Supabase Auth > Users, or leave blank for single-user setups.
+# USER_ID=your-user-uuid-here
+
+# --store-conversations flag
+# Stores conversation-level pyramid summaries in the chatgpt_conversations table.
+# You MUST run schema.sql in your Supabase SQL Editor before using this flag.
+# See: recipes/chatgpt-conversation-import/schema.sql

--- a/recipes/chatgpt-conversation-import/.gitignore
+++ b/recipes/chatgpt-conversation-import/.gitignore
@@ -1,3 +1,7 @@
 chatgpt-sync-log.json
 *.env
 __pycache__/
+# Import reports contain personal data — never commit
+*-report*.md
+full-import-report.md
+test-report*.md

--- a/recipes/chatgpt-conversation-import/README.md
+++ b/recipes/chatgpt-conversation-import/README.md
@@ -4,7 +4,7 @@
 
 ## What It Does
 
-Takes your ChatGPT data export, filters out trivial conversations (poems, one-liners, image requests), uses an LLM to distill each remaining conversation into 1-3 standalone thoughts, and loads them into your Open Brain with vector embeddings and metadata. The result is semantically searchable knowledge extracted from every meaningful ChatGPT conversation you've ever had.
+Takes your ChatGPT data export, resolves conversation branches, dispatches across 14 content types (text, voice transcripts, web search results, code execution output, and more), filters out trivial conversations using signal-based scoring, and uses an LLM to extract 2-5 distinct, typed thoughts per conversation. Each thought is classified as one of 6 types — decision, preference, learning, context, brainstorm, or reference — and loaded into your Open Brain with vector embeddings and enriched metadata. The result is semantically searchable knowledge extracted from every meaningful ChatGPT conversation you've ever had.
 
 ## Prerequisites
 
@@ -12,7 +12,7 @@ Takes your ChatGPT data export, filters out trivial conversations (poems, one-li
 - Your ChatGPT data export (Settings → Data Controls → Export Data in ChatGPT)
 - Python 3.10+
 - Your Supabase project URL and service role key (from your credential tracker)
-- OpenRouter API key (for LLM summarization and embedding generation)
+- OpenRouter API key (for LLM extraction and embedding generation)
 
 ## Credential Tracker
 
@@ -72,7 +72,7 @@ All three values come from your credential tracker. You can also copy `.env.exam
 python import-chatgpt.py path/to/chatgpt-export.zip --dry-run --limit 10
 ```
 
-This parses, filters, and summarizes 10 conversations without writing anything to your database. Review the output to see what would be imported and how the LLM distills each conversation.
+This parses, filters, and extracts knowledge from 10 conversations without writing anything to your database. Review the output to see what would be imported and how the LLM distills each conversation into typed thoughts.
 
 ### 6. Run the full import
 
@@ -81,20 +81,24 @@ python import-chatgpt.py path/to/chatgpt-export.zip
 ```
 
 The script will:
-1. Extract conversations from the zip (or directory)
-2. Filter out trivial conversations (see How It Works below)
-3. Summarize each remaining conversation into 1-3 standalone thoughts via LLM
-4. Generate a vector embedding for each thought
-5. Insert each thought into your `thoughts` table in Supabase
+1. Extract conversations from the zip (or directory), including sharded JSON files
+2. Resolve conversation branches by walking the `current_node` path
+3. Dispatch across 14 content types (extract text, skip model reasoning, strip code blocks)
+4. Filter out trivial conversations using signal-based scoring
+5. Detect session boundaries within long conversations (4h+ gaps)
+6. Extract 2-5 typed thoughts per conversation via LLM knowledge extraction
+7. Check for semantic duplicates against existing thoughts (0.92 similarity threshold)
+8. Generate a vector embedding for each thought (from the thought content, not the prefix)
+9. Insert each thought into your `thoughts` table with enriched metadata
 
-Progress prints to the console as it runs. A sync log (`chatgpt-sync-log.json`) tracks which conversations have been imported, so you can safely re-run the script after future exports without duplicating data.
+Progress prints to the console with ETA as it runs. A sync log (`chatgpt-sync-log.json`) tracks which conversations have been imported, so you can safely re-run the script after future exports without duplicating data. Conversations with new messages since the last import are automatically re-processed.
 
 ### 7. Verify in your database
 
 Open your Supabase dashboard → Table Editor → `thoughts`. You should see new rows with:
-- `content`: prefixed with `[ChatGPT: title | date]`
-- `metadata`: includes `source: "chatgpt"`, conversation title, date, and URL
-- `embedding`: a 1536-dimension vector
+- `content`: prefixed with `[ChatGPT: title | date]`, followed by a self-contained thought statement
+- `metadata`: includes `source: "chatgpt"`, thought `type`, `topics`, `people`, `confidence`, model, conversation URL, and more
+- `embedding`: a 1536-dimension vector (generated from the thought content, not the prefix)
 
 ### 8. Test a search
 
@@ -106,67 +110,179 @@ Search my brain for topics I discussed with ChatGPT about [something you know yo
 
 ## Expected Outcome
 
-After a full import, your `thoughts` table contains distilled knowledge from every non-trivial ChatGPT conversation. Each thought is a standalone statement (not a raw transcript) that makes sense without the original conversation context.
+After a full import, your `thoughts` table contains distilled knowledge from every non-trivial ChatGPT conversation. Each thought is a standalone statement with type, topics, people, and confidence — not a raw transcript — that makes sense without the original conversation context.
 
-From a real production run with ~2 years of ChatGPT history:
+Results depend on export size, filtering, and model. Example from a real 2,300-conversation export:
 
-| Metric | Value |
-|--------|-------|
-| Conversations scanned | 741 |
-| Filtered as trivial | 437 (59%) |
-| Processed | 304 |
-| Thoughts generated | 589 |
-| Estimated API cost | $0.08 |
+| Metric | gpt-4o-mini (default) | gpt-4o | With --focus |
+|--------|----------------------|--------|-------------|
+| Conversations scanned | 2,341 | 2,341 | 2,341 |
+| Filtered (single-turn, short) | ~1,000 (43%) | ~1,000 (43%) | ~1,000 (43%) |
+| Sent to LLM | ~1,300 | ~1,300 | ~300 |
+| Thoughts generated | ~800-1,500 | ~800-1,500 | ~250-400 |
+| Estimated API cost | ~$1.30 | ~$20 | ~$0.50-10 |
 
-The filtering is aggressive by design — most ChatGPT conversations are throwaway Q&A. The script keeps only conversations with enough substance to produce lasting knowledge.
+Using `--focus` reduces LLM calls significantly — conversations outside your focus areas return empty thoughts. Use `--model ollama` for $0.
+
+Each thought includes structured metadata:
+
+```json
+{
+  "content": "[ChatGPT: Database Migration Strategy | 2025-09-15] Chose PostgreSQL over DynamoDB for the new order service. Key factors: complex joins for reporting, strong consistency requirements, existing team expertise. DynamoDB considered for write throughput but rejected due to access pattern limitations.",
+  "metadata": {
+    "source": "chatgpt",
+    "type": "decision",
+    "topics": ["database", "architecture"],
+    "people": [],
+    "confidence": "firm",
+    "chatgpt_model": "gpt-4o",
+    "chatgpt_message_count": 34,
+    "chatgpt_conversation_type": "technical_architecture",
+    "chatgpt_conversation_url": "https://chatgpt.com/c/abc-123"
+  }
+}
+```
+
+## Thought Types
+
+The LLM classifies each extracted thought into one of 6 types:
+
+| Type | What it captures | Example |
+|------|-----------------|---------|
+| `decision` | A choice made with reasoning | "Chose PostgreSQL over DynamoDB for the order service. Needed complex joins for reporting." |
+| `preference` | Values, criteria, tastes revealed | "For baby gear: prioritize stability on hardwood, easy cleaning, grows-with-child over brand." |
+| `learning` | Facts, patterns, insights discovered | "Tungsten in X-ray machines: high atomic number produces X-rays efficiently when electrified." |
+| `context` | People, projects, situations | "Platform team owns the API gateway and auth service. Infrastructure team handles deployments and monitoring." |
+| `brainstorm` | Ideas explored, strategies considered | "For externalizing an internal product: start with design partner program, not public launch." |
+| `reference` | How-tos, recipes, reusable procedures | "Carbon steel pan seasoning: scrub with steel wool, dry on stove, apply thin flaxseed oil layer." |
+
+Each thought also carries a `confidence` level: `firm` (clear conclusion), `tentative` (leaning toward), or `exploring` (still open).
 
 ## How It Works
 
 ### Three-stage pipeline
 
-**Stage 1: Filtering** — Each conversation passes through 6 filters before it reaches the LLM:
+**Stage 1: Parsing and Filtering** — Each conversation is parsed and scored before it reaches the LLM:
 
-| Filter | What it catches |
-|--------|----------------|
-| Already imported | Conversations processed in a previous run (sync log) |
-| Too few messages | < 4 messages total (not enough substance) |
-| Too little text | < 20 words of user text |
-| Title patterns | Poems, jokes, image generation, translations, bedtime stories |
-| Do-not-remember | Conversations you marked as "don't remember" in ChatGPT |
-| Date range | Outside your `--after` / `--before` window |
+- **Branch resolution**: Walks from `current_node` to root via parent pointers, producing the canonical conversation path (no interleaved regenerations from abandoned branches)
+- **Content type dispatch**: 14 content types are handled in three buckets — extract text from (text, multimodal_text, execution_output, web search, code), skip entirely (model reasoning/thoughts, reasoning_recap, system errors), and metadata only (tether_quote, custom instructions)
+- **Voice conversations**: Audio transcriptions are extracted from `multimodal_text` parts. Voice conversations are more substantive on average and are never auto-filtered
+- **Signal-based filtering**: Replaces regex title matching. Single-turn conversations are skipped. Conversations with 10+ messages are always processed. Borderline conversations (2-9 messages) are checked for word count and title presence, then the LLM decides
 
-**Stage 2: Summarization** — Surviving conversations go to an LLM (gpt-4o-mini by default via OpenRouter) with a carefully tuned prompt. The LLM extracts 1-3 standalone thoughts per conversation, focusing on:
-- Decisions and reasoning
-- People and relationships
-- Strategies and architectural choices
-- Lessons learned and preferences
+**Stage 2: Knowledge Extraction** — Surviving conversations go to an LLM (gpt-4o-mini by default via OpenRouter) with a structured extraction prompt. The LLM returns 0-5 typed thoughts per conversation as JSON, each with content, type, topics, people, and confidence. For multi-day conversations, session boundaries are detected at 4h+ gaps and each session is extracted separately.
 
-The LLM is instructed to return empty for conversations that are just generic Q&A, coding help without decisions, or creative tasks.
+The LLM is instructed to:
+- Extract decisions with reasoning, including what was rejected and why
+- Capture preferences, criteria, and values
+- Record architectural and strategic choices (not code)
+- Preserve personal context that looks ephemeral but encodes life situation
+- Return empty for conversations that are just generic Q&A, creative tasks, or ephemeral lookups
 
-**Stage 3: Ingestion** — Each thought gets a vector embedding (text-embedding-3-small, 1536 dimensions) and is inserted into your `thoughts` table with metadata linking back to the original ChatGPT conversation.
+**Stage 3: Ingestion** — Each thought gets a vector embedding (text-embedding-3-small, 1536 dimensions) generated from the thought content itself (not the `[ChatGPT: title]` prefix). Before insertion, semantic deduplication checks for near-duplicates using `match_thoughts` RPC at a 0.92 similarity threshold. Each thought is inserted into your `thoughts` table with enriched metadata including model, conversation type, voice, and confidence.
 
 ### Deduplication
 
-The sync log (`chatgpt-sync-log.json`) stores a hash of each processed conversation. Re-running the script after a new ChatGPT export only processes new conversations. The hash is based on conversation title + creation timestamp.
+Two layers of deduplication prevent redundant thoughts:
+
+1. **Sync log** (`chatgpt-sync-log.json`): Tracks each processed conversation by hash and `update_time`. Re-running the script after a new export only processes new conversations or conversations with new messages since the last import.
+2. **Semantic dedup**: Before inserting, each thought is checked against existing thoughts via `match_thoughts` at 0.92 similarity. This catches redundant thoughts when the same topic was discussed across multiple conversations.
+
+## `--store-conversations`
+
+The `--store-conversations` flag enables an optional conversation history table that stores conversation-level metadata and pyramid summaries alongside the extracted thoughts.
+
+### What it does
+
+When enabled, each processed conversation is also stored in a `chatgpt_conversations` table with:
+- **Pyramid summaries** at 5 detail levels (8-word label, 16-word sentence, 32-word card, 64-word paragraph, 128-word full summary)
+- **HNSW-indexed embedding** of the 128-word summary for conversation-level semantic search
+- **Searchable arrays** for key topics and people mentioned
+- **Export metadata** including model, voice, custom GPT identifier, and conversation URL
+
+### What it enables
+
+- **Temporal browsing**: "What was I working on in October?" via `create_time` queries
+- **Source attribution**: Search thoughts, find a decision, follow `chatgpt_conversation_id` back to the full conversation summary and ChatGPT URL
+- **Progressive disclosure**: Use the 8-word summary for timelines, 32-word for dashboard cards, 128-word for full context
+- **Smarter re-imports**: Content hash detects conversations with changed content
+
+### How to set it up
+
+1. Open the Supabase SQL Editor in your project dashboard
+2. Paste and run the contents of `schema.sql` from this recipe folder
+3. Pass `--store-conversations` when running the import:
+
+```bash
+python import-chatgpt.py path/to/export.zip --store-conversations
+```
+
+The pyramid summaries are generated in the same LLM call as the thought extraction, adding only ~200 extra output tokens per conversation (~$0.05 total for 1,400 conversations).
 
 ## Options Reference
 
 | Flag | Description | Default |
 |------|-------------|---------|
-| `--dry-run` | Parse, filter, summarize — but don't write to database | Off |
+| `--dry-run` | Parse, filter, extract — but don't write to database | Off |
 | `--after YYYY-MM-DD` | Only process conversations created after this date | None |
 | `--before YYYY-MM-DD` | Only process conversations created before this date | None |
 | `--limit N` | Max conversations to process (0 = unlimited) | 0 |
-| `--model openrouter` | LLM backend for summarization: `openrouter` or `ollama` | `openrouter` |
+| `--min-messages N` | Minimum messages for a conversation to be processed | 5 |
+| `--min-words N` | Minimum word count for borderline conversations | 50 |
+| `--focus TOPICS` | Focus extraction on specific topics (preset or custom text — see below) | All topics |
+| `--store-conversations` | Also store conversation summaries with pyramid detail levels (requires `schema.sql`) | Off |
+| `--model openrouter` | LLM backend for extraction: `openrouter` or `ollama` | `openrouter` |
+| `--openrouter-model ID` | Which OpenRouter model to use | `openai/gpt-4o-mini` |
 | `--ollama-model NAME` | Which Ollama model to use (requires `--model ollama`) | `qwen3` |
-| `--raw` | Skip LLM summarization, ingest user messages as-is | Off |
+| `--raw` | Skip LLM extraction, ingest user messages as-is | Off |
 | `--verbose` | Print full thought text during processing | Off |
 | `--report FILE` | Write a markdown report of everything imported | None |
 | `--ingest-endpoint` | Use custom `INGEST_URL`/`INGEST_KEY` instead of Supabase direct insert | Off |
 
+### `--focus` — Topic Filtering
+
+By default, the script extracts knowledge from all conversations. Use `--focus` to narrow extraction to specific domains, saving API cost and reducing noise from conversations you don't care about.
+
+**Presets** (one word, easy to remember):
+
+| Preset | Extracts | Skips |
+|--------|----------|-------|
+| `tech` | Architecture, engineering, system design, code patterns, infrastructure | Shopping, recipes, health, creative tasks |
+| `strategy` | Business strategy, product decisions, career, leadership, hiring | Shopping, recipes, technical details, creative |
+| `personal` | Family, health, relationships, values, home, personal finance | Work topics, technical details, shopping |
+| `creative` | Writing, design, art, content strategy, storytelling | Technical, business, shopping, health |
+| `all` | Everything (default behavior) | Only ephemeral lookups |
+
+**Examples with presets:**
+
+```bash
+# Only tech and engineering knowledge
+python import-chatgpt.py export.zip --focus tech
+
+# Only business and career decisions
+python import-chatgpt.py export.zip --focus strategy
+
+# Combine with date filter for recent tech decisions
+python import-chatgpt.py export.zip --focus tech --after 2025-01-01
+```
+
+**Custom focus** (any free-text description):
+
+```bash
+# Specific domains
+python import-chatgpt.py export.zip --focus "AI/ML, prompt engineering, LLM architecture"
+
+# Multiple interests
+python import-chatgpt.py export.zip --focus "parenting, nutrition, home renovation"
+
+# Very specific
+python import-chatgpt.py export.zip --focus "AWS infrastructure, Kubernetes, CI/CD pipelines"
+```
+
+When `--focus` is set, conversations outside your focus areas will return `{"thoughts": [], "skip_reason": "off-topic"}` — you still pay for the LLM call, but no thoughts are created. Combine with `--min-messages` to skip short conversations before they reach the LLM.
+
 ### Using a local LLM (free, private)
 
-If you don't want to send your conversations to OpenRouter, use Ollama for local summarization:
+If you don't want to send your conversations to OpenRouter, use Ollama for local extraction:
 
 ```bash
 # Install Ollama and pull a model
@@ -176,27 +292,27 @@ ollama pull qwen3
 python import-chatgpt.py export.zip --model ollama --ollama-model qwen3
 ```
 
-Note: embeddings still use OpenRouter (text-embedding-3-small) for Supabase direct insert mode. Only the summarization step runs locally.
+Note: embeddings still use OpenRouter (text-embedding-3-small) for Supabase direct insert mode. Only the extraction step runs locally.
 
 ## Cost Estimates
 
-All costs are via OpenRouter at current pricing.
+All costs are via OpenRouter at current pricing. The v2 pipeline sends full dialogue (user + assistant messages) to the LLM and requests structured JSON extraction, which uses more input tokens but captures significantly more knowledge.
 
 | Component | Model | Cost |
 |-----------|-------|------|
-| Summarization | gpt-4o-mini | ~$0.15/1M input + $0.60/1M output |
+| Knowledge extraction | gpt-4o-mini | ~$0.15/1M input + $0.60/1M output |
 | Embeddings | text-embedding-3-small | ~$0.02/1M tokens |
 
-**Typical costs by export size:**
+**Typical costs by export size (~$0.001/conversation):**
 
 | Export size | Processed | Thoughts | Est. cost |
 |-------------|-----------|----------|-----------|
-| 100 conversations | ~40 | ~80 | ~$0.01 |
-| 500 conversations | ~200 | ~400 | ~$0.05 |
-| 1000 conversations | ~400 | ~800 | ~$0.10 |
-| 5000 conversations | ~2000 | ~4000 | ~$0.50 |
+| 100 conversations | ~60 | ~180 | ~$0.06 |
+| 500 conversations | ~300 | ~900 | ~$0.30 |
+| 1000 conversations | ~600 | ~1,800 | ~$0.60 |
+| 5000 conversations | ~3,000 | ~9,000 | ~$3.00 |
 
-These assume ~60% of conversations are filtered as trivial and ~2 thoughts per conversation.
+These assume ~40% of conversations are filtered as trivial and ~3 thoughts per conversation. Add `--store-conversations` for ~$0.00004 extra per conversation (pyramid summaries in the same LLM call). Use `--model ollama` for $0 extraction cost (embeddings still use OpenRouter).
 
 ## Troubleshooting
 
@@ -207,16 +323,22 @@ Solution: ChatGPT exports come as a zip file. Make sure you've either (a) pointe
 Solution: Make sure you've exported the environment variable in your current terminal session: `export OPENROUTER_API_KEY=sk-or-v1-...`. Environment variables don't persist between terminal windows.
 
 **Issue: Import is very slow**
-Solution: Each conversation requires one LLM call (summarization) and 1-3 embedding calls (one per thought). For 500+ conversations, expect 15-30 minutes. Use `--limit 10` to test first, then run the full import. Progress prints to the console so you can see it working.
+Solution: Each conversation requires one LLM call (knowledge extraction) and 1-3 embedding calls (one per thought) plus a dedup check per thought. For 500+ conversations, expect 15-30 minutes. Use `--limit 10` to test first, then run the full import. Progress prints to the console with ETA so you can track it.
 
-**Issue: Most conversations return "No thoughts extracted"**
-Solution: This is expected behavior. The LLM is deliberately selective — it only extracts knowledge worth retrieving months from now. Generic Q&A, coding help, and creative tasks get empty summaries. Use `--raw` if you want to import everything without filtering.
+**Issue: Getting empty thoughts for most conversations**
+Solution: This is expected for many conversations — the LLM only extracts knowledge worth retrieving months from now. If too many conversations are returning empty, try lowering `--min-messages` (default 5) to allow shorter conversations through, or lowering `--min-words` (default 50) to relax the word count threshold. Use `--raw` if you want to import everything without LLM extraction.
+
+**Issue: JSON parse errors from LLM**
+Solution: This is normal occasionally — the LLM sometimes returns malformed JSON despite being asked for structured output. The script falls back to empty extraction for that conversation and continues. If it happens frequently with Ollama, try a different model (`--ollama-model llama3.1`).
 
 **Issue: Some conversations are missing after import**
-Solution: Conversations with fewer than 4 messages or fewer than 20 words of user text are filtered automatically. Title patterns like "poem", "joke", "image of" are also filtered. Run with `--dry-run --verbose` to see what's being filtered and why.
+Solution: Conversations with fewer than 2 messages (single-turn) are always filtered. Untitled conversations with 5 or fewer messages are also filtered. Conversations with 10+ messages are always processed regardless of content. Run with `--dry-run --verbose` to see what's being filtered and why.
 
 **Issue: Want to re-import after a new ChatGPT export**
-Solution: Just run the script again pointing at your new export. The sync log (`chatgpt-sync-log.json`) tracks which conversations have been processed. Only new conversations will be imported. If you want to start fresh, delete `chatgpt-sync-log.json`.
+Solution: Just run the script again pointing at your new export. The sync log (`chatgpt-sync-log.json`) tracks which conversations have been processed and their `update_time`. Only new conversations and conversations with new messages will be re-processed. If you want to start fresh, delete `chatgpt-sync-log.json`.
 
 **Issue: `Failed to generate embedding` errors**
 Solution: Check that your OpenRouter API key is valid and has credits. Go to openrouter.ai/credits to verify your balance. The embedding model (text-embedding-3-small) costs $0.02 per million tokens — even a large import costs pennies.
+
+**Issue: How to use `--store-conversations`**
+Solution: You need to create the `chatgpt_conversations` table first. Open the Supabase SQL Editor, paste the contents of `schema.sql` from this recipe folder, and run it. Then pass `--store-conversations` on your next import run. The table stores conversation-level summaries and metadata — it is optional and the core thought import works without it.

--- a/recipes/chatgpt-conversation-import/README.md
+++ b/recipes/chatgpt-conversation-import/README.md
@@ -226,7 +226,7 @@ The pyramid summaries are generated in the same LLM call as the thought extracti
 | `--after YYYY-MM-DD` | Only process conversations created after this date | None |
 | `--before YYYY-MM-DD` | Only process conversations created before this date | None |
 | `--limit N` | Max conversations to process (0 = unlimited) | 0 |
-| `--min-messages N` | Minimum messages for a conversation to be processed | 5 |
+| `--min-messages N` | Minimum messages for a conversation to be processed | 2 |
 | `--min-words N` | Minimum word count for borderline conversations | 50 |
 | `--focus TOPICS` | Focus extraction on specific topics (preset or custom text — see below) | All topics |
 | `--store-conversations` | Also store conversation summaries with pyramid detail levels (requires `schema.sql`) | Off |

--- a/recipes/chatgpt-conversation-import/chatgpt_parser.py
+++ b/recipes/chatgpt-conversation-import/chatgpt_parser.py
@@ -1,0 +1,448 @@
+"""
+ChatGPT Export Parser — parsing, content-type dispatch, filtering, session splitting.
+
+This module handles the data extraction side of the ChatGPT import pipeline:
+- Export file parsing (zip and directory)
+- Conversation tree resolution (branch handling via current_node)
+- Content-type-aware message extraction (14 content types)
+- Session boundary detection for multi-day conversations
+- Signal-based conversation filtering
+
+Used by import-chatgpt.py.
+"""
+
+import hashlib
+import json
+import os
+import re
+import sys
+import zipfile
+from datetime import datetime, timezone
+from pathlib import Path
+
+# ─── Constants ───────────────────────────────────────────────────────────────
+
+# Signal-based filtering thresholds
+MIN_MESSAGES_SKIP = 2        # Skip if fewer than this many messages
+MIN_MESSAGES_ALWAYS = 10     # Always process if at least this many messages
+MIN_WORDS_BORDERLINE = 50    # Minimum words for borderline conversations (3-9 msgs)
+
+# Content types to skip entirely (model internals, no knowledge value)
+SKIP_CONTENT_TYPES = {
+    "thoughts",              # Model chain-of-thought reasoning
+    "reasoning_recap",       # "Thought for 2m 34s" UI element
+    "computer_output",       # Operator screenshots
+    "system_error",          # Browser errors
+    "super_widget",          # Rare interactive widgets
+    "citable_code_output",   # Rare code output format
+    "tether_quote",          # Full third-party web pages — too much noise
+    "user_editable_context", # Custom instructions — system metadata, not content
+}
+
+# Citation marker pattern for web search results
+CITATION_MARKER_RE = re.compile(r"\u3010\d+\u2020[^\u3011]*\u3011")
+
+# Fenced code block pattern for stripping generated code
+CODE_BLOCK_RE = re.compile(r"```[\s\S]*?```")
+
+# Context window management
+SESSION_GAP_HOURS = 4           # Hours between messages to split sessions
+MAX_CONTEXT_TOKENS = 100_000    # Approximate token limit for LLM context
+CHARS_PER_TOKEN = 4             # Rough approximation
+MAX_CONTEXT_CHARS = MAX_CONTEXT_TOKENS * CHARS_PER_TOKEN  # ~400,000 chars
+SMALL_EXPORT_THRESHOLD = 500    # Skip session splitting below this
+
+
+# ─── ChatGPT Export Parsing ──────────────────────────────────────────────────
+
+
+def extract_conversations(source_path):
+    """Extract conversations from a ChatGPT export zip or extracted directory.
+
+    Handles both single conversations.json and the multi-file format
+    (conversations-000.json through conversations-NNN.json) that OpenAI
+    uses for large exports.
+    """
+    source = Path(source_path)
+
+    if source.is_dir():
+        return _load_conversations_from_dir(source)
+
+    with zipfile.ZipFile(source, "r") as zf:
+        conv_re = re.compile(r"(?:^|/)conversations(?:-\d+)?\.json$")
+        candidates = [n for n in zf.namelist() if conv_re.search(n)]
+        if not candidates:
+            print("Error: No conversations JSON files found in zip archive.")
+            print("  Expected conversations.json or conversations-000.json, etc.")
+            sys.exit(1)
+
+        all_conversations = []
+        for name in sorted(candidates):
+            with zf.open(name) as f:
+                convs = json.load(f)
+                if isinstance(convs, list):
+                    all_conversations.extend(convs)
+                else:
+                    print(f"  Warning: {name} is not a JSON array, skipping.")
+        if not all_conversations:
+            print("Error: Conversation files were found but contained no data.")
+            sys.exit(1)
+        print(f"  Loaded {len(candidates)} conversation file(s) from zip.")
+        return all_conversations
+
+
+def _load_conversations_from_dir(directory):
+    """Load conversations from an already-extracted export directory."""
+    conv_re = re.compile(r"^conversations(?:-\d+)?\.json$")
+    candidates = sorted(f for f in os.listdir(directory) if conv_re.match(f))
+    if not candidates:
+        print(f"Error: No conversations JSON files found in {directory}")
+        print("  Expected conversations.json or conversations-000.json, etc.")
+        sys.exit(1)
+
+    all_conversations = []
+    for name in candidates:
+        filepath = os.path.join(directory, name)
+        with open(filepath) as f:
+            convs = json.load(f)
+            if isinstance(convs, list):
+                all_conversations.extend(convs)
+            else:
+                print(f"  Warning: {name} is not a JSON array, skipping.")
+    if not all_conversations:
+        print("Error: Conversation files were found but contained no data.")
+        sys.exit(1)
+    print(f"  Loaded {len(candidates)} conversation file(s) from directory.")
+    return all_conversations
+
+
+def conversation_hash(conv):
+    """Generate a stable hash ID for a conversation."""
+    title = conv.get("title", "")
+    create_time = str(conv.get("create_time", ""))
+    raw = f"{title}|{create_time}"
+    return hashlib.sha256(raw.encode()).hexdigest()[:16]
+
+
+# ─── Branch Resolution ───────────────────────────────────────────────────────
+
+
+def resolve_canonical_path(mapping, current_node=None):
+    """Walk from current_node to root via parent pointers, then reverse.
+
+    If current_node is provided and exists in mapping, use it as the leaf.
+    Otherwise, fall back to the largest-subtree heuristic.
+    Returns list of message dicts in conversation order.
+    """
+    if not mapping:
+        return []
+
+    # Strategy 1: Use current_node if available
+    if current_node and current_node in mapping:
+        path = []
+        node_id = current_node
+        while node_id and node_id in mapping:
+            node = mapping[node_id]
+            msg = node.get("message")
+            if msg and msg.get("content"):
+                path.append(msg)
+            node_id = node.get("parent")
+        path.reverse()
+        return path
+
+    # Strategy 2: Fallback — find root(s), pick largest subtree at each branch
+    roots = []
+    for node_id, node in mapping.items():
+        parent = node.get("parent")
+        if parent is None or parent not in mapping:
+            roots.append(node_id)
+
+    if not roots:
+        return []
+
+    messages = []
+
+    def subtree_size(nid):
+        if nid not in mapping:
+            return 0
+        count = 1
+        for child in mapping[nid].get("children", []):
+            count += subtree_size(child)
+        return count
+
+    def walk_largest(node_id):
+        if node_id not in mapping:
+            return
+        node = mapping[node_id]
+        msg = node.get("message")
+        if msg and msg.get("content"):
+            messages.append(msg)
+        children = node.get("children", [])
+        if children:
+            # Pick child with largest subtree (user's likely chosen path)
+            best = max(children, key=subtree_size)
+            walk_largest(best)
+
+    walk_largest(roots[0])
+    return messages
+
+
+# ─── Content Type Dispatch ───────────────────────────────────────────────────
+
+
+def _extract_text_from_content(content, content_type):
+    """Extract text from a message content dict based on content_type."""
+
+    if content_type == "text":
+        text_parts = content.get("parts", [])
+        return "\n".join(str(p) for p in text_parts if isinstance(p, str)).strip()
+
+    if content_type == "multimodal_text":
+        # Mixed parts: extract strings + audio transcriptions
+        extracted = []
+        for part in content.get("parts", []):
+            if isinstance(part, str):
+                extracted.append(part)
+            elif isinstance(part, dict):
+                # Voice transcription
+                transcription = part.get("audio_transcription", {})
+                if isinstance(transcription, dict):
+                    text = transcription.get("text", "")
+                    if text:
+                        extracted.append(text)
+        return "\n".join(extracted).strip()
+
+    if content_type == "execution_output":
+        text_parts = content.get("parts", [])
+        text = "\n".join(str(p) for p in text_parts if isinstance(p, str)).strip()
+        # Skip image display markers
+        return "" if text == "<<ImageDisplayed>>" else text
+
+    if content_type == "tether_browsing_display":
+        text_parts = content.get("parts", [])
+        text = "\n".join(str(p) for p in text_parts if isinstance(p, str)).strip()
+        # Strip citation markers like 【4†source】
+        return CITATION_MARKER_RE.sub("", text).strip()
+
+    if content_type == "sonic_webpage":
+        snippet = content.get("snippet", "")
+        text = snippet.strip() if isinstance(snippet, str) else ""
+        return CITATION_MARKER_RE.sub("", text).strip()
+
+    if content_type == "code":
+        text_parts = content.get("parts", [])
+        text = "\n".join(str(p) for p in text_parts if isinstance(p, str)).strip()
+        # Strip fenced code blocks, keep surrounding prose explanation
+        return CODE_BLOCK_RE.sub("", text).strip()
+
+    # Unknown content type: best-effort fallback — extract string parts
+    text_parts = content.get("parts", [])
+    if text_parts:
+        return "\n".join(str(p) for p in text_parts if isinstance(p, str)).strip()
+
+    return ""
+
+
+def extract_dialogue_text(messages):
+    """Extract full dialogue with role prefixes and content-type dispatch.
+
+    Includes both user and assistant messages. Applies content-type-aware
+    extraction: skips model reasoning, strips citation markers, extracts
+    voice transcriptions.
+    """
+    parts = []
+    for msg in messages:
+        author = msg.get("author", {})
+        role = author.get("role", "")
+        if role == "system":
+            continue  # System messages are metadata, not content
+
+        content = msg.get("content", {})
+        content_type = content.get("content_type", "text")
+
+        # Skip model internal content types
+        if content_type in SKIP_CONTENT_TYPES:
+            continue
+
+        text = _extract_text_from_content(content, content_type)
+        if not text:
+            continue
+
+        # Role prefix
+        prefix = "User" if role == "user" else "Assistant"
+        parts.append(f"{prefix}: {text}")
+
+    return "\n\n".join(parts)
+
+
+def count_messages(messages):
+    """Count total messages (all roles) that have extractable text content."""
+    count = 0
+    for msg in messages:
+        content = msg.get("content", {})
+        content_type = content.get("content_type", "text")
+        if content_type in SKIP_CONTENT_TYPES:
+            continue
+        text = _extract_text_from_content(content, content_type)
+        if text:
+            count += 1
+    return count
+
+
+def extract_conversation_metadata(conv):
+    """Extract free metadata from conversation export JSON (zero API cost)."""
+    return {
+        "model_slug": conv.get("default_model_slug"),
+        "gizmo_id": conv.get("gizmo_id"),
+        "gizmo_type": conv.get("gizmo_type"),
+        "voice": conv.get("voice"),
+        "conversation_origin": conv.get("conversation_origin"),
+        "is_archived": conv.get("is_archived", False),
+        "is_starred": conv.get("is_starred", False),
+        "async_status": conv.get("async_status"),
+    }
+
+
+# ─── Session Splitting ──────────────────────────────────────────────────────
+
+
+def split_sessions(messages):
+    """Split messages into sessions based on timestamp gaps.
+
+    A gap of SESSION_GAP_HOURS or more between consecutive messages
+    indicates a new session. Returns a list of message lists.
+    """
+    if not messages:
+        return []
+
+    sessions = [[]]
+    prev_time = None
+
+    for msg in messages:
+        create_time = msg.get("create_time")
+        if create_time and prev_time:
+            gap_hours = (create_time - prev_time) / 3600
+            if gap_hours >= SESSION_GAP_HOURS:
+                sessions.append([])
+        sessions[-1].append(msg)
+        if create_time:
+            prev_time = create_time
+
+    return [s for s in sessions if s]  # Filter empty
+
+
+def _truncate_session(text):
+    """Truncate a session to first ~3000 tokens + last ~1000 tokens."""
+    head_chars = 3000 * CHARS_PER_TOKEN  # ~12,000 chars
+    tail_chars = 1000 * CHARS_PER_TOKEN  # ~4,000 chars
+
+    if len(text) <= head_chars + tail_chars:
+        return text
+
+    return (
+        text[:head_chars]
+        + "\n\n[... middle truncated ...]\n\n"
+        + text[-tail_chars:]
+    )
+
+
+def prepare_dialogue_for_extraction(messages, total_conversations):
+    """Prepare dialogue text for LLM extraction, handling context window limits.
+
+    For small exports (<500 conversations), skip session splitting.
+    For conversations exceeding MAX_CONTEXT_CHARS, split on session boundaries.
+    For individual sessions exceeding MAX_CONTEXT_CHARS, truncate to
+    first ~3000 tokens + last ~1000 tokens.
+    """
+    dialogue = extract_dialogue_text(messages)
+
+    # Fast path: fits in context window
+    if len(dialogue) <= MAX_CONTEXT_CHARS:
+        return [dialogue]
+
+    # Small export fast path: no session splitting
+    if total_conversations < SMALL_EXPORT_THRESHOLD:
+        return [_truncate_session(dialogue)]
+
+    # Split into sessions
+    sessions = split_sessions(messages)
+    session_texts = []
+    for session_msgs in sessions:
+        text = extract_dialogue_text(session_msgs)
+        if not text:
+            continue
+        if len(text) > MAX_CONTEXT_CHARS:
+            text = _truncate_session(text)
+        session_texts.append(text)
+
+    return session_texts if session_texts else [_truncate_session(dialogue)]
+
+
+# ─── Conversation Filtering ─────────────────────────────────────────────────
+
+
+def should_skip(conv, dialogue_text, message_count, sync_log, args):
+    """Return a skip reason string, or None if the conversation should be processed.
+
+    Uses signal-based scoring instead of regex title matching:
+    - Single-turn conversations: skip
+    - 10+ messages: always process
+    - Borderline (2-9 messages): check word count, untitled filter
+    - Let the LLM decide for borderline cases via skip_reason in extraction
+    """
+    conv_id = conversation_hash(conv)
+
+    # Already imported — but check for updates
+    sync_entry = sync_log["ingested_ids"].get(conv_id)
+    if sync_entry:
+        # Support old format (bare string) and new format (dict)
+        if isinstance(sync_entry, str):
+            return "already_imported"
+        update_time = conv.get("update_time", 0)
+        if update_time and update_time > sync_entry.get("update_time", 0):
+            pass  # Conversation has new messages; re-process
+        else:
+            return "already_imported"
+
+    # Date filtering
+    create_time = conv.get("create_time")
+    if create_time:
+        conv_date = datetime.fromtimestamp(create_time, tz=timezone.utc).date()
+        if args.after and conv_date < args.after:
+            return "before_date_filter"
+        if args.before and conv_date > args.before:
+            return "after_date_filter"
+
+    # Explicitly marked "do not remember"
+    if conv.get("is_do_not_remember"):
+        return "do_not_remember"
+
+    # CLI override for min messages
+    min_skip = getattr(args, "min_messages", MIN_MESSAGES_SKIP) or MIN_MESSAGES_SKIP
+    min_always = MIN_MESSAGES_ALWAYS
+
+    # Single-turn: skip
+    if message_count < min_skip:
+        return "single_turn"
+
+    # 10+ messages: always process (high-value threshold)
+    if message_count >= min_always:
+        return None
+
+    # Borderline (2-9 messages): check signals
+    title = conv.get("title") or ""
+    word_count = len(dialogue_text.split())
+
+    # CLI override for min words
+    min_words = getattr(args, "min_score", MIN_WORDS_BORDERLINE) or MIN_WORDS_BORDERLINE
+
+    # Untitled with few messages: likely throwaway
+    if not title and message_count <= 5:
+        return "untitled_short"
+
+    # Too little text overall
+    if word_count < min_words:
+        return "too_little_text"
+
+    # Let the LLM decide for everything else
+    return None

--- a/recipes/chatgpt-conversation-import/chatgpt_parser.py
+++ b/recipes/chatgpt-conversation-import/chatgpt_parser.py
@@ -434,7 +434,7 @@ def should_skip(conv, dialogue_text, message_count, sync_log, args):
     word_count = len(dialogue_text.split())
 
     # CLI override for min words
-    min_words = getattr(args, "min_score", MIN_WORDS_BORDERLINE) or MIN_WORDS_BORDERLINE
+    min_words = getattr(args, "min_words", MIN_WORDS_BORDERLINE) or MIN_WORDS_BORDERLINE
 
     # Untitled with few messages: likely throwaway
     if not title and message_count <= 5:

--- a/recipes/chatgpt-conversation-import/import-chatgpt.py
+++ b/recipes/chatgpt-conversation-import/import-chatgpt.py
@@ -1,10 +1,10 @@
 #!/usr/bin/env python3
 """
-Open Brain — ChatGPT Export Importer
+Open Brain — ChatGPT Export Importer (v2)
 
 Extracts conversations from a ChatGPT data export (zip or extracted directory),
-filters trivial ones, summarizes each into 1-3 distilled thoughts via LLM,
-and loads them into your Open Brain instance.
+filters trivial ones, extracts 2-5 structured knowledge thoughts per conversation
+via LLM, and loads them into your Open Brain instance.
 
 Supports both single conversations.json and the multi-file format
 (conversations-000.json through conversations-NNN.json) used in large exports.
@@ -19,21 +19,25 @@ Ingestion modes:
     --ingest-endpoint:    Custom endpoint (requires INGEST_URL, INGEST_KEY)
 
 Options:
-    --dry-run              Parse, filter, summarize, but don't ingest
+    --dry-run              Parse, filter, extract, but don't ingest
     --after YYYY-MM-DD     Only conversations created after this date
     --before YYYY-MM-DD    Only conversations created before this date
     --limit N              Max conversations to process
     --model openrouter     LLM backend: openrouter (default) or ollama
     --ollama-model NAME    Ollama model name (default: qwen3)
-    --raw                  Skip summarization, ingest user messages directly
-    --verbose              Show full summaries during processing
+    --raw                  Skip extraction, ingest user messages directly
+    --verbose              Show full thoughts during processing
     --report FILE          Write a markdown report of everything imported
     --ingest-endpoint      Use INGEST_URL/INGEST_KEY instead of Supabase direct insert
+    --store-conversations  Also store conversation metadata and pyramid summaries
+    --min-messages N       Override minimum message count for filtering
+    --min-words N          Override minimum word count for borderline filtering
+    --max-words N          Skip conversations exceeding N words (default: 50000)
 
 Environment variables:
     SUPABASE_URL               Supabase project URL (required for default mode)
     SUPABASE_SERVICE_ROLE_KEY  Supabase service role key (required for default mode)
-    OPENROUTER_API_KEY         OpenRouter API key (required for summarization + embeddings)
+    OPENROUTER_API_KEY         OpenRouter API key (required for extraction + embeddings)
     INGEST_URL                 Custom ingest endpoint URL (required with --ingest-endpoint)
     INGEST_KEY                 Custom ingest endpoint auth key (required with --ingest-endpoint)
 """
@@ -42,12 +46,21 @@ import argparse
 import hashlib
 import json
 import os
-import re
 import sys
 import time
-import zipfile
 from datetime import datetime, timezone
 from pathlib import Path
+
+from chatgpt_parser import (
+    conversation_hash,
+    count_messages,
+    extract_conversation_metadata,
+    extract_conversations,
+    extract_dialogue_text,
+    prepare_dialogue_for_extraction,
+    resolve_canonical_path,
+    should_skip,
+)
 
 # ─── Configuration ───────────────────────────────────────────────────────────
 
@@ -62,47 +75,171 @@ OPENROUTER_API_KEY = os.environ.get("OPENROUTER_API_KEY", "")
 INGEST_URL = os.environ.get("INGEST_URL", "")
 INGEST_KEY = os.environ.get("INGEST_KEY", "")
 
-# Filtering thresholds
-MIN_TOTAL_MESSAGES = 4
-MIN_USER_WORDS = 20
-SKIP_TITLE_PATTERNS = re.compile(
-    r"do not remember|forget this|don't remember|ignore this"
-    r"|limerick|haiku|poem |joke |riddle"
-    r"|image of|generate.*image|draw |create.*art"
-    r"|tooth fairy|santa letter|bedtime stor"
-    r"|translate this|what is .{1,15} in \w+",
-    re.IGNORECASE,
-)
+# ─── Focus Presets ───────────────────────────────────────────────────────────
 
-SUMMARIZATION_PROMPT = """\
-You are distilling a ChatGPT conversation into standalone thoughts for a \
-personal knowledge base. Your job is to be HIGHLY SELECTIVE — only extract \
-knowledge that would be valuable to retrieve months or years from now.
+FOCUS_PRESETS = {
+    "tech": (
+        'IMPORTANT FOCUS FILTER: Only extract thoughts DIRECTLY about technology, '
+        'software architecture, engineering decisions, system design, code patterns, '
+        'infrastructure, DevOps, APIs, databases, and technical problem-solving. '
+        'Be STRICT — if the conversation is primarily about product shopping, cooking, '
+        'health, pets, home appliances, travel, or general knowledge, return '
+        '{"thoughts": [], "skip_reason": "off-topic"} even if there is a minor '
+        'technical element. The conversation\'s MAIN subject must be technology.'
+    ),
+    "strategy": (
+        'IMPORTANT FOCUS FILTER: Only extract thoughts DIRECTLY about business strategy, '
+        'product decisions, career planning, organizational design, market analysis, '
+        'competitive positioning, hiring, leadership, and professional growth. '
+        'Be STRICT — if the conversation is primarily about product shopping, cooking, '
+        'health, pets, home topics, or general knowledge, return '
+        '{"thoughts": [], "skip_reason": "off-topic"} even if there is a minor '
+        'strategic element. The conversation\'s MAIN subject must be business/career.'
+    ),
+    "personal": (
+        'IMPORTANT FOCUS FILTER: Only extract thoughts DIRECTLY about family, parenting, '
+        'health decisions, relationships, personal values, life goals, home improvement, '
+        'and personal finance. '
+        'Be STRICT — if the conversation is primarily about work, technology, product '
+        'comparisons, or general knowledge, return '
+        '{"thoughts": [], "skip_reason": "off-topic"}. '
+        'The conversation\'s MAIN subject must be personal life.'
+    ),
+    "creative": (
+        'IMPORTANT FOCUS FILTER: Only extract thoughts DIRECTLY about writing, design, '
+        'art direction, creative process, content strategy, storytelling, and aesthetic '
+        'decisions. '
+        'Be STRICT — if the conversation is primarily about technology, business, '
+        'shopping, health, or general knowledge, return '
+        '{"thoughts": [], "skip_reason": "off-topic"}. '
+        'The conversation\'s MAIN subject must be creative work.'
+    ),
+}
 
-CAPTURE these (1-3 thoughts max):
-- Decisions made and the reasoning behind them
-- People mentioned with context (who they are, relationship, what was discussed)
-- Project plans, strategies, or architectural choices
-- Lessons learned, mistakes acknowledged, preferences discovered
-- Business context: companies, roles, goals, metrics
-- Personal values, beliefs, or frameworks articulated
 
-SKIP these entirely (return empty):
-- One-off creative tasks (poems, letters, stories, jokes)
-- Generic Q&A or factual lookups
-- Coding help with no lasting architectural decisions
-- Hypothetical explorations with no conclusion
-- Short tasks where the user just needed something written/formatted
+def build_focus_instruction(focus_arg):
+    """Convert --focus argument to a prompt instruction.
 
-Each thought must be:
-- A clear, standalone statement (makes sense without the conversation)
-- Written in first person
-- Anchored with names, dates, or project context when available
-- 1-3 sentences
+    Accepts a preset name (tech, strategy, personal, creative) or
+    free-text description. Returns empty string if no focus set.
+    """
+    if not focus_arg or focus_arg.lower() == "all":
+        return ""
 
-Return JSON: {"thoughts": ["thought1", "thought2"]}
-If the conversation has nothing worth capturing, return {"thoughts": []}
-Err on the side of returning empty — less is more."""
+    # Check for preset
+    preset = FOCUS_PRESETS.get(focus_arg.lower())
+    if preset:
+        return f"\n\n{preset}"
+
+    # Free-text: wrap in a strict FOCUS instruction
+    return (
+        f"\n\nIMPORTANT FOCUS FILTER: Only extract thoughts DIRECTLY related to: {focus_arg}. "
+        f"Be STRICT — if the conversation is primarily about something else "
+        f"(e.g., product shopping, cooking, health, pets, home appliances, travel), "
+        f'return {{"thoughts": [], "skip_reason": "off-topic"}} even if there is a '
+        f"minor tangential connection to the focus topics. "
+        f"The conversation's MAIN subject must match the focus areas."
+    )
+
+
+KNOWLEDGE_EXTRACTION_PROMPT = """\
+You are extracting lasting knowledge from a ChatGPT conversation.
+The goal is to capture decisions, preferences, learnings, context, and
+brainstorming insights that would be valuable to recall months or years later.
+
+For each distinct piece of knowledge, return a JSON object in the "thoughts" array.
+
+Each thought must have:
+- "content": The knowledge itself, written as a clear, self-contained statement
+  (2-4 sentences). Include specifics: names, numbers, reasoning.
+  A reader should understand this without seeing the conversation.
+- "type": One of "decision", "preference", "learning", "context", "brainstorm", "reference"
+- "topics": 1-3 topic tags
+- "people": Names of people mentioned (empty array if none)
+- "confidence": "firm" (clear conclusion), "tentative" (leaning toward),
+  or "exploring" (still open)
+
+Rules:
+- Extract 0-5 thoughts per conversation. Zero is fine if nothing is brain-worthy.
+- Skip ephemeral lookups (unit conversions, simple facts easily re-googled).
+- Skip creative tasks (poems, image generation, jokes).
+- Be careful with personal-context conversations that LOOK ephemeral: "what tax bracket am I in
+  after this raise" encodes income context (extract as context type). "Best stroller for twins"
+  encodes family situation. "Severance pay rules" encodes career context. When in doubt, extract.
+- For product comparisons: capture what was chosen, what was rejected, and WHY.
+- For technical discussions: capture the architecture/approach decided on, not the code.
+- For brainstorming: capture the most promising ideas and the reasoning.
+- Never include generated code — only the reasoning and decisions around it.
+- Write in the same language as the conversation.
+
+Return ONLY a JSON object: {{"thoughts": [...], "conversation_type": "...", "skip_reason": "..."}}
+If nothing is worth extracting, return {{"thoughts": [], "skip_reason": "ephemeral lookup"}}.
+
+Title: {title}
+Date: {date}
+Message count: {message_count}
+Model: {model}
+
+Conversation:
+{dialogue_text}"""
+
+KNOWLEDGE_EXTRACTION_PROMPT_WITH_SUMMARIES = """\
+You are extracting lasting knowledge from a ChatGPT conversation.
+The goal is to capture decisions, preferences, learnings, context, and
+brainstorming insights that would be valuable to recall months or years later.
+
+For each distinct piece of knowledge, return a JSON object in the "thoughts" array.
+
+Each thought must have:
+- "content": The knowledge itself, written as a clear, self-contained statement
+  (2-4 sentences). Include specifics: names, numbers, reasoning.
+  A reader should understand this without seeing the conversation.
+- "type": One of "decision", "preference", "learning", "context", "brainstorm", "reference"
+- "topics": 1-3 topic tags
+- "people": Names of people mentioned (empty array if none)
+- "confidence": "firm" (clear conclusion), "tentative" (leaning toward),
+  or "exploring" (still open)
+
+Rules:
+- Extract 0-5 thoughts per conversation. Zero is fine if nothing is brain-worthy.
+- Skip ephemeral lookups (unit conversions, simple facts easily re-googled).
+- Skip creative tasks (poems, image generation, jokes).
+- Be careful with personal-context conversations that LOOK ephemeral: "what tax bracket am I in
+  after this raise" encodes income context (extract as context type). "Best stroller for twins"
+  encodes family situation. "Severance pay rules" encodes career context. When in doubt, extract.
+- For product comparisons: capture what was chosen, what was rejected, and WHY.
+- For technical discussions: capture the architecture/approach decided on, not the code.
+- For brainstorming: capture the most promising ideas and the reasoning.
+- Never include generated code — only the reasoning and decisions around it.
+- Write in the same language as the conversation.
+
+ALSO return pyramid summaries of the conversation at 5 lengths:
+- "summary_8w": ~8 words — a label for a timeline or list
+- "summary_16w": ~16 words — one sentence with the key outcome
+- "summary_32w": ~32 words — card preview with key details
+- "summary_64w": ~64 words — short paragraph with reasoning and alternatives
+- "summary_128w": ~128 words — full summary with decisions, people, and context
+
+Return ONLY a JSON object:
+{{
+  "thoughts": [...],
+  "conversation_type": "...",
+  "skip_reason": "...",
+  "summary_8w": "...",
+  "summary_16w": "...",
+  "summary_32w": "...",
+  "summary_64w": "...",
+  "summary_128w": "..."
+}}
+If nothing is worth extracting, still return summaries but set thoughts to [].
+
+Title: {title}
+Date: {date}
+Message count: {message_count}
+Model: {model}
+
+Conversation:
+{dialogue_text}"""
 
 # ─── Sync Log ────────────────────────────────────────────────────────────────
 
@@ -136,215 +273,104 @@ def http_post_with_retry(url, headers, body, retries=2):
     """POST with exponential backoff retry on transient failures."""
     for attempt in range(retries + 1):
         try:
-            resp = requests.post(url, headers=headers, json=body, timeout=30)
+            resp = requests.post(url, headers=headers, json=body, timeout=120)
             if resp.status_code >= 500 and attempt < retries:
                 time.sleep(1 * (attempt + 1))
                 continue
             return resp
-        except requests.RequestException:
+        except requests.RequestException as e:
             if attempt < retries:
                 time.sleep(1 * (attempt + 1))
                 continue
-            raise
+            print(f"   Warning: HTTP request failed after {retries + 1} attempts: {e}")
+            return None
     return None  # unreachable
 
 
-# ─── ChatGPT Export Parsing ──────────────────────────────────────────────────
+# ─── LLM Knowledge Extraction ───────────────────────────────────────────────
 
 
-def extract_conversations(source_path):
-    """Extract conversations from a ChatGPT export zip or extracted directory.
+def _parse_extraction_response(raw_content, store_conversations=False):
+    """Parse the structured JSON response from the LLM extraction.
 
-    Handles both single conversations.json and the multi-file format
-    (conversations-000.json through conversations-NNN.json) that OpenAI
-    uses for large exports.
+    Returns a dict with thoughts, conversation_type, skip_reason, and
+    optionally summaries.
     """
-    source = Path(source_path)
+    try:
+        # Strip markdown code fences if present (common with Anthropic models)
+        text = raw_content.strip()
+        if text.startswith("```"):
+            # Remove opening ```json or ``` and closing ```
+            lines = text.split("\n")
+            if lines[0].startswith("```"):
+                lines = lines[1:]
+            if lines and lines[-1].strip() == "```":
+                lines = lines[:-1]
+            text = "\n".join(lines)
+        result = json.loads(text)
+    except (json.JSONDecodeError, TypeError) as e:
+        # Try to find JSON object in the response text
+        try:
+            start = raw_content.index("{")
+            end = raw_content.rindex("}") + 1
+            result = json.loads(raw_content[start:end])
+        except (ValueError, json.JSONDecodeError):
+            print(f"   Warning: Failed to parse extraction response: {e}")
+            return {"thoughts": [], "conversation_type": "", "skip_reason": "parse_error"}
 
-    if source.is_dir():
-        return _load_conversations_from_dir(source)
+    thoughts = result.get("thoughts", [])
+    # Validate each thought is a dict with required fields
+    valid_thoughts = []
+    for t in thoughts:
+        if isinstance(t, dict) and t.get("content"):
+            valid_thoughts.append({
+                "content": t["content"],
+                "type": t.get("type", "learning"),
+                "topics": t.get("topics", []),
+                "people": t.get("people", []),
+                "confidence": t.get("confidence", "firm"),
+            })
+        elif isinstance(t, str) and t.strip():
+            # Backward compat: plain string thoughts from older prompts
+            valid_thoughts.append({
+                "content": t.strip(),
+                "type": "learning",
+                "topics": [],
+                "people": [],
+                "confidence": "firm",
+            })
 
-    with zipfile.ZipFile(source, "r") as zf:
-        conv_re = re.compile(r"(?:^|/)conversations(?:-\d+)?\.json$")
-        candidates = [n for n in zf.namelist() if conv_re.search(n)]
-        if not candidates:
-            print("Error: No conversations JSON files found in zip archive.")
-            print("  Expected conversations.json or conversations-000.json, etc.")
-            sys.exit(1)
+    extraction = {
+        "thoughts": valid_thoughts,
+        "conversation_type": result.get("conversation_type", ""),
+        "skip_reason": result.get("skip_reason"),
+    }
 
-        all_conversations = []
-        for name in sorted(candidates):
-            with zf.open(name) as f:
-                convs = json.load(f)
-                if isinstance(convs, list):
-                    all_conversations.extend(convs)
-                else:
-                    print(f"  Warning: {name} is not a JSON array, skipping.")
-        if not all_conversations:
-            print("Error: Conversation files were found but contained no data.")
-            sys.exit(1)
-        print(f"  Loaded {len(candidates)} conversation file(s) from zip.")
-        return all_conversations
+    if store_conversations:
+        extraction["summaries"] = {
+            k: result.get(k, "")
+            for k in ("summary_8w", "summary_16w", "summary_32w", "summary_64w", "summary_128w")
+        }
 
-
-def _load_conversations_from_dir(directory):
-    """Load conversations from an already-extracted export directory."""
-    conv_re = re.compile(r"^conversations(?:-\d+)?\.json$")
-    candidates = sorted(f for f in os.listdir(directory) if conv_re.match(f))
-    if not candidates:
-        print(f"Error: No conversations JSON files found in {directory}")
-        print("  Expected conversations.json or conversations-000.json, etc.")
-        sys.exit(1)
-
-    all_conversations = []
-    for name in candidates:
-        filepath = os.path.join(directory, name)
-        with open(filepath) as f:
-            convs = json.load(f)
-            if isinstance(convs, list):
-                all_conversations.extend(convs)
-            else:
-                print(f"  Warning: {name} is not a JSON array, skipping.")
-    if not all_conversations:
-        print("Error: Conversation files were found but contained no data.")
-        sys.exit(1)
-    print(f"  Loaded {len(candidates)} conversation file(s) from directory.")
-    return all_conversations
-
-
-def conversation_hash(conv):
-    """Generate a stable hash ID for a conversation."""
-    title = conv.get("title", "")
-    create_time = str(conv.get("create_time", ""))
-    raw = f"{title}|{create_time}"
-    return hashlib.sha256(raw.encode()).hexdigest()[:16]
+    return extraction
 
 
-def walk_messages(mapping):
-    """Walk the mapping tree to extract messages in conversation order.
-
-    The mapping is a dict of node_id -> node. Each node has an optional
-    'message' field and 'parent'/'children' references forming a tree.
-    We find the root (no parent or parent not in mapping) and walk depth-first.
-    """
-    if not mapping:
-        return []
-
-    # Find root node(s): nodes whose parent is None or not in the mapping
-    roots = []
-    for node_id, node in mapping.items():
-        parent = node.get("parent")
-        if parent is None or parent not in mapping:
-            roots.append(node_id)
-
-    if not roots:
-        return []
-
-    # Walk from root depth-first, visiting all branches.
-    # Most conversations are linear; branched ones yield all paths.
-    messages = []
-    visited = set()
-
-    def walk(node_id):
-        if node_id in visited or node_id not in mapping:
-            return
-        visited.add(node_id)
-        node = mapping[node_id]
-        msg = node.get("message")
-        if msg and msg.get("content"):
-            messages.append(msg)
-        children = node.get("children", [])
-        for child_id in children:
-            walk(child_id)
-
-    for root_id in roots:
-        walk(root_id)
-
-    return messages
-
-
-def extract_user_text(messages):
-    """Extract text from user messages only, concatenated with separators."""
-    parts = []
-    for msg in messages:
-        author = msg.get("author", {})
-        if author.get("role") != "user":
-            continue
-        content = msg.get("content", {})
-        if content.get("content_type") != "text":
-            continue
-        text_parts = content.get("parts", [])
-        text = "\n".join(str(p) for p in text_parts if isinstance(p, str)).strip()
-        if text:
-            parts.append(text)
-    return "\n---\n".join(parts)
-
-
-def count_messages(messages):
-    """Count total messages (all roles) that have text content."""
-    count = 0
-    for msg in messages:
-        content = msg.get("content", {})
-        if content.get("content_type") == "text":
-            parts = content.get("parts", [])
-            text = "".join(str(p) for p in parts if isinstance(p, str)).strip()
-            if text:
-                count += 1
-    return count
-
-
-# ─── Conversation Filtering ─────────────────────────────────────────────────
-
-
-def should_skip(conv, user_text, message_count, sync_log, args):
-    """Return a skip reason string, or None if the conversation should be processed."""
-    conv_id = conversation_hash(conv)
-
-    # Already imported
-    if conv_id in sync_log["ingested_ids"]:
-        return "already_imported"
-
-    # Date filtering
-    create_time = conv.get("create_time")
-    if create_time:
-        conv_date = datetime.fromtimestamp(create_time, tz=timezone.utc).date()
-        if args.after and conv_date < args.after:
-            return "before_date_filter"
-        if args.before and conv_date > args.before:
-            return "after_date_filter"
-
-    # Explicitly marked "do not remember" by the user in ChatGPT
-    if conv.get("is_do_not_remember"):
-        return "do_not_remember"
-
-    # Too few messages
-    if message_count < MIN_TOTAL_MESSAGES:
-        return "too_few_messages"
-
-    # Title-based skip
-    title = conv.get("title") or ""
-    if SKIP_TITLE_PATTERNS.search(title):
-        return "skip_title"
-
-    # Not enough user text
-    word_count = len(user_text.split())
-    if word_count < MIN_USER_WORDS:
-        return "too_little_text"
-
-    return None
-
-
-# ─── LLM Summarization ──────────────────────────────────────────────────────
-
-
-def summarize_openrouter(title, date_str, user_text):
-    """Summarize a conversation into thoughts using OpenRouter."""
+def summarize_openrouter(title, date_str, dialogue_text, message_count, model_slug, store_conversations=False, openrouter_model="openai/gpt-4o-mini", focus_instruction=""):
+    """Extract knowledge from a conversation using OpenRouter."""
     if not OPENROUTER_API_KEY:
-        print("Error: OPENROUTER_API_KEY environment variable required for summarization.")
+        print("Error: OPENROUTER_API_KEY environment variable required for extraction.")
         sys.exit(1)
 
-    # Truncate to ~6000 chars to stay within context limits
-    truncated = user_text[:6000]
+    prompt_template = KNOWLEDGE_EXTRACTION_PROMPT_WITH_SUMMARIES if store_conversations else KNOWLEDGE_EXTRACTION_PROMPT
+    prompt = prompt_template.format(
+        title=title,
+        date=date_str,
+        message_count=message_count,
+        model=model_slug,
+        dialogue_text=dialogue_text,
+    )
+    if focus_instruction:
+        prompt = prompt.replace("\nTitle:", f"{focus_instruction}\n\nTitle:")
 
     resp = http_post_with_retry(
         f"{OPENROUTER_BASE}/chat/completions",
@@ -353,14 +379,10 @@ def summarize_openrouter(title, date_str, user_text):
             "Content-Type": "application/json",
         },
         body={
-            "model": "openai/gpt-4o-mini",
+            "model": openrouter_model,
             "response_format": {"type": "json_object"},
             "messages": [
-                {"role": "system", "content": SUMMARIZATION_PROMPT},
-                {
-                    "role": "user",
-                    "content": f"Conversation title: {title}\nDate: {date_str}\n\nUser messages:\n{truncated}",
-                },
+                {"role": "user", "content": prompt},
             ],
             "temperature": 0,
         },
@@ -368,28 +390,35 @@ def summarize_openrouter(title, date_str, user_text):
 
     if not resp or resp.status_code != 200:
         status = resp.status_code if resp else "no response"
-        print(f"   Warning: Summarization failed ({status}), skipping conversation.")
-        return []
+        detail = ""
+        try:
+            detail = resp.text[:300] if resp else ""
+        except Exception:
+            pass
+        print(f"   Warning: Extraction failed ({status}): {detail}")
+        return {"thoughts": [], "conversation_type": "", "skip_reason": "api_error"}
 
     try:
         data = resp.json()
-        result = json.loads(data["choices"][0]["message"]["content"])
-        thoughts = result.get("thoughts", [])
-        return [t for t in thoughts if isinstance(t, str) and t.strip()]
-    except (KeyError, json.JSONDecodeError, IndexError) as e:
-        print(f"   Warning: Failed to parse summarization response: {e}")
-        return []
+        raw_content = data["choices"][0]["message"]["content"]
+        return _parse_extraction_response(raw_content, store_conversations)
+    except (KeyError, IndexError) as e:
+        print(f"   Warning: Failed to parse extraction response: {e}")
+        return {"thoughts": [], "conversation_type": "", "skip_reason": "parse_error"}
 
 
-def summarize_ollama(title, date_str, user_text, model_name="qwen3"):
-    """Summarize a conversation using a local Ollama model."""
-    truncated = user_text[:6000]
-
-    prompt = (
-        f"{SUMMARIZATION_PROMPT}\n\n"
-        f"Conversation title: {title}\nDate: {date_str}\n\n"
-        f"User messages:\n{truncated}"
+def summarize_ollama(title, date_str, dialogue_text, message_count, model_slug, model_name="qwen3", store_conversations=False, focus_instruction=""):
+    """Extract knowledge from a conversation using a local Ollama model."""
+    prompt_template = KNOWLEDGE_EXTRACTION_PROMPT_WITH_SUMMARIES if store_conversations else KNOWLEDGE_EXTRACTION_PROMPT
+    prompt = prompt_template.format(
+        title=title,
+        date=date_str,
+        message_count=message_count,
+        model=model_slug,
+        dialogue_text=dialogue_text,
     )
+    if focus_instruction:
+        prompt = prompt.replace("\nTitle:", f"{focus_instruction}\n\nTitle:")
 
     try:
         resp = requests.post(
@@ -404,27 +433,27 @@ def summarize_ollama(title, date_str, user_text, model_name="qwen3"):
         )
     except requests.RequestException as e:
         print(f"   Warning: Ollama request failed: {e}")
-        return []
+        return {"thoughts": [], "conversation_type": "", "skip_reason": "api_error"}
 
     if resp.status_code != 200:
         print(f"   Warning: Ollama returned {resp.status_code}")
-        return []
+        return {"thoughts": [], "conversation_type": "", "skip_reason": "api_error"}
 
     try:
         raw = resp.json().get("response", "")
-        result = json.loads(raw)
-        thoughts = result.get("thoughts", [])
-        return [t for t in thoughts if isinstance(t, str) and t.strip()]
+        return _parse_extraction_response(raw, store_conversations)
     except (json.JSONDecodeError, KeyError) as e:
         print(f"   Warning: Failed to parse Ollama response: {e}")
-        return []
+        return {"thoughts": [], "conversation_type": "", "skip_reason": "parse_error"}
 
 
-def summarize(title, date_str, user_text, args):
-    """Dispatch to the appropriate summarization backend."""
+def summarize(title, date_str, dialogue_text, message_count, model_slug, args):
+    """Dispatch to the appropriate extraction backend."""
+    store_conversations = getattr(args, "store_conversations", False)
+    focus_instruction = build_focus_instruction(getattr(args, "focus", None))
     if args.model == "ollama":
-        return summarize_ollama(title, date_str, user_text, args.ollama_model)
-    return summarize_openrouter(title, date_str, user_text)
+        return summarize_ollama(title, date_str, dialogue_text, message_count, model_slug, args.ollama_model, store_conversations, focus_instruction)
+    return summarize_openrouter(title, date_str, dialogue_text, message_count, model_slug, store_conversations, args.openrouter_model, focus_instruction)
 
 
 # ─── Embedding Generation ───────────────────────────────────────────────────
@@ -459,12 +488,57 @@ def generate_embedding(text):
         return None
 
 
+# ─── Semantic Deduplication ──────────────────────────────────────────────────
+
+
+def check_semantic_duplicate(thought_text, threshold=0.92):
+    """Check if a semantically similar thought already exists.
+
+    Uses the match_thoughts RPC with a high similarity threshold.
+    Returns True if a near-duplicate exists, False otherwise.
+    """
+    embedding = generate_embedding(thought_text)
+    if not embedding:
+        return False  # Can't check; allow insertion
+
+    resp = http_post_with_retry(
+        f"{SUPABASE_URL}/rest/v1/rpc/match_thoughts",
+        headers={
+            "Content-Type": "application/json",
+            "apikey": SUPABASE_SERVICE_ROLE_KEY,
+            "Authorization": f"Bearer {SUPABASE_SERVICE_ROLE_KEY}",
+        },
+        body={
+            "query_embedding": embedding,
+            "match_threshold": threshold,
+            "match_count": 1,
+            "filter": {"source": "chatgpt"},
+        },
+    )
+
+    if not resp or resp.status_code != 200:
+        return False  # Can't check; allow insertion
+
+    try:
+        data = resp.json()
+        return len(data) > 0
+    except (json.JSONDecodeError, TypeError):
+        return False
+
+
 # ─── Ingestion ───────────────────────────────────────────────────────────────
 
 
-def ingest_thought_supabase(content, metadata_dict):
-    """Insert a thought directly into Supabase with a generated embedding."""
-    embedding = generate_embedding(content)
+def ingest_thought_supabase(content, metadata_dict, embed_text=None):
+    """Insert a thought directly into Supabase with a generated embedding.
+
+    Args:
+        content: Full thought content (stored in DB, includes prefix)
+        metadata_dict: Metadata JSONB
+        embed_text: Text to generate embedding from (default: content).
+                    Use this to embed only the thought text, not the prefix.
+    """
+    embedding = generate_embedding(embed_text or content)
     if not embedding:
         return {"ok": False, "error": "Failed to generate embedding"}
 
@@ -524,6 +598,98 @@ def ingest_thought_endpoint(content, extra_metadata, full_text=None):
         return {"ok": False, "error": f"Invalid JSON response: {resp.status_code}"}
 
 
+# ─── Conversation Storage (--store-conversations) ───────────────────────────
+
+
+def store_conversation(conv, extraction, conv_meta, message_count, import_batch):
+    """Insert or update a conversation record in chatgpt_conversations.
+
+    Uses chatgpt_id as the unique key for upsert.
+    Embeds the 128-word summary for semantic search.
+    """
+    chatgpt_id = conv.get("id", "")
+    if not chatgpt_id:
+        return {"ok": False, "error": "No conversation ID"}
+
+    summaries = extraction.get("summaries", {})
+    summary_128w = summaries.get("summary_128w", "")
+
+    # Generate embedding from 128w summary
+    embedding = generate_embedding(summary_128w) if summary_128w else None
+
+    # Collect topics and people from all extracted thoughts
+    all_topics = []
+    all_people = []
+    for t in extraction.get("thoughts", []):
+        all_topics.extend(t.get("topics", []))
+        all_people.extend(t.get("people", []))
+    key_topics = list(set(all_topics))
+    people_mentioned = list(set(all_people))
+
+    create_time = conv.get("create_time")
+    update_time = conv.get("update_time")
+
+    # Build content hash for re-import detection
+    content_hash = hashlib.sha256(
+        json.dumps(conv.get("mapping", {}), sort_keys=True, default=str).encode()
+    ).hexdigest()[:32]
+
+    body = {
+        "chatgpt_id": chatgpt_id,
+        "title": conv.get("title", ""),
+        "create_time": datetime.fromtimestamp(create_time, tz=timezone.utc).isoformat() if create_time else None,
+        "update_time": datetime.fromtimestamp(update_time, tz=timezone.utc).isoformat() if update_time else None,
+        "model_slug": conv_meta.get("model_slug"),
+        "message_count": message_count,
+        "conversation_type": extraction.get("conversation_type", ""),
+        "summary_8w": summaries.get("summary_8w", ""),
+        "summary_16w": summaries.get("summary_16w", ""),
+        "summary_32w": summaries.get("summary_32w", ""),
+        "summary_64w": summaries.get("summary_64w", ""),
+        "summary_128w": summary_128w,
+        "key_topics": key_topics,
+        "people_mentioned": people_mentioned,
+        "voice": conv_meta.get("voice"),
+        "gizmo_id": conv_meta.get("gizmo_id"),
+        "gizmo_type": conv_meta.get("gizmo_type"),
+        "conversation_origin": conv_meta.get("conversation_origin"),
+        "conversation_url": f"https://chatgpt.com/c/{chatgpt_id}",
+        "content_hash": content_hash,
+        "import_batch": import_batch,
+    }
+
+    if embedding:
+        body["embedding"] = embedding
+
+    # Include user_id if provided (required for RLS; auth.uid() is NULL with service_role)
+    user_id = os.environ.get("USER_ID", "")
+    if user_id:
+        body["user_id"] = user_id
+
+    # Upsert: insert or update on chatgpt_id conflict
+    resp = http_post_with_retry(
+        f"{SUPABASE_URL}/rest/v1/chatgpt_conversations?on_conflict=chatgpt_id",
+        headers={
+            "Content-Type": "application/json",
+            "apikey": SUPABASE_SERVICE_ROLE_KEY,
+            "Authorization": f"Bearer {SUPABASE_SERVICE_ROLE_KEY}",
+            "Prefer": "return=minimal,resolution=merge-duplicates",
+        },
+        body=body,
+    )
+
+    if not resp:
+        return {"ok": False, "error": "No response from Supabase"}
+    if resp.status_code not in (200, 201):
+        try:
+            error_detail = resp.json()
+        except ValueError:
+            error_detail = resp.text
+        return {"ok": False, "error": f"HTTP {resp.status_code}: {error_detail}"}
+
+    return {"ok": True}
+
+
 # ─── CLI ─────────────────────────────────────────────────────────────────────
 
 
@@ -546,19 +712,45 @@ Examples:
   python import-chatgpt.py export.zip --after 2024-01-01
   python import-chatgpt.py export.zip --model ollama --ollama-model qwen3
   python import-chatgpt.py export.zip --raw --limit 50
-  python import-chatgpt.py export.zip --ingest-endpoint""",
+  python import-chatgpt.py export.zip --ingest-endpoint
+  python import-chatgpt.py export.zip --store-conversations
+  python import-chatgpt.py export.zip --focus "technology, architecture, career decisions"
+  python import-chatgpt.py export.zip --focus tech
+  python import-chatgpt.py export.zip --focus personal""",
     )
     parser.add_argument("zip_path", help="Path to ChatGPT data export zip file or extracted directory")
-    parser.add_argument("--dry-run", action="store_true", help="Parse and summarize but don't ingest")
+    parser.add_argument("--dry-run", action="store_true", help="Parse and extract but don't ingest")
     parser.add_argument("--after", type=parse_date, help="Only conversations after YYYY-MM-DD")
     parser.add_argument("--before", type=parse_date, help="Only conversations before YYYY-MM-DD")
     parser.add_argument("--limit", type=int, default=0, help="Max conversations to process (0 = unlimited)")
     parser.add_argument("--model", choices=["openrouter", "ollama"], default="openrouter", help="LLM backend (default: openrouter)")
     parser.add_argument("--ollama-model", default="qwen3", help="Ollama model name (default: qwen3)")
-    parser.add_argument("--raw", action="store_true", help="Skip summarization, ingest user messages directly")
-    parser.add_argument("--verbose", action="store_true", help="Show full summaries during processing")
+    parser.add_argument("--raw", action="store_true", help="Skip extraction, ingest user messages directly")
+    parser.add_argument("--verbose", action="store_true", help="Show full thoughts during processing")
     parser.add_argument("--report", type=str, metavar="FILE", help="Write a markdown report of everything imported")
     parser.add_argument("--ingest-endpoint", action="store_true", help="Use INGEST_URL/INGEST_KEY instead of Supabase direct insert")
+    parser.add_argument("--store-conversations", action="store_true", help="Also store conversation metadata and pyramid summaries in chatgpt_conversations table")
+    parser.add_argument("--min-messages", type=int, default=0, help="Override minimum message count for filtering")
+    parser.add_argument("--min-words", type=int, default=0, help="Override minimum word count for borderline filtering (default: 50)")
+    parser.add_argument("--max-words", type=int, default=50000, help="Skip conversations exceeding this word count (default: 50000, ~$1+ per conversation with gpt-4o)")
+    parser.add_argument("--openrouter-model", default="openai/gpt-4o-mini", help="OpenRouter model for extraction (default: openai/gpt-4o-mini)")
+    parser.add_argument("--focus", type=str, default=None, metavar="TOPICS", help="""\
+Focus extraction on specific topics. Accepts a preset name or custom description.
+
+Presets:
+  tech       - Technology, architecture, engineering, code design, system decisions
+  strategy   - Business strategy, product decisions, career moves, planning
+  personal   - Family, health, relationships, personal values, life decisions
+  creative   - Writing, design, art direction, creative process
+  all        - No filter (default behavior)
+
+Custom: Any free-text description of what to focus on, e.g.:
+  --focus "technology, architecture, career decisions, business strategy"
+  --focus "parenting, health, home improvement"
+  --focus "AI/ML, prompt engineering, LLM architecture"
+
+When set, the LLM will prioritize extracting thoughts matching your focus
+and skip conversations outside it.""")
     return parser.parse_args()
 
 
@@ -595,8 +787,8 @@ def main():
                 sys.exit(1)
 
     if not args.raw and args.model == "openrouter" and not OPENROUTER_API_KEY:
-        print("Error: OPENROUTER_API_KEY environment variable required for summarization.")
-        print("Use --raw to skip summarization, or --model ollama for local inference.")
+        print("Error: OPENROUTER_API_KEY environment variable required for extraction.")
+        print("Use --raw to skip extraction, or --model ollama for local inference.")
         sys.exit(1)
 
     print(f"\nExtracting conversations from {args.zip_path}...")
@@ -611,19 +803,32 @@ def main():
     # Display run configuration
     mode = "DRY RUN" if args.dry_run else "LIVE"
     ingest_mode = "custom endpoint" if args.ingest_endpoint else "Supabase direct insert"
-    summarize_mode = "raw (no summarization)" if args.raw else f"{args.model}"
+    summarize_mode = "raw (no extraction)" if args.raw else f"{args.model}"
     if args.model == "ollama" and not args.raw:
         summarize_mode += f" ({args.ollama_model})"
     print(f"  Mode:        {mode}")
     if not args.dry_run:
         print(f"  Ingestion:   {ingest_mode}")
-    print(f"  Summarizer:  {summarize_mode}")
+    print(f"  Extraction:  {summarize_mode}")
     if args.after:
         print(f"  After:       {args.after}")
     if args.before:
         print(f"  Before:      {args.before}")
     if args.limit:
         print(f"  Limit:       {args.limit}")
+    if args.store_conversations:
+        if args.ingest_endpoint:
+            print(f"  Warning: --store-conversations is not supported with --ingest-endpoint and will be ignored.")
+        else:
+            print(f"  Store convs: enabled")
+    if args.max_words:
+        print(f"  Max words:   {args.max_words}")
+    if args.focus:
+        preset = FOCUS_PRESETS.get(args.focus.lower())
+        if preset:
+            print(f"  Focus:       {args.focus} (preset)")
+        else:
+            print(f"  Focus:       {args.focus}")
     print()
 
     # Counters
@@ -635,21 +840,33 @@ def main():
     thoughts_generated = 0
     ingested = 0
     errors = 0
-    total_user_words = 0
+    total_words = 0
+    conversations_stored = 0
+    duplicates_skipped = 0
     report_entries = []
+    start_time = time.time()
+    import_batch = datetime.now(timezone.utc).strftime("%Y%m%d-%H%M%S")
+
+    # Pre-compute total_to_process estimate (for ETA)
+    total_to_process = args.limit if args.limit else total
 
     for conv in conversations:
         # Respect limit
         if args.limit and processed >= args.limit:
             break
 
-        # Parse conversation
-        messages = walk_messages(conv.get("mapping", {}))
-        user_text = extract_user_text(messages)
+        # 1. Parse conversation (branch resolution via current_node)
+        messages = resolve_canonical_path(conv.get("mapping", {}), conv.get("current_node"))
+
+        # 2. Extract dialogue (full user + assistant with content-type dispatch)
+        dialogue_text = extract_dialogue_text(messages)
         message_count = count_messages(messages)
 
-        # Filter
-        skip_reason = should_skip(conv, user_text, message_count, sync_log, args)
+        # 3. Extract metadata (free, from export JSON)
+        conv_meta = extract_conversation_metadata(conv)
+
+        # 4. Filter (signal-based)
+        skip_reason = should_skip(conv, dialogue_text, message_count, sync_log, args)
         if skip_reason:
             if skip_reason == "already_imported":
                 already_imported += 1
@@ -659,10 +876,17 @@ def main():
             continue
 
         processed += 1
-        word_count = len(user_text.split())
-        total_user_words += word_count
+        word_count = len(dialogue_text.split())
+        total_words += word_count
 
         title = conv.get("title", "(untitled)")
+
+        # Skip conversations exceeding --max-words (avoids burning tokens on monster conversations)
+        if args.max_words and word_count > args.max_words:
+            filtered += 1
+            filter_reasons["max_words"] = filter_reasons.get("max_words", 0) + 1
+            print(f"   Skipping '{title}' ({word_count} words exceeds --max-words {args.max_words})")
+            continue
         create_time = conv.get("create_time")
         date_str = (
             datetime.fromtimestamp(create_time, tz=timezone.utc).strftime("%Y-%m-%d")
@@ -672,59 +896,154 @@ def main():
         conv_id = conversation_hash(conv)
         chatgpt_id = conv.get("id", "")
 
-        print(f"{processed}. {title}")
-        url_display = f"https://chatgpt.com/c/{chatgpt_id}" if chatgpt_id else "no id"
-        print(f"   {message_count} messages | {word_count} user words | {date_str} | {url_display}")
+        # Progress display with ETA
+        extracted_count = thoughts_generated  # Only conversations that produced thoughts
+        elapsed = time.time() - start_time
+        skipped_so_far = already_imported + filtered
+        examined_so_far = processed + skipped_so_far
+        pct = int(examined_so_far / total_to_process * 100) if total_to_process else 0
 
-        # Summarize or use raw
-        if args.raw:
-            thoughts = [user_text]
+        # ETA based on total examination rate (includes fast skips + slow extractions)
+        if examined_so_far > 1:
+            per_conv = elapsed / examined_so_far
+            remaining = total_to_process - examined_so_far
+            eta_seconds = remaining * per_conv
+            eta_str = f"~{int(eta_seconds // 60)}m{int(eta_seconds % 60)}s"
         else:
-            thoughts = summarize(title, date_str, user_text, args)
+            eta_str = "..."
 
-        thoughts_generated += len(thoughts)
+        print(f"[{pct}% | {examined_so_far}/{total_to_process}] {title}")
+        url_display = f"https://chatgpt.com/c/{chatgpt_id}" if chatgpt_id else "no id"
+        print(f"   {message_count} msgs | {word_count} words | {date_str} | {url_display}")
+        print(f"   {thoughts_generated} thoughts from {processed - filtered} convs | {skipped_so_far} skipped | ETA {eta_str}")
 
-        if not thoughts:
-            print("   -> No thoughts extracted (empty summary)")
+        # 5. Prepare text for extraction (context window aware, session splitting)
+        session_texts = prepare_dialogue_for_extraction(messages, total)
+
+        # 6. Extract knowledge (multi-session merge)
+        all_thoughts = []
+        conversation_type = ""
+        summaries = {}
+
+        for session_text in session_texts:
+            if not session_text:
+                continue
+            if args.raw:
+                all_thoughts.append({
+                    "content": session_text,
+                    "type": "reference",
+                    "topics": [],
+                    "people": [],
+                    "confidence": "firm",
+                })
+            else:
+                extraction = summarize(title, date_str, session_text, message_count,
+                                       conv_meta.get("model_slug", ""), args)
+                all_thoughts.extend(extraction.get("thoughts", []))
+                if not conversation_type:
+                    conversation_type = extraction.get("conversation_type", "")
+                if extraction.get("summaries"):
+                    summaries = extraction["summaries"]  # Use last session's summaries
+
+        # Build merged extraction result
+        extraction = {
+            "thoughts": all_thoughts,
+            "conversation_type": conversation_type,
+            "summaries": summaries,
+        }
+
+        thoughts_generated += len(all_thoughts)
+
+        if not all_thoughts:
+            print("   -> No thoughts extracted")
             if not args.dry_run:
-                sync_log["ingested_ids"][conv_id] = datetime.now(timezone.utc).isoformat()
+                sync_log["ingested_ids"][conv_id] = {
+                    "imported_at": datetime.now(timezone.utc).isoformat(),
+                    "update_time": conv.get("update_time", 0),
+                }
                 save_sync_log(sync_log)
             print()
             continue
 
         if args.verbose or args.dry_run:
-            for i, thought in enumerate(thoughts, 1):
-                preview = thought if len(thought) <= 200 else thought[:200] + "..."
-                print(f"   Thought {i}: {preview}")
+            for i, thought_data in enumerate(all_thoughts, 1):
+                content = thought_data["content"]
+                preview = content if len(content) <= 200 else content[:200] + "..."
+                thought_type = thought_data.get("type", "")
+                topics = ", ".join(thought_data.get("topics", []))
+                people = ", ".join(thought_data.get("people", []))
+                confidence = thought_data.get("confidence", "")
+                tags = []
+                if topics:
+                    tags.append(topics)
+                if people:
+                    tags.append(f"people: {people}")
+                if confidence and confidence != "firm":
+                    tags.append(confidence)
+                tag_str = f" ({'; '.join(tags)})" if tags else ""
+                print(f"   Thought {i} [{thought_type}]{tag_str}: {preview}")
+
+        if (args.verbose or args.dry_run) and summaries:
+            print(f"   --- Conversation Summary ---")
+            for level in ("summary_8w", "summary_16w", "summary_32w", "summary_64w", "summary_128w"):
+                text = summaries.get(level, "")
+                if text:
+                    label = level.replace("summary_", "")
+                    print(f"   [{label}] {text}")
 
         if args.report:
             report_entries.append({
                 "title": title,
                 "date": date_str,
                 "messages": message_count,
-                "user_words": word_count,
-                "thoughts": thoughts,
+                "words": word_count,
+                "thoughts": all_thoughts,  # Full thought dicts with content, type, topics, people, confidence
+                "conversation_type": conversation_type,
+                "summaries": summaries,
             })
 
         if args.dry_run:
             print()
             continue
 
-        # Build metadata
-        metadata = {
-            "source": "chatgpt",
-            "chatgpt_title": title,
-            "chatgpt_date": date_str,
-            "conversation_id": chatgpt_id,
-        }
-        if chatgpt_id:
-            metadata["conversation_url"] = f"https://chatgpt.com/c/{chatgpt_id}"
-
-        # Ingest thoughts
+        # 7. Ingest thoughts
         all_ok = True
-        for i, thought in enumerate(thoughts):
-            content = f"[ChatGPT: {title} | {date_str}] {thought}"
+        for i, thought_data in enumerate(all_thoughts):
+            # Build enriched metadata per thought
+            metadata = {
+                # Existing OB1 fields (MCP-compatible)
+                "source": "chatgpt",
+                "type": thought_data["type"],
+                "topics": thought_data["topics"],
+                "people": thought_data["people"],
+                "action_items": [],
 
+                # ChatGPT provenance
+                "chatgpt_conversation_id": chatgpt_id,
+                "chatgpt_title": title,
+                "chatgpt_date": date_str,
+                "chatgpt_conversation_url": f"https://chatgpt.com/c/{chatgpt_id}" if chatgpt_id else None,
+
+                # Enrichment fields
+                "chatgpt_model": conv_meta["model_slug"],
+                "chatgpt_message_count": message_count,
+                "chatgpt_conversation_type": extraction.get("conversation_type", ""),
+                "confidence": thought_data["confidence"],
+                "voice": conv_meta["voice"],
+                "gizmo_id": conv_meta["gizmo_id"],
+                "language": extraction.get("language", "en"),
+            }
+
+            content = f"[ChatGPT: {title} | {date_str}] {thought_data['content']}"
+
+            # Semantic dedup check (Supabase direct mode only)
+            if not args.ingest_endpoint:
+                if check_semantic_duplicate(thought_data["content"]):
+                    print(f"   -> Thought {i + 1} skipped (semantic duplicate)")
+                    duplicates_skipped += 1
+                    continue
+
+            # Ingest — embed thought content, not the [ChatGPT: title] prefix
             if args.ingest_endpoint:
                 extra_metadata = {
                     "chatgpt_title": title,
@@ -732,13 +1051,13 @@ def main():
                     "chatgpt_conversation_hash": conv_id,
                     "source_ref": metadata,
                 }
-                result = ingest_thought_endpoint(content, extra_metadata, full_text=user_text)
+                result = ingest_thought_endpoint(content, extra_metadata, full_text=dialogue_text)
             else:
-                result = ingest_thought_supabase(content, metadata)
+                result = ingest_thought_supabase(content, metadata, embed_text=thought_data["content"])
 
             if result.get("ok"):
                 ingested += 1
-                print(f"   -> Thought {i + 1} ingested")
+                print(f"   -> Thought {i + 1} ingested [{thought_data['type']}]")
             else:
                 errors += 1
                 all_ok = False
@@ -746,49 +1065,74 @@ def main():
 
             time.sleep(0.2)  # Rate limit
 
-        # Update sync log on success
+        # 8. Store conversation (--store-conversations)
+        if args.store_conversations and not args.ingest_endpoint:
+            conv_result = store_conversation(conv, extraction, conv_meta, message_count, import_batch)
+            if conv_result.get("ok"):
+                conversations_stored += 1
+                print(f"   -> Conversation stored")
+            else:
+                print(f"   -> WARNING: Conversation store failed: {conv_result.get('error')}")
+
+        # 9. Update sync log (with update_time for re-import detection)
         if all_ok:
-            sync_log["ingested_ids"][conv_id] = datetime.now(timezone.utc).isoformat()
+            sync_log["ingested_ids"][conv_id] = {
+                "imported_at": datetime.now(timezone.utc).isoformat(),
+                "update_time": conv.get("update_time", 0),
+            }
             save_sync_log(sync_log)
 
         print()
 
     # ─── Summary ─────────────────────────────────────────────────────────────
 
-    print("─" * 60)
+    print("\u2500" * 60)
     print("Summary:")
     print(f"  Conversations found:    {total}")
     if already_imported > 0:
         print(f"  Already imported:       {already_imported} (skipped)")
     if filtered > 0:
         reasons = ", ".join(f"{v} {k}" for k, v in sorted(filter_reasons.items(), key=lambda x: -x[1]))
-        print(f"  Filtered (trivial):     {filtered} ({reasons})")
+        print(f"  Filtered:               {filtered} ({reasons})")
     print(f"  Processed:              {processed}")
-    print(f"  Total user words:       {total_user_words:,}")
+    print(f"  Total words:            {total_words:,}")
     print(f"  Thoughts generated:     {thoughts_generated}")
+    if duplicates_skipped > 0:
+        print(f"  Duplicates skipped:     {duplicates_skipped}")
     if not args.dry_run:
         print(f"  Ingested:               {ingested}")
         print(f"  Errors:                 {errors}")
+    if args.store_conversations and conversations_stored > 0:
+        print(f"  Conversations stored:   {conversations_stored}")
 
-    # Cost estimation
+    # Cost estimation (updated for new pipeline)
     if not args.raw and processed > 0:
         # gpt-4o-mini via OpenRouter: ~$0.15/1M input, ~$0.60/1M output
-        # Rough estimate: avg 800 tokens input per conv, 200 tokens output
-        est_input_tokens = processed * 800
-        est_output_tokens = processed * 200
+        # avg 4000 tokens input per conv, 300 tokens output
+        est_input_tokens = processed * 4000
+        est_output_tokens = processed * 300
+        if args.store_conversations:
+            est_output_tokens += processed * 200  # Pyramid summaries
         summarize_cost = (est_input_tokens * 0.15 / 1_000_000) + (est_output_tokens * 0.60 / 1_000_000)
     else:
         summarize_cost = 0
 
     # Embedding cost: $0.02/1M tokens, ~100 tokens per thought
     embedding_cost = thoughts_generated * 100 * 0.02 / 1_000_000
+    # Add dedup check embedding cost
+    embedding_cost += thoughts_generated * 100 * 0.02 / 1_000_000
+    if args.store_conversations:
+        embedding_cost += conversations_stored * 150 * 0.02 / 1_000_000
     total_cost = summarize_cost + embedding_cost
     print(f"  Est. API cost:          ${total_cost:.4f}")
     if summarize_cost > 0:
-        print(f"    Summarization:        ${summarize_cost:.4f}")
+        print(f"    Extraction:           ${summarize_cost:.4f}")
     if embedding_cost > 0:
         print(f"    Embeddings:           ${embedding_cost:.4f}")
-    print("─" * 60)
+
+    elapsed = time.time() - start_time
+    print(f"  Elapsed time:           {int(elapsed // 60)}m{int(elapsed % 60)}s")
+    print("\u2500" * 60)
 
     if args.report and report_entries:
         _write_report(args.report, report_entries, {
@@ -800,8 +1144,10 @@ def main():
             "thoughts_generated": thoughts_generated,
             "ingested": ingested,
             "errors": errors,
-            "total_user_words": total_user_words,
+            "total_words": total_words,
             "dry_run": args.dry_run,
+            "conversations_stored": conversations_stored,
+            "duplicates_skipped": duplicates_skipped,
         })
 
 
@@ -816,21 +1162,45 @@ def _write_report(filepath, entries, stats):
         f.write(f"| Metric | Value |\n|--------|-------|\n")
         f.write(f"| Conversations found | {stats['total']} |\n")
         f.write(f"| Already imported | {stats['already_imported']} |\n")
-        f.write(f"| Filtered (trivial) | {stats['filtered']} |\n")
+        f.write(f"| Filtered | {stats['filtered']} |\n")
         f.write(f"| Processed | {stats['processed']} |\n")
         f.write(f"| Thoughts generated | {stats['thoughts_generated']} |\n")
+        if stats.get("duplicates_skipped"):
+            f.write(f"| Duplicates skipped | {stats['duplicates_skipped']} |\n")
         if not stats["dry_run"]:
             f.write(f"| Ingested | {stats['ingested']} |\n")
             f.write(f"| Errors | {stats['errors']} |\n")
-        f.write(f"| Total user words | {stats['total_user_words']:,} |\n")
+        if stats.get("conversations_stored"):
+            f.write(f"| Conversations stored | {stats['conversations_stored']} |\n")
+        f.write(f"| Total words | {stats['total_words']:,} |\n")
         f.write("\n")
 
         f.write("## Conversations\n\n")
         for entry in entries:
-            f.write(f"### {entry['title']} ({entry['date']})\n\n")
-            f.write(f"_{entry['messages']} messages, {entry['user_words']} user words_\n\n")
+            conv_type = entry.get("conversation_type", "")
+            type_label = f" [{conv_type}]" if conv_type else ""
+            f.write(f"### {entry['title']} ({entry['date']}){type_label}\n\n")
+            f.write(f"_{entry['messages']} messages, {entry['words']} words_\n\n")
             for i, thought in enumerate(entry["thoughts"], 1):
-                f.write(f"{i}. {thought}\n")
+                if isinstance(thought, dict):
+                    thought_type = thought.get("type", "")
+                    content = thought.get("content", "")
+                    topics = ", ".join(thought.get("topics", []))
+                    people = ", ".join(thought.get("people", []))
+                    confidence = thought.get("confidence", "")
+                    type_tag = f"`{thought_type}`" if thought_type else ""
+                    meta_parts = []
+                    if topics:
+                        meta_parts.append(f"topics: {topics}")
+                    if people:
+                        meta_parts.append(f"people: {people}")
+                    if confidence:
+                        meta_parts.append(f"confidence: {confidence}")
+                    meta_str = f" _({'; '.join(meta_parts)})_" if meta_parts else ""
+                    f.write(f"{i}. {type_tag} {content}{meta_str}\n")
+                else:
+                    # Backward compat: plain string thoughts
+                    f.write(f"{i}. {thought}\n")
             f.write("\n")
 
     print(f"\nReport written to {filepath}")

--- a/recipes/chatgpt-conversation-import/metadata.json
+++ b/recipes/chatgpt-conversation-import/metadata.json
@@ -1,20 +1,20 @@
 {
   "name": "ChatGPT Conversation Import",
-  "description": "Parse your ChatGPT data export, filter trivial conversations, summarize each via LLM into standalone thoughts, and ingest them into Open Brain with embeddings.",
+  "description": "Parse your ChatGPT data export, resolve conversation branches, extract 2-5 typed thoughts per conversation via LLM knowledge extraction (decisions, preferences, learnings, context, brainstorms, references), and ingest them into Open Brain with enriched metadata and embeddings.",
   "category": "recipes",
   "author": {
     "name": "Matt Hallett",
     "github": "matthallett1"
   },
-  "version": "1.0.0",
+  "version": "2.0.0",
   "requires": {
     "open_brain": true,
     "services": ["OpenRouter"],
     "tools": ["Python 3.10+"]
   },
-  "tags": ["chatgpt", "import", "conversations", "migration", "summarization"],
+  "tags": ["chatgpt", "import", "conversations", "migration", "knowledge-extraction"],
   "difficulty": "beginner",
   "estimated_time": "20 minutes",
   "created": "2026-03-10",
-  "updated": "2026-03-13"
+  "updated": "2026-04-10"
 }

--- a/recipes/chatgpt-conversation-import/schema.sql
+++ b/recipes/chatgpt-conversation-import/schema.sql
@@ -1,0 +1,125 @@
+-- ============================================
+-- ChatGPT Conversations — OB1 Extension Schema
+-- ============================================
+-- Opt-in table for storing conversation-level summaries
+-- with pyramid detail levels. Used with --store-conversations.
+--
+-- Enables:
+--   - Temporal browsing ("what was I working on in October?")
+--   - Source attribution ("show me the conversation behind this decision")
+--   - Smarter re-imports (content_hash change detection)
+--
+-- Prerequisites:
+--   - pgvector extension must be enabled (standard on Supabase)
+--   - Run this in your Supabase SQL Editor before using --store-conversations
+-- ============================================
+
+-- ----------------------------------------
+-- Conversation history table
+-- ----------------------------------------
+-- Each row = one ChatGPT conversation with pyramid summaries.
+-- Thoughts in the thoughts table link back here via
+-- metadata.chatgpt_conversation_id = chatgpt_id.
+
+CREATE TABLE IF NOT EXISTS chatgpt_conversations (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    user_id UUID REFERENCES auth.users(id) DEFAULT auth.uid(),  -- NULL allowed for service_role inserts; set USER_ID env var for multi-tenant
+
+    -- ChatGPT identifiers
+    chatgpt_id TEXT UNIQUE,                 -- Original ChatGPT conversation ID
+    title TEXT,
+    create_time TIMESTAMPTZ,
+    update_time TIMESTAMPTZ,
+
+    -- Conversation metadata
+    model_slug TEXT,                        -- Primary model used (e.g. gpt-4o, gpt-5-2-thinking)
+    message_count INTEGER,
+    conversation_type TEXT,                 -- LLM-classified: product_research, technical_architecture, etc.
+
+    -- Pyramid summaries (progressive disclosure)
+    --   8w:  List/timeline label
+    --  16w:  One-sentence card title with key outcome
+    --  32w:  Dashboard card preview (1-2 sentences)
+    --  64w:  Short paragraph with reasoning and alternatives
+    -- 128w:  Full summary — embedded for semantic search
+    summary_8w TEXT,
+    summary_16w TEXT,
+    summary_32w TEXT,
+    summary_64w TEXT,
+    summary_128w TEXT,
+
+    -- Searchable metadata (extracted by LLM)
+    key_topics TEXT[],
+    people_mentioned TEXT[],
+
+    -- Export-native metadata (free, no LLM cost)
+    voice TEXT,                             -- Voice persona (opaque string), NULL for typed conversations
+    gizmo_id TEXT,                          -- Custom GPT identifier
+    gizmo_type TEXT,                        -- "gpt" (public) or "snorlax" (Projects)
+    conversation_origin TEXT,               -- e.g. "apple" for iOS/macOS
+    conversation_url TEXT,                  -- https://chatgpt.com/c/{chatgpt_id}
+
+    -- Processing metadata
+    content_hash TEXT,                      -- SHA-256 of conversation content for re-import change detection
+    import_batch TEXT,                      -- Groups conversations from the same import run
+    processed_at TIMESTAMPTZ DEFAULT now(),
+
+    -- Embedding of the 128w summary (for conversation-level semantic search)
+    embedding vector(1536)
+);
+
+COMMENT ON TABLE chatgpt_conversations IS 'ChatGPT conversation summaries with pyramid detail levels. Populated by import-chatgpt.py --store-conversations.';
+
+-- ----------------------------------------
+-- Row Level Security
+-- ----------------------------------------
+
+ALTER TABLE chatgpt_conversations ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY chatgpt_conversations_user_policy ON chatgpt_conversations
+    FOR ALL
+    USING (auth.uid() = user_id)
+    WITH CHECK (auth.uid() = user_id);
+
+-- ----------------------------------------
+-- GRANT permissions to service_role
+-- ----------------------------------------
+-- Supabase no longer auto-grants CRUD on new projects.
+
+GRANT SELECT, INSERT, UPDATE, DELETE ON TABLE public.chatgpt_conversations TO service_role;
+
+-- ----------------------------------------
+-- Indexes for performance
+-- ----------------------------------------
+
+-- Semantic search over conversation summaries (128w embedding)
+CREATE INDEX IF NOT EXISTS idx_chatgpt_conv_embedding
+    ON chatgpt_conversations USING hnsw (embedding vector_cosine_ops);
+
+-- Filter by conversation type (product_research, technical_architecture, etc.)
+CREATE INDEX IF NOT EXISTS idx_chatgpt_conv_type
+    ON chatgpt_conversations (conversation_type);
+
+-- Temporal browsing: "what was I working on in October?"
+CREATE INDEX IF NOT EXISTS idx_chatgpt_conv_create_time
+    ON chatgpt_conversations (create_time DESC);
+
+-- Topic-based filtering and search
+CREATE INDEX IF NOT EXISTS idx_chatgpt_conv_topics
+    ON chatgpt_conversations USING GIN (key_topics);
+
+-- User isolation for multi-tenant queries
+CREATE INDEX IF NOT EXISTS idx_chatgpt_conv_user
+    ON chatgpt_conversations (user_id);
+
+-- ----------------------------------------
+-- Verification
+-- ----------------------------------------
+-- Run this to confirm the table was created:
+--
+-- SELECT table_name FROM information_schema.tables
+-- WHERE table_name = 'chatgpt_conversations';
+--
+-- Check indexes:
+-- SELECT indexname FROM pg_indexes
+-- WHERE tablename = 'chatgpt_conversations';


### PR DESCRIPTION
## Contribution Type

- [x] Recipe (`/recipes`)
- [ ] Schema (`/schemas`)
- [ ] Dashboard (`/dashboards`)
- [ ] Integration (`/integrations`)
- [ ] Skill (`/skills`)
- [ ] Repo improvement (docs, CI, templates)

## What does this do?

Upgrades the ChatGPT conversation import from 1-3 sentence summarization to structured knowledge extraction producing 2-5 typed thoughts per conversation (decision, preference, learning, context, brainstorm, reference). Adds content type dispatch for 14 export formats in ChatGPT exports (text, voice transcripts, model reasoning, web search results, code execution output, etc), signal-based filtering, session boundary detection, semantic deduplication, and enriched metadata. 

**New flags:**
--focus (topic filtering — e.g. --focus tech to extract only technical conversations, or --focus "AI/ML, career decisions" for custom topics),
--store-conversations (optional conversation-level pyramid summaries at 5 detail levels for later search & retrieval, e.g. 8w: "Database migration strategy discussion", 32w: "Evaluated PostgreSQL vs DynamoDB for the new service. Chose PostgreSQL for complex queries and joins. DynamoDB considered for write throughput but rejected due to access pattern limitations."),
--openrouter-model (model selection), 
--max-words (skip oversized conversations). 

All existing CLI flags preserved.

## Requirements

- OpenRouter API key (or local Ollama installation for $0 usage)
- Python 3.10+ with `requests` library
- ChatGPT data export (Settings → Data Controls → Export)

## Checklist

- [x] I've read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] My contribution has a `README.md` with prerequisites, step-by-step instructions, and expected outcome
- [x] My `metadata.json` has all required fields
- [x] If my contribution depends on a skill or primitive, I declared it in metadata.json and linked it in the README
- [x] I tested this on my own Open Brain instance
- [x] No credentials, API keys, or secrets are included

Note: Built on the original recipe by Matt Hallett so left as author in metadata.json.

## Testing

Tested on a real 3.6GB ChatGPT export (2,341 conversations):
- Dry run with Ollama (local, $0)
- Dry run with gpt-4o-mini (default), gpt-4o, and Claude Haiku via --openrouter-model
- Full live import: ~300 conversations matched --focus filter, ~287 thoughts extracted with enriched metadata
- --store-conversations verified pyramid summaries (8w/16w/32w/64w/128w) in Supabase
- --focus tested with presets (tech, strategy) and custom free-text descriptions
- --max-words correctly skips oversized conversations (106K+ words)
- Re-import correctly skips already-processed conversations via sync log
- All original CLI flags verified (--dry-run, --model ollama, --after/--before, --limit, --report, --verbose, --raw, --ingest-endpoint)

## Note

A companion extension (`extensions/chatgpt-conversations/`) providing MCP tools for querying the conversation history table will be submitted as a separate PR pending maintainer discussion, per CONTRIBUTING.md guidance on curated extensions. I wanted to keep storing conversations alongside the import to minimize token burn should people choose to store them.