### PR TITLE
[extensions] ChatGPT Conversation History: browse and search with pyr…

### DIFF
--- a/extensions/chatgpt-conversations/.env.example
+++ b/extensions/chatgpt-conversations/.env.example
@@ -1,0 +1,15 @@
+# SUPABASE_URL and SUPABASE_SERVICE_ROLE_KEY are auto-injected by Supabase Edge Functions.
+# You do NOT need to set them manually.
+
+# MCP access key — used to authenticate requests from Claude Desktop
+MCP_ACCESS_KEY=your-mcp-access-key
+
+# Optional: User UUID for multi-tenant filtering. If not set, returns all conversations.
+# Find yours in Supabase Auth > Users.
+# DEFAULT_USER_ID=your-user-uuid
+
+# Required for search_conversations tool (generates query embeddings via OpenRouter).
+# Not needed for list_conversations (which uses SQL filters only).
+# This is the same key used by the core Open Brain MCP server.
+# If already set as a Supabase secret, all edge functions share it automatically.
+OPENROUTER_API_KEY=your-openrouter-key

--- a/extensions/chatgpt-conversations/README.md
+++ b/extensions/chatgpt-conversations/README.md
@@ -1,0 +1,388 @@
+# ChatGPT Conversation History
+
+## Learning Path: Extension 7
+
+| Extension | Name | Status |
+|-----------|------|--------|
+| 1 | Household Knowledge Base | Complete |
+| 2 | Home Maintenance Tracker | Complete |
+| 3 | Family Calendar | Complete |
+| 4 | Meal Planning | Complete |
+| 5 | Professional CRM | Complete |
+| 6 | Job Hunt Pipeline | Complete |
+| **7** | **ChatGPT Conversation History** | **<-- You are here** |
+
+> [!NOTE]
+> This extension's position in the learning path is provisional and may be adjusted by maintainers. It builds on the ChatGPT Import recipe rather than a previous extension.
+
+## Why This Matters
+
+Your Open Brain captures decisions, preferences, and learnings as individual thoughts — but sometimes you need the bigger picture. Which conversation led to that architecture decision? What month were you researching that topic? The ChatGPT Import recipe extracts knowledge into thoughts, and optionally stores conversation-level summaries alongside them. This extension makes those conversation summaries searchable and browsable — connecting your extracted thoughts back to the conversations they came from, with pyramid summaries that let you scan timelines or dive deep into any conversation's full context.
+
+## What It Does
+
+A semantic search and date-based browsing interface over your imported conversation history. The ChatGPT Import recipe extracts pyramid summaries at five detail levels (8-word labels through 128-word full summaries), and this extension exposes two MCP tools to query them: browse by date/type/topic, or search by meaning.
+
+> [!TIP]
+> The tool names (`list_conversations`, `search_conversations`) are deliberately generic — they are not tied to ChatGPT specifically. The underlying table is `chatgpt_conversations` today, but future import recipes (Claude conversations, Gemini, etc.) could populate the same schema, and these tools would query them without changes.
+
+## What You'll Learn
+
+- Semantic vector search with Supabase `pgvector` and an RPC match function
+- Pyramid summaries for progressive disclosure (same pattern used in local-rag)
+- Date-range and metadata filtering on structured conversation data
+- Building MCP tools that query pre-populated data (vs. CRUD extensions)
+
+## Prerequisites
+
+- Working Open Brain setup ([guide](../../docs/01-getting-started.md))
+- Supabase CLI installed and linked to your project
+- ChatGPT Import recipe run with the `--store-conversations` flag (`recipes/chatgpt-conversation-import/`)
+- `pgvector` extension enabled in your Supabase project (enabled by default on new projects)
+
+## Credential Tracker
+
+Copy this block into a text editor and fill it in as you go.
+
+> **Already have your Supabase credentials from the [Setup Guide](../../docs/01-getting-started.md)?** You just need the same Project URL, Secret key, and Project ref.
+
+```text
+CHATGPT CONVERSATIONS -- CREDENTIAL TRACKER
+--------------------------------------
+
+SUPABASE (from your Open Brain setup)
+  Project URL:           ____________
+  Secret key:            ____________
+  Project ref:           ____________
+
+GENERATED DURING SETUP
+  Default User ID:       ____________
+  MCP Access Key:        ____________  (same key for all extensions)
+  MCP Server URL:        ____________
+  MCP Connection URL:    ____________
+
+--------------------------------------
+```
+
+---
+
+![Step 1](https://img.shields.io/badge/Step_1-Add_the_Search_Function-00897B?style=for-the-badge)
+
+> [!IMPORTANT]
+> This extension requires the ChatGPT Import recipe to be set up first. The `chatgpt_conversations` table and its permissions are created by the recipe's `schema.sql`. Run that before proceeding.
+> See: [ChatGPT Conversation Import recipe](../../recipes/chatgpt-conversation-import/)
+
+![1.1](https://img.shields.io/badge/1.1-Create_the_Match_Function-555?style=for-the-badge&labelColor=00897B)
+
+In your Supabase SQL Editor (`https://supabase.com/dashboard/project/YOUR_PROJECT_ID/sql/new`), paste and Run the extension's `schema.sql`:
+
+<details>
+<summary>📋 <strong>SQL: match_conversations RPC function</strong> (click to expand)</summary>
+
+```sql
+-- Semantic search over conversation 128w summary embeddings.
+-- The chatgpt_conversations table is created by the ChatGPT Import recipe.
+CREATE OR REPLACE FUNCTION match_conversations(
+    query_embedding vector(1536),
+    match_threshold float DEFAULT 0.5,
+    match_count int DEFAULT 10,
+    p_user_id uuid DEFAULT NULL
+) RETURNS TABLE (
+    id uuid,
+    chatgpt_id text,
+    title text,
+    conversation_type text,
+    create_time timestamptz,
+    summary_8w text,
+    summary_16w text,
+    summary_32w text,
+    summary_64w text,
+    summary_128w text,
+    key_topics text[],
+    people_mentioned text[],
+    conversation_url text,
+    similarity float
+) LANGUAGE plpgsql AS $$
+BEGIN
+    RETURN QUERY
+    SELECT
+        c.id, c.chatgpt_id, c.title, c.conversation_type, c.create_time,
+        c.summary_8w, c.summary_16w, c.summary_32w, c.summary_64w, c.summary_128w,
+        c.key_topics, c.people_mentioned, c.conversation_url,
+        (1 - (c.embedding <=> query_embedding))::float AS similarity
+    FROM chatgpt_conversations c
+    WHERE 1 - (c.embedding <=> query_embedding) >= match_threshold
+      AND (p_user_id IS NULL OR c.user_id = p_user_id)
+    ORDER BY c.embedding <=> query_embedding
+    LIMIT match_count;
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION match_conversations(vector, float, int, uuid) TO service_role;
+```
+
+</details>
+
+![1.2](https://img.shields.io/badge/1.2-Verify-555?style=for-the-badge&labelColor=00897B)
+
+✅ **Done when:** The `match_conversations` function appears under Database > Functions in your Supabase dashboard, and the `chatgpt_conversations` table (created by the recipe) already has data from a `--store-conversations` import run.
+
+---
+
+![Step 2](https://img.shields.io/badge/Step_2-Deploy_the_MCP_Server-00897B?style=for-the-badge)
+
+Follow the [Deploy an Edge Function](../../primitives/deploy-edge-function/) guide using these values:
+
+| Setting | Value |
+|---------|-------|
+| Function name | `chatgpt-conversations-mcp` |
+| Download path | `extensions/chatgpt-conversations` |
+
+> [!TIP]
+> If you already deployed the core Open Brain server, this process is identical — just with a different function name and download path.
+
+✅ **Done when:** `supabase functions list` shows `chatgpt-conversations-mcp` as `ACTIVE`.
+
+---
+
+![Step 3](https://img.shields.io/badge/Step_3-Connect_to_Your_AI-00897B?style=for-the-badge)
+
+Follow the [Remote MCP Connection](../../primitives/remote-mcp/) guide to connect this extension to Claude Desktop, ChatGPT, Claude Code, or any other MCP client.
+
+| Setting | Value |
+|---------|-------|
+| Connector name | `ChatGPT Conversations` |
+| URL | Your **MCP Connection URL** from the credential tracker |
+
+✅ **Done when:** Your AI client shows the extension's tools in its available tools list.
+
+---
+
+![Step 4](https://img.shields.io/badge/Step_4-Test_It-00897B?style=for-the-badge)
+
+Try these prompts in your AI client:
+
+1. **"List my last 10 conversations"** — should return recent conversations with 32w summaries showing titles, dates, and types
+2. **"Search my conversations for architecture decisions"** — should return semantically relevant conversations with 64w summaries
+3. **"What was I working on in January?"** — should return conversations from that month with enough detail to jog your memory
+
+> [!CAUTION]
+> If any prompt returns an error, check the Edge Function logs in your Supabase dashboard (Edge Functions > `chatgpt-conversations-mcp` > Logs) before troubleshooting further.
+
+<!-- break between blockquotes for markdownlint MD028 -->
+
+> [!NOTE]
+> No results? This extension queries data populated by the ChatGPT Import recipe. You must run `import-chatgpt.py --store-conversations` before these tools will return anything.
+
+✅ **Done when:** All test prompts return expected results with pyramid summaries at the appropriate detail level.
+
+---
+
+## Available Tools
+
+### `list_conversations`
+
+Browse conversations by date, type, or topic. No embedding required — uses metadata filters and date ranges.
+
+| Param | Type | Default | Description |
+|-------|------|---------|-------------|
+| `after` | string (ISO date) | null | Conversations created after this date |
+| `before` | string (ISO date) | null | Conversations created before this date |
+| `type` | string | null | Filter by conversation_type (e.g., `product_research`, `technical_architecture`, `business_strategy`) |
+| `topic` | string | null | Filter by key_topics (array contains match) |
+| `limit` | number | 20 | Max results returned |
+| `detail` | string | `"32w"` | Pyramid summary level: `8w`, `16w`, `32w`, `64w`, `128w` |
+
+**Example prompts:**
+
+```
+Show my tech conversations from July 2025
+```
+
+```
+List my last 10 strategy conversations
+```
+
+```
+What conversations did I have about hiring in Q1?
+```
+
+### `search_conversations`
+
+Semantic search over conversation summaries. Embeds your query and matches against the 128w summary embeddings using cosine similarity.
+
+**Note:** This tool requires `OPENROUTER_API_KEY` to generate query embeddings at search time. If you already set this key when deploying the core Open Brain MCP server, it's shared across all edge functions automatically. If not, set it with: `supabase secrets set OPENROUTER_API_KEY=sk-or-v1-...`
+
+`list_conversations` does NOT need this key (it uses SQL filters only).
+
+| Param | Type | Default | Description |
+|-------|------|---------|-------------|
+| `query` | string | (required) | What to search for |
+| `limit` | number | 10 | Max results returned |
+| `threshold` | number | 0.5 | Minimum similarity score (0 to 1) |
+| `detail` | string | `"64w"` | Pyramid summary level to return |
+
+**Example prompts:**
+
+```
+Find conversations about RFID
+```
+
+```
+Search for MVP discussions
+```
+
+```
+What conversations mention patent filing?
+```
+
+---
+
+## Progressive Disclosure
+
+Both tools accept a `detail` parameter that controls how much summary text is returned per conversation. This follows the pyramid summary pattern: short labels for scanning, full summaries for deep reading.
+
+| Level | Words | Use Case | Example |
+|-------|-------|----------|---------|
+| `8w` | ~8 | Timeline labels, quick scanning | "Database migration strategy discussion" |
+| `16w` | ~16 | One-sentence summaries, card titles | "Evaluated PostgreSQL vs DynamoDB for the order service, chose PostgreSQL for complex queries" |
+| `32w` | ~32 | Card previews (default for `list_conversations`) | Key details with enough context to decide if you want to read more |
+| `64w` | ~64 | Short paragraphs (default for `search_conversations`) | Decisions, reasoning, and alternatives considered |
+| `128w` | ~128 | Full summaries, deep context | Complete summary with people, context, decisions, and tradeoffs. This is what gets embedded for semantic search. |
+
+The defaults are tuned for each tool's primary use case: `list_conversations` defaults to `32w` because you are scanning a timeline, while `search_conversations` defaults to `64w` because you are evaluating specific matches.
+
+---
+
+## Database Schema
+
+The extension uses a single table and one RPC function:
+
+**`chatgpt_conversations`** — One row per imported ChatGPT conversation. Stores the original title, creation/update timestamps, model used, message count, LLM-classified conversation type, five pyramid summary levels, topic and people arrays, export-native metadata (voice, custom GPT, origin), and a 1536-dimensional embedding of the 128w summary.
+
+**`match_conversations()`** — Supabase RPC function for semantic search. Takes a query embedding, similarity threshold, and match count. Returns conversations ranked by cosine similarity with their title, type, summary, URL, and creation time.
+
+Key indexes:
+
+- **HNSW** on the embedding column for fast approximate nearest-neighbor search
+- **B-tree** on `create_time DESC` for date-range browsing
+- **B-tree** on `conversation_type` for type filtering
+- **GIN** on `key_topics` for topic array containment queries
+
+---
+
+## Cross-Extension Integration
+
+### Thoughts to Conversations
+
+Each thought extracted by the ChatGPT Import recipe includes a `chatgpt_conversation_id` in its metadata JSONB. This links back to the `chatgpt_conversations` table. Your agent can follow this link to provide source attribution: "You made this decision during a conversation on January 15th — here is the full context."
+
+**Example workflow:**
+
+1. You search your Open Brain thoughts and find: "Chose event-driven architecture for the notification service"
+2. The thought's metadata contains `chatgpt_conversation_id`
+3. Your agent uses `search_conversations` or `list_conversations` to pull up the full conversation summary
+4. You get the reasoning, alternatives considered, and a link back to the original ChatGPT conversation
+
+---
+
+## Example Queries
+
+These are natural-language prompts you can use with your AI client:
+
+```
+What was I working on last month?
+```
+
+```
+Find my conversations about architecture decisions
+```
+
+```
+List conversations mentioning PRFAQ
+```
+
+```
+Search for discussions about hiring
+```
+
+```
+Show me all product research conversations from 2025
+```
+
+```
+What voice conversations did I have about the MVP?
+```
+
+```
+Find conversations where I discussed Redis
+```
+
+```
+List my strategy conversations from the last 3 months
+```
+
+---
+
+## Expected Outcome
+
+After completing this extension, you should be able to:
+
+1. Browse your ChatGPT conversation history by date range, topic, or conversation type
+2. Search conversations semantically — find discussions by meaning, not just keywords
+3. Control the level of detail returned, from 8-word labels to 128-word full summaries
+4. Follow links from extracted thoughts back to their source conversations
+5. Open the original ChatGPT conversation via the stored URL
+
+Your agent will be able to answer questions like:
+- "What was I researching in October?"
+- "Find conversations where I made hiring decisions"
+- "Show me my most recent technical architecture discussions"
+- "What did I discuss about the product launch strategy?"
+- "List all conversations about the RFID project"
+
+---
+
+## Troubleshooting
+
+For common issues (connection errors, 401s, deployment problems), see [Common Troubleshooting](../../primitives/troubleshooting/).
+
+**Extension-specific issues:**
+
+**"No results returned" for any query**
+- This extension queries data populated by the ChatGPT Import recipe. Run `import-chatgpt.py --store-conversations` first. Without `--store-conversations`, the recipe writes thoughts but does not populate the `chatgpt_conversations` table.
+
+**"Permission denied for table chatgpt_conversations"**
+- The table permissions were not granted. Run the GRANT SQL from the ChatGPT Import recipe's `schema.sql`.
+
+**"relation 'chatgpt_conversations' does not exist"**
+- The table is created by the ChatGPT Import recipe, not this extension. Run the recipe's `schema.sql` first (see [ChatGPT Conversation Import recipe](../../recipes/chatgpt-conversation-import/)).
+
+**"function match_conversations does not exist"**
+- The RPC function was not created. Run this extension's `schema.sql` from Step 1.
+
+**`search_conversations` returns no results but `list_conversations` works**
+- `search_conversations` requires `OPENROUTER_API_KEY` to generate query embeddings at search time. `list_conversations` uses SQL filters and doesn't need it. Set the key: `supabase secrets set OPENROUTER_API_KEY=sk-or-v1-...`. If the core Open Brain MCP server already uses this key, it's shared across all edge functions.
+
+**`list_conversations` returns no results but data exists in Supabase**
+- The edge function filters by `user_id`. If conversations were imported without the `USER_ID` env var (rows have `user_id = NULL`), the filter may exclude them. The extension matches both the `DEFAULT_USER_ID` and NULL rows, but verify `DEFAULT_USER_ID` is set correctly in your edge function secrets.
+
+**Conversations show empty summaries**
+- The conversations were imported before `--store-conversations` was implemented, or the LLM failed to generate summaries for some conversations. Re-run the import with `--store-conversations` to regenerate.
+
+**Search returns results but they seem irrelevant**
+- The similarity `threshold` defaults to 0.5. Try lowering it to 0.3 for broader results, or raising it to 0.7 for stricter matches. If all results score low, the query may not match any conversation topics in your history.
+
+---
+
+## Next Steps
+
+This is currently the final extension in the learning path. As the OB1 community grows, new extensions will be added here.
+
+**Ideas for what's next:**
+- **Claude/Gemini conversation import** — The tools and schema are source-agnostic. A future import recipe for Claude conversations or other AI assistants could populate the same `chatgpt_conversations` table (or a renamed `conversations` table), and `list_conversations` / `search_conversations` would query them without changes.
+- A dashboard for visualizing conversation trends over time
+- Cross-extension search that queries thoughts AND conversations in one tool
+- Automated re-import when a new export is detected
+
+> **Tool hygiene:** This extension adds 2 MCP tools to your AI's context window. As you build more extensions, the total tool count grows — and with it, the context cost and risk of your AI picking the wrong tool. See the [MCP Tool Audit & Optimization Guide](../../docs/05-tool-audit.md) for strategies on auditing, merging, and scoping your tools.

--- a/extensions/chatgpt-conversations/deno.json
+++ b/extensions/chatgpt-conversations/deno.json
@@ -1,0 +1,9 @@
+{
+  "imports": {
+    "@hono/mcp": "npm:@hono/mcp@0.1.1",
+    "@modelcontextprotocol/sdk": "npm:@modelcontextprotocol/sdk@1.24.3",
+    "hono": "npm:hono@4.9.2",
+    "zod": "npm:zod@4.1.13",
+    "@supabase/supabase-js": "npm:@supabase/supabase-js@2.47.10"
+  }
+}

--- a/extensions/chatgpt-conversations/index.ts
+++ b/extensions/chatgpt-conversations/index.ts
@@ -1,0 +1,285 @@
+/**
+ * Extension: ChatGPT Conversation History MCP Server
+ *
+ * Provides tools for querying imported ChatGPT conversation history:
+ * - list_conversations: Browse by date, type, topic with progressive disclosure
+ * - search_conversations: Semantic search over 128w summary embeddings
+ */
+
+import { Hono } from "hono";
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { StreamableHTTPTransport } from "@hono/mcp";
+import { z } from "zod";
+import { createClient } from "@supabase/supabase-js";
+
+const OPENROUTER_BASE = "https://openrouter.ai/api/v1";
+
+async function getEmbedding(text: string): Promise<number[]> {
+  const apiKey = Deno.env.get("OPENROUTER_API_KEY");
+  if (!apiKey) throw new Error("OPENROUTER_API_KEY not configured");
+
+  const r = await fetch(`${OPENROUTER_BASE}/embeddings`, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${apiKey}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      model: "openai/text-embedding-3-small",
+      input: text,
+    }),
+  });
+  if (!r.ok) {
+    const msg = await r.text().catch(() => "");
+    throw new Error(`OpenRouter embeddings failed: ${r.status} ${msg}`);
+  }
+  const d = await r.json();
+  return d.data[0].embedding;
+}
+
+/** Map detail level to the corresponding summary column name */
+function summaryColumn(detail: string): string {
+  const valid = ["8w", "16w", "32w", "64w", "128w"];
+  if (!valid.includes(detail)) return "summary_32w";
+  return `summary_${detail}`;
+}
+
+const app = new Hono();
+
+app.post("*", async (c) => {
+  // Fix: Claude Desktop connectors don't send the Accept header that
+  // StreamableHTTPTransport requires. Build a patched request if missing.
+  if (!c.req.header("accept")?.includes("text/event-stream")) {
+    const headers = new Headers(c.req.raw.headers);
+    headers.set("Accept", "application/json, text/event-stream");
+    const patched = new Request(c.req.raw.url, {
+      method: c.req.raw.method,
+      headers,
+      body: c.req.raw.body,
+      // @ts-ignore -- duplex required for streaming body in Deno
+      duplex: "half",
+    });
+    Object.defineProperty(c.req, "raw", { value: patched, writable: true });
+  }
+
+  const key = c.req.query("key") || c.req.header("x-access-key");
+  const expected = Deno.env.get("MCP_ACCESS_KEY");
+  if (!key || key !== expected) {
+    return c.json({ error: "Unauthorized" }, 401);
+  }
+
+  const supabase = createClient(
+    Deno.env.get("SUPABASE_URL")!,
+    Deno.env.get("SUPABASE_SERVICE_ROLE_KEY")!,
+  );
+
+  const userId = Deno.env.get("DEFAULT_USER_ID") || null;
+
+  const server = new McpServer(
+    { name: "chatgpt-conversations", version: "1.0.0" },
+  );
+
+  // -------------------------------------------------------
+  // Tool 1: list_conversations
+  // Browse conversations by date, type, topic with pyramid summaries
+  // -------------------------------------------------------
+  server.tool(
+    "list_conversations",
+    "Browse imported ChatGPT conversations by date range, type, or topic. Returns pyramid summaries at the requested detail level. Use for temporal queries like 'what was I working on in October?' or 'show my strategy conversations'.",
+    {
+      after: z.string().optional().describe("Show conversations after this date (ISO 8601, e.g. '2025-10-01')"),
+      before: z.string().optional().describe("Show conversations before this date (ISO 8601, e.g. '2025-11-01')"),
+      type: z.string().optional().describe("Filter by conversation_type (e.g. 'product_research', 'technical_architecture', 'business_strategy')"),
+      topic: z.string().optional().describe("Filter by key_topics array contains (e.g. 'database', 'architecture')"),
+      limit: z.number().optional().default(20).describe("Max results (default 20)"),
+      detail: z.enum(["8w", "16w", "32w", "64w", "128w"]).optional().default("32w").describe("Pyramid summary level: 8w=label, 16w=sentence, 32w=card, 64w=paragraph, 128w=full"),
+    },
+    async ({ after, before, type, topic, limit, detail }) => {
+      try {
+        const col = summaryColumn(detail);
+
+        // Select only the columns we need, including the requested summary level
+        let queryBuilder = supabase
+          .from("chatgpt_conversations")
+          .select(`title, create_time, conversation_type, ${col}, key_topics, conversation_url`);
+
+        // Filter by user_id if set — use .or() to also match NULL user_id rows
+        // (rows imported without USER_ID env var set)
+        if (userId) {
+          queryBuilder = queryBuilder.or(`user_id.eq.${userId},user_id.is.null`);
+        }
+
+        if (after) {
+          queryBuilder = queryBuilder.gte("create_time", after);
+        }
+        if (before) {
+          queryBuilder = queryBuilder.lt("create_time", before);
+        }
+        if (type) {
+          queryBuilder = queryBuilder.eq("conversation_type", type);
+        }
+        if (topic) {
+          queryBuilder = queryBuilder.contains("key_topics", [topic]);
+        }
+
+        const { data, error } = await queryBuilder
+          .order("create_time", { ascending: false })
+          .limit(limit);
+
+        if (error) {
+          throw new Error(`Failed to list conversations: ${error.message}`);
+        }
+
+        if (!data || data.length === 0) {
+          const filters = [];
+          if (after) filters.push(`after ${after}`);
+          if (before) filters.push(`before ${before}`);
+          if (type) filters.push(`type=${type}`);
+          if (topic) filters.push(`topic=${topic}`);
+          const filterDesc = filters.length ? ` (${filters.join(", ")})` : "";
+          return {
+            content: [{ type: "text", text: `No conversations found${filterDesc}.` }],
+          };
+        }
+
+        const results = data.map((conv: Record<string, unknown>, i: number) => {
+          const date = conv.create_time
+            ? new Date(conv.create_time as string).toLocaleDateString()
+            : "unknown date";
+          const summary = conv[col] || "(no summary at this detail level)";
+          const topics = Array.isArray(conv.key_topics) && conv.key_topics.length
+            ? `Topics: ${(conv.key_topics as string[]).join(", ")}`
+            : "";
+
+          const parts = [
+            `--- ${i + 1}. ${conv.title || "Untitled"} ---`,
+            `Date: ${date}`,
+            `Type: ${conv.conversation_type || "unknown"}`,
+          ];
+          if (topics) parts.push(topics);
+          parts.push(`Summary (${detail}): ${summary}`);
+          if (conv.conversation_url) parts.push(`URL: ${conv.conversation_url}`);
+          return parts.join("\n");
+        });
+
+        return {
+          content: [{
+            type: "text",
+            text: `Found ${data.length} conversation(s):\n\n${results.join("\n\n")}`,
+          }],
+        };
+      } catch (error) {
+        const errorMessage = error instanceof Error ? error.message : String(error);
+        return {
+          content: [{ type: "text", text: JSON.stringify({ success: false, error: errorMessage }) }],
+          isError: true,
+        };
+      }
+    },
+  );
+
+  // -------------------------------------------------------
+  // Tool 2: search_conversations
+  // Semantic search over 128w summary embeddings
+  // -------------------------------------------------------
+  server.tool(
+    "search_conversations",
+    "Semantic search over conversation history using 128w summary embeddings. Returns conversations ranked by relevance with pyramid summaries at the requested detail level. Use for queries like 'find conversations about database migration' or 'architecture discussions'.",
+    {
+      query: z.string().describe("What to search for (natural language query)"),
+      limit: z.number().optional().default(10).describe("Max results (default 10)"),
+      threshold: z.number().optional().default(0.5).describe("Similarity cutoff 0-1 (default 0.5)"),
+      detail: z.enum(["8w", "16w", "32w", "64w", "128w"]).optional().default("64w").describe("Pyramid summary level: 8w=label, 16w=sentence, 32w=card, 64w=paragraph, 128w=full"),
+    },
+    async ({ query, limit, threshold, detail }) => {
+      try {
+        const qEmb = await getEmbedding(query);
+        const { data, error } = await supabase.rpc("match_conversations", {
+          query_embedding: qEmb,
+          match_threshold: threshold,
+          match_count: limit,
+          p_user_id: null, // NULL matches all rows; RLS handles multi-tenant isolation
+        });
+
+        if (error) {
+          return {
+            content: [{ type: "text", text: `Search error: ${error.message}` }],
+            isError: true,
+          };
+        }
+
+        if (!data || data.length === 0) {
+          return {
+            content: [{ type: "text", text: `No conversations found matching "${query}".` }],
+          };
+        }
+
+        const col = summaryColumn(detail);
+
+        const results = data.map(
+          (
+            conv: {
+              title: string;
+              create_time: string;
+              conversation_type: string;
+              summary_8w: string;
+              summary_16w: string;
+              summary_32w: string;
+              summary_64w: string;
+              summary_128w: string;
+              key_topics: string[];
+              people_mentioned: string[];
+              conversation_url: string;
+              similarity: number;
+            },
+            i: number,
+          ) => {
+            const date = conv.create_time
+              ? new Date(conv.create_time).toLocaleDateString()
+              : "unknown date";
+            const summary = (conv as Record<string, unknown>)[col] || conv.summary_64w || "(no summary)";
+            const topics = Array.isArray(conv.key_topics) && conv.key_topics.length
+              ? `Topics: ${conv.key_topics.join(", ")}`
+              : "";
+            const people = Array.isArray(conv.people_mentioned) && conv.people_mentioned.length
+              ? `People: ${conv.people_mentioned.join(", ")}`
+              : "";
+
+            const parts = [
+              `--- Result ${i + 1} (${(conv.similarity * 100).toFixed(1)}% match) ---`,
+              `Title: ${conv.title || "Untitled"}`,
+              `Date: ${date}`,
+              `Type: ${conv.conversation_type || "unknown"}`,
+            ];
+            if (topics) parts.push(topics);
+            if (people) parts.push(people);
+            parts.push(`Summary (${detail}): ${summary}`);
+            if (conv.conversation_url) parts.push(`URL: ${conv.conversation_url}`);
+            return parts.join("\n");
+          },
+        );
+
+        return {
+          content: [{
+            type: "text",
+            text: `Found ${data.length} conversation(s) matching "${query}":\n\n${results.join("\n\n")}`,
+          }],
+        };
+      } catch (err: unknown) {
+        const errorMessage = err instanceof Error ? err.message : String(err);
+        return {
+          content: [{ type: "text", text: JSON.stringify({ success: false, error: errorMessage }) }],
+          isError: true,
+        };
+      }
+    },
+  );
+
+  const transport = new StreamableHTTPTransport();
+  await server.connect(transport);
+  return transport.handleRequest(c);
+});
+
+app.get("*", (c) => c.json({ status: "ok", service: "ChatGPT Conversations MCP", version: "1.0.0" }));
+
+Deno.serve(app.fetch);

--- a/extensions/chatgpt-conversations/metadata.json
+++ b/extensions/chatgpt-conversations/metadata.json
@@ -1,0 +1,23 @@
+{
+  "name": "ChatGPT Conversation History",
+  "description": "Browse and search imported ChatGPT conversations with pyramid summaries. List by date/type/topic or semantic search over 128w summary embeddings.",
+  "category": "extensions",
+  "author": {
+    "name": "Derek Gourlay",
+    "github": "dgourlay"
+  },
+  "version": "1.0.0",
+  "requires": {
+    "open_brain": true,
+    "services": ["OpenRouter"],
+    "tools": ["Supabase CLI"],
+    "recipes": ["chatgpt-conversation-import"]
+  },
+  "requires_primitives": ["deploy-edge-function", "remote-mcp"],
+  "learning_order": 7,
+  "tags": ["chatgpt", "conversations", "search", "history", "semantic-search"],
+  "difficulty": "intermediate",
+  "estimated_time": "30 minutes",
+  "created": "2026-04-09",
+  "updated": "2026-04-09"
+}

--- a/extensions/chatgpt-conversations/schema.sql
+++ b/extensions/chatgpt-conversations/schema.sql
@@ -1,0 +1,60 @@
+-- ============================================
+-- ChatGPT Conversations Extension — RPC Functions
+-- ============================================
+-- This extension adds search capabilities to the chatgpt_conversations
+-- table created by the ChatGPT Import recipe.
+--
+-- Prerequisites:
+--   1. Run recipes/chatgpt-conversation-import/schema.sql first
+--      (creates the chatgpt_conversations table)
+--   2. Then run this file to add the search function
+-- ============================================
+
+-- ----------------------------------------
+-- RPC: match_conversations
+-- ----------------------------------------
+-- Semantic search over conversation 128w summary embeddings.
+-- Follows the same pattern as match_thoughts in the core schema.
+-- Scoped to a single user via p_user_id (NULL = no filter, for single-user setups).
+
+CREATE OR REPLACE FUNCTION match_conversations(
+    query_embedding vector(1536),
+    match_threshold float DEFAULT 0.5,
+    match_count int DEFAULT 10,
+    p_user_id uuid DEFAULT NULL
+)
+RETURNS TABLE (
+    id uuid,
+    chatgpt_id text,
+    title text,
+    conversation_type text,
+    create_time timestamptz,
+    summary_8w text,
+    summary_16w text,
+    summary_32w text,
+    summary_64w text,
+    summary_128w text,
+    key_topics text[],
+    people_mentioned text[],
+    conversation_url text,
+    similarity float
+)
+LANGUAGE plpgsql
+AS $$
+BEGIN
+    RETURN QUERY
+    SELECT
+        c.id, c.chatgpt_id, c.title, c.conversation_type, c.create_time,
+        c.summary_8w, c.summary_16w, c.summary_32w, c.summary_64w, c.summary_128w,
+        c.key_topics, c.people_mentioned, c.conversation_url,
+        (1 - (c.embedding <=> query_embedding))::float AS similarity
+    FROM chatgpt_conversations c
+    WHERE 1 - (c.embedding <=> query_embedding) >= match_threshold
+      AND (p_user_id IS NULL OR c.user_id = p_user_id)
+    ORDER BY c.embedding <=> query_embedding
+    LIMIT match_count;
+END;
+$$;
+
+-- Grant execute on the RPC function to service_role
+GRANT EXECUTE ON FUNCTION match_conversations(vector, float, int, uuid) TO service_role;


### PR DESCRIPTION
Body:
## Contribution Type

- [ ] Recipe (`/recipes`)
- [ ] Schema (`/schemas`)
- [ ] Dashboard (`/dashboards`)
- [ ] Integration (`/integrations`)
- [ ] Skill (`/skills`)
- [ ] Repo improvement (docs, CI, templates)

> Note: This is an extension. Per CONTRIBUTING.md, extensions are curated and should be discussed with maintainers first. Happy to adjust learning_order, scope, or positioning based on feedback. Submitted
separately from the companion recipe [PR #171](https://github.com/NateBJones-Projects/OB1/pull/171).

## What does this do?

Adds an MCP extension for querying ChatGPT conversation history imported by the ChatGPT Import recipe (with --store-conversations). Two tools: list_conversations (browse by date, type, or topic) and
search_conversations (semantic search over 128w summary embeddings). Both support progressive disclosure via a detail parameter — from 8-word timeline labels to 128-word full summaries. Tool names are
intentionally generic for future multi-source extensibility (Claude, Gemini imports could use the same tools).

## Requirements

- ChatGPT Import recipe (#171) run with `--store-conversations`
- Supabase CLI (for deploying the edge function)
- OpenRouter API key (for search_conversations query embedding generation)

## Checklist

- [x] I've read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] My contribution has a `README.md` with prerequisites, step-by-step instructions, and expected outcome
- [x] My `metadata.json` has all required fields
- [x] If my contribution depends on a skill or primitive, I declared it in metadata.json and linked it in the README
- [x] I tested this on my own Open Brain instance
- [x] No credentials, API keys, or secrets are included

## Testing

- Deployed as Supabase Edge Function and verified via curl and Claude Desktop
- list_conversations returns conversations with pyramid summaries at all 5 detail levels
- search_conversations performs semantic search via match_conversations RPC
- Tested with real imported conversations from a 2,300-conversation ChatGPT export
- User_id filtering handles both NULL rows (single-user) and multi-tenant setups
- OPENROUTER_API_KEY requirement documented for search_conversations

## Relationship to other PRs

This extension depends on [PR #171 - [recipes] ChatGPT import v2](https://github.com/NateBJones-Projects/OB1/pull/171) which creates the `chatgpt_conversations` table and populates it via `--store-conversations`. This PR adds the query interface.
