### PR TITLE
[recipes] Add Repo Learning Coach recipe

### DIFF
--- a/recipes/repo-learning-coach/.env.example
+++ b/recipes/repo-learning-coach/.env.example
@@ -1,0 +1,5 @@
+SUPABASE_URL=https://your-project-ref.supabase.co
+SUPABASE_SERVICE_ROLE_KEY=your-service-role-key
+OPENROUTER_API_KEY=your-openrouter-key
+OPENROUTER_EMBEDDING_MODEL=openai/text-embedding-3-small
+PORT=8787

--- a/recipes/repo-learning-coach/.gitignore
+++ b/recipes/repo-learning-coach/.gitignore
@@ -1,0 +1,28 @@
+# Logs
+logs
+*.log
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+pnpm-debug.log*
+lerna-debug.log*
+
+node_modules
+dist
+dist-ssr
+.env
+data/*.sqlite
+data/*.sqlite-shm
+data/*.sqlite-wal
+*.local
+
+# Editor directories and files
+.vscode/*
+!.vscode/extensions.json
+.idea
+.DS_Store
+*.suo
+*.ntvs*
+*.njsproj
+*.sln
+*.sw?

--- a/recipes/repo-learning-coach/README.md
+++ b/recipes/repo-learning-coach/README.md
@@ -1,0 +1,261 @@
+# Repo Learning Coach
+
+> Turn repo research into a local lesson app backed by Supabase learning tables, with durable takeaways captured into Open Brain.
+
+## What It Does
+
+Repo Learning Coach gives you a local React + Express learning workspace for understanding a codebase. Research docs and lesson files live in markdown, structured learning state lives in dedicated Supabase tables, and the best takeaways flow back into `thoughts` so they can resurface in future sessions.
+
+Unlike an OB1 extension, this stays a local app in v1. It uses your existing Open Brain project as the backend, but it does not create a new MCP server.
+
+## Prerequisites
+
+- Working Open Brain setup ([guide](../../docs/01-getting-started.md))
+- Node.js 18+ and `npm`
+- Supabase project URL and service role key from your existing Open Brain setup
+- OpenRouter API key for related-thought retrieval and durable capture into `thoughts`
+
+## Credential Tracker
+
+Copy this block into a text editor and fill it in as you go.
+
+```text
+REPO LEARNING COACH -- CREDENTIAL TRACKER
+-----------------------------------------
+
+FROM YOUR OPEN BRAIN SETUP
+  Supabase Project URL:        ____________
+  Supabase Service Role Key:   ____________
+  OpenRouter API Key:          ____________
+
+LOCAL APP
+  Recipe folder path:          ____________
+  Local app URL:               ____________
+
+-----------------------------------------
+```
+
+![Step 1](https://img.shields.io/badge/Step_1-Create_the_Learning_Tables-1E88E5?style=for-the-badge)
+
+Open your Supabase SQL Editor and run the contents of [schema.sql](./schema.sql).
+
+<details>
+<summary>📋 <strong>SQL: Repo Learning Coach tables</strong> (copy from <code>schema.sql</code>)</summary>
+
+This recipe keeps its structured state in these tables:
+
+- `repo_learning_projects`
+- `repo_learning_research_documents`
+- `repo_learning_tracks`
+- `repo_learning_lessons`
+- `repo_learning_quizzes`
+- `repo_learning_quiz_questions`
+- `repo_learning_lesson_progress`
+- `repo_learning_quiz_attempts`
+- `repo_learning_quiz_responses`
+- `repo_learning_lesson_comments`
+
+The SQL also creates the `updated_at` trigger helper and grants `service_role` access for every table.
+
+</details>
+
+> [!IMPORTANT]
+> This recipe does **not** modify the core `thoughts` table. The only Open Brain integration is through the existing `upsert_thought` and `match_thoughts` path your OB1 setup already provides.
+
+✅ **Done when:** The new `repo_learning_*` tables appear in Supabase Table Editor and the query finishes without errors.
+
+---
+
+![Step 2](https://img.shields.io/badge/Step_2-Configure_the_Local_App-1E88E5?style=for-the-badge)
+
+**1. Move into the recipe folder:**
+
+```bash
+cd recipes/repo-learning-coach
+```
+
+**2. Copy the environment file:**
+
+```bash
+cp .env.example .env
+```
+
+**3. Fill in the variables:**
+
+```text
+SUPABASE_URL=https://your-project-ref.supabase.co
+SUPABASE_SERVICE_ROLE_KEY=your-service-role-key
+OPENROUTER_API_KEY=your-openrouter-key
+OPENROUTER_EMBEDDING_MODEL=openai/text-embedding-3-small
+PORT=8787
+```
+
+**4. Install dependencies:**
+
+```bash
+npm install
+```
+
+✅ **Done when:** `node_modules/` exists and your `.env` file contains real values.
+
+---
+
+![Step 3](https://img.shields.io/badge/Step_3-Sync_the_Source_Content-1E88E5?style=for-the-badge)
+
+The recipe treats markdown as the source of truth.
+
+**1. Run the importer:**
+
+```bash
+npm run sync
+```
+
+**2. Inspect the content files if you want to understand the contract:**
+
+- Project config: [repo-learning.config.ts](./repo-learning.config.ts)
+- Research docs: [research/](./research/)
+- Lessons: [curriculum/lessons/](./curriculum/lessons/)
+
+> [!NOTE]
+> Re-running `npm run sync` updates research and lesson content without wiping learner-generated progress, comments, or quiz history.
+
+✅ **Done when:** The sync command reports lesson and research counts, and you can see rows in the new `repo_learning_*` tables.
+
+---
+
+![Step 4](https://img.shields.io/badge/Step_4-Run_the_App-1E88E5?style=for-the-badge)
+
+**1. Start the local app:**
+
+```bash
+npm run dev
+```
+
+**2. Open the browser UI:**
+
+```text
+http://localhost:5173
+```
+
+You should see:
+
+- a lesson path in the sidebar
+- a research library
+- lesson progress controls
+- quizzes and note capture
+- an Open Brain capture panel
+- related thoughts when the bridge is configured successfully
+
+✅ **Done when:** You can open a lesson, save progress, submit a quiz, and save a note without errors.
+
+---
+
+![Step 5](https://img.shields.io/badge/Step_5-Adapt_It_to_Your_Repo-1E88E5?style=for-the-badge)
+
+To retarget this recipe to a new repo, change content first, not app code.
+
+**1. Update the project identity in [repo-learning.config.ts](./repo-learning.config.ts).**
+
+**2. Replace the sample research docs in [research/](./research/).**
+
+Each research file uses frontmatter:
+
+```yaml
+---
+slug: architecture-overview
+title: Architecture Overview
+summary: What matters most about the system design.
+category: architecture
+sourceUrl: https://example.com/optional-source
+---
+```
+
+**3. Replace the lesson files in [curriculum/lessons/](./curriculum/lessons/).**
+
+Each lesson file uses frontmatter for the lesson metadata and quiz, followed by markdown for the actual lesson body:
+
+```yaml
+---
+slug: orient-the-system
+title: Orient the System
+stage: Foundations
+difficulty: Intro
+order: 1
+estimatedMinutes: 20
+summary: What this lesson is trying to teach.
+goals:
+  - First goal
+  - Second goal
+relatedResearch:
+  - architecture-overview
+quiz:
+  title: Check the basics
+  passingScore: 70
+  questions:
+    - prompt: A real question
+      options:
+        - Option A
+        - Option B
+      correctOption: Option A
+      explanation: Why that answer is right.
+---
+```
+
+**4. Re-run the importer:**
+
+```bash
+npm run sync
+```
+
+✅ **Done when:** Your own repo title, research docs, and lessons show up in the UI.
+
+---
+
+![Step 6](https://img.shields.io/badge/Step_6-Use_the_Open_Brain_Bridge-1E88E5?style=for-the-badge)
+
+Open a lesson and use the **Open Brain capture** panel to save one of three artifact types:
+
+- `Takeaway` — a durable lesson insight
+- `Confusion note` — something worth resurfacing later
+- `Lesson summary` — a reusable summary for future work
+
+The lesson view also shows **Related thoughts** pulled from your existing `thoughts` table when OpenRouter retrieval is configured.
+
+> [!TIP]
+> Keep this bridge narrow. Capture durable artifacts, not every note or every quiz result.
+
+✅ **Done when:** Clicking **Send to Open Brain** returns a success message and a later search can find that saved artifact.
+
+## Expected Outcome
+
+When working correctly, you should have:
+
+- a local lesson app running against your existing OB1 Supabase project
+- research and lesson content sourced from plain markdown files
+- persistent progress, notes, and quiz history in dedicated `repo_learning_*` tables
+- explicit capture of durable learning artifacts back into `thoughts`
+- lesson views that can surface related prior thoughts from Open Brain
+
+## Future Extraction Path
+
+This v1 intentionally keeps the UI local. If you want to turn it into a hosted OB1 dashboard later, the clean extraction path is:
+
+1. keep the content contract and Supabase tables the same
+2. move the React app into `dashboards/`
+3. keep the capture/retrieval bridge behind the existing server-layer interface
+
+That way the frontend can move without redesigning the learning schema.
+
+## Troubleshooting
+
+**Issue: `npm run sync` fails with a missing table error**  
+Solution: Run the full contents of [schema.sql](./schema.sql) in Supabase first. The app assumes the `repo_learning_*` tables already exist.
+
+**Issue: The app loads, but “Related thoughts” stays empty**  
+Solution: Check `OPENROUTER_API_KEY` in `.env`. The bridge needs embeddings to query `match_thoughts`. Also make sure your Open Brain already has useful content in `thoughts`.
+
+**Issue: “Send to Open Brain” fails**  
+Solution: Confirm your OB1 project includes the usual `upsert_thought` flow from the core setup and that your service role key is correct. This recipe writes through that existing path; it does not define its own capture RPC.
+
+**Issue: Re-syncing creates duplicate lessons**  
+Solution: Keep lesson `slug` values stable. The importer uses slugs as the durable source-of-truth key for content updates.

--- a/recipes/repo-learning-coach/README.md
+++ b/recipes/repo-learning-coach/README.md
@@ -117,7 +117,7 @@ npm run sync
 - Lessons: [curriculum/lessons/](./curriculum/lessons/)
 
 > [!NOTE]
-> Re-running `npm run sync` updates research and lesson content without wiping learner-generated progress, comments, or quiz history.
+> Re-running `npm run sync` updates content in place for surviving lesson and research slugs. If you delete or rename source content, the importer prunes the stale database rows so markdown remains the source of truth.
 
 ✅ **Done when:** The sync command reports lesson and research counts, and you can see rows in the new `repo_learning_*` tables.
 

--- a/recipes/repo-learning-coach/curriculum/lessons/01-orient-the-learning-coach.md
+++ b/recipes/repo-learning-coach/curriculum/lessons/01-orient-the-learning-coach.md
@@ -1,0 +1,75 @@
+---
+slug: orient-the-learning-coach
+title: Orient the Learning Coach
+stage: Foundations
+difficulty: Intro
+order: 1
+estimatedMinutes: 15
+summary: Understand the product boundary so you do not collapse the learning app, Open Brain, and repo content into one blurry system.
+goals:
+  - Distinguish the local teaching surface from the durable Open Brain memory layer.
+  - Explain why this ships as a recipe instead of an extension.
+  - Identify the three pieces you adapt for a new repo.
+relatedResearch:
+  - recipe-overview
+  - content-contract
+quiz:
+  title: Check the product boundary
+  passingScore: 70
+  questions:
+    - prompt: Why is Repo Learning Coach an OB1 recipe instead of an extension?
+      options:
+        - Because recipes are allowed to have any number of dashboards.
+        - Because the product is a local app and content workflow, not a remote MCP server.
+        - Because extensions cannot use Supabase.
+        - Because lessons should never connect to thoughts.
+      correctOption: Because the product is a local app and content workflow, not a remote MCP server.
+      explanation: OB1 extensions are remote MCP builds. This recipe preserves a local app UX instead.
+    - prompt: Which layer should own quizzes, comments, and progress?
+      options:
+        - The core thoughts table
+        - Dedicated learning tables
+        - The MCP connector URL
+        - The browser only, with no persistence
+      correctOption: Dedicated learning tables
+      explanation: Structured learning state belongs in its own tables so thoughts can stay a durable memory layer.
+    - prompt: What should you mostly change when adapting this recipe to a new repo?
+      options:
+        - The React router and server framework
+        - The project config plus research and lesson files
+        - The Open Brain MCP server code
+        - The Supabase auth model
+      correctOption: The project config plus research and lesson files
+      explanation: The recipe is built so adaptation happens in content files, not core app rewrites.
+---
+
+## The boundary to keep clear
+
+Repo Learning Coach works because it keeps three concerns separate:
+
+- the reusable app
+- the repo-specific content
+- the durable Open Brain memory loop
+
+When those get blurred together, every new repo turns into a rewrite.
+
+## What changes per repo
+
+For a new repo, the important edits should be:
+
+- the config file that names the project and defines the lesson/research directories
+- the research markdown
+- the lesson markdown
+
+That means the app can stay boring in a good way.
+
+## Why that is the right v1
+
+The original prototype proved the UX. OB1 needs the architecture translated.
+
+That translation is:
+
+- local Express + React stays
+- the original local prototype backend becomes Supabase tables
+- hardcoded seeds become frontmatter-driven content
+- useful outputs get captured back into `thoughts`

--- a/recipes/repo-learning-coach/curriculum/lessons/02-separate-content-from-runtime.md
+++ b/recipes/repo-learning-coach/curriculum/lessons/02-separate-content-from-runtime.md
@@ -1,0 +1,72 @@
+---
+slug: separate-content-from-runtime
+title: Separate Content from Runtime
+stage: Systems
+difficulty: Intermediate
+order: 2
+estimatedMinutes: 20
+summary: The importer is the contract that keeps markdown content and structured lesson state in sync without overwriting learner history.
+goals:
+  - Explain why frontmatter is the right contract for research and lesson content.
+  - Understand why the sync step upserts content but preserves learner-generated history.
+  - Recognize the role of stable slugs in keeping lessons and quiz history aligned.
+relatedResearch:
+  - content-contract
+quiz:
+  title: Check the content contract
+  passingScore: 70
+  questions:
+    - prompt: Why use markdown plus frontmatter for research and lessons?
+      options:
+        - It is easier to hide complexity from the operator.
+        - It keeps repo-specific content inspectable, editable, and easy to diff.
+        - It removes the need for a sync pipeline.
+        - It makes Supabase migrations unnecessary.
+      correctOption: It keeps repo-specific content inspectable, editable, and easy to diff.
+      explanation: The whole point is to make repo adaptation happen in content files instead of buried code or prompts.
+    - prompt: What should the sync step avoid overwriting?
+      options:
+        - Lesson summaries and quiz prompts
+        - Project title and track metadata
+        - Learner progress, comments, and quiz attempt history
+        - Research content hashes
+      correctOption: Learner progress, comments, and quiz attempt history
+      explanation: The importer updates source-controlled content while preserving user-generated learning state.
+    - prompt: Why do stable slugs matter?
+      options:
+        - They let the browser avoid React state.
+        - They let the importer update the right lesson records across re-syncs.
+        - They remove the need for UUIDs.
+        - They make embeddings cheaper.
+      correctOption: They let the importer update the right lesson records across re-syncs.
+      explanation: Slugs are the stable source-of-truth keys for content updates.
+---
+
+## Content should be portable
+
+When a lesson changes, you want to edit a markdown file, not crack open the application data layer.
+
+That is why the recipe moves away from a monolithic `content.ts` file.
+
+## The importer is the real contract
+
+The important job of the sync step is not just “load the files.”
+
+It is to preserve the boundary between:
+
+- source-controlled content
+- learner-generated state
+
+That means:
+
+- lessons and research get updated from markdown
+- progress, comments, and quiz attempts stay intact
+
+## Treat slugs as stable IDs
+
+If you rename lesson files casually, you create new records instead of updating existing ones.
+
+The practical rule is simple:
+
+- edit the content freely
+- change slugs intentionally

--- a/recipes/repo-learning-coach/curriculum/lessons/03-capture-durable-learning.md
+++ b/recipes/repo-learning-coach/curriculum/lessons/03-capture-durable-learning.md
@@ -1,0 +1,76 @@
+---
+slug: capture-durable-learning
+title: Capture Durable Learning
+stage: Advanced
+difficulty: Intermediate
+order: 3
+estimatedMinutes: 18
+summary: Use the Open Brain bridge to save what matters from the learning session without duplicating the whole learning database into thoughts.
+goals:
+  - Identify which learning artifacts belong in thoughts and which do not.
+  - Explain how related thought retrieval strengthens a lesson at the moment of use.
+  - Use explicit capture actions instead of hiding writes inside the app.
+relatedResearch:
+  - brain-bridge
+  - recipe-overview
+quiz:
+  title: Check the memory loop
+  passingScore: 70
+  questions:
+    - prompt: Which artifact is the best fit for capture into thoughts?
+      options:
+        - Every quiz response
+        - Every comment, regardless of quality
+        - A durable takeaway or follow-up worth resurfacing later
+        - The full learning dashboard state
+      correctOption: A durable takeaway or follow-up worth resurfacing later
+      explanation: Thoughts should hold durable memory artifacts, not the entire learning system.
+    - prompt: Why surface related prior thoughts inside a lesson?
+      options:
+        - To replace the lesson content entirely
+        - To bring relevant prior context into the moment the learner needs it
+        - To avoid storing research documents
+        - To make the app work without Supabase
+      correctOption: To bring relevant prior context into the moment the learner needs it
+      explanation: The lesson becomes stronger when OB1 can re-surface earlier work right when it is useful.
+    - prompt: Why keep capture explicit?
+      options:
+        - Because explicit writes are easier to trust and operate
+        - Because Open Brain cannot store summaries
+        - Because quizzes should never influence memory
+        - Because local apps cannot call Supabase RPCs
+      correctOption: Because explicit writes are easier to trust and operate
+      explanation: Hidden writes make the system harder to trust. Explicit capture keeps the memory loop inspectable.
+---
+
+## The narrow bridge is the right bridge
+
+If you push the entire learning app into `thoughts`, you lose the value of structured state.
+
+If you never capture anything back into `thoughts`, the learning work stays trapped inside one app.
+
+The recipe needs the middle path.
+
+## What to capture
+
+Good capture candidates:
+
+- a concise takeaway you want to remember later
+- a confusion note that should resurface in a future build session
+- a summary of what this lesson changed for you
+
+Bad capture candidates:
+
+- raw quiz submissions
+- every note just because it exists
+- internal table state
+
+## What retrieval gives you
+
+Related thoughts turn isolated lessons into compounding context.
+
+A lesson about a subsystem is more useful when the learner can also see:
+
+- prior decisions
+- earlier experiments
+- notes from another session that hit the same theme

--- a/recipes/repo-learning-coach/eslint.config.js
+++ b/recipes/repo-learning-coach/eslint.config.js
@@ -1,0 +1,23 @@
+import js from '@eslint/js'
+import globals from 'globals'
+import reactHooks from 'eslint-plugin-react-hooks'
+import reactRefresh from 'eslint-plugin-react-refresh'
+import tseslint from 'typescript-eslint'
+import { defineConfig, globalIgnores } from 'eslint/config'
+
+export default defineConfig([
+  globalIgnores(['dist']),
+  {
+    files: ['**/*.{ts,tsx}'],
+    extends: [
+      js.configs.recommended,
+      tseslint.configs.recommended,
+      reactHooks.configs.flat.recommended,
+      reactRefresh.configs.vite,
+    ],
+    languageOptions: {
+      ecmaVersion: 2020,
+      globals: globals.browser,
+    },
+  },
+])

--- a/recipes/repo-learning-coach/index.html
+++ b/recipes/repo-learning-coach/index.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Repo Learning Coach</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/recipes/repo-learning-coach/metadata.json
+++ b/recipes/repo-learning-coach/metadata.json
@@ -1,0 +1,26 @@
+{
+  "name": "Repo Learning Coach",
+  "description": "Run a local learning app backed by Supabase tables inside your Open Brain project, with file-based curriculum content and durable captures into thoughts.",
+  "category": "recipes",
+  "author": {
+    "name": "Jonathan Edwards"
+  },
+  "version": "1.0.0",
+  "requires": {
+    "open_brain": true,
+    "services": ["OpenRouter"],
+    "tools": ["Node.js 18+"]
+  },
+  "tags": [
+    "learning",
+    "onboarding",
+    "curriculum",
+    "repo",
+    "supabase",
+    "thoughts"
+  ],
+  "difficulty": "intermediate",
+  "estimated_time": "45 minutes",
+  "created": "2026-04-12",
+  "updated": "2026-04-12"
+}

--- a/recipes/repo-learning-coach/package-lock.json
+++ b/recipes/repo-learning-coach/package-lock.json
@@ -1,0 +1,5839 @@
+{
+  "name": "repo-learning-coach",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "repo-learning-coach",
+      "version": "1.0.0",
+      "dependencies": {
+        "@supabase/supabase-js": "^2.47.10",
+        "express": "^5.2.1",
+        "gray-matter": "^4.0.3",
+        "react": "^19.2.0",
+        "react-dom": "^19.2.0",
+        "react-markdown": "^10.1.0",
+        "zod": "^4.1.13"
+      },
+      "devDependencies": {
+        "@eslint/js": "^9.39.1",
+        "@types/express": "^5.0.5",
+        "@types/node": "^24.6.0",
+        "@types/react": "^19.2.2",
+        "@types/react-dom": "^19.2.2",
+        "@vitejs/plugin-react": "^5.0.4",
+        "concurrently": "^9.2.1",
+        "eslint": "^9.39.1",
+        "eslint-plugin-react-hooks": "^7.0.1",
+        "eslint-plugin-react-refresh": "^0.4.24",
+        "globals": "^16.4.0",
+        "tsx": "^4.21.0",
+        "typescript": "~5.9.3",
+        "typescript-eslint": "^8.46.0",
+        "vite": "^7.1.7"
+      }
+    },
+    "node_modules/@babel/code-frame": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz",
+      "integrity": "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.28.5",
+        "js-tokens": "^4.0.0",
+        "picocolors": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/compat-data": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.0.tgz",
+      "integrity": "sha512-T1NCJqT/j9+cn8fvkt7jtwbLBfLC/1y1c7NtCeXFRgzGTsafi68MRv8yzkYSapBnFA6L3U2VSc02ciDzoAJhJg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/core": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz",
+      "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.0",
+        "@babel/generator": "^7.29.0",
+        "@babel/helper-compilation-targets": "^7.28.6",
+        "@babel/helper-module-transforms": "^7.28.6",
+        "@babel/helpers": "^7.28.6",
+        "@babel/parser": "^7.29.0",
+        "@babel/template": "^7.28.6",
+        "@babel/traverse": "^7.29.0",
+        "@babel/types": "^7.29.0",
+        "@jridgewell/remapping": "^2.3.5",
+        "convert-source-map": "^2.0.0",
+        "debug": "^4.1.0",
+        "gensync": "^1.0.0-beta.2",
+        "json5": "^2.2.3",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/babel"
+      }
+    },
+    "node_modules/@babel/generator": {
+      "version": "7.29.1",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.1.tgz",
+      "integrity": "sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.0",
+        "@babel/types": "^7.29.0",
+        "@jridgewell/gen-mapping": "^0.3.12",
+        "@jridgewell/trace-mapping": "^0.3.28",
+        "jsesc": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-compilation-targets": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.28.6.tgz",
+      "integrity": "sha512-JYtls3hqi15fcx5GaSNL7SCTJ2MNmjrkHXg4FSpOA/grxK8KwyZ5bubHsCq8FXCkua6xhuaaBit+3b7+VZRfcA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/compat-data": "^7.28.6",
+        "@babel/helper-validator-option": "^7.27.1",
+        "browserslist": "^4.24.0",
+        "lru-cache": "^5.1.1",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-globals": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.28.0.tgz",
+      "integrity": "sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-imports": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.28.6.tgz",
+      "integrity": "sha512-l5XkZK7r7wa9LucGw9LwZyyCUscb4x37JWTPz7swwFE/0FMQAGpiWUZn8u9DzkSBWEcK25jmvubfpw2dnAMdbw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/traverse": "^7.28.6",
+        "@babel/types": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-transforms": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.28.6.tgz",
+      "integrity": "sha512-67oXFAYr2cDLDVGLXTEABjdBJZ6drElUSI7WKp70NrpyISso3plG9SAGEF6y7zbha/wOzUByWWTJvEDVNIUGcA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-module-imports": "^7.28.6",
+        "@babel/helper-validator-identifier": "^7.28.5",
+        "@babel/traverse": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/helper-plugin-utils": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.28.6.tgz",
+      "integrity": "sha512-S9gzZ/bz83GRysI7gAD4wPT/AI3uCnY+9xn+Mx/KPs2JwHJIz1W8PZkg2cqyt3RNOBM8ejcXhV6y8Og7ly/Dug==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
+      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.28.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
+      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-option": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.27.1.tgz",
+      "integrity": "sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helpers": {
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.2.tgz",
+      "integrity": "sha512-HoGuUs4sCZNezVEKdVcwqmZN8GoHirLUcLaYVNBK2J0DadGtdcqgr3BCbvH8+XUo4NGjNl3VOtSjEKNzqfFgKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/template": "^7.28.6",
+        "@babel/types": "^7.29.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.2.tgz",
+      "integrity": "sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.29.0"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-react-jsx-self": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-self/-/plugin-transform-react-jsx-self-7.27.1.tgz",
+      "integrity": "sha512-6UzkCs+ejGdZ5mFFC/OCUrv028ab2fp1znZmCZjAOBKiBK2jXD1O+BPSfX8X2qjJ75fZBMSnQn3Rq2mrBJK2mw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-react-jsx-source": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-source/-/plugin-transform-react-jsx-source-7.27.1.tgz",
+      "integrity": "sha512-zbwoTsBruTeKB9hSq73ha66iFeJHuaFkUbwvqElnygoNbj/jHRsSeokowZFN3CZ64IvEqcmmkVe89OPXc7ldAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/template": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.28.6.tgz",
+      "integrity": "sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.28.6",
+        "@babel/parser": "^7.28.6",
+        "@babel/types": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/traverse": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.0.tgz",
+      "integrity": "sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.0",
+        "@babel/generator": "^7.29.0",
+        "@babel/helper-globals": "^7.28.0",
+        "@babel/parser": "^7.29.0",
+        "@babel/template": "^7.28.6",
+        "@babel/types": "^7.29.0",
+        "debug": "^4.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
+      "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.27.1",
+        "@babel/helper-validator-identifier": "^7.28.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.7.tgz",
+      "integrity": "sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.7.tgz",
+      "integrity": "sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.7.tgz",
+      "integrity": "sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.7.tgz",
+      "integrity": "sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.7.tgz",
+      "integrity": "sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.7.tgz",
+      "integrity": "sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.7.tgz",
+      "integrity": "sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.7.tgz",
+      "integrity": "sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.7.tgz",
+      "integrity": "sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.7.tgz",
+      "integrity": "sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.7.tgz",
+      "integrity": "sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.7.tgz",
+      "integrity": "sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.7.tgz",
+      "integrity": "sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.7.tgz",
+      "integrity": "sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.7.tgz",
+      "integrity": "sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.7.tgz",
+      "integrity": "sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.7.tgz",
+      "integrity": "sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.7.tgz",
+      "integrity": "sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.7.tgz",
+      "integrity": "sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.7.tgz",
+      "integrity": "sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.7.tgz",
+      "integrity": "sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@eslint-community/eslint-utils": {
+      "version": "4.9.1",
+      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.9.1.tgz",
+      "integrity": "sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eslint-visitor-keys": "^3.4.3"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^6.0.0 || ^7.0.0 || >=8.0.0"
+      }
+    },
+    "node_modules/@eslint-community/eslint-utils/node_modules/eslint-visitor-keys": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
+      "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@eslint-community/regexpp": {
+      "version": "4.12.2",
+      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.12.2.tgz",
+      "integrity": "sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@eslint/config-array": {
+      "version": "0.21.2",
+      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.21.2.tgz",
+      "integrity": "sha512-nJl2KGTlrf9GjLimgIru+V/mzgSK0ABCDQRvxw5BjURL7WfH5uoWmizbH7QB6MmnMBd8cIC9uceWnezL1VZWWw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/object-schema": "^2.1.7",
+        "debug": "^4.3.1",
+        "minimatch": "^3.1.5"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/config-helpers": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.4.2.tgz",
+      "integrity": "sha512-gBrxN88gOIf3R7ja5K9slwNayVcZgK6SOUORm2uBzTeIEfeVaIhOpCtTox3P6R7o2jLFwLFTLnC7kU/RGcYEgw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/core": "^0.17.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/core": {
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.17.0.tgz",
+      "integrity": "sha512-yL/sLrpmtDaFEiUj1osRP4TI2MDz1AddJL+jZ7KSqvBuliN4xqYY54IfdN8qD8Toa6g1iloph1fxQNkjOxrrpQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@types/json-schema": "^7.0.15"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/eslintrc": {
+      "version": "3.3.5",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.3.5.tgz",
+      "integrity": "sha512-4IlJx0X0qftVsN5E+/vGujTRIFtwuLbNsVUe7TO6zYPDR1O6nFwvwhIKEKSrl6dZchmYBITazxKoUYOjdtjlRg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^6.14.0",
+        "debug": "^4.3.2",
+        "espree": "^10.0.1",
+        "globals": "^14.0.0",
+        "ignore": "^5.2.0",
+        "import-fresh": "^3.2.1",
+        "js-yaml": "^4.1.1",
+        "minimatch": "^3.1.5",
+        "strip-json-comments": "^3.1.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@eslint/eslintrc/node_modules/globals": {
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-14.0.0.tgz",
+      "integrity": "sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@eslint/js": {
+      "version": "9.39.4",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.39.4.tgz",
+      "integrity": "sha512-nE7DEIchvtiFTwBw4Lfbu59PG+kCofhjsKaCWzxTpt4lfRjRMqG6uMBzKXuEcyXhOHoUp9riAm7/aWYGhXZ9cw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://eslint.org/donate"
+      }
+    },
+    "node_modules/@eslint/object-schema": {
+      "version": "2.1.7",
+      "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-2.1.7.tgz",
+      "integrity": "sha512-VtAOaymWVfZcmZbp6E2mympDIHvyjXs/12LqWYjVw6qjrfF+VK+fyG33kChz3nnK+SU5/NeHOqrTEHS8sXO3OA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/plugin-kit": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.4.1.tgz",
+      "integrity": "sha512-43/qtrDUokr7LJqoF2c3+RInu/t4zfrpYdoSDfYyhg52rwLV6TnOvdG4fXm7IkSB3wErkcmJS9iEhjVtOSEjjA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/core": "^0.17.0",
+        "levn": "^0.4.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@humanfs/core": {
+      "version": "0.19.1",
+      "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.1.tgz",
+      "integrity": "sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanfs/node": {
+      "version": "0.16.7",
+      "resolved": "https://registry.npmjs.org/@humanfs/node/-/node-0.16.7.tgz",
+      "integrity": "sha512-/zUx+yOsIrG4Y43Eh2peDeKCxlRt/gET6aHfaKpuq267qXdYDFViVHfMaLyygZOnl0kGWxFIgsBy8QFuTLUXEQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@humanfs/core": "^0.19.1",
+        "@humanwhocodes/retry": "^0.4.0"
+      },
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanwhocodes/module-importer": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz",
+      "integrity": "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.22"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nzakas"
+      }
+    },
+    "node_modules/@humanwhocodes/retry": {
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.4.3.tgz",
+      "integrity": "sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nzakas"
+      }
+    },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/remapping": {
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
+      "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.0-rc.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.3.tgz",
+      "integrity": "sha512-eybk3TjzzzV97Dlj5c+XrBFW57eTNhzod66y9HrBlzJ6NsCrWCp/2kaPS3K9wJmurBC0Tdw4yPjXKZqlznim3Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.60.1.tgz",
+      "integrity": "sha512-d6FinEBLdIiK+1uACUttJKfgZREXrF0Qc2SmLII7W2AD8FfiZ9Wjd+rD/iRuf5s5dWrr1GgwXCvPqOuDquOowA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.60.1.tgz",
+      "integrity": "sha512-YjG/EwIDvvYI1YvYbHvDz/BYHtkY4ygUIXHnTdLhG+hKIQFBiosfWiACWortsKPKU/+dUwQQCKQM3qrDe8c9BA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.60.1.tgz",
+      "integrity": "sha512-mjCpF7GmkRtSJwon+Rq1N8+pI+8l7w5g9Z3vWj4T7abguC4Czwi3Yu/pFaLvA3TTeMVjnu3ctigusqWUfjZzvw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.60.1.tgz",
+      "integrity": "sha512-haZ7hJ1JT4e9hqkoT9R/19XW2QKqjfJVv+i5AGg57S+nLk9lQnJ1F/eZloRO3o9Scy9CM3wQ9l+dkXtcBgN5Ew==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.60.1.tgz",
+      "integrity": "sha512-czw90wpQq3ZsAVBlinZjAYTKduOjTywlG7fEeWKUA7oCmpA8xdTkxZZlwNJKWqILlq0wehoZcJYfBvOyhPTQ6w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.60.1.tgz",
+      "integrity": "sha512-KVB2rqsxTHuBtfOeySEyzEOB7ltlB/ux38iu2rBQzkjbwRVlkhAGIEDiiYnO2kFOkJp+Z7pUXKyrRRFuFUKt+g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.60.1.tgz",
+      "integrity": "sha512-L+34Qqil+v5uC0zEubW7uByo78WOCIrBvci69E7sFASRl0X7b/MB6Cqd1lky/CtcSVTydWa2WZwFuWexjS5o6g==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.60.1.tgz",
+      "integrity": "sha512-n83O8rt4v34hgFzlkb1ycniJh7IR5RCIqt6mz1VRJD6pmhRi0CXdmfnLu9dIUS6buzh60IvACM842Ffb3xd6Gg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.60.1.tgz",
+      "integrity": "sha512-Nql7sTeAzhTAja3QXeAI48+/+GjBJ+QmAH13snn0AJSNL50JsDqotyudHyMbO2RbJkskbMbFJfIJKWA6R1LCJQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.60.1.tgz",
+      "integrity": "sha512-+pUymDhd0ys9GcKZPPWlFiZ67sTWV5UU6zOJat02M1+PiuSGDziyRuI/pPue3hoUwm2uGfxdL+trT6Z9rxnlMA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.60.1.tgz",
+      "integrity": "sha512-VSvgvQeIcsEvY4bKDHEDWcpW4Yw7BtlKG1GUT4FzBUlEKQK0rWHYBqQt6Fm2taXS+1bXvJT6kICu5ZwqKCnvlQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.60.1.tgz",
+      "integrity": "sha512-4LqhUomJqwe641gsPp6xLfhqWMbQV04KtPp7/dIp0nzPxAkNY1AbwL5W0MQpcalLYk07vaW9Kp1PBhdpZYYcEw==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.60.1.tgz",
+      "integrity": "sha512-tLQQ9aPvkBxOc/EUT6j3pyeMD6Hb8QF2BTBnCQWP/uu1lhc9AIrIjKnLYMEroIz/JvtGYgI9dF3AxHZNaEH0rw==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.60.1.tgz",
+      "integrity": "sha512-RMxFhJwc9fSXP6PqmAz4cbv3kAyvD1etJFjTx4ONqFP9DkTkXsAMU4v3Vyc5BgzC+anz7nS/9tp4obsKfqkDHg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.60.1.tgz",
+      "integrity": "sha512-QKgFl+Yc1eEk6MmOBfRHYF6lTxiiiV3/z/BRrbSiW2I7AFTXoBFvdMEyglohPj//2mZS4hDOqeB0H1ACh3sBbg==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.60.1.tgz",
+      "integrity": "sha512-RAjXjP/8c6ZtzatZcA1RaQr6O1TRhzC+adn8YZDnChliZHviqIjmvFwHcxi4JKPSDAt6Uhf/7vqcBzQJy0PDJg==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.60.1.tgz",
+      "integrity": "sha512-wcuocpaOlaL1COBYiA89O6yfjlp3RwKDeTIA0hM7OpmhR1Bjo9j31G1uQVpDlTvwxGn2nQs65fBFL5UFd76FcQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.60.1.tgz",
+      "integrity": "sha512-77PpsFQUCOiZR9+LQEFg9GClyfkNXj1MP6wRnzYs0EeWbPcHs02AXu4xuUbM1zhwn3wqaizle3AEYg5aeoohhg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.60.1.tgz",
+      "integrity": "sha512-5cIATbk5vynAjqqmyBjlciMJl1+R/CwX9oLk/EyiFXDWd95KpHdrOJT//rnUl4cUcskrd0jCCw3wpZnhIHdD9w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.60.1.tgz",
+      "integrity": "sha512-cl0w09WsCi17mcmWqqglez9Gk8isgeWvoUZ3WiJFYSR3zjBQc2J5/ihSjpl+VLjPqjQ/1hJRcqBfLjssREQILw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.60.1.tgz",
+      "integrity": "sha512-4Cv23ZrONRbNtbZa37mLSueXUCtN7MXccChtKpUnQNgF010rjrjfHx3QxkS2PI7LqGT5xXyYs1a7LbzAwT0iCA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.60.1.tgz",
+      "integrity": "sha512-i1okWYkA4FJICtr7KpYzFpRTHgy5jdDbZiWfvny21iIKky5YExiDXP+zbXzm3dUcFpkEeYNHgQ5fuG236JPq0g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.60.1.tgz",
+      "integrity": "sha512-u09m3CuwLzShA0EYKMNiFgcjjzwqtUMLmuCJLeZWjjOYA3IT2Di09KaxGBTP9xVztWyIWjVdsB2E9goMjZvTQg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.60.1.tgz",
+      "integrity": "sha512-k+600V9Zl1CM7eZxJgMyTUzmrmhB/0XZnF4pRypKAlAgxmedUA+1v9R+XOFv56W4SlHEzfeMtzujLJD22Uz5zg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.60.1.tgz",
+      "integrity": "sha512-lWMnixq/QzxyhTV6NjQJ4SFo1J6PvOX8vUx5Wb4bBPsEb+8xZ89Bz6kOXpfXj9ak9AHTQVQzlgzBEc1SyM27xQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@supabase/auth-js": {
+      "version": "2.103.0",
+      "resolved": "https://registry.npmjs.org/@supabase/auth-js/-/auth-js-2.103.0.tgz",
+      "integrity": "sha512-6zAanO6c+6gpHOlt5Lb9TlBBkJdZiUWkWCJKAxzkywBDcwaHlLJKXnjQGX6GyVCyKRR1e7sTq4re/yRTH6U/9A==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@supabase/functions-js": {
+      "version": "2.103.0",
+      "resolved": "https://registry.npmjs.org/@supabase/functions-js/-/functions-js-2.103.0.tgz",
+      "integrity": "sha512-YrneV2NjskUkkmkZ2Jt2n3elBgbWzV4Y1M9MM370z2Zd5ZPFqFbY8KIoPwuNjtAGE9YrpKBxnbZqeF07BiN9Og==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@supabase/phoenix": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@supabase/phoenix/-/phoenix-0.4.0.tgz",
+      "integrity": "sha512-RHSx8bHS02xwfHdAbX5Lpbo6PXbgyf7lTaXTlwtFDPwOIw64NnVRwFAXGojHhjtVYI+PEPNSWwkL90f4agN3bw==",
+      "license": "MIT"
+    },
+    "node_modules/@supabase/postgrest-js": {
+      "version": "2.103.0",
+      "resolved": "https://registry.npmjs.org/@supabase/postgrest-js/-/postgrest-js-2.103.0.tgz",
+      "integrity": "sha512-rC3sRxYdPZymkp2CZR1MiNQgbOleD01bGsW8VxEKRR5nMkLZ1NgAS1QTQf78Wh30czFyk505ZYr9Od8/mWT2TA==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@supabase/realtime-js": {
+      "version": "2.103.0",
+      "resolved": "https://registry.npmjs.org/@supabase/realtime-js/-/realtime-js-2.103.0.tgz",
+      "integrity": "sha512-gcPtXzZ6izyyBVf2of7K3dEt8CScPJn8VcSlQq6oWL9QoE1kqfQl0oFrOMHd5qrcADewxI7OxxosLB8W4XqtIQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/phoenix": "^0.4.0",
+        "@types/ws": "^8.18.1",
+        "tslib": "2.8.1",
+        "ws": "^8.18.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@supabase/storage-js": {
+      "version": "2.103.0",
+      "resolved": "https://registry.npmjs.org/@supabase/storage-js/-/storage-js-2.103.0.tgz",
+      "integrity": "sha512-DHmlvdAXwtOmZNbkIZi4lkobPR3XjIzoOgzoz5duMf6G+sDeY015YrzMJCnqdccuYr7X5x4yYuSwF//RoN2dvQ==",
+      "license": "MIT",
+      "dependencies": {
+        "iceberg-js": "^0.8.1",
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@supabase/supabase-js": {
+      "version": "2.103.0",
+      "resolved": "https://registry.npmjs.org/@supabase/supabase-js/-/supabase-js-2.103.0.tgz",
+      "integrity": "sha512-j/6q5+LtXbR/YOLSLhy7Na74RD1cV2v+KwIIuuqMEjk1JpLEEyu0ynwDHpGoxMncDQl+R5FogaVqZm+85lZvtw==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/auth-js": "2.103.0",
+        "@supabase/functions-js": "2.103.0",
+        "@supabase/postgrest-js": "2.103.0",
+        "@supabase/realtime-js": "2.103.0",
+        "@supabase/storage-js": "2.103.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@types/babel__core": {
+      "version": "7.20.5",
+      "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
+      "integrity": "sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.20.7",
+        "@babel/types": "^7.20.7",
+        "@types/babel__generator": "*",
+        "@types/babel__template": "*",
+        "@types/babel__traverse": "*"
+      }
+    },
+    "node_modules/@types/babel__generator": {
+      "version": "7.27.0",
+      "resolved": "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.27.0.tgz",
+      "integrity": "sha512-ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "node_modules/@types/babel__template": {
+      "version": "7.4.4",
+      "resolved": "https://registry.npmjs.org/@types/babel__template/-/babel__template-7.4.4.tgz",
+      "integrity": "sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.1.0",
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "node_modules/@types/babel__traverse": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.28.0.tgz",
+      "integrity": "sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.28.2"
+      }
+    },
+    "node_modules/@types/body-parser": {
+      "version": "1.19.6",
+      "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.6.tgz",
+      "integrity": "sha512-HLFeCYgz89uk22N5Qg3dvGvsv46B8GLvKKo1zKG4NybA8U2DiEO3w9lqGg29t/tfLRJpJ6iQxnVw4OnB7MoM9g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/connect": "*",
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/connect": {
+      "version": "3.4.38",
+      "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.38.tgz",
+      "integrity": "sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/debug": {
+      "version": "4.1.13",
+      "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.13.tgz",
+      "integrity": "sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/ms": "*"
+      }
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "license": "MIT"
+    },
+    "node_modules/@types/estree-jsx": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@types/estree-jsx/-/estree-jsx-1.0.5.tgz",
+      "integrity": "sha512-52CcUVNFyfb1A2ALocQw/Dd1BQFNmSdkuC3BkZ6iqhdMfQz7JWOFRuJFloOzjk+6WijU56m9oKXFAXc7o3Towg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "*"
+      }
+    },
+    "node_modules/@types/express": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/@types/express/-/express-5.0.6.tgz",
+      "integrity": "sha512-sKYVuV7Sv9fbPIt/442koC7+IIwK5olP1KWeD88e/idgoJqDm3JV/YUiPwkoKK92ylff2MGxSz1CSjsXelx0YA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/body-parser": "*",
+        "@types/express-serve-static-core": "^5.0.0",
+        "@types/serve-static": "^2"
+      }
+    },
+    "node_modules/@types/express-serve-static-core": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-5.1.1.tgz",
+      "integrity": "sha512-v4zIMr/cX7/d2BpAEX3KNKL/JrT1s43s96lLvvdTmza1oEvDudCqK9aF/djc/SWgy8Yh0h30TZx5VpzqFCxk5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "@types/qs": "*",
+        "@types/range-parser": "*",
+        "@types/send": "*"
+      }
+    },
+    "node_modules/@types/hast": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/hast/-/hast-3.0.4.tgz",
+      "integrity": "sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "*"
+      }
+    },
+    "node_modules/@types/http-errors": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@types/http-errors/-/http-errors-2.0.5.tgz",
+      "integrity": "sha512-r8Tayk8HJnX0FztbZN7oVqGccWgw98T/0neJphO91KkmOzug1KkofZURD4UaD5uH8AqcFLfdPErnBod0u71/qg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/json-schema": {
+      "version": "7.0.15",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
+      "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/mdast": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-4.0.4.tgz",
+      "integrity": "sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "*"
+      }
+    },
+    "node_modules/@types/ms": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@types/ms/-/ms-2.1.0.tgz",
+      "integrity": "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "24.12.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.12.2.tgz",
+      "integrity": "sha512-A1sre26ke7HDIuY/M23nd9gfB+nrmhtYyMINbjI1zHJxYteKR6qSMX56FsmjMcDb3SMcjJg5BiRRgOCC/yBD0g==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.16.0"
+      }
+    },
+    "node_modules/@types/qs": {
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.15.0.tgz",
+      "integrity": "sha512-JawvT8iBVWpzTrz3EGw9BTQFg3BQNmwERdKE22vlTxawwtbyUSlMppvZYKLZzB5zgACXdXxbD3m1bXaMqP/9ow==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/range-parser": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.7.tgz",
+      "integrity": "sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/react": {
+      "version": "19.2.14",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
+      "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
+      "license": "MIT",
+      "dependencies": {
+        "csstype": "^3.2.2"
+      }
+    },
+    "node_modules/@types/react-dom": {
+      "version": "19.2.3",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.3.tgz",
+      "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "^19.2.0"
+      }
+    },
+    "node_modules/@types/send": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@types/send/-/send-1.2.1.tgz",
+      "integrity": "sha512-arsCikDvlU99zl1g69TcAB3mzZPpxgw0UQnaHeC1Nwb015xp8bknZv5rIfri9xTOcMuaVgvabfIRA7PSZVuZIQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/serve-static": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-2.2.0.tgz",
+      "integrity": "sha512-8mam4H1NHLtu7nmtalF7eyBH14QyOASmcxHhSfEoRyr0nP/YdoesEtU+uSRvMe96TW/HPTtkoKqQLl53N7UXMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/http-errors": "*",
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/unist": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
+      "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
+      "license": "MIT"
+    },
+    "node_modules/@types/ws": {
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@typescript-eslint/eslint-plugin": {
+      "version": "8.58.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.58.1.tgz",
+      "integrity": "sha512-eSkwoemjo76bdXl2MYqtxg51HNwUSkWfODUOQ3PaTLZGh9uIWWFZIjyjaJnex7wXDu+TRx+ATsnSxdN9YWfRTQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/regexpp": "^4.12.2",
+        "@typescript-eslint/scope-manager": "8.58.1",
+        "@typescript-eslint/type-utils": "8.58.1",
+        "@typescript-eslint/utils": "8.58.1",
+        "@typescript-eslint/visitor-keys": "8.58.1",
+        "ignore": "^7.0.5",
+        "natural-compare": "^1.4.0",
+        "ts-api-utils": "^2.5.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "@typescript-eslint/parser": "^8.58.1",
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/eslint-plugin/node_modules/ignore": {
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
+      "integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/@typescript-eslint/parser": {
+      "version": "8.58.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.58.1.tgz",
+      "integrity": "sha512-gGkiNMPqerb2cJSVcruigx9eHBlLG14fSdPdqMoOcBfh+vvn4iCq2C8MzUB89PrxOXk0y3GZ1yIWb9aOzL93bw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/scope-manager": "8.58.1",
+        "@typescript-eslint/types": "8.58.1",
+        "@typescript-eslint/typescript-estree": "8.58.1",
+        "@typescript-eslint/visitor-keys": "8.58.1",
+        "debug": "^4.4.3"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/project-service": {
+      "version": "8.58.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.58.1.tgz",
+      "integrity": "sha512-gfQ8fk6cxhtptek+/8ZIqw8YrRW5048Gug8Ts5IYcMLCw18iUgrZAEY/D7s4hkI0FxEfGakKuPK/XUMPzPxi5g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/tsconfig-utils": "^8.58.1",
+        "@typescript-eslint/types": "^8.58.1",
+        "debug": "^4.4.3"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/scope-manager": {
+      "version": "8.58.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.58.1.tgz",
+      "integrity": "sha512-TPYUEqJK6avLcEjumWsIuTpuYODTTDAtoMdt8ZZa93uWMTX13Nb8L5leSje1NluammvU+oI3QRr5lLXPgihX3w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.58.1",
+        "@typescript-eslint/visitor-keys": "8.58.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/tsconfig-utils": {
+      "version": "8.58.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.58.1.tgz",
+      "integrity": "sha512-JAr2hOIct2Q+qk3G+8YFfqkqi7sC86uNryT+2i5HzMa2MPjw4qNFvtjnw1IiA1rP7QhNKVe21mSSLaSjwA1Olw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/type-utils": {
+      "version": "8.58.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.58.1.tgz",
+      "integrity": "sha512-HUFxvTJVroT+0rXVJC7eD5zol6ID+Sn5npVPWoFuHGg9Ncq5Q4EYstqR+UOqaNRFXi5TYkpXXkLhoCHe3G0+7w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.58.1",
+        "@typescript-eslint/typescript-estree": "8.58.1",
+        "@typescript-eslint/utils": "8.58.1",
+        "debug": "^4.4.3",
+        "ts-api-utils": "^2.5.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/types": {
+      "version": "8.58.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.58.1.tgz",
+      "integrity": "sha512-io/dV5Aw5ezwzfPBBWLoT+5QfVtP8O7q4Kftjn5azJ88bYyp/ZMCsyW1lpKK46EXJcaYMZ1JtYj+s/7TdzmQMw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree": {
+      "version": "8.58.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.58.1.tgz",
+      "integrity": "sha512-w4w7WR7GHOjqqPnvAYbazq+Y5oS68b9CzasGtnd6jIeOIeKUzYzupGTB2T4LTPSv4d+WPeccbxuneTFHYgAAWg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/project-service": "8.58.1",
+        "@typescript-eslint/tsconfig-utils": "8.58.1",
+        "@typescript-eslint/types": "8.58.1",
+        "@typescript-eslint/visitor-keys": "8.58.1",
+        "debug": "^4.4.3",
+        "minimatch": "^10.2.2",
+        "semver": "^7.7.3",
+        "tinyglobby": "^0.2.15",
+        "ts-api-utils": "^2.5.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
+      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/minimatch": {
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.5"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@typescript-eslint/utils": {
+      "version": "8.58.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.58.1.tgz",
+      "integrity": "sha512-Ln8R0tmWC7pTtLOzgJzYTXSCjJ9rDNHAqTaVONF4FEi2qwce8mD9iSOxOpLFFvWp/wBFlew0mjM1L1ihYWfBdQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.9.1",
+        "@typescript-eslint/scope-manager": "8.58.1",
+        "@typescript-eslint/types": "8.58.1",
+        "@typescript-eslint/typescript-estree": "8.58.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/visitor-keys": {
+      "version": "8.58.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.58.1.tgz",
+      "integrity": "sha512-y+vH7QE8ycjoa0bWciFg7OpFcipUuem1ujhrdLtq1gByKwfbC7bPeKsiny9e0urg93DqwGcHey+bGRKCnF1nZQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.58.1",
+        "eslint-visitor-keys": "^5.0.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/visitor-keys/node_modules/eslint-visitor-keys": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
+      "integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@ungap/structured-clone": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.0.tgz",
+      "integrity": "sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==",
+      "license": "ISC"
+    },
+    "node_modules/@vitejs/plugin-react": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-5.2.0.tgz",
+      "integrity": "sha512-YmKkfhOAi3wsB1PhJq5Scj3GXMn3WvtQ/JC0xoopuHoXSdmtdStOpFrYaT1kie2YgFBcIe64ROzMYRjCrYOdYw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.29.0",
+        "@babel/plugin-transform-react-jsx-self": "^7.27.1",
+        "@babel/plugin-transform-react-jsx-source": "^7.27.1",
+        "@rolldown/pluginutils": "1.0.0-rc.3",
+        "@types/babel__core": "^7.20.5",
+        "react-refresh": "^0.18.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "peerDependencies": {
+        "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/accepts": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
+      "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "^3.0.0",
+        "negotiator": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/acorn": {
+      "version": "8.16.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
+      "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/acorn-jsx": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
+      "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "6.14.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
+      "integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "dev": true,
+      "license": "Python-2.0"
+    },
+    "node_modules/bail": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/bail/-/bail-2.0.2.tgz",
+      "integrity": "sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/baseline-browser-mapping": {
+      "version": "2.10.18",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.18.tgz",
+      "integrity": "sha512-VSnGQAOLtP5mib/DPyg2/t+Tlv65NTBz83BJBJvmLVHHuKJVaDOBvJJykiT5TR++em5nfAySPccDZDa4oSrn8A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "baseline-browser-mapping": "dist/cli.cjs"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/body-parser": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.2.tgz",
+      "integrity": "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "^3.1.2",
+        "content-type": "^1.0.5",
+        "debug": "^4.4.3",
+        "http-errors": "^2.0.0",
+        "iconv-lite": "^0.7.0",
+        "on-finished": "^2.4.1",
+        "qs": "^6.14.1",
+        "raw-body": "^3.0.1",
+        "type-is": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/brace-expansion": {
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/browserslist": {
+      "version": "4.28.2",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.2.tgz",
+      "integrity": "sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "baseline-browser-mapping": "^2.10.12",
+        "caniuse-lite": "^1.0.30001782",
+        "electron-to-chromium": "^1.5.328",
+        "node-releases": "^2.0.36",
+        "update-browserslist-db": "^1.2.3"
+      },
+      "bin": {
+        "browserslist": "cli.js"
+      },
+      "engines": {
+        "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      }
+    },
+    "node_modules/bytes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/callsites": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
+      "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/caniuse-lite": {
+      "version": "1.0.30001787",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001787.tgz",
+      "integrity": "sha512-mNcrMN9KeI68u7muanUpEejSLghOKlVhRqS/Za2IeyGllJ9I9otGpR9g3nsw7n4W378TE/LyIteA0+/FOZm4Kg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "CC-BY-4.0"
+    },
+    "node_modules/ccount": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/ccount/-/ccount-2.0.1.tgz",
+      "integrity": "sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/chalk/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/character-entities": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/character-entities/-/character-entities-2.0.2.tgz",
+      "integrity": "sha512-shx7oQ0Awen/BRIdkjkvz54PnEEI/EjwXDSIZp86/KKdbafHh1Df/RYGBhn4hbe2+uKC9FnT5UCEdyPz3ai9hQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/character-entities-html4": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/character-entities-html4/-/character-entities-html4-2.1.0.tgz",
+      "integrity": "sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/character-entities-legacy": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/character-entities-legacy/-/character-entities-legacy-3.0.0.tgz",
+      "integrity": "sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/character-reference-invalid": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/character-reference-invalid/-/character-reference-invalid-2.0.1.tgz",
+      "integrity": "sha512-iBZ4F4wRbyORVsu0jPV7gXkOsGYjGHPmAyv+HiHG8gi5PtC9KI2j1+v8/tlibRvjoWX027ypmG/n0HtO5t7unw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/cliui": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.1",
+        "wrap-ansi": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/comma-separated-tokens": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/comma-separated-tokens/-/comma-separated-tokens-2.0.3.tgz",
+      "integrity": "sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/concurrently": {
+      "version": "9.2.1",
+      "resolved": "https://registry.npmjs.org/concurrently/-/concurrently-9.2.1.tgz",
+      "integrity": "sha512-fsfrO0MxV64Znoy8/l1vVIjjHa29SZyyqPgQBwhiDcaW8wJc2W3XWVOGx4M3oJBnv/zdUZIIp1gDeS98GzP8Ng==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "4.1.2",
+        "rxjs": "7.8.2",
+        "shell-quote": "1.8.3",
+        "supports-color": "8.1.1",
+        "tree-kill": "1.2.2",
+        "yargs": "17.7.2"
+      },
+      "bin": {
+        "conc": "dist/bin/concurrently.js",
+        "concurrently": "dist/bin/concurrently.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/open-cli-tools/concurrently?sponsor=1"
+      }
+    },
+    "node_modules/content-disposition": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.1.0.tgz",
+      "integrity": "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/content-type": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-signature": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.6.0"
+      }
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/csstype": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+      "license": "MIT"
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/decode-named-character-reference": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/decode-named-character-reference/-/decode-named-character-reference-1.3.0.tgz",
+      "integrity": "sha512-GtpQYB283KrPp6nRw50q3U9/VfOutZOe103qlN7BPP6Ad27xYnOIWv4lPzo8HCAL+mMZofJ9KEy30fq6MfaK6Q==",
+      "license": "MIT",
+      "dependencies": {
+        "character-entities": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/deep-is": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
+      "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/devlop": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/devlop/-/devlop-1.1.0.tgz",
+      "integrity": "sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==",
+      "license": "MIT",
+      "dependencies": {
+        "dequal": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "license": "MIT"
+    },
+    "node_modules/electron-to-chromium": {
+      "version": "1.5.335",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.335.tgz",
+      "integrity": "sha512-q9n5T4BR4Xwa2cwbrwcsDJtHD/enpQ5S1xF1IAtdqf5AAgqDFmR/aakqH3ChFdqd/QXJhS3rnnXFtexU7rax6Q==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.7.tgz",
+      "integrity": "sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.27.7",
+        "@esbuild/android-arm": "0.27.7",
+        "@esbuild/android-arm64": "0.27.7",
+        "@esbuild/android-x64": "0.27.7",
+        "@esbuild/darwin-arm64": "0.27.7",
+        "@esbuild/darwin-x64": "0.27.7",
+        "@esbuild/freebsd-arm64": "0.27.7",
+        "@esbuild/freebsd-x64": "0.27.7",
+        "@esbuild/linux-arm": "0.27.7",
+        "@esbuild/linux-arm64": "0.27.7",
+        "@esbuild/linux-ia32": "0.27.7",
+        "@esbuild/linux-loong64": "0.27.7",
+        "@esbuild/linux-mips64el": "0.27.7",
+        "@esbuild/linux-ppc64": "0.27.7",
+        "@esbuild/linux-riscv64": "0.27.7",
+        "@esbuild/linux-s390x": "0.27.7",
+        "@esbuild/linux-x64": "0.27.7",
+        "@esbuild/netbsd-arm64": "0.27.7",
+        "@esbuild/netbsd-x64": "0.27.7",
+        "@esbuild/openbsd-arm64": "0.27.7",
+        "@esbuild/openbsd-x64": "0.27.7",
+        "@esbuild/openharmony-arm64": "0.27.7",
+        "@esbuild/sunos-x64": "0.27.7",
+        "@esbuild/win32-arm64": "0.27.7",
+        "@esbuild/win32-ia32": "0.27.7",
+        "@esbuild/win32-x64": "0.27.7"
+      }
+    },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "license": "MIT"
+    },
+    "node_modules/escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/eslint": {
+      "version": "9.39.4",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.39.4.tgz",
+      "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.8.0",
+        "@eslint-community/regexpp": "^4.12.1",
+        "@eslint/config-array": "^0.21.2",
+        "@eslint/config-helpers": "^0.4.2",
+        "@eslint/core": "^0.17.0",
+        "@eslint/eslintrc": "^3.3.5",
+        "@eslint/js": "9.39.4",
+        "@eslint/plugin-kit": "^0.4.1",
+        "@humanfs/node": "^0.16.6",
+        "@humanwhocodes/module-importer": "^1.0.1",
+        "@humanwhocodes/retry": "^0.4.2",
+        "@types/estree": "^1.0.6",
+        "ajv": "^6.14.0",
+        "chalk": "^4.0.0",
+        "cross-spawn": "^7.0.6",
+        "debug": "^4.3.2",
+        "escape-string-regexp": "^4.0.0",
+        "eslint-scope": "^8.4.0",
+        "eslint-visitor-keys": "^4.2.1",
+        "espree": "^10.4.0",
+        "esquery": "^1.5.0",
+        "esutils": "^2.0.2",
+        "fast-deep-equal": "^3.1.3",
+        "file-entry-cache": "^8.0.0",
+        "find-up": "^5.0.0",
+        "glob-parent": "^6.0.2",
+        "ignore": "^5.2.0",
+        "imurmurhash": "^0.1.4",
+        "is-glob": "^4.0.0",
+        "json-stable-stringify-without-jsonify": "^1.0.1",
+        "lodash.merge": "^4.6.2",
+        "minimatch": "^3.1.5",
+        "natural-compare": "^1.4.0",
+        "optionator": "^0.9.3"
+      },
+      "bin": {
+        "eslint": "bin/eslint.js"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://eslint.org/donate"
+      },
+      "peerDependencies": {
+        "jiti": "*"
+      },
+      "peerDependenciesMeta": {
+        "jiti": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/eslint-plugin-react-hooks": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-7.0.1.tgz",
+      "integrity": "sha512-O0d0m04evaNzEPoSW+59Mezf8Qt0InfgGIBJnpC0h3NH/WjUAR7BIKUfysC6todmtiZ/A0oUVS8Gce0WhBrHsA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.24.4",
+        "@babel/parser": "^7.24.4",
+        "hermes-parser": "^0.25.1",
+        "zod": "^3.25.0 || ^4.0.0",
+        "zod-validation-error": "^3.5.0 || ^4.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "eslint": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0 || ^9.0.0"
+      }
+    },
+    "node_modules/eslint-plugin-react-refresh": {
+      "version": "0.4.26",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react-refresh/-/eslint-plugin-react-refresh-0.4.26.tgz",
+      "integrity": "sha512-1RETEylht2O6FM/MvgnyvT+8K21wLqDNg4qD51Zj3guhjt433XbnnkVttHMyaVyAFD03QSV4LPS5iE3VQmO7XQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "eslint": ">=8.40"
+      }
+    },
+    "node_modules/eslint-scope": {
+      "version": "8.4.0",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-8.4.0.tgz",
+      "integrity": "sha512-sNXOfKCn74rt8RICKMvJS7XKV/Xk9kA7DyJr8mJik3S7Cwgy3qlkkmyS2uQB3jiJg6VNdZd/pDBJu0nvG2NlTg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "esrecurse": "^4.3.0",
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint-visitor-keys": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
+      "integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/espree": {
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-10.4.0.tgz",
+      "integrity": "sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "acorn": "^8.15.0",
+        "acorn-jsx": "^5.3.2",
+        "eslint-visitor-keys": "^4.2.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/esprima": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+      "license": "BSD-2-Clause",
+      "bin": {
+        "esparse": "bin/esparse.js",
+        "esvalidate": "bin/esvalidate.js"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/esquery": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.7.0.tgz",
+      "integrity": "sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "estraverse": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/esrecurse": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
+      "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/estraverse": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+      "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/estree-util-is-identifier-name": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/estree-util-is-identifier-name/-/estree-util-is-identifier-name-3.0.0.tgz",
+      "integrity": "sha512-hFtqIDZTIUZ9BXLb8y4pYGyk6+wekIivNVTcmvk8NoOh+VeRn5y6cEHzbURrWbfp1fIqdVipilzj+lfaadNZmg==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/esutils": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
+      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/express": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
+      "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "^2.0.0",
+        "body-parser": "^2.2.1",
+        "content-disposition": "^1.0.0",
+        "content-type": "^1.0.5",
+        "cookie": "^0.7.1",
+        "cookie-signature": "^1.2.1",
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "finalhandler": "^2.1.0",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.0",
+        "merge-descriptors": "^2.0.0",
+        "mime-types": "^3.0.0",
+        "on-finished": "^2.4.1",
+        "once": "^1.4.0",
+        "parseurl": "^1.3.3",
+        "proxy-addr": "^2.0.7",
+        "qs": "^6.14.0",
+        "range-parser": "^1.2.1",
+        "router": "^2.2.0",
+        "send": "^1.1.0",
+        "serve-static": "^2.2.0",
+        "statuses": "^2.0.1",
+        "type-is": "^2.0.1",
+        "vary": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/extend": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+      "license": "MIT"
+    },
+    "node_modules/extend-shallow": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+      "integrity": "sha512-zCnTtlxNoAiDc3gqY2aYAWFx7XWWiasuF2K8Me5WbN8otHKTUKBwjPtNpRs/rbUZm7KxWAaNj7P1a/p52GbVug==",
+      "license": "MIT",
+      "dependencies": {
+        "is-extendable": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-json-stable-stringify": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-levenshtein": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+      "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/file-entry-cache": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
+      "integrity": "sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "flat-cache": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/finalhandler": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
+      "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "on-finished": "^2.4.1",
+        "parseurl": "^1.3.3",
+        "statuses": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/find-up": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+      "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^6.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/flat-cache": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-4.0.1.tgz",
+      "integrity": "sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "flatted": "^3.2.9",
+        "keyv": "^4.5.4"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/flatted": {
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
+      "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/forwarded": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fresh": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
+      "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/gensync": {
+      "version": "1.0.0-beta.2",
+      "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
+      "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/get-tsconfig": {
+      "version": "4.13.7",
+      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.13.7.tgz",
+      "integrity": "sha512-7tN6rFgBlMgpBML5j8typ92BKFi2sFQvIdpAqLA2beia5avZDrMs0FLZiM5etShWq5irVyGcGMEA1jcDaK7A/Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "resolve-pkg-maps": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
+      }
+    },
+    "node_modules/glob-parent": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
+      "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/globals": {
+      "version": "16.5.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-16.5.0.tgz",
+      "integrity": "sha512-c/c15i26VrJ4IRt5Z89DnIzCGDn9EcebibhAOjw5ibqEHsE1wLUgkPn9RDmNcUKyU87GeaL633nyJ+pplFR2ZQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/gray-matter": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/gray-matter/-/gray-matter-4.0.3.tgz",
+      "integrity": "sha512-5v6yZd4JK3eMI3FqqCouswVqwugaA9r4dNZB1wwcmrD02QkV5H0y7XBQW8QwQqEaZY1pM9aqORSORhJRdNK44Q==",
+      "license": "MIT",
+      "dependencies": {
+        "js-yaml": "^3.13.1",
+        "kind-of": "^6.0.2",
+        "section-matter": "^1.0.0",
+        "strip-bom-string": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=6.0"
+      }
+    },
+    "node_modules/gray-matter/node_modules/argparse": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "license": "MIT",
+      "dependencies": {
+        "sprintf-js": "~1.0.2"
+      }
+    },
+    "node_modules/gray-matter/node_modules/js-yaml": {
+      "version": "3.14.2",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
+      "integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^1.0.7",
+        "esprima": "^4.0.0"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/hast-util-to-jsx-runtime": {
+      "version": "2.3.6",
+      "resolved": "https://registry.npmjs.org/hast-util-to-jsx-runtime/-/hast-util-to-jsx-runtime-2.3.6.tgz",
+      "integrity": "sha512-zl6s8LwNyo1P9uw+XJGvZtdFF1GdAkOg8ujOw+4Pyb76874fLps4ueHXDhXWdk6YHQ6OgUtinliG7RsYvCbbBg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0",
+        "@types/hast": "^3.0.0",
+        "@types/unist": "^3.0.0",
+        "comma-separated-tokens": "^2.0.0",
+        "devlop": "^1.0.0",
+        "estree-util-is-identifier-name": "^3.0.0",
+        "hast-util-whitespace": "^3.0.0",
+        "mdast-util-mdx-expression": "^2.0.0",
+        "mdast-util-mdx-jsx": "^3.0.0",
+        "mdast-util-mdxjs-esm": "^2.0.0",
+        "property-information": "^7.0.0",
+        "space-separated-tokens": "^2.0.0",
+        "style-to-js": "^1.0.0",
+        "unist-util-position": "^5.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-whitespace": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/hast-util-whitespace/-/hast-util-whitespace-3.0.0.tgz",
+      "integrity": "sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hermes-estree": {
+      "version": "0.25.1",
+      "resolved": "https://registry.npmjs.org/hermes-estree/-/hermes-estree-0.25.1.tgz",
+      "integrity": "sha512-0wUoCcLp+5Ev5pDW2OriHC2MJCbwLwuRx+gAqMTOkGKJJiBCLjtrvy4PWUGn6MIVefecRpzoOZ/UV6iGdOr+Cw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/hermes-parser": {
+      "version": "0.25.1",
+      "resolved": "https://registry.npmjs.org/hermes-parser/-/hermes-parser-0.25.1.tgz",
+      "integrity": "sha512-6pEjquH3rqaI6cYAXYPcz9MS4rY6R4ngRgrgfDshRptUZIc3lw0MCIJIGDj9++mfySOuPTHB4nrSW99BCvOPIA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "hermes-estree": "0.25.1"
+      }
+    },
+    "node_modules/html-url-attributes": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/html-url-attributes/-/html-url-attributes-3.0.1.tgz",
+      "integrity": "sha512-ol6UPyBWqsrO6EJySPz2O7ZSr856WDrEzM5zMqp+FJJLGMW35cLYmmZnl0vztAZxRUoNZJFTCohfjuIJ8I4QBQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/http-errors": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/iceberg-js": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/iceberg-js/-/iceberg-js-0.8.1.tgz",
+      "integrity": "sha512-1dhVQZXhcHje7798IVM+xoo/1ZdVfzOMIc8/rgVSijRK38EDqOJoGula9N/8ZI5RD8QTxNQtK/Gozpr+qUqRRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
+      "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/ignore": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
+      "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/import-fresh": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
+      "integrity": "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "parent-module": "^1.0.0",
+        "resolve-from": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/imurmurhash": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+      "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.19"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/inline-style-parser": {
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/inline-style-parser/-/inline-style-parser-0.2.7.tgz",
+      "integrity": "sha512-Nb2ctOyNR8DqQoR0OwRG95uNWIC0C1lCgf5Naz5H6Ji72KZ8OcFZLz2P5sNgwlyoJ8Yif11oMuYs5pBQa86csA==",
+      "license": "MIT"
+    },
+    "node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/is-alphabetical": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-alphabetical/-/is-alphabetical-2.0.1.tgz",
+      "integrity": "sha512-FWyyY60MeTNyeSRpkM2Iry0G9hpr7/9kD40mD/cGQEuilcZYS4okz8SN2Q6rLCJ8gbCt6fN+rC+6tMGS99LaxQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/is-alphanumerical": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-alphanumerical/-/is-alphanumerical-2.0.1.tgz",
+      "integrity": "sha512-hmbYhX/9MUMF5uh7tOXyK/n0ZvWpad5caBA17GsC6vyuCqaWliRG5K1qS9inmUhEMaOBIW7/whAnSwveW/LtZw==",
+      "license": "MIT",
+      "dependencies": {
+        "is-alphabetical": "^2.0.0",
+        "is-decimal": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/is-decimal": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-decimal/-/is-decimal-2.0.1.tgz",
+      "integrity": "sha512-AAB9hiomQs5DXWcRB1rqsxGUstbRroFOPPVAomNk/3XHR5JyEZChOyTWe2oayKnsSsr/kcGqF+z6yuH6HHpN0A==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/is-extendable": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
+      "integrity": "sha512-5BMULNob1vgFX6EjQw5izWDxrecWK9AM72rugNr0TFldMOi0fj6Jk+zeKIt0xGj4cEfQIJth4w3OKWOJ4f+AFw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-glob": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-extglob": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-hexadecimal": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-hexadecimal/-/is-hexadecimal-2.0.1.tgz",
+      "integrity": "sha512-DgZQp241c8oO6cA1SbTEWiXeoxV42vlcJxgH+B3hi1AiqqKruZR3ZGF8In3fj4+/y/7rHvlOZLZtgJ/4ttYGZg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/is-plain-obj": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-4.1.0.tgz",
+      "integrity": "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-promise": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
+      "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
+      "license": "MIT"
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/js-yaml": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
+      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/jsesc": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
+      "integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "jsesc": "bin/jsesc"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/json-buffer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
+      "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-stable-stringify-without-jsonify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
+      "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json5": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "json5": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/keyv": {
+      "version": "4.5.4",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
+      "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "json-buffer": "3.0.1"
+      }
+    },
+    "node_modules/kind-of": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
+      "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/levn": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
+      "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "prelude-ls": "^1.2.1",
+        "type-check": "~0.4.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/locate-path": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+      "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/lodash.merge": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
+      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/longest-streak": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/longest-streak/-/longest-streak-3.1.0.tgz",
+      "integrity": "sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/lru-cache": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+      "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/mdast-util-from-markdown": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/mdast-util-from-markdown/-/mdast-util-from-markdown-2.0.3.tgz",
+      "integrity": "sha512-W4mAWTvSlKvf8L6J+VN9yLSqQ9AOAAvHuoDAmPkz4dHf553m5gVj2ejadHJhoJmcmxEnOv6Pa8XJhpxE93kb8Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "@types/unist": "^3.0.0",
+        "decode-named-character-reference": "^1.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-to-string": "^4.0.0",
+        "micromark": "^4.0.0",
+        "micromark-util-decode-numeric-character-reference": "^2.0.0",
+        "micromark-util-decode-string": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0",
+        "unist-util-stringify-position": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-mdx-expression": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-mdx-expression/-/mdast-util-mdx-expression-2.0.1.tgz",
+      "integrity": "sha512-J6f+9hUp+ldTZqKRSg7Vw5V6MqjATc+3E4gf3CFNcuZNWD8XdyI6zQ8GqH7f8169MM6P7hMBRDVGnn7oHB9kXQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree-jsx": "^1.0.0",
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-mdx-jsx": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-mdx-jsx/-/mdast-util-mdx-jsx-3.2.0.tgz",
+      "integrity": "sha512-lj/z8v0r6ZtsN/cGNNtemmmfoLAFZnjMbNyLzBafjzikOM+glrjNHPlf6lQDOTccj9n5b0PPihEBbhneMyGs1Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree-jsx": "^1.0.0",
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "@types/unist": "^3.0.0",
+        "ccount": "^2.0.0",
+        "devlop": "^1.1.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0",
+        "parse-entities": "^4.0.0",
+        "stringify-entities": "^4.0.0",
+        "unist-util-stringify-position": "^4.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-mdxjs-esm": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-mdxjs-esm/-/mdast-util-mdxjs-esm-2.0.1.tgz",
+      "integrity": "sha512-EcmOpxsZ96CvlP03NghtH1EsLtr0n9Tm4lPUJUBccV9RwUOneqSycg19n5HGzCf+10LozMRSObtVr3ee1WoHtg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree-jsx": "^1.0.0",
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-phrasing": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-phrasing/-/mdast-util-phrasing-4.1.0.tgz",
+      "integrity": "sha512-TqICwyvJJpBwvGAMZjj4J2n0X8QWp21b9l0o7eXyVJ25YNWYbJDVIyD1bZXE6WtV6RmKJVYmQAKWa0zWOABz2w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "unist-util-is": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-to-hast": {
+      "version": "13.2.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-hast/-/mdast-util-to-hast-13.2.1.tgz",
+      "integrity": "sha512-cctsq2wp5vTsLIcaymblUriiTcZd0CwWtCbLvrOzYCDZoWyMNV8sZ7krj09FSnsiJi3WVsHLM4k6Dq/yaPyCXA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "@ungap/structured-clone": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "trim-lines": "^3.0.0",
+        "unist-util-position": "^5.0.0",
+        "unist-util-visit": "^5.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-to-markdown": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-markdown/-/mdast-util-to-markdown-2.1.2.tgz",
+      "integrity": "sha512-xj68wMTvGXVOKonmog6LwyJKrYXZPvlwabaryTjLh9LuvovB/KAH+kvi8Gjj+7rJjsFi23nkUxRQv1KqSroMqA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "@types/unist": "^3.0.0",
+        "longest-streak": "^3.0.0",
+        "mdast-util-phrasing": "^4.0.0",
+        "mdast-util-to-string": "^4.0.0",
+        "micromark-util-classify-character": "^2.0.0",
+        "micromark-util-decode-string": "^2.0.0",
+        "unist-util-visit": "^5.0.0",
+        "zwitch": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-to-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-string/-/mdast-util-to-string-4.0.0.tgz",
+      "integrity": "sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/media-typer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
+      "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/merge-descriptors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
+      "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/micromark": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/micromark/-/micromark-4.0.2.tgz",
+      "integrity": "sha512-zpe98Q6kvavpCr1NPVSCMebCKfD7CA2NqZ+rykeNhONIJBpc1tFKt9hucLGwha3jNTNI8lHpctWJWoimVF4PfA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@types/debug": "^4.0.0",
+        "debug": "^4.0.0",
+        "decode-named-character-reference": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-core-commonmark": "^2.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-combine-extensions": "^2.0.0",
+        "micromark-util-decode-numeric-character-reference": "^2.0.0",
+        "micromark-util-encode": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-resolve-all": "^2.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "micromark-util-subtokenize": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-core-commonmark": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/micromark-core-commonmark/-/micromark-core-commonmark-2.0.3.tgz",
+      "integrity": "sha512-RDBrHEMSxVFLg6xvnXmb1Ayr2WzLAWjeSATAoxwKYJV94TeNavgoIdA0a9ytzDSVzBy2YKFK+emCPOEibLeCrg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "decode-named-character-reference": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-factory-destination": "^2.0.0",
+        "micromark-factory-label": "^2.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-factory-title": "^2.0.0",
+        "micromark-factory-whitespace": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-classify-character": "^2.0.0",
+        "micromark-util-html-tag-name": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-resolve-all": "^2.0.0",
+        "micromark-util-subtokenize": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-destination": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-destination/-/micromark-factory-destination-2.0.1.tgz",
+      "integrity": "sha512-Xe6rDdJlkmbFRExpTOmRj9N3MaWmbAgdpSrBQvCFqhezUn4AHqJHbaEnfbVYYiexVSs//tqOdY/DxhjdCiJnIA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-label": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-label/-/micromark-factory-label-2.0.1.tgz",
+      "integrity": "sha512-VFMekyQExqIW7xIChcXn4ok29YE3rnuyveW3wZQWWqF4Nv9Wk5rgJ99KzPvHjkmPXF93FXIbBp6YdW3t71/7Vg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-space": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-space/-/micromark-factory-space-2.0.1.tgz",
+      "integrity": "sha512-zRkxjtBxxLd2Sc0d+fbnEunsTj46SWXgXciZmHq0kDYGnck/ZSGj9/wULTV95uoeYiK5hRXP2mJ98Uo4cq/LQg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-title": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-title/-/micromark-factory-title-2.0.1.tgz",
+      "integrity": "sha512-5bZ+3CjhAd9eChYTHsjy6TGxpOFSKgKKJPJxr293jTbfry2KDoWkhBb6TcPVB4NmzaPhMs1Frm9AZH7OD4Cjzw==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-whitespace": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-whitespace/-/micromark-factory-whitespace-2.0.1.tgz",
+      "integrity": "sha512-Ob0nuZ3PKt/n0hORHyvoD9uZhr+Za8sFoP+OnMcnWK5lngSzALgQYKMr9RJVOWLqQYuyn6ulqGWSXdwf6F80lQ==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-character": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-character/-/micromark-util-character-2.1.1.tgz",
+      "integrity": "sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-chunked": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-chunked/-/micromark-util-chunked-2.0.1.tgz",
+      "integrity": "sha512-QUNFEOPELfmvv+4xiNg2sRYeS/P84pTW0TCgP5zc9FpXetHY0ab7SxKyAQCNCc1eK0459uoLI1y5oO5Vc1dbhA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-classify-character": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-classify-character/-/micromark-util-classify-character-2.0.1.tgz",
+      "integrity": "sha512-K0kHzM6afW/MbeWYWLjoHQv1sgg2Q9EccHEDzSkxiP/EaagNzCm7T/WMKZ3rjMbvIpvBiZgwR3dKMygtA4mG1Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-combine-extensions": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-combine-extensions/-/micromark-util-combine-extensions-2.0.1.tgz",
+      "integrity": "sha512-OnAnH8Ujmy59JcyZw8JSbK9cGpdVY44NKgSM7E9Eh7DiLS2E9RNQf0dONaGDzEG9yjEl5hcqeIsj4hfRkLH/Bg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-decode-numeric-character-reference": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/micromark-util-decode-numeric-character-reference/-/micromark-util-decode-numeric-character-reference-2.0.2.tgz",
+      "integrity": "sha512-ccUbYk6CwVdkmCQMyr64dXz42EfHGkPQlBj5p7YVGzq8I7CtjXZJrubAYezf7Rp+bjPseiROqe7G6foFd+lEuw==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-decode-string": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-decode-string/-/micromark-util-decode-string-2.0.1.tgz",
+      "integrity": "sha512-nDV/77Fj6eH1ynwscYTOsbK7rR//Uj0bZXBwJZRfaLEJ1iGBR6kIfNmlNqaqJf649EP0F3NWNdeJi03elllNUQ==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "decode-named-character-reference": "^1.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-decode-numeric-character-reference": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-encode": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-encode/-/micromark-util-encode-2.0.1.tgz",
+      "integrity": "sha512-c3cVx2y4KqUnwopcO9b/SCdo2O67LwJJ/UyqGfbigahfegL9myoEFoDYZgkT7f36T0bLrM9hZTAaAyH+PCAXjw==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/micromark-util-html-tag-name": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-html-tag-name/-/micromark-util-html-tag-name-2.0.1.tgz",
+      "integrity": "sha512-2cNEiYDhCWKI+Gs9T0Tiysk136SnR13hhO8yW6BGNyhOC4qYFnwF1nKfD3HFAIXA5c45RrIG1ub11GiXeYd1xA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/micromark-util-normalize-identifier": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-normalize-identifier/-/micromark-util-normalize-identifier-2.0.1.tgz",
+      "integrity": "sha512-sxPqmo70LyARJs0w2UclACPUUEqltCkJ6PhKdMIDuJ3gSf/Q+/GIe3WKl0Ijb/GyH9lOpUkRAO2wp0GVkLvS9Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-resolve-all": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-resolve-all/-/micromark-util-resolve-all-2.0.1.tgz",
+      "integrity": "sha512-VdQyxFWFT2/FGJgwQnJYbe1jjQoNTS4RjglmSjTUlpUMa95Htx9NHeYW4rGDJzbjvCsl9eLjMQwGeElsqmzcHg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-sanitize-uri": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-sanitize-uri/-/micromark-util-sanitize-uri-2.0.1.tgz",
+      "integrity": "sha512-9N9IomZ/YuGGZZmQec1MbgxtlgougxTodVwDzzEouPKo3qFWvymFHWcnDi2vzV1ff6kas9ucW+o3yzJK9YB1AQ==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-encode": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-subtokenize": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-util-subtokenize/-/micromark-util-subtokenize-2.1.0.tgz",
+      "integrity": "sha512-XQLu552iSctvnEcgXw6+Sx75GflAPNED1qx7eBJ+wydBb2KCbRZe+NwvIEEMM83uml1+2WSXpBAcp9IUCgCYWA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-symbol": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-symbol/-/micromark-util-symbol-2.0.1.tgz",
+      "integrity": "sha512-vs5t8Apaud9N28kgCrRUdEed4UJ+wWNvicHLPxCa9ENlYuAY31M0ETy5y1vA33YoNPDFTghEbnh6efaE8h4x0Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/micromark-util-types": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/micromark-util-types/-/micromark-util-types-2.0.2.tgz",
+      "integrity": "sha512-Yw0ECSpJoViF1qTU4DC6NwtC4aWGt1EkzaQB8KPPyCRR8z9TWeV0HbEFGTO+ZY1wB22zmxnJqhPyTpOVCpeHTA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/minimatch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.11",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
+      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/natural-compare": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
+      "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/negotiator": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
+      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/node-releases": {
+      "version": "2.0.37",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.37.tgz",
+      "integrity": "sha512-1h5gKZCF+pO/o3Iqt5Jp7wc9rH3eJJ0+nh/CIoiRwjRxde/hAHyLPXYN4V3CqKAbiZPSeJFSWHmJsbkicta0Eg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "license": "MIT",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/optionator": {
+      "version": "0.9.4",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
+      "integrity": "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "deep-is": "^0.1.3",
+        "fast-levenshtein": "^2.0.6",
+        "levn": "^0.4.1",
+        "prelude-ls": "^1.2.1",
+        "type-check": "^0.4.0",
+        "word-wrap": "^1.2.5"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/p-limit": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "yocto-queue": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-locate": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+      "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/parent-module": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
+      "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "callsites": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/parse-entities": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/parse-entities/-/parse-entities-4.0.2.tgz",
+      "integrity": "sha512-GG2AQYWoLgL877gQIKeRPGO1xF9+eG1ujIb5soS5gPvLQ1y2o8FL90w2QWNdf9I361Mpp7726c+lj3U0qK1uGw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^2.0.0",
+        "character-entities-legacy": "^3.0.0",
+        "character-reference-invalid": "^2.0.0",
+        "decode-named-character-reference": "^1.0.0",
+        "is-alphanumerical": "^2.0.0",
+        "is-decimal": "^2.0.0",
+        "is-hexadecimal": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/parse-entities/node_modules/@types/unist": {
+      "version": "2.0.11",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.11.tgz",
+      "integrity": "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==",
+      "license": "MIT"
+    },
+    "node_modules/parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/path-exists": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+      "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.9",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.9.tgz",
+      "integrity": "sha512-7a70Nsot+EMX9fFU3064K/kdHWZqGVY+BADLyXc8Dfv+mTLLVl6JzJpPaCZ2kQL9gIJvKXSLMHhqdRRjwQeFtw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.11",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/prelude-ls": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
+      "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/property-information": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/property-information/-/property-information-7.1.0.tgz",
+      "integrity": "sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/proxy-addr": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "license": "MIT",
+      "dependencies": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/qs": {
+      "version": "6.15.1",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.1.tgz",
+      "integrity": "sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/range-parser": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/raw-body": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
+      "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.7.0",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/react": {
+      "version": "19.2.5",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.2.5.tgz",
+      "integrity": "sha512-llUJLzz1zTUBrskt2pwZgLq59AemifIftw4aB7JxOqf1HY2FDaGDxgwpAPVzHU1kdWabH7FauP4i1oEeer2WCA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-dom": {
+      "version": "19.2.5",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.5.tgz",
+      "integrity": "sha512-J5bAZz+DXMMwW/wV3xzKke59Af6CHY7G4uYLN1OvBcKEsWOs4pQExj86BBKamxl/Ik5bx9whOrvBlSDfWzgSag==",
+      "license": "MIT",
+      "dependencies": {
+        "scheduler": "^0.27.0"
+      },
+      "peerDependencies": {
+        "react": "^19.2.5"
+      }
+    },
+    "node_modules/react-markdown": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/react-markdown/-/react-markdown-10.1.0.tgz",
+      "integrity": "sha512-qKxVopLT/TyA6BX3Ue5NwabOsAzm0Q7kAPwq6L+wWDwisYs7R8vZ0nRXqq6rkueboxpkjvLGU9fWifiX/ZZFxQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "hast-util-to-jsx-runtime": "^2.0.0",
+        "html-url-attributes": "^3.0.0",
+        "mdast-util-to-hast": "^13.0.0",
+        "remark-parse": "^11.0.0",
+        "remark-rehype": "^11.0.0",
+        "unified": "^11.0.0",
+        "unist-util-visit": "^5.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      },
+      "peerDependencies": {
+        "@types/react": ">=18",
+        "react": ">=18"
+      }
+    },
+    "node_modules/react-refresh": {
+      "version": "0.18.0",
+      "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.18.0.tgz",
+      "integrity": "sha512-QgT5//D3jfjJb6Gsjxv0Slpj23ip+HtOpnNgnb2S5zU3CB26G/IDPGoy4RJB42wzFE46DRsstbW6tKHoKbhAxw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/remark-parse": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/remark-parse/-/remark-parse-11.0.0.tgz",
+      "integrity": "sha512-FCxlKLNGknS5ba/1lmpYijMUzX2esxW5xQqjWxw2eHFfS2MSdaHVINFmhjo+qN1WhZhNimq0dZATN9pH0IDrpA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "micromark-util-types": "^2.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-rehype": {
+      "version": "11.1.2",
+      "resolved": "https://registry.npmjs.org/remark-rehype/-/remark-rehype-11.1.2.tgz",
+      "integrity": "sha512-Dh7l57ianaEoIpzbp0PC9UKAdCSVklD8E5Rpw7ETfbTl3FqcOOgq5q2LVDhgGCkaBv7p24JXikPdvhhmHvKMsw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "mdast-util-to-hast": "^13.0.0",
+        "unified": "^11.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/resolve-from": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+      "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/resolve-pkg-maps": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
+      "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.1.tgz",
+      "integrity": "sha512-VmtB2rFU/GroZ4oL8+ZqXgSA38O6GR8KSIvWmEFv63pQ0G6KaBH9s07PO8XTXP4vI+3UJUEypOfjkGfmSBBR0w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.8"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.60.1",
+        "@rollup/rollup-android-arm64": "4.60.1",
+        "@rollup/rollup-darwin-arm64": "4.60.1",
+        "@rollup/rollup-darwin-x64": "4.60.1",
+        "@rollup/rollup-freebsd-arm64": "4.60.1",
+        "@rollup/rollup-freebsd-x64": "4.60.1",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.60.1",
+        "@rollup/rollup-linux-arm-musleabihf": "4.60.1",
+        "@rollup/rollup-linux-arm64-gnu": "4.60.1",
+        "@rollup/rollup-linux-arm64-musl": "4.60.1",
+        "@rollup/rollup-linux-loong64-gnu": "4.60.1",
+        "@rollup/rollup-linux-loong64-musl": "4.60.1",
+        "@rollup/rollup-linux-ppc64-gnu": "4.60.1",
+        "@rollup/rollup-linux-ppc64-musl": "4.60.1",
+        "@rollup/rollup-linux-riscv64-gnu": "4.60.1",
+        "@rollup/rollup-linux-riscv64-musl": "4.60.1",
+        "@rollup/rollup-linux-s390x-gnu": "4.60.1",
+        "@rollup/rollup-linux-x64-gnu": "4.60.1",
+        "@rollup/rollup-linux-x64-musl": "4.60.1",
+        "@rollup/rollup-openbsd-x64": "4.60.1",
+        "@rollup/rollup-openharmony-arm64": "4.60.1",
+        "@rollup/rollup-win32-arm64-msvc": "4.60.1",
+        "@rollup/rollup-win32-ia32-msvc": "4.60.1",
+        "@rollup/rollup-win32-x64-gnu": "4.60.1",
+        "@rollup/rollup-win32-x64-msvc": "4.60.1",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/router": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
+      "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "is-promise": "^4.0.0",
+        "parseurl": "^1.3.3",
+        "path-to-regexp": "^8.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/rxjs": {
+      "version": "7.8.2",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz",
+      "integrity": "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
+    },
+    "node_modules/scheduler": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
+      "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
+      "license": "MIT"
+    },
+    "node_modules/section-matter": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/section-matter/-/section-matter-1.0.0.tgz",
+      "integrity": "sha512-vfD3pmTzGpufjScBh50YHKzEu2lxBWhVEHsNGoEXmCmn2hKGfeNLYMzCJpe8cD7gqX7TJluOVpBkAequ6dgMmA==",
+      "license": "MIT",
+      "dependencies": {
+        "extend-shallow": "^2.0.1",
+        "kind-of": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/send": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
+      "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.1",
+        "mime-types": "^3.0.2",
+        "ms": "^2.1.3",
+        "on-finished": "^2.4.1",
+        "range-parser": "^1.2.1",
+        "statuses": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/serve-static": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
+      "integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "parseurl": "^1.3.3",
+        "send": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "license": "ISC"
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shell-quote": {
+      "version": "1.8.3",
+      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.3.tgz",
+      "integrity": "sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
+      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3",
+        "side-channel-list": "^1.0.0",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/space-separated-tokens": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/space-separated-tokens/-/space-separated-tokens-2.0.2.tgz",
+      "integrity": "sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/sprintf-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/stringify-entities": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/stringify-entities/-/stringify-entities-4.0.4.tgz",
+      "integrity": "sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg==",
+      "license": "MIT",
+      "dependencies": {
+        "character-entities-html4": "^2.0.0",
+        "character-entities-legacy": "^3.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-bom-string": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/strip-bom-string/-/strip-bom-string-1.0.0.tgz",
+      "integrity": "sha512-uCC2VHvQRYu+lMh4My/sFNmF2klFymLX1wHJeXnbEJERpV/ZsVuonzerjfrGpIGF7LBVa1O7i9kjiWvJiFck8g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/strip-json-comments": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
+      "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/style-to-js": {
+      "version": "1.1.21",
+      "resolved": "https://registry.npmjs.org/style-to-js/-/style-to-js-1.1.21.tgz",
+      "integrity": "sha512-RjQetxJrrUJLQPHbLku6U/ocGtzyjbJMP9lCNK7Ag0CNh690nSH8woqWH9u16nMjYBAok+i7JO1NP2pOy8IsPQ==",
+      "license": "MIT",
+      "dependencies": {
+        "style-to-object": "1.0.14"
+      }
+    },
+    "node_modules/style-to-object": {
+      "version": "1.0.14",
+      "resolved": "https://registry.npmjs.org/style-to-object/-/style-to-object-1.0.14.tgz",
+      "integrity": "sha512-LIN7rULI0jBscWQYaSswptyderlarFkjQ+t79nzty8tcIAceVomEVlLzH5VP4Cmsv6MtKhs7qaAiwlcp+Mgaxw==",
+      "license": "MIT",
+      "dependencies": {
+        "inline-style-parser": "0.2.7"
+      }
+    },
+    "node_modules/supports-color": {
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
+      "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/supports-color?sponsor=1"
+      }
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.16",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
+      "integrity": "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/tree-kill": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/tree-kill/-/tree-kill-1.2.2.tgz",
+      "integrity": "sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "tree-kill": "cli.js"
+      }
+    },
+    "node_modules/trim-lines": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/trim-lines/-/trim-lines-3.0.1.tgz",
+      "integrity": "sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/trough": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/trough/-/trough-2.2.0.tgz",
+      "integrity": "sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/ts-api-utils": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.5.0.tgz",
+      "integrity": "sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.12"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4"
+      }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/tsx": {
+      "version": "4.21.0",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.21.0.tgz",
+      "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.27.0",
+        "get-tsconfig": "^4.7.5"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
+    },
+    "node_modules/type-check": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
+      "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "prelude-ls": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/type-is": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.0.1.tgz",
+      "integrity": "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==",
+      "license": "MIT",
+      "dependencies": {
+        "content-type": "^1.0.5",
+        "media-typer": "^1.1.0",
+        "mime-types": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/typescript-eslint": {
+      "version": "8.58.1",
+      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.58.1.tgz",
+      "integrity": "sha512-gf6/oHChByg9HJvhMO1iBexJh12AqqTfnuxscMDOVqfJW3htsdRJI/GfPpHTTcyeB8cSTUY2JcZmVgoyPqcrDg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/eslint-plugin": "8.58.1",
+        "@typescript-eslint/parser": "8.58.1",
+        "@typescript-eslint/typescript-estree": "8.58.1",
+        "@typescript-eslint/utils": "8.58.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
+      "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
+      "license": "MIT"
+    },
+    "node_modules/unified": {
+      "version": "11.0.5",
+      "resolved": "https://registry.npmjs.org/unified/-/unified-11.0.5.tgz",
+      "integrity": "sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "bail": "^2.0.0",
+        "devlop": "^1.0.0",
+        "extend": "^3.0.0",
+        "is-plain-obj": "^4.0.0",
+        "trough": "^2.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-is": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-6.0.1.tgz",
+      "integrity": "sha512-LsiILbtBETkDz8I9p1dQ0uyRUWuaQzd/cuEeS1hoRSyW5E5XGmTzlwY1OrNzzakGowI9Dr/I8HVaw4hTtnxy8g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-position": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-position/-/unist-util-position-5.0.0.tgz",
+      "integrity": "sha512-fucsC7HjXvkB5R3kTCO7kUjRdrS0BJt3M/FPxmHMBOm8JQi2BsHAHFsy27E0EolP8rp0NzXsJ+jNPyDWvOJZPA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-stringify-position": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-4.0.0.tgz",
+      "integrity": "sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-visit": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-5.1.0.tgz",
+      "integrity": "sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-is": "^6.0.0",
+        "unist-util-visit-parents": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-visit-parents": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-6.0.2.tgz",
+      "integrity": "sha512-goh1s1TBrqSqukSc8wrjwWhL0hiJxgA8m4kFxGlQ+8FYQ3C/m11FcTs4YYem7V664AhHVvgoQLk890Ssdsr2IQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-is": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/update-browserslist-db": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
+      "integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "escalade": "^3.2.0",
+        "picocolors": "^1.1.1"
+      },
+      "bin": {
+        "update-browserslist-db": "cli.js"
+      },
+      "peerDependencies": {
+        "browserslist": ">= 4.21.0"
+      }
+    },
+    "node_modules/uri-js": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
+      "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/vfile": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/vfile/-/vfile-6.0.3.tgz",
+      "integrity": "sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/vfile-message": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-4.0.3.tgz",
+      "integrity": "sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-stringify-position": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/vite": {
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.2.tgz",
+      "integrity": "sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.27.0",
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.3",
+        "postcss": "^8.5.6",
+        "rollup": "^4.43.0",
+        "tinyglobby": "^0.2.15"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "lightningcss": "^1.21.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/word-wrap": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
+      "integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "license": "ISC"
+    },
+    "node_modules/ws": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
+      "integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/y18n": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/yallist": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/yargs": {
+      "version": "17.7.2",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
+      "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^8.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.3",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^21.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/yargs-parser": {
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/yocto-queue": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zod": {
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
+      "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zod-validation-error": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/zod-validation-error/-/zod-validation-error-4.0.2.tgz",
+      "integrity": "sha512-Q6/nZLe6jxuU80qb/4uJ4t5v2VEZ44lzQjPDhYJNztRQ4wyWc6VF3D3Kb/fAuPetZQnhS3hnajCf9CsWesghLQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.0 || ^4.0.0"
+      }
+    },
+    "node_modules/zwitch": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/zwitch/-/zwitch-2.0.4.tgz",
+      "integrity": "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    }
+  }
+}

--- a/recipes/repo-learning-coach/package.json
+++ b/recipes/repo-learning-coach/package.json
@@ -1,0 +1,42 @@
+{
+  "name": "repo-learning-coach",
+  "private": true,
+  "version": "1.0.0",
+  "type": "module",
+  "scripts": {
+    "dev": "concurrently -k \"npm:dev:server\" \"npm:dev:client\"",
+    "dev:client": "vite --host",
+    "dev:server": "tsx watch server/index.ts",
+    "build": "tsc -b && vite build",
+    "serve": "NODE_ENV=production tsx server/index.ts",
+    "sync": "tsx server/sync-content.ts",
+    "lint": "eslint .",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "@supabase/supabase-js": "^2.47.10",
+    "express": "^5.2.1",
+    "gray-matter": "^4.0.3",
+    "react": "^19.2.0",
+    "react-dom": "^19.2.0",
+    "react-markdown": "^10.1.0",
+    "zod": "^4.1.13"
+  },
+  "devDependencies": {
+    "@eslint/js": "^9.39.1",
+    "@types/express": "^5.0.5",
+    "@types/node": "^24.6.0",
+    "@types/react": "^19.2.2",
+    "@types/react-dom": "^19.2.2",
+    "@vitejs/plugin-react": "^5.0.4",
+    "concurrently": "^9.2.1",
+    "eslint": "^9.39.1",
+    "eslint-plugin-react-hooks": "^7.0.1",
+    "eslint-plugin-react-refresh": "^0.4.24",
+    "globals": "^16.4.0",
+    "tsx": "^4.21.0",
+    "typescript": "~5.9.3",
+    "typescript-eslint": "^8.46.0",
+    "vite": "^7.1.7"
+  }
+}

--- a/recipes/repo-learning-coach/public/favicon.svg
+++ b/recipes/repo-learning-coach/public/favicon.svg
@@ -1,0 +1,11 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="64" height="64" viewBox="0 0 64 64" fill="none">
+  <rect width="64" height="64" rx="18" fill="#102442" />
+  <path
+    d="M16 16H28L34 34L40 16H48L37 48H31L16 16Z"
+    fill="#F7D8A1"
+  />
+  <path
+    d="M25 22H36C42.0751 22 47 26.9249 47 33C47 39.0751 42.0751 44 36 44H30.5V37.5H35.4C37.9405 37.5 40 35.4405 40 32.9C40 30.3595 37.9405 28.3 35.4 28.3H25V22Z"
+    fill="#9ED5CC"
+  />
+</svg>

--- a/recipes/repo-learning-coach/repo-learning.config.ts
+++ b/recipes/repo-learning-coach/repo-learning.config.ts
@@ -1,0 +1,38 @@
+export type RepoLearningConfig = {
+  slug: string
+  title: string
+  description: string
+  audience: string
+  researchDirectory: string[]
+  lessonDirectory: string[]
+  track: {
+    slug: string
+    title: string
+    description: string
+  }
+  brainIntegration: {
+    sourceTag: string
+    relatedThoughtLimit: number
+  }
+}
+
+export const REPO_LEARNING_CONFIG: RepoLearningConfig = {
+  slug: 'repo-learning-coach-sample',
+  title: 'Repo Learning Coach',
+  description:
+    'A Supabase-backed learning workspace that turns repo research into lessons, quizzes, progress tracking, and durable Open Brain captures.',
+  audience:
+    'Solo builders, maintainers, and collaborators who need a fast way to understand a codebase without losing the reasoning behind it.',
+  researchDirectory: ['research'],
+  lessonDirectory: ['curriculum', 'lessons'],
+  track: {
+    slug: 'repo-learning-foundations',
+    title: 'Repo Learning Foundations',
+    description:
+      'A sample path that shows how to separate reusable learning infrastructure from repo-specific research and onboarding content.',
+  },
+  brainIntegration: {
+    sourceTag: 'repo-learning-coach',
+    relatedThoughtLimit: 5,
+  },
+}

--- a/recipes/repo-learning-coach/research/01-what-the-recipe-builds.md
+++ b/recipes/repo-learning-coach/research/01-what-the-recipe-builds.md
@@ -1,0 +1,29 @@
+---
+slug: recipe-overview
+title: What Repo Learning Coach Builds
+summary: The product boundary for the recipe: a local learning app backed by Supabase tables inside an existing Open Brain project.
+category: orientation
+---
+
+# What Repo Learning Coach Builds
+
+Repo Learning Coach is not a new MCP server and it is not a replacement for your core Open Brain setup.
+
+It is a local app that does three jobs:
+
+1. turns repo research into a browseable library
+2. turns that research into a lesson path with quizzes and notes
+3. captures the durable outputs of learning back into `thoughts`
+
+That boundary matters.
+
+The local app owns the teaching surface: lessons, quiz state, comments, and progress.
+Open Brain owns the durable memory layer: the things worth surfacing again later across other sessions and tools.
+
+The result is a cleaner split than the original local-first prototype:
+
+- local UI for active onboarding and study
+- Supabase tables for structured learning state
+- `thoughts` only for durable takeaways and follow-up questions
+
+That keeps the recipe compatible with OB1 instead of turning it into a parallel product stack.

--- a/recipes/repo-learning-coach/research/02-content-contract.md
+++ b/recipes/repo-learning-coach/research/02-content-contract.md
@@ -1,0 +1,32 @@
+---
+slug: content-contract
+title: The Content Contract
+summary: The repo-specific surface is plain files: one config file, research markdown, and lesson markdown with frontmatter.
+category: architecture
+---
+
+# The Content Contract
+
+Repo Learning Coach is designed so adaptation happens in files, not in application code.
+
+The contract is intentionally small:
+
+- `repo-learning.config.ts` defines the project identity and where content lives
+- `research/*.md` stores source notes with frontmatter
+- `curriculum/lessons/*.md` stores lesson bodies plus quiz data in frontmatter
+
+This keeps the adaptation surface inspectable and diffable.
+
+If you want to retarget the recipe to a new repo, you should mainly be changing:
+
+- project metadata
+- research documents
+- lesson documents
+
+You should not be redesigning the Express server or React app every time.
+
+That is the same architectural idea that made the original prototype interesting, but reshaped for OB1:
+
+- content is repo-specific
+- the app/runtime is reusable
+- the importer is the contract that keeps both aligned

--- a/recipes/repo-learning-coach/research/03-brain-bridge.md
+++ b/recipes/repo-learning-coach/research/03-brain-bridge.md
@@ -1,0 +1,31 @@
+---
+slug: brain-bridge
+title: The Open Brain Bridge
+summary: How lesson summaries, takeaways, and follow-up questions get captured into thoughts without duplicating the whole learning database there.
+category: integration
+---
+
+# The Open Brain Bridge
+
+The bridge into Open Brain should stay narrow on purpose.
+
+Repo Learning Coach has richer structured state than `thoughts`:
+
+- quizzes
+- progress
+- lesson comments
+- curriculum order
+
+Those belong in dedicated learning tables.
+
+What belongs in `thoughts` is the durable part:
+
+- a takeaway worth resurfacing later
+- a confusion note worth revisiting in another session
+- a summary that should influence future work
+
+That gives you a useful memory loop without forcing the whole learning system into the generic thought schema.
+
+The bridge also works in the other direction.
+
+When a lesson opens, the server can search `thoughts` for related context and surface it in the lesson view. That makes prior work visible at the moment it matters, which is exactly what OB1 is good at.

--- a/recipes/repo-learning-coach/schema.sql
+++ b/recipes/repo-learning-coach/schema.sql
@@ -1,0 +1,183 @@
+create or replace function public.repo_learning_touch_updated_at()
+returns trigger as $$
+begin
+  new.updated_at = now();
+  return new;
+end;
+$$ language plpgsql;
+
+create table if not exists public.repo_learning_projects (
+  id uuid primary key default gen_random_uuid(),
+  slug text not null unique,
+  title text not null,
+  description text not null,
+  audience text not null,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+create table if not exists public.repo_learning_research_documents (
+  id uuid primary key default gen_random_uuid(),
+  project_id uuid not null references public.repo_learning_projects(id) on delete cascade,
+  slug text not null unique,
+  title text not null,
+  summary text not null,
+  category text not null,
+  content text not null,
+  source_path text not null unique,
+  source_url text,
+  content_hash text not null,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+create table if not exists public.repo_learning_tracks (
+  id uuid primary key default gen_random_uuid(),
+  project_id uuid not null references public.repo_learning_projects(id) on delete cascade,
+  slug text not null unique,
+  title text not null,
+  description text not null,
+  order_index integer not null,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+create table if not exists public.repo_learning_lessons (
+  id uuid primary key default gen_random_uuid(),
+  project_id uuid not null references public.repo_learning_projects(id) on delete cascade,
+  track_id uuid not null references public.repo_learning_tracks(id) on delete cascade,
+  slug text not null unique,
+  title text not null,
+  stage text not null,
+  difficulty text not null,
+  order_index integer not null,
+  estimated_minutes integer not null,
+  summary text not null,
+  goals_json jsonb not null default '[]'::jsonb,
+  content text not null,
+  related_research_json jsonb not null default '[]'::jsonb,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+create table if not exists public.repo_learning_quizzes (
+  id uuid primary key default gen_random_uuid(),
+  lesson_id uuid not null unique references public.repo_learning_lessons(id) on delete cascade,
+  title text not null,
+  passing_score integer not null default 70,
+  question_count integer not null default 0,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+create table if not exists public.repo_learning_quiz_questions (
+  id uuid primary key default gen_random_uuid(),
+  quiz_id uuid not null references public.repo_learning_quizzes(id) on delete cascade,
+  order_index integer not null,
+  prompt text not null,
+  options_json jsonb not null default '[]'::jsonb,
+  correct_option text not null,
+  explanation text not null,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  unique (quiz_id, order_index)
+);
+
+create table if not exists public.repo_learning_lesson_progress (
+  id uuid primary key default gen_random_uuid(),
+  lesson_id uuid not null unique references public.repo_learning_lessons(id) on delete cascade,
+  status text not null default 'not_started',
+  confidence integer not null default 1,
+  quiz_average integer not null default 0,
+  quiz_best integer not null default 0,
+  last_viewed_at timestamptz,
+  completed_at timestamptz,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+create table if not exists public.repo_learning_quiz_attempts (
+  id uuid primary key default gen_random_uuid(),
+  quiz_id uuid not null references public.repo_learning_quizzes(id) on delete cascade,
+  score integer not null,
+  total_questions integer not null,
+  created_at timestamptz not null default now()
+);
+
+create table if not exists public.repo_learning_quiz_responses (
+  id uuid primary key default gen_random_uuid(),
+  attempt_id uuid not null references public.repo_learning_quiz_attempts(id) on delete cascade,
+  question_id uuid not null references public.repo_learning_quiz_questions(id) on delete cascade,
+  selected_option text not null,
+  is_correct boolean not null,
+  created_at timestamptz not null default now()
+);
+
+create table if not exists public.repo_learning_lesson_comments (
+  id uuid primary key default gen_random_uuid(),
+  lesson_id uuid not null references public.repo_learning_lessons(id) on delete cascade,
+  body text not null,
+  understanding_state text not null,
+  created_at timestamptz not null default now()
+);
+
+create index if not exists repo_learning_research_documents_project_idx
+  on public.repo_learning_research_documents(project_id);
+
+create index if not exists repo_learning_tracks_project_idx
+  on public.repo_learning_tracks(project_id, order_index);
+
+create index if not exists repo_learning_lessons_track_idx
+  on public.repo_learning_lessons(track_id, order_index);
+
+create index if not exists repo_learning_quiz_attempts_quiz_idx
+  on public.repo_learning_quiz_attempts(quiz_id, created_at desc);
+
+create index if not exists repo_learning_lesson_comments_lesson_idx
+  on public.repo_learning_lesson_comments(lesson_id, created_at desc);
+
+drop trigger if exists repo_learning_projects_touch_updated_at on public.repo_learning_projects;
+create trigger repo_learning_projects_touch_updated_at
+before update on public.repo_learning_projects
+for each row execute function public.repo_learning_touch_updated_at();
+
+drop trigger if exists repo_learning_research_documents_touch_updated_at on public.repo_learning_research_documents;
+create trigger repo_learning_research_documents_touch_updated_at
+before update on public.repo_learning_research_documents
+for each row execute function public.repo_learning_touch_updated_at();
+
+drop trigger if exists repo_learning_tracks_touch_updated_at on public.repo_learning_tracks;
+create trigger repo_learning_tracks_touch_updated_at
+before update on public.repo_learning_tracks
+for each row execute function public.repo_learning_touch_updated_at();
+
+drop trigger if exists repo_learning_lessons_touch_updated_at on public.repo_learning_lessons;
+create trigger repo_learning_lessons_touch_updated_at
+before update on public.repo_learning_lessons
+for each row execute function public.repo_learning_touch_updated_at();
+
+drop trigger if exists repo_learning_quizzes_touch_updated_at on public.repo_learning_quizzes;
+create trigger repo_learning_quizzes_touch_updated_at
+before update on public.repo_learning_quizzes
+for each row execute function public.repo_learning_touch_updated_at();
+
+drop trigger if exists repo_learning_quiz_questions_touch_updated_at on public.repo_learning_quiz_questions;
+create trigger repo_learning_quiz_questions_touch_updated_at
+before update on public.repo_learning_quiz_questions
+for each row execute function public.repo_learning_touch_updated_at();
+
+drop trigger if exists repo_learning_lesson_progress_touch_updated_at on public.repo_learning_lesson_progress;
+create trigger repo_learning_lesson_progress_touch_updated_at
+before update on public.repo_learning_lesson_progress
+for each row execute function public.repo_learning_touch_updated_at();
+
+grant select, insert, update, delete on table public.repo_learning_projects to service_role;
+grant select, insert, update, delete on table public.repo_learning_research_documents to service_role;
+grant select, insert, update, delete on table public.repo_learning_tracks to service_role;
+grant select, insert, update, delete on table public.repo_learning_lessons to service_role;
+grant select, insert, update, delete on table public.repo_learning_quizzes to service_role;
+grant select, insert, update, delete on table public.repo_learning_quiz_questions to service_role;
+grant select, insert, update, delete on table public.repo_learning_lesson_progress to service_role;
+grant select, insert, update, delete on table public.repo_learning_quiz_attempts to service_role;
+grant select, insert, update, delete on table public.repo_learning_quiz_responses to service_role;
+grant select, insert, update, delete on table public.repo_learning_lesson_comments to service_role;

--- a/recipes/repo-learning-coach/server/brain.ts
+++ b/recipes/repo-learning-coach/server/brain.ts
@@ -1,0 +1,228 @@
+import { REPO_LEARNING_CONFIG } from '../repo-learning.config.js'
+
+import { APP_ENV, supabase } from './supabase.js'
+
+export type BrainBridgeState = {
+  enabled: boolean
+  reason: string | null
+}
+
+export type LearningArtifactKind = 'takeaway' | 'confusion' | 'summary'
+
+export type RelatedThoughtSummary = {
+  id: string
+  content: string
+  createdAt: string
+  similarity: number
+  metadata: Record<string, unknown>
+}
+
+type LessonThoughtContext = {
+  slug: string
+  title: string
+  summary: string
+  goals: string[]
+}
+
+type CaptureArtifactInput = {
+  kind: LearningArtifactKind
+  content: string
+  lesson: LessonThoughtContext & {
+    status: string
+    confidence: number
+  }
+}
+
+const OPENROUTER_BASE_URL = 'https://openrouter.ai/api/v1'
+
+export const getBrainBridgeState = (): BrainBridgeState =>
+  APP_ENV.openrouterApiKey
+    ? { enabled: true, reason: null }
+    : {
+        enabled: false,
+        reason:
+          'Set OPENROUTER_API_KEY to enable related-thought retrieval and capture into thoughts.',
+      }
+
+const ensureBrainBridge = () => {
+  const state = getBrainBridgeState()
+
+  if (!state.enabled) {
+    throw new Error(state.reason ?? 'Open Brain bridge is disabled.')
+  }
+}
+
+const getEmbedding = async (text: string): Promise<number[]> => {
+  ensureBrainBridge()
+
+  const response = await fetch(`${OPENROUTER_BASE_URL}/embeddings`, {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${APP_ENV.openrouterApiKey}`,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({
+      model: APP_ENV.openrouterEmbeddingModel,
+      input: text,
+    }),
+  })
+
+  if (!response.ok) {
+    const errorText = await response.text().catch(() => '')
+    throw new Error(
+      `OpenRouter embeddings failed: ${response.status} ${errorText}`.trim(),
+    )
+  }
+
+  const payload = (await response.json()) as {
+    data?: Array<{ embedding?: number[] }>
+  }
+
+  const embedding = payload.data?.[0]?.embedding
+
+  if (!embedding) {
+    throw new Error('OpenRouter did not return an embedding vector.')
+  }
+
+  return embedding
+}
+
+const buildSearchQuery = (
+  lesson: LessonThoughtContext,
+  relatedResearchTitles: string[],
+) =>
+  [
+    lesson.title,
+    lesson.summary,
+    `Goals: ${lesson.goals.join('; ')}`,
+    relatedResearchTitles.length
+      ? `Related research: ${relatedResearchTitles.join('; ')}`
+      : '',
+    'Search for prior thoughts that would help someone understand, apply, or remember this lesson.',
+  ]
+    .filter(Boolean)
+    .join('\n')
+
+const buildArtifactContent = ({ kind, content, lesson }: CaptureArtifactInput) => {
+  const trimmed = content.trim()
+
+  if (kind === 'summary' && trimmed.length === 0) {
+    return [
+      `Learning summary for ${lesson.title}.`,
+      lesson.summary,
+      `Status: ${lesson.status}. Confidence: ${lesson.confidence}/5.`,
+      lesson.goals.length ? `Goals covered: ${lesson.goals.join('; ')}` : '',
+      `Source: ${REPO_LEARNING_CONFIG.title}.`,
+    ]
+      .filter(Boolean)
+      .join(' ')
+  }
+
+  if (trimmed.length === 0) {
+    throw new Error('Artifact content is required for takeaways and confusion notes.')
+  }
+
+  if (kind === 'takeaway') {
+    return `Learning takeaway from ${lesson.title}: ${trimmed}`
+  }
+
+  if (kind === 'confusion') {
+    return `Follow-up question from ${lesson.title}: ${trimmed}`
+  }
+
+  return `Learning summary from ${lesson.title}: ${trimmed}`
+}
+
+export const findRelatedThoughtsForLesson = async (
+  lesson: LessonThoughtContext,
+  relatedResearchTitles: string[],
+): Promise<RelatedThoughtSummary[]> => {
+  const state = getBrainBridgeState()
+
+  if (!state.enabled) {
+    return []
+  }
+
+  const queryEmbedding = await getEmbedding(
+    buildSearchQuery(lesson, relatedResearchTitles),
+  )
+
+  const { data, error } = await supabase.rpc('match_thoughts', {
+    query_embedding: queryEmbedding,
+    match_threshold: 0.35,
+    match_count: REPO_LEARNING_CONFIG.brainIntegration.relatedThoughtLimit,
+    filter: {},
+  })
+
+  if (error) {
+    throw new Error(`match_thoughts failed: ${error.message}`)
+  }
+
+  return (data ?? []).map(
+    (row: {
+      id: string
+      content: string
+      created_at: string
+      similarity: number
+      metadata: Record<string, unknown> | null
+    }) => ({
+      id: row.id,
+      content: row.content,
+      createdAt: row.created_at,
+      similarity: row.similarity,
+      metadata: row.metadata ?? {},
+    }),
+  )
+}
+
+export const captureLearningArtifact = async ({
+  kind,
+  content,
+  lesson,
+}: CaptureArtifactInput) => {
+  const artifactContent = buildArtifactContent({ kind, content, lesson })
+  const embedding = await getEmbedding(artifactContent)
+  const metadata = {
+    source: REPO_LEARNING_CONFIG.brainIntegration.sourceTag,
+    type: 'lesson',
+    project_slug: REPO_LEARNING_CONFIG.slug,
+    project_title: REPO_LEARNING_CONFIG.title,
+    lesson_slug: lesson.slug,
+    lesson_title: lesson.title,
+    artifact_kind: kind,
+    topics: [
+      REPO_LEARNING_CONFIG.slug,
+      lesson.slug,
+      kind === 'confusion' ? 'learning-followup' : 'learning-takeaway',
+    ],
+  }
+
+  const { data, error } = await supabase.rpc('upsert_thought', {
+    p_content: artifactContent,
+    p_payload: { metadata },
+  })
+
+  if (error) {
+    throw new Error(`upsert_thought failed: ${error.message}`)
+  }
+
+  const thoughtId = (data as { id?: string } | null)?.id
+
+  if (!thoughtId) {
+    throw new Error('upsert_thought did not return an id.')
+  }
+
+  const { error: embeddingError } = await supabase
+    .from('thoughts')
+    .update({ embedding })
+    .eq('id', thoughtId)
+
+  if (embeddingError) {
+    throw new Error(`Failed to store embedding: ${embeddingError.message}`)
+  }
+
+  return {
+    thoughtId,
+    message: `Saved ${kind} to Open Brain.`,
+  }
+}

--- a/recipes/repo-learning-coach/server/content-loader.ts
+++ b/recipes/repo-learning-coach/server/content-loader.ts
@@ -1,0 +1,129 @@
+import { createHash } from 'node:crypto'
+import { readdirSync, readFileSync } from 'node:fs'
+import { basename, extname, resolve } from 'node:path'
+
+import matter from 'gray-matter'
+import { z } from 'zod'
+
+import { LESSON_DIR, RESEARCH_DIR, toAppRelativePath } from './paths.js'
+
+const slugFromFileName = (fileName: string) =>
+  basename(fileName, extname(fileName))
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-|-$/g, '')
+
+const researchFrontmatterSchema = z.object({
+  slug: z.string().min(1).optional(),
+  title: z.string().min(1),
+  summary: z.string().min(1),
+  category: z.string().min(1),
+  sourceUrl: z.string().min(1).optional(),
+})
+
+const quizQuestionSchema = z.object({
+  prompt: z.string().min(1),
+  options: z.array(z.string().min(1)).min(2),
+  correctOption: z.string().min(1),
+  explanation: z.string().min(1),
+})
+
+const lessonFrontmatterSchema = z.object({
+  slug: z.string().min(1).optional(),
+  title: z.string().min(1),
+  stage: z.string().min(1),
+  difficulty: z.string().min(1),
+  order: z.number().int().positive(),
+  estimatedMinutes: z.number().int().positive(),
+  summary: z.string().min(1),
+  goals: z.array(z.string().min(1)).min(1),
+  relatedResearch: z.array(z.string().min(1)).default([]),
+  quiz: z.object({
+    title: z.string().min(1),
+    passingScore: z.number().int().min(0).max(100).default(70),
+    questions: z.array(quizQuestionSchema).min(1),
+  }),
+})
+
+export type LoadedResearchDocument = {
+  slug: string
+  title: string
+  summary: string
+  category: string
+  content: string
+  sourcePath: string
+  sourceUrl: string | null
+  contentHash: string
+}
+
+export type LoadedLesson = {
+  slug: string
+  title: string
+  stage: string
+  difficulty: string
+  orderIndex: number
+  estimatedMinutes: number
+  summary: string
+  goals: string[]
+  content: string
+  relatedResearchSlugs: string[]
+  quiz: {
+    title: string
+    passingScore: number
+    questions: Array<{
+      prompt: string
+      options: string[]
+      correctOption: string
+      explanation: string
+    }>
+  }
+  sourcePath: string
+}
+
+const markdownFilesIn = (directory: string) =>
+  readdirSync(directory)
+    .filter((fileName) => extname(fileName) === '.md')
+    .sort()
+
+export const loadResearchDocuments = (): LoadedResearchDocument[] =>
+  markdownFilesIn(RESEARCH_DIR).map((fileName) => {
+    const absolutePath = resolve(RESEARCH_DIR, fileName)
+    const file = matter(readFileSync(absolutePath, 'utf8'))
+    const frontmatter = researchFrontmatterSchema.parse(file.data)
+    const content = file.content.trim()
+
+    return {
+      slug: frontmatter.slug ?? slugFromFileName(fileName),
+      title: frontmatter.title,
+      summary: frontmatter.summary,
+      category: frontmatter.category,
+      content,
+      sourcePath: toAppRelativePath(absolutePath),
+      sourceUrl: frontmatter.sourceUrl ?? null,
+      contentHash: createHash('sha1').update(content).digest('hex'),
+    }
+  })
+
+export const loadLessons = (): LoadedLesson[] =>
+  markdownFilesIn(LESSON_DIR)
+    .map((fileName) => {
+      const absolutePath = resolve(LESSON_DIR, fileName)
+      const file = matter(readFileSync(absolutePath, 'utf8'))
+      const frontmatter = lessonFrontmatterSchema.parse(file.data)
+
+      return {
+        slug: frontmatter.slug ?? slugFromFileName(fileName),
+        title: frontmatter.title,
+        stage: frontmatter.stage,
+        difficulty: frontmatter.difficulty,
+        orderIndex: frontmatter.order,
+        estimatedMinutes: frontmatter.estimatedMinutes,
+        summary: frontmatter.summary,
+        goals: frontmatter.goals,
+        content: file.content.trim(),
+        relatedResearchSlugs: frontmatter.relatedResearch,
+        quiz: frontmatter.quiz,
+        sourcePath: toAppRelativePath(absolutePath),
+      }
+    })
+    .sort((a, b) => a.orderIndex - b.orderIndex)

--- a/recipes/repo-learning-coach/server/content-loader.ts
+++ b/recipes/repo-learning-coach/server/content-loader.ts
@@ -85,8 +85,32 @@ const markdownFilesIn = (directory: string) =>
     .filter((fileName) => extname(fileName) === '.md')
     .sort()
 
-export const loadResearchDocuments = (): LoadedResearchDocument[] =>
-  markdownFilesIn(RESEARCH_DIR).map((fileName) => {
+const ensureUniqueSlugs = <
+  T extends {
+    slug: string
+    sourcePath: string
+  },
+>(
+  items: T[],
+  itemType: string,
+) => {
+  const seen = new Map<string, string>()
+
+  for (const item of items) {
+    const existing = seen.get(item.slug)
+
+    if (existing) {
+      throw new Error(
+        `Duplicate ${itemType} slug "${item.slug}" found in ${existing} and ${item.sourcePath}.`,
+      )
+    }
+
+    seen.set(item.slug, item.sourcePath)
+  }
+}
+
+export const loadResearchDocuments = (): LoadedResearchDocument[] => {
+  const documents = markdownFilesIn(RESEARCH_DIR).map((fileName) => {
     const absolutePath = resolve(RESEARCH_DIR, fileName)
     const file = matter(readFileSync(absolutePath, 'utf8'))
     const frontmatter = researchFrontmatterSchema.parse(file.data)
@@ -103,13 +127,32 @@ export const loadResearchDocuments = (): LoadedResearchDocument[] =>
       contentHash: createHash('sha1').update(content).digest('hex'),
     }
   })
+  ensureUniqueSlugs(documents, 'research')
+  return documents
+}
 
-export const loadLessons = (): LoadedLesson[] =>
-  markdownFilesIn(LESSON_DIR)
+export const loadLessons = (knownResearchSlugs: Set<string> = new Set()): LoadedLesson[] => {
+  const lessons = markdownFilesIn(LESSON_DIR)
     .map((fileName) => {
       const absolutePath = resolve(LESSON_DIR, fileName)
       const file = matter(readFileSync(absolutePath, 'utf8'))
       const frontmatter = lessonFrontmatterSchema.parse(file.data)
+
+      for (const question of frontmatter.quiz.questions) {
+        if (!question.options.includes(question.correctOption)) {
+          throw new Error(
+            `Lesson ${fileName} has a quiz question whose correctOption is not in options.`,
+          )
+        }
+      }
+
+      for (const relatedSlug of frontmatter.relatedResearch) {
+        if (knownResearchSlugs.size > 0 && !knownResearchSlugs.has(relatedSlug)) {
+          throw new Error(
+            `Lesson ${fileName} references unknown research slug "${relatedSlug}".`,
+          )
+        }
+      }
 
       return {
         slug: frontmatter.slug ?? slugFromFileName(fileName),
@@ -127,3 +170,6 @@ export const loadLessons = (): LoadedLesson[] =>
       }
     })
     .sort((a, b) => a.orderIndex - b.orderIndex)
+  ensureUniqueSlugs(lessons, 'lesson')
+  return lessons
+}

--- a/recipes/repo-learning-coach/server/db.ts
+++ b/recipes/repo-learning-coach/server/db.ts
@@ -67,6 +67,8 @@ type ProjectRow = {
 }
 
 type ResearchDocumentDetailRow = {
+  id: string
+  project_id: string
   slug: string
   title: string
   summary: string
@@ -74,6 +76,17 @@ type ResearchDocumentDetailRow = {
   content: string
   source_path: string
   source_url: string | null
+}
+
+type ResearchIdentityRow = {
+  id: string
+  slug: string
+  source_path: string
+}
+
+type LessonIdentityRow = {
+  id: string
+  slug: string
 }
 
 type QueryResult<T> = PromiseLike<{
@@ -142,17 +155,21 @@ const getProject = async () =>
     `Project ${REPO_LEARNING_CONFIG.slug} was not found. Run npm run sync first.`,
   )
 
-const getLessonRowBySlug = async (slug: string) =>
-  unwrapSingle<LessonRow>(
+const getLessonRowBySlug = async (slug: string) => {
+  const project = await getProject()
+
+  return unwrapSingle<LessonRow>(
     supabase
       .from('repo_learning_lessons')
       .select(
         'id, slug, title, stage, difficulty, order_index, estimated_minutes, summary, goals_json, content, related_research_json',
       )
+      .eq('project_id', project.id)
       .eq('slug', slug)
       .single(),
     `Lesson ${slug} was not found.`,
   ) as Promise<LessonRow>
+}
 
 const getProgressByLessonId = async (lessonId: string) =>
   maybeSingle(
@@ -221,7 +238,7 @@ const getBrainBridgeForLesson = async (
 export const syncContentToSupabase = async () => {
   const timestamp = now()
   const researchDocuments = loadResearchDocuments()
-  const lessons = loadLessons()
+  const lessons = loadLessons(new Set(researchDocuments.map((document) => document.slug)))
 
   const project = await unwrapSingle<{ id: string }>(
     supabase
@@ -258,13 +275,35 @@ export const syncContentToSupabase = async () => {
     'Failed to create or update the learning track.',
   )
 
+  const { data: existingResearchRows, error: existingResearchError } = await supabase
+    .from('repo_learning_research_documents')
+    .select('id, slug, source_path')
+    .eq('project_id', project.id)
+
+  if (existingResearchError) {
+    throw new Error(existingResearchError.message)
+  }
+
+  const researchBySlug = new Map(
+    ((existingResearchRows ?? []) as ResearchIdentityRow[]).map((row) => [row.slug, row]),
+  )
+  const researchBySourcePath = new Map(
+    ((existingResearchRows ?? []) as ResearchIdentityRow[]).map((row) => [
+      row.source_path,
+      row,
+    ]),
+  )
+  const keptResearchIds = new Set<string>()
+
   for (const document of researchDocuments) {
-    await unwrapSingle<{ id: string }>(
-      supabase
-        .from('repo_learning_research_documents')
-        .upsert(
-          {
-            project_id: project.id,
+    const existing =
+      researchBySlug.get(document.slug) ?? researchBySourcePath.get(document.sourcePath)
+
+    if (existing) {
+      await ensureNoError(
+        supabase
+          .from('repo_learning_research_documents')
+          .update({
             slug: document.slug,
             title: document.title,
             summary: document.summary,
@@ -274,21 +313,73 @@ export const syncContentToSupabase = async () => {
             source_url: document.sourceUrl,
             content_hash: document.contentHash,
             updated_at: timestamp,
-          },
-          { onConflict: 'slug' },
-        )
+          })
+          .eq('id', existing.id),
+      )
+      keptResearchIds.add(existing.id)
+      continue
+    }
+
+    const inserted = await unwrapSingle<{ id: string }>(
+      supabase
+        .from('repo_learning_research_documents')
+        .insert({
+          project_id: project.id,
+          slug: document.slug,
+          title: document.title,
+          summary: document.summary,
+          category: document.category,
+          content: document.content,
+          source_path: document.sourcePath,
+          source_url: document.sourceUrl,
+          content_hash: document.contentHash,
+          updated_at: timestamp,
+        })
         .select('id')
         .single(),
       `Failed to sync research document ${document.slug}.`,
     )
+
+    keptResearchIds.add(inserted.id)
   }
 
-  for (const lesson of lessons) {
-    const lessonRow = await unwrapSingle<{ id: string }>(
+  const staleResearchIds = ((existingResearchRows ?? []) as ResearchIdentityRow[])
+    .map((row) => row.id)
+    .filter((id) => !keptResearchIds.has(id))
+
+  if (staleResearchIds.length > 0) {
+    await ensureNoError(
       supabase
-        .from('repo_learning_lessons')
-        .upsert(
-          {
+        .from('repo_learning_research_documents')
+        .delete()
+        .in('id', staleResearchIds),
+    )
+  }
+
+  const { data: existingLessonRows, error: existingLessonError } = await supabase
+    .from('repo_learning_lessons')
+    .select('id, slug')
+    .eq('project_id', project.id)
+
+  if (existingLessonError) {
+    throw new Error(existingLessonError.message)
+  }
+
+  const lessonBySlug = new Map(
+    ((existingLessonRows ?? []) as LessonIdentityRow[]).map((row) => [row.slug, row]),
+  )
+  const keptLessonIds = new Set<string>()
+
+  for (const lesson of lessons) {
+    const existingLesson = lessonBySlug.get(lesson.slug)
+    let lessonId: string
+
+    if (existingLesson) {
+      lessonId = existingLesson.id
+      await ensureNoError(
+        supabase
+          .from('repo_learning_lessons')
+          .update({
             project_id: project.id,
             track_id: track.id,
             slug: lesson.slug,
@@ -302,20 +393,44 @@ export const syncContentToSupabase = async () => {
             content: lesson.content,
             related_research_json: lesson.relatedResearchSlugs,
             updated_at: timestamp,
-          },
-          { onConflict: 'slug' },
-        )
-        .select('id')
-        .single(),
-      `Failed to sync lesson ${lesson.slug}.`,
-    )
+          })
+          .eq('id', lessonId),
+      )
+    } else {
+      const insertedLesson = await unwrapSingle<{ id: string }>(
+        supabase
+          .from('repo_learning_lessons')
+          .insert({
+            project_id: project.id,
+            track_id: track.id,
+            slug: lesson.slug,
+            title: lesson.title,
+            stage: lesson.stage,
+            difficulty: lesson.difficulty,
+            order_index: lesson.orderIndex,
+            estimated_minutes: lesson.estimatedMinutes,
+            summary: lesson.summary,
+            goals_json: lesson.goals,
+            content: lesson.content,
+            related_research_json: lesson.relatedResearchSlugs,
+            updated_at: timestamp,
+          })
+          .select('id')
+          .single(),
+        `Failed to sync lesson ${lesson.slug}.`,
+      )
+
+      lessonId = insertedLesson.id
+    }
+
+    keptLessonIds.add(lessonId)
 
     const quizRow = await unwrapSingle<{ id: string }>(
       supabase
         .from('repo_learning_quizzes')
         .upsert(
           {
-            lesson_id: lessonRow.id,
+            lesson_id: lessonId,
             title: lesson.quiz.title,
             passing_score: lesson.quiz.passingScore,
             question_count: lesson.quiz.questions.length,
@@ -353,7 +468,7 @@ export const syncContentToSupabase = async () => {
     await ensureNoError(
       supabase.from('repo_learning_lesson_progress').upsert(
         {
-          lesson_id: lessonRow.id,
+          lesson_id: lessonId,
           status: 'not_started',
           confidence: 1,
           quiz_average: 0,
@@ -366,6 +481,24 @@ export const syncContentToSupabase = async () => {
         },
       ),
     )
+
+    await ensureNoError(
+      supabase
+        .from('repo_learning_quiz_questions')
+        .delete()
+        .eq('quiz_id', quizRow.id)
+        .gt('order_index', lesson.quiz.questions.length),
+    )
+  }
+
+  const staleLessonIds = ((existingLessonRows ?? []) as LessonIdentityRow[])
+    .map((row) => row.id)
+    .filter((id) => !keptLessonIds.has(id))
+
+  if (staleLessonIds.length > 0) {
+    await ensureNoError(
+      supabase.from('repo_learning_lessons').delete().in('id', staleLessonIds),
+    )
   }
 
   return {
@@ -376,40 +509,61 @@ export const syncContentToSupabase = async () => {
 
 export const getBootstrapData = async () => {
   const project = await getProject()
-
-  const [
-    { data: lessonRows, error: lessonError },
-    { data: progressRows, error: progressError },
-    { data: commentRows, error: commentError },
-    { data: researchRows, error: researchError },
-    { data: attemptRows, error: attemptError },
-  ] = await Promise.all([
-    supabase
-      .from('repo_learning_lessons')
-      .select(
-        'id, slug, title, stage, difficulty, order_index, estimated_minutes, summary',
-      )
-      .order('order_index'),
-    supabase
-      .from('repo_learning_lesson_progress')
-      .select(
-        'lesson_id, status, confidence, quiz_average, quiz_best, last_viewed_at, completed_at',
-      ),
-    supabase
-      .from('repo_learning_lesson_comments')
-      .select('lesson_id, understanding_state'),
-    supabase
-      .from('repo_learning_research_documents')
-      .select('slug, title, summary, category')
-      .order('title'),
-    supabase.from('repo_learning_quiz_attempts').select('score'),
-  ])
+  const { data: lessonRows, error: lessonError } = await supabase
+    .from('repo_learning_lessons')
+    .select('id, slug, title, stage, difficulty, order_index, estimated_minutes, summary')
+    .eq('project_id', project.id)
+    .order('order_index')
 
   if (lessonError) throw new Error(lessonError.message)
+
+  const lessonIds = (lessonRows ?? []).map((lesson) => lesson.id)
+  const { data: progressRows, error: progressError } =
+    lessonIds.length > 0
+      ? await supabase
+          .from('repo_learning_lesson_progress')
+          .select(
+            'lesson_id, status, confidence, quiz_average, quiz_best, last_viewed_at, completed_at',
+          )
+          .in('lesson_id', lessonIds)
+      : { data: [], error: null }
+
+  const { data: commentRows, error: commentError } =
+    lessonIds.length > 0
+      ? await supabase
+          .from('repo_learning_lesson_comments')
+          .select('lesson_id, understanding_state')
+          .in('lesson_id', lessonIds)
+      : { data: [], error: null }
+
+  const { data: quizRows, error: quizError } =
+    lessonIds.length > 0
+      ? await supabase
+          .from('repo_learning_quizzes')
+          .select('id, lesson_id')
+          .in('lesson_id', lessonIds)
+      : { data: [], error: null }
+
+  const quizIds = (quizRows ?? []).map((quiz) => quiz.id)
+  const { data: attemptRows, error: attemptError } =
+    quizIds.length > 0
+      ? await supabase
+          .from('repo_learning_quiz_attempts')
+          .select('score')
+          .in('quiz_id', quizIds)
+      : { data: [], error: null }
+
+  const { data: researchRows, error: researchError } = await supabase
+    .from('repo_learning_research_documents')
+    .select('slug, title, summary, category')
+    .eq('project_id', project.id)
+    .order('title')
+
   if (progressError) throw new Error(progressError.message)
   if (commentError) throw new Error(commentError.message)
-  if (researchError) throw new Error(researchError.message)
+  if (quizError) throw new Error(quizError.message)
   if (attemptError) throw new Error(attemptError.message)
+  if (researchError) throw new Error(researchError.message)
 
   const progressByLessonId = new Map(
     (progressRows ?? []).map((row) => [row.lesson_id, row as ProgressRow]),
@@ -487,6 +641,7 @@ export const getBootstrapData = async () => {
 }
 
 export const getLessonDetail = async (slug: string) => {
+  const project = await getProject()
   const lesson = await getLessonRowBySlug(slug)
   const [progress, quiz, commentResponse] = await Promise.all([
     getProgressByLessonId(lesson.id),
@@ -527,6 +682,7 @@ export const getLessonDetail = async (slug: string) => {
       return supabase
         .from('repo_learning_research_documents')
         .select('slug, title, summary, category')
+        .eq('project_id', project.id)
         .in('slug', relatedResearchSlugs)
     })(),
   ])
@@ -615,22 +771,27 @@ export const getLessonDetail = async (slug: string) => {
 }
 
 export const getResearchDocumentDetail = async (slug: string) =>
-  unwrapSingle<ResearchDocumentDetailRow>(
-    supabase
-      .from('repo_learning_research_documents')
-      .select('slug, title, summary, category, content, source_path, source_url')
-      .eq('slug', slug)
-      .single(),
-    `Research document ${slug} was not found.`,
-  ).then((document) => ({
-    slug: document.slug,
-    title: document.title,
-    summary: document.summary,
-    category: document.category,
-    content: document.content,
-    sourcePath: document.source_path,
-    sourceUrl: document.source_url,
-  }))
+  getProject().then((project) =>
+    unwrapSingle<ResearchDocumentDetailRow>(
+      supabase
+        .from('repo_learning_research_documents')
+        .select(
+          'id, project_id, slug, title, summary, category, content, source_path, source_url',
+        )
+        .eq('project_id', project.id)
+        .eq('slug', slug)
+        .single(),
+      `Research document ${slug} was not found.`,
+    ).then((document) => ({
+      slug: document.slug,
+      title: document.title,
+      summary: document.summary,
+      category: document.category,
+      content: document.content,
+      sourcePath: document.source_path,
+      sourceUrl: document.source_url,
+    })),
+  )
 
 export const updateLessonProgress = async (
   slug: string,
@@ -751,53 +912,60 @@ export const submitQuizAnswers = async (
     `Failed to save quiz attempt for ${quizId}.`,
   )
 
-  await ensureNoError(
-    supabase.from('repo_learning_quiz_responses').insert(
-      results.map((result) => ({
-        attempt_id: attempt.id,
-        question_id: result.questionId,
-        selected_option: result.selectedOption,
-        is_correct: result.isCorrect,
-      })),
-    ),
-  )
+  try {
+    await ensureNoError(
+      supabase.from('repo_learning_quiz_responses').insert(
+        results.map((result) => ({
+          attempt_id: attempt.id,
+          question_id: result.questionId,
+          selected_option: result.selectedOption,
+          is_correct: result.isCorrect,
+        })),
+      ),
+    )
 
-  const { data: attemptRows, error: attemptError } = await supabase
-    .from('repo_learning_quiz_attempts')
-    .select('score')
-    .eq('quiz_id', quizId)
+    const { data: attemptRows, error: attemptError } = await supabase
+      .from('repo_learning_quiz_attempts')
+      .select('score')
+      .eq('quiz_id', quizId)
 
-  if (attemptError) {
-    throw new Error(attemptError.message)
+    if (attemptError) {
+      throw new Error(attemptError.message)
+    }
+
+    const existingProgress = await getProgressByLessonId(quiz.lesson_id)
+    const allScores = (attemptRows ?? []).map((row) => row.score)
+    const timestamp = now()
+
+    await ensureNoError(
+      supabase.from('repo_learning_lesson_progress').upsert(
+        {
+          lesson_id: quiz.lesson_id,
+          status:
+            existingProgress?.status === 'not_started'
+              ? 'in_progress'
+              : existingProgress?.status ?? 'in_progress',
+          confidence: existingProgress?.confidence ?? 1,
+          quiz_average:
+            allScores.length > 0
+              ? Math.round(
+                  allScores.reduce((sum, value) => sum + value, 0) / allScores.length,
+                )
+              : 0,
+          quiz_best: allScores.length > 0 ? Math.max(...allScores) : 0,
+          last_viewed_at: timestamp,
+          completed_at: existingProgress?.completed_at,
+          updated_at: timestamp,
+        },
+        { onConflict: 'lesson_id' },
+      ),
+    )
+  } catch (error) {
+    await ensureNoError(
+      supabase.from('repo_learning_quiz_attempts').delete().eq('id', attempt.id),
+    )
+    throw error
   }
-
-  const existingProgress = await getProgressByLessonId(quiz.lesson_id)
-  const allScores = (attemptRows ?? []).map((row) => row.score)
-  const timestamp = now()
-
-  await ensureNoError(
-    supabase.from('repo_learning_lesson_progress').upsert(
-      {
-        lesson_id: quiz.lesson_id,
-        status:
-          existingProgress?.status === 'not_started'
-            ? 'in_progress'
-            : existingProgress?.status ?? 'in_progress',
-        confidence: existingProgress?.confidence ?? 1,
-        quiz_average:
-          allScores.length > 0
-            ? Math.round(
-                allScores.reduce((sum, value) => sum + value, 0) / allScores.length,
-              )
-            : 0,
-        quiz_best: allScores.length > 0 ? Math.max(...allScores) : 0,
-        last_viewed_at: timestamp,
-        completed_at: existingProgress?.completed_at,
-        updated_at: timestamp,
-      },
-      { onConflict: 'lesson_id' },
-    ),
-  )
 
   return {
     score,

--- a/recipes/repo-learning-coach/server/db.ts
+++ b/recipes/repo-learning-coach/server/db.ts
@@ -1,0 +1,830 @@
+import { REPO_LEARNING_CONFIG } from '../repo-learning.config.js'
+
+import {
+  captureLearningArtifact,
+  findRelatedThoughtsForLesson,
+  getBrainBridgeState,
+  type LearningArtifactKind,
+} from './brain.js'
+import { loadLessons, loadResearchDocuments } from './content-loader.js'
+import { supabase } from './supabase.js'
+
+export type LessonStatus = 'not_started' | 'in_progress' | 'completed'
+export type UnderstandingState =
+  | 'clear'
+  | 'unsure'
+  | 'confused'
+  | 'want_more_depth'
+  | 'want_examples'
+
+type LessonRow = {
+  id: string
+  slug: string
+  title: string
+  stage: string
+  difficulty: string
+  order_index: number
+  estimated_minutes: number
+  summary: string
+  goals_json: unknown
+  content: string
+  related_research_json: unknown
+}
+
+type ProgressRow = {
+  lesson_id: string
+  status: LessonStatus
+  confidence: number
+  quiz_average: number
+  quiz_best: number
+  last_viewed_at: string | null
+  completed_at: string | null
+}
+
+type QuizRow = {
+  id: string
+  lesson_id: string
+  title: string
+  passing_score: number
+  question_count: number
+}
+
+type QuestionRow = {
+  id: string
+  order_index: number
+  prompt: string
+  options_json: unknown
+  correct_option: string
+  explanation: string
+}
+
+type ProjectRow = {
+  id: string
+  slug: string
+  title: string
+  description: string
+  audience: string
+}
+
+type ResearchDocumentDetailRow = {
+  slug: string
+  title: string
+  summary: string
+  category: string
+  content: string
+  source_path: string
+  source_url: string | null
+}
+
+type QueryResult<T> = PromiseLike<{
+  data: T | null
+  error: { message: string } | null
+}>
+
+type ErrorOnlyResult = PromiseLike<{
+  error: { message: string } | null
+}>
+
+const now = () => new Date().toISOString()
+
+const unwrapSingle = async <T>(
+  promise: QueryResult<T>,
+  fallbackMessage: string,
+) => {
+  const { data, error } = await promise
+
+  if (error) {
+    throw new Error(error.message)
+  }
+
+  if (!data) {
+    throw new Error(fallbackMessage)
+  }
+
+  return data
+}
+
+const maybeSingle = async <T>(
+  promise: QueryResult<T>,
+) => {
+  const { data, error } = await promise
+
+  if (error) {
+    throw new Error(error.message)
+  }
+
+  return data
+}
+
+const ensureNoError = async (promise: ErrorOnlyResult) => {
+  const { error } = await promise
+
+  if (error) {
+    throw new Error(error.message)
+  }
+}
+
+const parseStringArray = (value: unknown, fieldName: string): string[] => {
+  if (!Array.isArray(value) || !value.every((item) => typeof item === 'string')) {
+    throw new Error(`${fieldName} is not a string array.`)
+  }
+
+  return value
+}
+
+const getProject = async () =>
+  unwrapSingle<ProjectRow>(
+    supabase
+      .from('repo_learning_projects')
+      .select('id, slug, title, description, audience')
+      .eq('slug', REPO_LEARNING_CONFIG.slug)
+      .single(),
+    `Project ${REPO_LEARNING_CONFIG.slug} was not found. Run npm run sync first.`,
+  )
+
+const getLessonRowBySlug = async (slug: string) =>
+  unwrapSingle<LessonRow>(
+    supabase
+      .from('repo_learning_lessons')
+      .select(
+        'id, slug, title, stage, difficulty, order_index, estimated_minutes, summary, goals_json, content, related_research_json',
+      )
+      .eq('slug', slug)
+      .single(),
+    `Lesson ${slug} was not found.`,
+  ) as Promise<LessonRow>
+
+const getProgressByLessonId = async (lessonId: string) =>
+  maybeSingle(
+    supabase
+      .from('repo_learning_lesson_progress')
+      .select(
+        'lesson_id, status, confidence, quiz_average, quiz_best, last_viewed_at, completed_at',
+      )
+      .eq('lesson_id', lessonId)
+      .single(),
+  ) as Promise<ProgressRow | null>
+
+const getQuizByLessonId = async (lessonId: string) =>
+  unwrapSingle<QuizRow>(
+    supabase
+      .from('repo_learning_quizzes')
+      .select('id, lesson_id, title, passing_score, question_count')
+      .eq('lesson_id', lessonId)
+      .single(),
+    `Quiz for lesson ${lessonId} was not found.`,
+  ) as Promise<QuizRow>
+
+const getQuestionRowsByQuizId = async (quizId: string, questionCount: number) => {
+  const { data, error } = await supabase
+    .from('repo_learning_quiz_questions')
+    .select('id, order_index, prompt, options_json, correct_option, explanation')
+    .eq('quiz_id', quizId)
+    .lte('order_index', questionCount)
+    .order('order_index')
+
+  if (error) {
+    throw new Error(error.message)
+  }
+
+  return (data ?? []) as QuestionRow[]
+}
+
+const getBrainBridgeForLesson = async (
+  lesson: {
+    slug: string
+    title: string
+    summary: string
+    goals: string[]
+  },
+  relatedResearchTitles: string[],
+) => {
+  let brainBridge = getBrainBridgeState()
+  let relatedThoughts: Awaited<ReturnType<typeof findRelatedThoughtsForLesson>> = []
+
+  if (!brainBridge.enabled) {
+    return { brainBridge, relatedThoughts }
+  }
+
+  try {
+    relatedThoughts = await findRelatedThoughtsForLesson(lesson, relatedResearchTitles)
+  } catch (error) {
+    brainBridge = {
+      enabled: false,
+      reason: error instanceof Error ? error.message : 'Failed to search related thoughts.',
+    }
+  }
+
+  return { brainBridge, relatedThoughts }
+}
+
+export const syncContentToSupabase = async () => {
+  const timestamp = now()
+  const researchDocuments = loadResearchDocuments()
+  const lessons = loadLessons()
+
+  const project = await unwrapSingle<{ id: string }>(
+    supabase
+      .from('repo_learning_projects')
+      .upsert(
+        {
+          slug: REPO_LEARNING_CONFIG.slug,
+          title: REPO_LEARNING_CONFIG.title,
+          description: REPO_LEARNING_CONFIG.description,
+          audience: REPO_LEARNING_CONFIG.audience,
+        },
+        { onConflict: 'slug' },
+      )
+      .select('id')
+      .single(),
+    'Failed to create or update the learning project.',
+  )
+
+  const track = await unwrapSingle<{ id: string }>(
+    supabase
+      .from('repo_learning_tracks')
+      .upsert(
+        {
+          project_id: project.id,
+          slug: REPO_LEARNING_CONFIG.track.slug,
+          title: REPO_LEARNING_CONFIG.track.title,
+          description: REPO_LEARNING_CONFIG.track.description,
+          order_index: 1,
+        },
+        { onConflict: 'slug' },
+      )
+      .select('id')
+      .single(),
+    'Failed to create or update the learning track.',
+  )
+
+  for (const document of researchDocuments) {
+    await unwrapSingle<{ id: string }>(
+      supabase
+        .from('repo_learning_research_documents')
+        .upsert(
+          {
+            project_id: project.id,
+            slug: document.slug,
+            title: document.title,
+            summary: document.summary,
+            category: document.category,
+            content: document.content,
+            source_path: document.sourcePath,
+            source_url: document.sourceUrl,
+            content_hash: document.contentHash,
+            updated_at: timestamp,
+          },
+          { onConflict: 'slug' },
+        )
+        .select('id')
+        .single(),
+      `Failed to sync research document ${document.slug}.`,
+    )
+  }
+
+  for (const lesson of lessons) {
+    const lessonRow = await unwrapSingle<{ id: string }>(
+      supabase
+        .from('repo_learning_lessons')
+        .upsert(
+          {
+            project_id: project.id,
+            track_id: track.id,
+            slug: lesson.slug,
+            title: lesson.title,
+            stage: lesson.stage,
+            difficulty: lesson.difficulty,
+            order_index: lesson.orderIndex,
+            estimated_minutes: lesson.estimatedMinutes,
+            summary: lesson.summary,
+            goals_json: lesson.goals,
+            content: lesson.content,
+            related_research_json: lesson.relatedResearchSlugs,
+            updated_at: timestamp,
+          },
+          { onConflict: 'slug' },
+        )
+        .select('id')
+        .single(),
+      `Failed to sync lesson ${lesson.slug}.`,
+    )
+
+    const quizRow = await unwrapSingle<{ id: string }>(
+      supabase
+        .from('repo_learning_quizzes')
+        .upsert(
+          {
+            lesson_id: lessonRow.id,
+            title: lesson.quiz.title,
+            passing_score: lesson.quiz.passingScore,
+            question_count: lesson.quiz.questions.length,
+            updated_at: timestamp,
+          },
+          { onConflict: 'lesson_id' },
+        )
+        .select('id')
+        .single(),
+      `Failed to sync quiz for lesson ${lesson.slug}.`,
+    )
+
+    for (const [index, question] of lesson.quiz.questions.entries()) {
+      await unwrapSingle<{ id: string }>(
+        supabase
+          .from('repo_learning_quiz_questions')
+          .upsert(
+            {
+              quiz_id: quizRow.id,
+              order_index: index + 1,
+              prompt: question.prompt,
+              options_json: question.options,
+              correct_option: question.correctOption,
+              explanation: question.explanation,
+              updated_at: timestamp,
+            },
+            { onConflict: 'quiz_id,order_index' },
+          )
+          .select('id')
+          .single(),
+        `Failed to sync question ${index + 1} for lesson ${lesson.slug}.`,
+      )
+    }
+
+    await ensureNoError(
+      supabase.from('repo_learning_lesson_progress').upsert(
+        {
+          lesson_id: lessonRow.id,
+          status: 'not_started',
+          confidence: 1,
+          quiz_average: 0,
+          quiz_best: 0,
+          updated_at: timestamp,
+        },
+        {
+          onConflict: 'lesson_id',
+          ignoreDuplicates: true,
+        },
+      ),
+    )
+  }
+
+  return {
+    lessons: lessons.length,
+    researchDocuments: researchDocuments.length,
+  }
+}
+
+export const getBootstrapData = async () => {
+  const project = await getProject()
+
+  const [
+    { data: lessonRows, error: lessonError },
+    { data: progressRows, error: progressError },
+    { data: commentRows, error: commentError },
+    { data: researchRows, error: researchError },
+    { data: attemptRows, error: attemptError },
+  ] = await Promise.all([
+    supabase
+      .from('repo_learning_lessons')
+      .select(
+        'id, slug, title, stage, difficulty, order_index, estimated_minutes, summary',
+      )
+      .order('order_index'),
+    supabase
+      .from('repo_learning_lesson_progress')
+      .select(
+        'lesson_id, status, confidence, quiz_average, quiz_best, last_viewed_at, completed_at',
+      ),
+    supabase
+      .from('repo_learning_lesson_comments')
+      .select('lesson_id, understanding_state'),
+    supabase
+      .from('repo_learning_research_documents')
+      .select('slug, title, summary, category')
+      .order('title'),
+    supabase.from('repo_learning_quiz_attempts').select('score'),
+  ])
+
+  if (lessonError) throw new Error(lessonError.message)
+  if (progressError) throw new Error(progressError.message)
+  if (commentError) throw new Error(commentError.message)
+  if (researchError) throw new Error(researchError.message)
+  if (attemptError) throw new Error(attemptError.message)
+
+  const progressByLessonId = new Map(
+    (progressRows ?? []).map((row) => [row.lesson_id, row as ProgressRow]),
+  )
+  const followUpCounts = new Map<string, number>()
+
+  for (const row of commentRows ?? []) {
+    if (
+      row.understanding_state === 'confused' ||
+      row.understanding_state === 'want_more_depth' ||
+      row.understanding_state === 'want_examples'
+    ) {
+      followUpCounts.set(
+        row.lesson_id,
+        (followUpCounts.get(row.lesson_id) ?? 0) + 1,
+      )
+    }
+  }
+
+  const lessons = (lessonRows ?? []).map((lesson) => {
+    const progress = progressByLessonId.get(lesson.id)
+
+    return {
+      slug: lesson.slug,
+      title: lesson.title,
+      stage: lesson.stage,
+      difficulty: lesson.difficulty,
+      orderIndex: lesson.order_index,
+      estimatedMinutes: lesson.estimated_minutes,
+      summary: lesson.summary,
+      status: progress?.status ?? 'not_started',
+      confidence: progress?.confidence ?? 1,
+      quizAverage: progress?.quiz_average ?? 0,
+      quizBest: progress?.quiz_best ?? 0,
+      followUpCount: followUpCounts.get(lesson.id) ?? 0,
+    }
+  })
+
+  const completedLessons = lessons.filter(
+    (lesson) => lesson.status === 'completed',
+  ).length
+  const scores = (attemptRows ?? []).map((row) => row.score)
+
+  return {
+    project: {
+      slug: project.slug,
+      title: project.title,
+      description: project.description,
+      audience: project.audience,
+    },
+    dashboard: {
+      totalLessons: lessons.length,
+      completedLessons,
+      averageQuizScore:
+        scores.length > 0
+          ? Math.round(scores.reduce((sum, score) => sum + score, 0) / scores.length)
+          : 0,
+      attemptCount: scores.length,
+      followUpCount: lessons.reduce(
+        (sum, lesson) => sum + lesson.followUpCount,
+        0,
+      ),
+      nextRecommendedLesson:
+        lessons.find((lesson) => lesson.status !== 'completed')?.slug ?? null,
+    },
+    lessons,
+    researchDocuments: (researchRows ?? []).map((row) => ({
+      slug: row.slug,
+      title: row.title,
+      summary: row.summary,
+      category: row.category,
+    })),
+    brainBridge: getBrainBridgeState(),
+  }
+}
+
+export const getLessonDetail = async (slug: string) => {
+  const lesson = await getLessonRowBySlug(slug)
+  const [progress, quiz, commentResponse] = await Promise.all([
+    getProgressByLessonId(lesson.id),
+    getQuizByLessonId(lesson.id),
+    supabase
+      .from('repo_learning_lesson_comments')
+      .select('id, body, understanding_state, created_at')
+      .eq('lesson_id', lesson.id)
+      .order('created_at', { ascending: false }),
+  ])
+
+  if (commentResponse.error) {
+    throw new Error(commentResponse.error.message)
+  }
+
+  const [
+    questionRows,
+    attemptResponse,
+    relatedResearchResponse,
+  ] = await Promise.all([
+    getQuestionRowsByQuizId(quiz.id, quiz.question_count),
+    supabase
+      .from('repo_learning_quiz_attempts')
+      .select('id, score, total_questions, created_at')
+      .eq('quiz_id', quiz.id)
+      .order('created_at', { ascending: false })
+      .limit(5),
+    (() => {
+      const relatedResearchSlugs = parseStringArray(
+        lesson.related_research_json,
+        'related_research_json',
+      )
+
+      if (relatedResearchSlugs.length === 0) {
+        return Promise.resolve({ data: [], error: null })
+      }
+
+      return supabase
+        .from('repo_learning_research_documents')
+        .select('slug, title, summary, category')
+        .in('slug', relatedResearchSlugs)
+    })(),
+  ])
+
+  if (attemptResponse.error) {
+    throw new Error(attemptResponse.error.message)
+  }
+
+  if (relatedResearchResponse.error) {
+    throw new Error(relatedResearchResponse.error.message)
+  }
+
+  const goals = parseStringArray(lesson.goals_json, 'goals_json')
+  const relatedResearchSlugs = parseStringArray(
+    lesson.related_research_json,
+    'related_research_json',
+  )
+  const relatedResearch = relatedResearchSlugs
+    .map((value) =>
+      (relatedResearchResponse.data ?? []).find((document) => document.slug === value),
+    )
+    .filter((document): document is NonNullable<typeof document> => Boolean(document))
+    .map((document) => ({
+      slug: document.slug,
+      title: document.title,
+      summary: document.summary,
+      category: document.category,
+    }))
+
+  const { brainBridge, relatedThoughts } = await getBrainBridgeForLesson(
+    {
+      slug: lesson.slug,
+      title: lesson.title,
+      summary: lesson.summary,
+      goals,
+    },
+    relatedResearch.map((document) => document.title),
+  )
+
+  return {
+    lesson: {
+      slug: lesson.slug,
+      title: lesson.title,
+      stage: lesson.stage,
+      difficulty: lesson.difficulty,
+      orderIndex: lesson.order_index,
+      estimatedMinutes: lesson.estimated_minutes,
+      summary: lesson.summary,
+      goals,
+      content: lesson.content,
+      status: progress?.status ?? 'not_started',
+      confidence: progress?.confidence ?? 1,
+      quizAverage: progress?.quiz_average ?? 0,
+      quizBest: progress?.quiz_best ?? 0,
+      lastViewedAt: progress?.last_viewed_at ?? null,
+      completedAt: progress?.completed_at ?? null,
+    },
+    quiz: {
+      id: quiz.id,
+      title: quiz.title,
+      passingScore: quiz.passing_score,
+      questions: questionRows.map((question) => ({
+        id: question.id,
+        orderIndex: question.order_index,
+        prompt: question.prompt,
+        options: parseStringArray(question.options_json, 'options_json'),
+        explanation: question.explanation,
+      })),
+      recentAttempts: (attemptResponse.data ?? []).map((attempt) => ({
+        id: attempt.id,
+        score: attempt.score,
+        totalQuestions: attempt.total_questions,
+        createdAt: attempt.created_at,
+      })),
+    },
+    comments: (commentResponse.data ?? []).map((comment) => ({
+      id: comment.id,
+      body: comment.body,
+      understandingState: comment.understanding_state as UnderstandingState,
+      createdAt: comment.created_at,
+    })),
+    relatedResearch,
+    relatedThoughts,
+    brainBridge,
+  }
+}
+
+export const getResearchDocumentDetail = async (slug: string) =>
+  unwrapSingle<ResearchDocumentDetailRow>(
+    supabase
+      .from('repo_learning_research_documents')
+      .select('slug, title, summary, category, content, source_path, source_url')
+      .eq('slug', slug)
+      .single(),
+    `Research document ${slug} was not found.`,
+  ).then((document) => ({
+    slug: document.slug,
+    title: document.title,
+    summary: document.summary,
+    category: document.category,
+    content: document.content,
+    sourcePath: document.source_path,
+    sourceUrl: document.source_url,
+  }))
+
+export const updateLessonProgress = async (
+  slug: string,
+  status: LessonStatus,
+  confidence: number,
+) => {
+  const lesson = await getLessonRowBySlug(slug)
+  const existingProgress = await getProgressByLessonId(lesson.id)
+  const timestamp = now()
+
+  await ensureNoError(
+    supabase.from('repo_learning_lesson_progress').upsert(
+      {
+        lesson_id: lesson.id,
+        status,
+        confidence,
+        quiz_average: existingProgress?.quiz_average ?? 0,
+        quiz_best: existingProgress?.quiz_best ?? 0,
+        last_viewed_at: timestamp,
+        completed_at:
+          status === 'completed'
+            ? existingProgress?.completed_at ?? timestamp
+            : existingProgress?.completed_at,
+        updated_at: timestamp,
+      },
+      { onConflict: 'lesson_id' },
+    ),
+  )
+
+  return getLessonDetail(slug)
+}
+
+export const addLessonComment = async (
+  slug: string,
+  body: string,
+  understandingState: UnderstandingState,
+) => {
+  const lesson = await getLessonRowBySlug(slug)
+  const existingProgress = await getProgressByLessonId(lesson.id)
+  const timestamp = now()
+
+  await ensureNoError(
+    supabase.from('repo_learning_lesson_comments').insert({
+      lesson_id: lesson.id,
+      body,
+      understanding_state: understandingState,
+    }),
+  )
+
+  await ensureNoError(
+    supabase.from('repo_learning_lesson_progress').upsert(
+      {
+        lesson_id: lesson.id,
+        status: existingProgress?.status ?? 'not_started',
+        confidence: existingProgress?.confidence ?? 1,
+        quiz_average: existingProgress?.quiz_average ?? 0,
+        quiz_best: existingProgress?.quiz_best ?? 0,
+        last_viewed_at: timestamp,
+        completed_at: existingProgress?.completed_at,
+        updated_at: timestamp,
+      },
+      { onConflict: 'lesson_id' },
+    ),
+  )
+
+  return getLessonDetail(slug)
+}
+
+export const submitQuizAnswers = async (
+  quizId: string,
+  answers: Array<{ questionId: string; selectedOption: string }>,
+) => {
+  const quiz = await unwrapSingle<QuizRow>(
+    supabase
+      .from('repo_learning_quizzes')
+      .select('id, lesson_id, title, passing_score, question_count')
+      .eq('id', quizId)
+      .single(),
+    `Quiz ${quizId} was not found.`,
+  ) as QuizRow
+
+  const questionRows = await getQuestionRowsByQuizId(quizId, quiz.question_count)
+
+  if (questionRows.length === 0) {
+    throw new Error('Quiz questions were not found.')
+  }
+
+  const answerMap = new Map(
+    answers.map((answer) => [answer.questionId, answer.selectedOption]),
+  )
+  const results = questionRows.map((question) => {
+    const selectedOption = answerMap.get(question.id) ?? ''
+    const isCorrect = selectedOption === question.correct_option
+
+    return {
+      questionId: question.id,
+      prompt: question.prompt,
+      selectedOption,
+      correctOption: question.correct_option,
+      explanation: question.explanation,
+      isCorrect,
+    }
+  })
+
+  const correctCount = results.filter((result) => result.isCorrect).length
+  const score = Math.round((correctCount / questionRows.length) * 100)
+
+  const attempt = await unwrapSingle<{ id: string }>(
+    supabase
+      .from('repo_learning_quiz_attempts')
+      .insert({
+        quiz_id: quizId,
+        score,
+        total_questions: questionRows.length,
+      })
+      .select('id')
+      .single(),
+    `Failed to save quiz attempt for ${quizId}.`,
+  )
+
+  await ensureNoError(
+    supabase.from('repo_learning_quiz_responses').insert(
+      results.map((result) => ({
+        attempt_id: attempt.id,
+        question_id: result.questionId,
+        selected_option: result.selectedOption,
+        is_correct: result.isCorrect,
+      })),
+    ),
+  )
+
+  const { data: attemptRows, error: attemptError } = await supabase
+    .from('repo_learning_quiz_attempts')
+    .select('score')
+    .eq('quiz_id', quizId)
+
+  if (attemptError) {
+    throw new Error(attemptError.message)
+  }
+
+  const existingProgress = await getProgressByLessonId(quiz.lesson_id)
+  const allScores = (attemptRows ?? []).map((row) => row.score)
+  const timestamp = now()
+
+  await ensureNoError(
+    supabase.from('repo_learning_lesson_progress').upsert(
+      {
+        lesson_id: quiz.lesson_id,
+        status:
+          existingProgress?.status === 'not_started'
+            ? 'in_progress'
+            : existingProgress?.status ?? 'in_progress',
+        confidence: existingProgress?.confidence ?? 1,
+        quiz_average:
+          allScores.length > 0
+            ? Math.round(
+                allScores.reduce((sum, value) => sum + value, 0) / allScores.length,
+              )
+            : 0,
+        quiz_best: allScores.length > 0 ? Math.max(...allScores) : 0,
+        last_viewed_at: timestamp,
+        completed_at: existingProgress?.completed_at,
+        updated_at: timestamp,
+      },
+      { onConflict: 'lesson_id' },
+    ),
+  )
+
+  return {
+    score,
+    totalQuestions: questionRows.length,
+    correctCount,
+    results,
+  }
+}
+
+export const captureLessonArtifact = async (
+  slug: string,
+  kind: LearningArtifactKind,
+  content: string,
+) => {
+  const detail = await getLessonDetail(slug)
+  const result = await captureLearningArtifact({
+    kind,
+    content,
+    lesson: {
+      slug: detail.lesson.slug,
+      title: detail.lesson.title,
+      summary: detail.lesson.summary,
+      goals: detail.lesson.goals,
+      status: detail.lesson.status,
+      confidence: detail.lesson.confidence,
+    },
+  })
+
+  return result
+}

--- a/recipes/repo-learning-coach/server/index.ts
+++ b/recipes/repo-learning-coach/server/index.ts
@@ -1,0 +1,186 @@
+import express from 'express'
+import { existsSync } from 'node:fs'
+import { z } from 'zod'
+
+import {
+  addLessonComment,
+  captureLessonArtifact,
+  getBootstrapData,
+  getLessonDetail,
+  getResearchDocumentDetail,
+  submitQuizAnswers,
+  syncContentToSupabase,
+  updateLessonProgress,
+} from './db.js'
+import { DIST_DIR } from './paths.js'
+
+const app = express()
+const port = Number(process.env.PORT ?? 8787)
+
+app.use(express.json())
+
+app.get('/api/bootstrap', async (_request, response) => {
+  try {
+    response.json(await getBootstrapData())
+  } catch (error) {
+    response.status(500).json({
+      error: error instanceof Error ? error.message : 'Failed to load bootstrap data.',
+    })
+  }
+})
+
+app.get('/api/lessons/:slug', async (request, response) => {
+  try {
+    response.json(await getLessonDetail(request.params.slug))
+  } catch (error) {
+    response.status(404).json({
+      error: error instanceof Error ? error.message : 'Lesson not found.',
+    })
+  }
+})
+
+app.post('/api/lessons/:slug/progress', async (request, response) => {
+  const payload = z.object({
+    status: z.enum(['not_started', 'in_progress', 'completed']),
+    confidence: z.number().int().min(1).max(5),
+  })
+
+  const parsed = payload.safeParse(request.body)
+
+  if (!parsed.success) {
+    response.status(400).json({ error: 'Invalid lesson progress payload.' })
+    return
+  }
+
+  try {
+    response.json(
+      await updateLessonProgress(
+        request.params.slug,
+        parsed.data.status,
+        parsed.data.confidence,
+      ),
+    )
+  } catch (error) {
+    response.status(400).json({
+      error: error instanceof Error ? error.message : 'Failed to update lesson progress.',
+    })
+  }
+})
+
+app.post('/api/lessons/:slug/comments', async (request, response) => {
+  const payload = z.object({
+    body: z.string().trim().min(10).max(5000),
+    understandingState: z.enum([
+      'clear',
+      'unsure',
+      'confused',
+      'want_more_depth',
+      'want_examples',
+    ]),
+  })
+
+  const parsed = payload.safeParse(request.body)
+
+  if (!parsed.success) {
+    response.status(400).json({ error: 'Invalid comment payload.' })
+    return
+  }
+
+  try {
+    response.json(
+      await addLessonComment(
+        request.params.slug,
+        parsed.data.body,
+        parsed.data.understandingState,
+      ),
+    )
+  } catch (error) {
+    response.status(400).json({
+      error: error instanceof Error ? error.message : 'Failed to save comment.',
+    })
+  }
+})
+
+app.post('/api/lessons/:slug/capture', async (request, response) => {
+  const payload = z.object({
+    kind: z.enum(['takeaway', 'confusion', 'summary']),
+    content: z.string().max(5000).default(''),
+  })
+
+  const parsed = payload.safeParse(request.body)
+
+  if (!parsed.success) {
+    response.status(400).json({ error: 'Invalid capture payload.' })
+    return
+  }
+
+  try {
+    response.json(
+      await captureLessonArtifact(
+        request.params.slug,
+        parsed.data.kind,
+        parsed.data.content,
+      ),
+    )
+  } catch (error) {
+    response.status(400).json({
+      error: error instanceof Error ? error.message : 'Failed to capture artifact.',
+    })
+  }
+})
+
+app.post('/api/quizzes/:quizId/submit', async (request, response) => {
+  const payload = z.object({
+    answers: z.array(
+      z.object({
+        questionId: z.string().uuid(),
+        selectedOption: z.string().min(1),
+      }),
+    ),
+  })
+
+  const parsed = payload.safeParse(request.body)
+
+  if (!parsed.success) {
+    response.status(400).json({ error: 'Invalid quiz payload.' })
+    return
+  }
+
+  try {
+    response.json(await submitQuizAnswers(request.params.quizId, parsed.data.answers))
+  } catch (error) {
+    response.status(400).json({
+      error: error instanceof Error ? error.message : 'Failed to submit quiz.',
+    })
+  }
+})
+
+app.get('/api/research/:slug', async (request, response) => {
+  try {
+    response.json(await getResearchDocumentDetail(request.params.slug))
+  } catch (error) {
+    response.status(404).json({
+      error: error instanceof Error ? error.message : 'Research document not found.',
+    })
+  }
+})
+
+if (process.env.NODE_ENV === 'production' && existsSync(DIST_DIR)) {
+  app.use(express.static(DIST_DIR))
+  app.get('*', (_request, response) => {
+    response.sendFile('index.html', { root: DIST_DIR })
+  })
+}
+
+const start = async () => {
+  await syncContentToSupabase()
+
+  app.listen(port, () => {
+    console.log(`repo-learning-coach server listening on http://localhost:${port}`)
+  })
+}
+
+void start().catch((error) => {
+  console.error(error instanceof Error ? error.message : error)
+  process.exitCode = 1
+})

--- a/recipes/repo-learning-coach/server/paths.ts
+++ b/recipes/repo-learning-coach/server/paths.ts
@@ -1,0 +1,13 @@
+import { dirname, relative, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+import { REPO_LEARNING_CONFIG } from '../repo-learning.config.js'
+
+const CURRENT_DIR = dirname(fileURLToPath(import.meta.url))
+
+export const APP_ROOT = resolve(CURRENT_DIR, '..')
+export const DIST_DIR = resolve(APP_ROOT, 'dist')
+export const RESEARCH_DIR = resolve(APP_ROOT, ...REPO_LEARNING_CONFIG.researchDirectory)
+export const LESSON_DIR = resolve(APP_ROOT, ...REPO_LEARNING_CONFIG.lessonDirectory)
+
+export const toAppRelativePath = (absolutePath: string) => relative(APP_ROOT, absolutePath)

--- a/recipes/repo-learning-coach/server/supabase.ts
+++ b/recipes/repo-learning-coach/server/supabase.ts
@@ -1,0 +1,30 @@
+import { createClient } from '@supabase/supabase-js'
+
+const requireEnv = (name: string) => {
+  const value = process.env[name]
+
+  if (!value) {
+    throw new Error(`Missing required environment variable: ${name}`)
+  }
+
+  return value
+}
+
+export const APP_ENV = {
+  supabaseUrl: requireEnv('SUPABASE_URL'),
+  supabaseServiceRoleKey: requireEnv('SUPABASE_SERVICE_ROLE_KEY'),
+  openrouterApiKey: process.env.OPENROUTER_API_KEY ?? '',
+  openrouterEmbeddingModel:
+    process.env.OPENROUTER_EMBEDDING_MODEL ?? 'openai/text-embedding-3-small',
+}
+
+export const supabase = createClient(
+  APP_ENV.supabaseUrl,
+  APP_ENV.supabaseServiceRoleKey,
+  {
+    auth: {
+      autoRefreshToken: false,
+      persistSession: false,
+    },
+  },
+)

--- a/recipes/repo-learning-coach/server/sync-content.ts
+++ b/recipes/repo-learning-coach/server/sync-content.ts
@@ -1,0 +1,13 @@
+import { syncContentToSupabase } from './db.js'
+
+const run = async () => {
+  const result = await syncContentToSupabase()
+  console.log(
+    `Synced ${result.lessons} lessons and ${result.researchDocuments} research documents.`,
+  )
+}
+
+void run().catch((error) => {
+  console.error(error instanceof Error ? error.message : error)
+  process.exitCode = 1
+})

--- a/recipes/repo-learning-coach/src/App.css
+++ b/recipes/repo-learning-coach/src/App.css
@@ -1,0 +1,524 @@
+.app-shell {
+  display: grid;
+  grid-template-columns: minmax(300px, 360px) minmax(0, 1fr);
+  min-height: 100vh;
+}
+
+.sidebar {
+  padding: 2rem 1.25rem;
+  background: rgba(15, 30, 53, 0.95);
+  color: #f8f3ea;
+  border-right: 1px solid rgba(255, 255, 255, 0.08);
+  position: sticky;
+  top: 0;
+  height: 100vh;
+  overflow-y: auto;
+}
+
+.sidebar__header h1,
+.hero-panel h2,
+.lesson-header h3,
+.section-heading h4,
+.section-heading h5 {
+  margin: 0;
+}
+
+.sidebar__copy,
+.hero-panel__copy,
+.content-card__summary,
+.nav-card p,
+.note-card p,
+.related-card p,
+.thought-card p,
+.empty-state {
+  margin: 0;
+  color: rgba(17, 24, 38, 0.72);
+}
+
+.sidebar__copy {
+  color: rgba(248, 243, 234, 0.78);
+}
+
+.hero-panel__copy--subtle {
+  margin-top: 0.65rem;
+  font-size: 0.94rem;
+}
+
+.eyebrow {
+  margin: 0 0 0.4rem;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  font-size: 0.72rem;
+  font-weight: 700;
+  color: #cda66d;
+}
+
+.sidebar__section {
+  margin-top: 1.5rem;
+}
+
+.sidebar__section-title {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 1rem;
+  margin-bottom: 0.75rem;
+  font-size: 0.88rem;
+  color: rgba(248, 243, 234, 0.82);
+}
+
+.sidebar__list {
+  display: grid;
+  gap: 0.8rem;
+}
+
+.sidebar__list--compact {
+  gap: 0.65rem;
+}
+
+.nav-card {
+  width: 100%;
+  text-align: left;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  background: rgba(255, 255, 255, 0.05);
+  color: #f8f3ea;
+  border-radius: 1rem;
+  padding: 0.95rem 1rem;
+  transition:
+    transform 160ms ease,
+    border-color 160ms ease,
+    background 160ms ease;
+}
+
+.nav-card:hover,
+.nav-card.is-active {
+  transform: translateY(-1px);
+  border-color: rgba(205, 166, 109, 0.6);
+  background: rgba(255, 255, 255, 0.1);
+}
+
+.nav-card p,
+.nav-card strong {
+  color: rgba(248, 243, 234, 0.86);
+}
+
+.nav-card__topline,
+.nav-card__meta,
+.section-heading,
+.note-card__header,
+.result-panel__meta,
+.research-meta,
+.hero-panel__stats,
+.view-toggle,
+.lesson-header,
+.lesson-header__badges {
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+}
+
+.nav-card__topline {
+  justify-content: space-between;
+  align-items: flex-start;
+  margin-bottom: 0.4rem;
+  font-weight: 600;
+}
+
+.nav-card__meta {
+  flex-wrap: wrap;
+  margin-top: 0.7rem;
+  font-size: 0.78rem;
+  color: rgba(248, 243, 234, 0.66);
+}
+
+.nav-card--compact strong {
+  display: block;
+  margin-bottom: 0.35rem;
+}
+
+.main-panel {
+  padding: 2rem;
+}
+
+.hero-panel {
+  display: flex;
+  justify-content: space-between;
+  gap: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 1.4rem;
+  background: rgba(255, 255, 255, 0.74);
+  border: 1px solid rgba(17, 24, 38, 0.08);
+  box-shadow: 0 24px 64px rgba(27, 40, 60, 0.08);
+}
+
+.hero-panel__stats {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(120px, 1fr));
+}
+
+.metric-card {
+  min-width: 120px;
+  padding: 0.85rem 1rem;
+  border-radius: 1rem;
+  background: linear-gradient(135deg, rgba(16, 28, 47, 0.92), rgba(30, 59, 86, 0.9));
+  color: #f8f3ea;
+}
+
+.metric-card span {
+  display: block;
+  font-size: 0.76rem;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: rgba(248, 243, 234, 0.72);
+}
+
+.metric-card strong {
+  display: block;
+  margin-top: 0.45rem;
+  font-size: 1.45rem;
+}
+
+.error-banner {
+  margin-top: 1rem;
+  padding: 0.9rem 1rem;
+  border-radius: 0.9rem;
+  background: rgba(191, 73, 66, 0.12);
+  border: 1px solid rgba(191, 73, 66, 0.3);
+  color: #7e221b;
+}
+
+.bridge-banner,
+.capture-message {
+  margin-top: 1rem;
+  padding: 0.9rem 1rem;
+  border-radius: 0.9rem;
+  border: 1px solid rgba(29, 74, 115, 0.18);
+  background: rgba(29, 74, 115, 0.08);
+  color: #204466;
+}
+
+.view-toggle {
+  margin: 1.2rem 0;
+}
+
+.view-toggle button,
+.status-controls button,
+.confidence-buttons button,
+.secondary-button,
+.related-card {
+  border: 1px solid rgba(17, 24, 38, 0.12);
+  background: rgba(255, 255, 255, 0.74);
+  color: #152033;
+  border-radius: 999px;
+  padding: 0.65rem 1rem;
+  cursor: pointer;
+}
+
+.view-toggle button.is-selected,
+.status-controls button.is-selected,
+.confidence-buttons button.is-selected {
+  background: #102442;
+  color: #f8f3ea;
+  border-color: #102442;
+}
+
+.content-grid {
+  display: grid;
+  grid-template-columns: minmax(0, 1.6fr) minmax(320px, 0.9fr);
+  gap: 1rem;
+}
+
+.content-card {
+  padding: 1.4rem;
+  border-radius: 1.35rem;
+  background: rgba(255, 255, 255, 0.8);
+  border: 1px solid rgba(17, 24, 38, 0.08);
+  box-shadow: 0 18px 48px rgba(27, 40, 60, 0.07);
+}
+
+.content-card--wide {
+  min-height: 60vh;
+}
+
+.side-column {
+  display: grid;
+  gap: 1rem;
+}
+
+.lesson-header {
+  justify-content: space-between;
+  align-items: flex-start;
+}
+
+.lesson-header__badges,
+.goal-list,
+.related-list,
+.confidence-buttons,
+.status-controls,
+.quiz-list,
+.note-list {
+  display: grid;
+  gap: 0.75rem;
+}
+
+.goal-list {
+  margin: 1rem 0 1.25rem;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.goal-pill {
+  padding: 0.75rem 0.9rem;
+  border-radius: 1rem;
+  background: rgba(238, 244, 242, 0.95);
+  border: 1px solid rgba(39, 85, 87, 0.1);
+  color: #204448;
+  font-weight: 500;
+}
+
+.status-pill,
+.meta-pill,
+.note-state {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 999px;
+  padding: 0.35rem 0.7rem;
+  font-size: 0.76rem;
+  font-weight: 600;
+}
+
+.status-not_started {
+  background: rgba(115, 124, 141, 0.15);
+  color: #455063;
+}
+
+.status-in_progress {
+  background: rgba(210, 142, 44, 0.15);
+  color: #8b5e17;
+}
+
+.status-completed {
+  background: rgba(36, 135, 92, 0.15);
+  color: #1d6947;
+}
+
+.meta-pill {
+  background: rgba(16, 36, 66, 0.08);
+  color: #233754;
+}
+
+.markdown-body {
+  color: #152033;
+}
+
+.markdown-body h2,
+.markdown-body h3 {
+  margin-top: 1.35rem;
+  margin-bottom: 0.55rem;
+}
+
+.markdown-body p,
+.markdown-body li {
+  color: rgba(21, 32, 51, 0.84);
+}
+
+.markdown-body ul {
+  padding-left: 1.25rem;
+}
+
+.muted {
+  color: rgba(21, 32, 51, 0.56);
+  font-size: 0.9rem;
+}
+
+.primary-button {
+  border: none;
+  background: linear-gradient(135deg, #102442, #1d4a73);
+  color: #f8f3ea;
+  border-radius: 0.95rem;
+  padding: 0.8rem 1rem;
+  cursor: pointer;
+  font-weight: 600;
+}
+
+.primary-button:disabled,
+.secondary-button:disabled {
+  opacity: 0.6;
+  cursor: default;
+}
+
+.field {
+  display: grid;
+  gap: 0.45rem;
+  margin-bottom: 0.85rem;
+}
+
+.field select,
+.field textarea {
+  width: 100%;
+  border: 1px solid rgba(17, 24, 38, 0.12);
+  border-radius: 0.95rem;
+  padding: 0.75rem 0.9rem;
+  background: rgba(255, 255, 255, 0.82);
+  color: #152033;
+}
+
+.quiz-question {
+  border: 1px solid rgba(17, 24, 38, 0.08);
+  border-radius: 1rem;
+  padding: 0.95rem 1rem;
+  margin: 0;
+}
+
+.quiz-question legend {
+  padding: 0 0.35rem;
+  font-weight: 600;
+}
+
+.quiz-option {
+  display: flex;
+  gap: 0.65rem;
+  padding: 0.45rem 0;
+}
+
+.quiz-feedback {
+  margin-top: 0.55rem;
+  padding-top: 0.55rem;
+  border-top: 1px dashed rgba(17, 24, 38, 0.12);
+}
+
+.quiz-feedback p {
+  margin-bottom: 0;
+}
+
+.result-panel {
+  margin-top: 0.95rem;
+  padding: 0.95rem 1rem;
+  border-radius: 1rem;
+  background: rgba(238, 244, 242, 0.95);
+}
+
+.result-panel__score span {
+  display: block;
+  font-size: 1.6rem;
+  font-weight: 700;
+  color: #204448;
+}
+
+.note-card {
+  padding: 0.9rem 1rem;
+  border-radius: 1rem;
+  background: rgba(255, 255, 255, 0.86);
+  border: 1px solid rgba(17, 24, 38, 0.08);
+}
+
+.note-clear {
+  background: rgba(36, 135, 92, 0.12);
+  color: #1d6947;
+}
+
+.note-unsure,
+.note-want_examples,
+.note-want_more_depth {
+  background: rgba(210, 142, 44, 0.14);
+  color: #8b5e17;
+}
+
+.note-confused {
+  background: rgba(191, 73, 66, 0.14);
+  color: #7e221b;
+}
+
+.related-card {
+  width: 100%;
+  text-align: left;
+  border-radius: 1rem;
+}
+
+.thought-card {
+  padding: 0.95rem 1rem;
+  border-radius: 1rem;
+  border: 1px solid rgba(17, 24, 38, 0.08);
+  background: rgba(255, 255, 255, 0.86);
+}
+
+.thought-card__meta {
+  display: flex;
+  align-items: center;
+  gap: 0.65rem;
+  margin-bottom: 0.5rem;
+}
+
+.secondary-link {
+  color: #204466;
+  font-weight: 600;
+  text-decoration: none;
+}
+
+.secondary-link:hover {
+  text-decoration: underline;
+}
+
+.panel-loader {
+  min-height: 40vh;
+  display: grid;
+  place-items: center;
+  gap: 1rem;
+  color: rgba(21, 32, 51, 0.62);
+}
+
+.panel-loader__pulse {
+  width: 3.2rem;
+  height: 3.2rem;
+  border-radius: 50%;
+  background: linear-gradient(135deg, rgba(205, 166, 109, 0.7), rgba(29, 74, 115, 0.75));
+  animation: pulse 1.4s infinite ease-in-out;
+}
+
+@keyframes pulse {
+  0%,
+  100% {
+    transform: scale(0.92);
+    opacity: 0.55;
+  }
+  50% {
+    transform: scale(1.04);
+    opacity: 1;
+  }
+}
+
+@media (max-width: 1120px) {
+  .app-shell {
+    grid-template-columns: 1fr;
+  }
+
+  .sidebar {
+    position: static;
+    height: auto;
+  }
+
+  .hero-panel,
+  .content-grid {
+    grid-template-columns: 1fr;
+    display: grid;
+  }
+}
+
+@media (max-width: 720px) {
+  .main-panel,
+  .sidebar {
+    padding: 1rem;
+  }
+
+  .hero-panel {
+    padding: 1rem;
+  }
+
+  .hero-panel__stats {
+    grid-template-columns: 1fr 1fr;
+  }
+
+  .lesson-header {
+    flex-direction: column;
+  }
+}

--- a/recipes/repo-learning-coach/src/App.tsx
+++ b/recipes/repo-learning-coach/src/App.tsx
@@ -1,0 +1,833 @@
+import { startTransition, useEffect, useState } from 'react'
+import ReactMarkdown from 'react-markdown'
+
+import {
+  addLessonComment,
+  captureLessonArtifact,
+  fetchBootstrap,
+  fetchLessonDetail,
+  fetchResearchDocument,
+  saveLessonProgress,
+  submitQuiz,
+} from './lib/api'
+import type {
+  BootstrapData,
+  LearningArtifactKind,
+  LessonDetail,
+  LessonStatus,
+  QuizResult,
+  ResearchDocumentDetail,
+  UnderstandingState,
+} from './lib/types'
+import './App.css'
+
+const confidenceLabels = [
+  'Very shaky',
+  'Basic grasp',
+  'Can explain it',
+  'Mostly solid',
+  'Could teach it',
+]
+
+const noteLabels: Record<UnderstandingState, string> = {
+  clear: 'I get it',
+  unsure: 'I am unsure',
+  confused: 'I am confused',
+  want_more_depth: 'I want more depth',
+  want_examples: 'I want examples',
+}
+
+const statusLabels: Record<LessonStatus, string> = {
+  not_started: 'Not started',
+  in_progress: 'In progress',
+  completed: 'Completed',
+}
+
+const artifactLabels: Record<LearningArtifactKind, string> = {
+  takeaway: 'Takeaway',
+  confusion: 'Confusion note',
+  summary: 'Lesson summary',
+}
+
+const artifactPlaceholders: Record<LearningArtifactKind, string> = {
+  takeaway:
+    'What is the durable point you want future-you or another AI session to remember?',
+  confusion:
+    'What is still unclear enough that it should resurface in a later session?',
+  summary:
+    'Optional. Leave blank to auto-generate a summary from the current lesson and progress state.',
+}
+
+const formatDate = (value: string | null) =>
+  value
+    ? new Intl.DateTimeFormat(undefined, {
+        month: 'short',
+        day: 'numeric',
+        hour: 'numeric',
+        minute: '2-digit',
+      }).format(new Date(value))
+    : 'Not yet'
+
+function App() {
+  const [bootstrap, setBootstrap] = useState<BootstrapData | null>(null)
+  const [activeView, setActiveView] = useState<'lesson' | 'research'>('lesson')
+  const [selectedLessonSlug, setSelectedLessonSlug] = useState<string | null>(null)
+  const [selectedResearchSlug, setSelectedResearchSlug] = useState<string | null>(null)
+  const [lessonDetail, setLessonDetail] = useState<LessonDetail | null>(null)
+  const [researchDetail, setResearchDetail] = useState<ResearchDocumentDetail | null>(
+    null,
+  )
+  const [lessonLoading, setLessonLoading] = useState(false)
+  const [researchLoading, setResearchLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [progressStatus, setProgressStatus] = useState<LessonStatus>('not_started')
+  const [confidence, setConfidence] = useState(1)
+  const [savingProgress, setSavingProgress] = useState(false)
+  const [commentBody, setCommentBody] = useState('')
+  const [understandingState, setUnderstandingState] =
+    useState<UnderstandingState>('unsure')
+  const [savingComment, setSavingComment] = useState(false)
+  const [quizAnswers, setQuizAnswers] = useState<Record<string, string>>({})
+  const [quizResult, setQuizResult] = useState<QuizResult | null>(null)
+  const [submittingQuiz, setSubmittingQuiz] = useState(false)
+  const [artifactType, setArtifactType] =
+    useState<LearningArtifactKind>('takeaway')
+  const [artifactBody, setArtifactBody] = useState('')
+  const [capturingArtifact, setCapturingArtifact] = useState(false)
+  const [captureMessage, setCaptureMessage] = useState<string | null>(null)
+
+  useEffect(() => {
+    void (async () => {
+      try {
+        const data = await fetchBootstrap()
+        setBootstrap(data)
+        setSelectedLessonSlug(
+          (current) => current ?? data.dashboard.nextRecommendedLesson ?? data.lessons[0]?.slug ?? null,
+        )
+        setSelectedResearchSlug(
+          (current) => current ?? data.researchDocuments[0]?.slug ?? null,
+        )
+      } catch (loadError) {
+        setError(loadError instanceof Error ? loadError.message : 'Failed to load app data.')
+      }
+    })()
+  }, [])
+
+  useEffect(() => {
+    if (!selectedLessonSlug) {
+      return
+    }
+
+    setLessonLoading(true)
+    setError(null)
+
+    void (async () => {
+      try {
+        const detail = await fetchLessonDetail(selectedLessonSlug)
+        setLessonDetail(detail)
+      } catch (loadError) {
+        setError(loadError instanceof Error ? loadError.message : 'Failed to load lesson.')
+      } finally {
+        setLessonLoading(false)
+      }
+    })()
+  }, [selectedLessonSlug])
+
+  useEffect(() => {
+    if (!selectedResearchSlug || activeView !== 'research') {
+      return
+    }
+
+    setResearchLoading(true)
+    setError(null)
+
+    void (async () => {
+      try {
+        const detail = await fetchResearchDocument(selectedResearchSlug)
+        setResearchDetail(detail)
+      } catch (loadError) {
+        setError(
+          loadError instanceof Error ? loadError.message : 'Failed to load research document.',
+        )
+      } finally {
+        setResearchLoading(false)
+      }
+    })()
+  }, [selectedResearchSlug, activeView])
+
+  useEffect(() => {
+    if (!lessonDetail) {
+      return
+    }
+
+    setProgressStatus(lessonDetail.lesson.status)
+    setConfidence(lessonDetail.lesson.confidence)
+    setCommentBody('')
+    setUnderstandingState('unsure')
+    setQuizAnswers({})
+    setQuizResult(null)
+    setArtifactType('takeaway')
+    setArtifactBody('')
+    setCaptureMessage(null)
+  }, [lessonDetail])
+
+  const selectedLessonSummary =
+    bootstrap?.lessons.find((lesson) => lesson.slug === selectedLessonSlug) ?? null
+
+  const refreshLessonAndDashboard = async (slug: string) => {
+    const [data, detail] = await Promise.all([fetchBootstrap(), fetchLessonDetail(slug)])
+    setBootstrap(data)
+    setLessonDetail(detail)
+  }
+
+  const handleLessonSelect = (slug: string) => {
+    startTransition(() => {
+      setActiveView('lesson')
+      setSelectedLessonSlug(slug)
+    })
+  }
+
+  const handleResearchSelect = (slug: string) => {
+    startTransition(() => {
+      setActiveView('research')
+      setSelectedResearchSlug(slug)
+    })
+  }
+
+  const handleSaveProgress = async () => {
+    if (!lessonDetail) {
+      return
+    }
+
+    setSavingProgress(true)
+    setError(null)
+
+    try {
+      await saveLessonProgress(lessonDetail.lesson.slug, progressStatus, confidence)
+      await refreshLessonAndDashboard(lessonDetail.lesson.slug)
+    } catch (saveError) {
+      setError(saveError instanceof Error ? saveError.message : 'Failed to save progress.')
+    } finally {
+      setSavingProgress(false)
+    }
+  }
+
+  const handleSaveComment = async () => {
+    if (!lessonDetail || commentBody.trim().length < 10) {
+      return
+    }
+
+    setSavingComment(true)
+    setError(null)
+
+    try {
+      await addLessonComment(
+        lessonDetail.lesson.slug,
+        commentBody.trim(),
+        understandingState,
+      )
+      await refreshLessonAndDashboard(lessonDetail.lesson.slug)
+      setCommentBody('')
+      setUnderstandingState('unsure')
+    } catch (saveError) {
+      setError(saveError instanceof Error ? saveError.message : 'Failed to save note.')
+    } finally {
+      setSavingComment(false)
+    }
+  }
+
+  const handleQuizSubmit = async () => {
+    if (!lessonDetail) {
+      return
+    }
+
+    const answers = lessonDetail.quiz.questions.map((question) => ({
+      questionId: question.id,
+      selectedOption: quizAnswers[question.id] ?? '',
+    }))
+
+    if (answers.some((answer) => answer.selectedOption.length === 0)) {
+      setError('Answer every quiz question before submitting.')
+      return
+    }
+
+    setSubmittingQuiz(true)
+    setError(null)
+
+    try {
+      const result = await submitQuiz(lessonDetail.quiz.id, answers)
+      setQuizResult(result)
+      await refreshLessonAndDashboard(lessonDetail.lesson.slug)
+    } catch (submitError) {
+      setError(submitError instanceof Error ? submitError.message : 'Failed to submit quiz.')
+    } finally {
+      setSubmittingQuiz(false)
+    }
+  }
+
+  const handleCaptureArtifact = async () => {
+    if (!lessonDetail) {
+      return
+    }
+
+    if (artifactType !== 'summary' && artifactBody.trim().length < 10) {
+      setError('Write a meaningful takeaway or follow-up note before capturing it.')
+      return
+    }
+
+    setCapturingArtifact(true)
+    setError(null)
+    setCaptureMessage(null)
+
+    try {
+      const result = await captureLessonArtifact(
+        lessonDetail.lesson.slug,
+        artifactType,
+        artifactBody.trim(),
+      )
+      setCaptureMessage(result.message)
+      await refreshLessonAndDashboard(lessonDetail.lesson.slug)
+      if (artifactType !== 'summary') {
+        setArtifactBody('')
+      }
+    } catch (captureError) {
+      setError(
+        captureError instanceof Error ? captureError.message : 'Failed to capture artifact.',
+      )
+    } finally {
+      setCapturingArtifact(false)
+    }
+  }
+
+  const progressPercent = bootstrap
+    ? Math.round(
+        (bootstrap.dashboard.completedLessons / Math.max(bootstrap.dashboard.totalLessons, 1)) *
+          100,
+      )
+    : 0
+
+  return (
+    <div className="app-shell">
+      <aside className="sidebar">
+        <div className="sidebar__header">
+          <p className="eyebrow">Supabase-backed onboarding for OB1</p>
+          <h1>Repo Learning Coach</h1>
+          <p className="sidebar__copy">
+            Research, lessons, notes, and quizzes live in dedicated learning tables.
+            Durable takeaways flow back into your Open Brain.
+          </p>
+        </div>
+
+        <section className="sidebar__section">
+          <div className="sidebar__section-title">
+            <span>Lesson path</span>
+            <span>
+              {bootstrap?.dashboard.completedLessons ?? 0}/
+              {bootstrap?.dashboard.totalLessons ?? 0}
+            </span>
+          </div>
+          <div className="sidebar__list">
+            {bootstrap?.lessons.map((lesson) => (
+              <button
+                key={lesson.slug}
+                className={`nav-card ${selectedLessonSlug === lesson.slug && activeView === 'lesson' ? 'is-active' : ''}`}
+                onClick={() => handleLessonSelect(lesson.slug)}
+                type="button"
+              >
+                <div className="nav-card__topline">
+                  <span>
+                    {lesson.orderIndex}. {lesson.title}
+                  </span>
+                  <span className={`status-pill status-${lesson.status}`}>
+                    {statusLabels[lesson.status]}
+                  </span>
+                </div>
+                <p>{lesson.summary}</p>
+                <div className="nav-card__meta">
+                  <span>{lesson.stage}</span>
+                  <span>{lesson.estimatedMinutes} min</span>
+                  <span>Best {lesson.quizBest}%</span>
+                  {lesson.followUpCount > 0 ? (
+                    <span>{lesson.followUpCount} follow-up</span>
+                  ) : null}
+                </div>
+              </button>
+            ))}
+          </div>
+        </section>
+
+        <section className="sidebar__section">
+          <div className="sidebar__section-title">
+            <span>Research library</span>
+            <span>{bootstrap?.researchDocuments.length ?? 0} docs</span>
+          </div>
+          <div className="sidebar__list sidebar__list--compact">
+            {bootstrap?.researchDocuments.map((document) => (
+              <button
+                key={document.slug}
+                className={`nav-card nav-card--compact ${selectedResearchSlug === document.slug && activeView === 'research' ? 'is-active' : ''}`}
+                onClick={() => handleResearchSelect(document.slug)}
+                type="button"
+              >
+                <strong>{document.title}</strong>
+                <p>{document.summary}</p>
+              </button>
+            ))}
+          </div>
+        </section>
+      </aside>
+
+      <main className="main-panel">
+        <header className="hero-panel">
+          <div>
+            <p className="eyebrow">Current curriculum</p>
+            <h2>{bootstrap?.project.title ?? 'Loading...'}</h2>
+            <p className="hero-panel__copy">
+              {bootstrap?.project.description ??
+                'Syncing research and lessons into Supabase-backed learning tables.'}
+            </p>
+            {bootstrap ? (
+              <p className="hero-panel__copy hero-panel__copy--subtle">
+                Audience: {bootstrap.project.audience}
+              </p>
+            ) : null}
+          </div>
+
+          <div className="hero-panel__stats">
+            <MetricCard label="Progress" value={`${progressPercent}%`} />
+            <MetricCard
+              label="Avg quiz"
+              value={`${bootstrap?.dashboard.averageQuizScore ?? 0}%`}
+            />
+            <MetricCard
+              label="Attempts"
+              value={String(bootstrap?.dashboard.attemptCount ?? 0)}
+            />
+            <MetricCard
+              label="Follow-ups"
+              value={String(bootstrap?.dashboard.followUpCount ?? 0)}
+            />
+          </div>
+        </header>
+
+        {bootstrap?.brainBridge.reason ? (
+          <div className="bridge-banner">{bootstrap.brainBridge.reason}</div>
+        ) : null}
+        {error ? <div className="error-banner">{error}</div> : null}
+
+        <div className="view-toggle">
+          <button
+            className={activeView === 'lesson' ? 'is-selected' : ''}
+            onClick={() => setActiveView('lesson')}
+            type="button"
+          >
+            Learning studio
+          </button>
+          <button
+            className={activeView === 'research' ? 'is-selected' : ''}
+            onClick={() => setActiveView('research')}
+            type="button"
+          >
+            Research vault
+          </button>
+        </div>
+
+        {activeView === 'lesson' ? (
+          lessonLoading || !lessonDetail ? (
+            <PanelLoader label="Loading lesson..." />
+          ) : (
+            <div className="content-grid">
+              <section className="content-card">
+                <div className="lesson-header">
+                  <div>
+                    <p className="eyebrow">
+                      Lesson {lessonDetail.lesson.orderIndex} · {lessonDetail.lesson.stage}
+                    </p>
+                    <h3>{lessonDetail.lesson.title}</h3>
+                    <p className="content-card__summary">{lessonDetail.lesson.summary}</p>
+                  </div>
+
+                  <div className="lesson-header__badges">
+                    <span className={`status-pill status-${lessonDetail.lesson.status}`}>
+                      {statusLabels[lessonDetail.lesson.status]}
+                    </span>
+                    <span className="meta-pill">{lessonDetail.lesson.difficulty}</span>
+                    <span className="meta-pill">
+                      {lessonDetail.lesson.estimatedMinutes} min
+                    </span>
+                  </div>
+                </div>
+
+                <div className="goal-list">
+                  {lessonDetail.lesson.goals.map((goal) => (
+                    <div key={goal} className="goal-pill">
+                      {goal}
+                    </div>
+                  ))}
+                </div>
+
+                <div className="markdown-body">
+                  <ReactMarkdown>{lessonDetail.lesson.content}</ReactMarkdown>
+                </div>
+              </section>
+
+              <section className="side-column">
+                <article className="content-card">
+                  <div className="section-heading">
+                    <h4>Progress</h4>
+                    <span className="muted">
+                      Last viewed {formatDate(lessonDetail.lesson.lastViewedAt)}
+                    </span>
+                  </div>
+
+                  <div className="status-controls">
+                    {(['not_started', 'in_progress', 'completed'] as LessonStatus[]).map(
+                      (status) => (
+                        <button
+                          key={status}
+                          className={progressStatus === status ? 'is-selected' : ''}
+                          onClick={() => setProgressStatus(status)}
+                          type="button"
+                        >
+                          {statusLabels[status]}
+                        </button>
+                      ),
+                    )}
+                  </div>
+
+                  <div className="confidence-scale">
+                    <div className="section-heading">
+                      <h5>Confidence</h5>
+                      <span className="muted">{confidenceLabels[confidence - 1]}</span>
+                    </div>
+                    <div className="confidence-buttons">
+                      {confidenceLabels.map((label, index) => (
+                        <button
+                          key={label}
+                          className={confidence === index + 1 ? 'is-selected' : ''}
+                          onClick={() => setConfidence(index + 1)}
+                          type="button"
+                        >
+                          {index + 1}
+                        </button>
+                      ))}
+                    </div>
+                  </div>
+
+                  <button
+                    className="primary-button"
+                    disabled={savingProgress}
+                    onClick={handleSaveProgress}
+                    type="button"
+                  >
+                    {savingProgress ? 'Saving...' : 'Save progress'}
+                  </button>
+                </article>
+
+                <article className="content-card">
+                  <div className="section-heading">
+                    <h4>{lessonDetail.quiz.title}</h4>
+                    <span className="muted">
+                      Target score {lessonDetail.quiz.passingScore}%
+                    </span>
+                  </div>
+
+                  <div className="quiz-list">
+                    {lessonDetail.quiz.questions.map((question) => (
+                      <fieldset key={question.id} className="quiz-question">
+                        <legend>
+                          {question.orderIndex}. {question.prompt}
+                        </legend>
+                        {question.options.map((option) => (
+                          <label key={option} className="quiz-option">
+                            <input
+                              checked={quizAnswers[question.id] === option}
+                              name={`question-${question.id}`}
+                              onChange={() =>
+                                setQuizAnswers((current) => ({
+                                  ...current,
+                                  [question.id]: option,
+                                }))
+                              }
+                              type="radio"
+                            />
+                            <span>{option}</span>
+                          </label>
+                        ))}
+                        {quizResult ? (
+                          <div className="quiz-feedback">
+                            <strong>
+                              {
+                                quizResult.results.find(
+                                  (result) => result.questionId === question.id,
+                                )?.correctOption
+                              }
+                            </strong>
+                            <p>{question.explanation}</p>
+                          </div>
+                        ) : null}
+                      </fieldset>
+                    ))}
+                  </div>
+
+                  <button
+                    className="primary-button"
+                    disabled={submittingQuiz}
+                    onClick={handleQuizSubmit}
+                    type="button"
+                  >
+                    {submittingQuiz ? 'Submitting...' : 'Submit quiz'}
+                  </button>
+
+                  {quizResult ? (
+                    <div className="result-panel">
+                      <div className="result-panel__score">
+                        <span>{quizResult.score}%</span>
+                        <small>
+                          {quizResult.correctCount}/{quizResult.totalQuestions} correct
+                        </small>
+                      </div>
+                      <div className="result-panel__meta">
+                        <span>Best score {lessonDetail.lesson.quizBest}%</span>
+                        <span>Average {lessonDetail.lesson.quizAverage}%</span>
+                      </div>
+                    </div>
+                  ) : null}
+                </article>
+
+                <article className="content-card">
+                  <div className="section-heading">
+                    <h4>Lesson notes</h4>
+                    <span className="muted">
+                      These notes stay in the learning tables and guide revisions later.
+                    </span>
+                  </div>
+
+                  <label className="field">
+                    <span>How did this land?</span>
+                    <select
+                      onChange={(event) =>
+                        setUnderstandingState(event.target.value as UnderstandingState)
+                      }
+                      value={understandingState}
+                    >
+                      {Object.entries(noteLabels).map(([value, label]) => (
+                        <option key={value} value={value}>
+                          {label}
+                        </option>
+                      ))}
+                    </select>
+                  </label>
+
+                  <label className="field">
+                    <span>Write what clicked or what did not.</span>
+                    <textarea
+                      onChange={(event) => setCommentBody(event.target.value)}
+                      placeholder="Example: I understand the importer boundary, but I still want a simpler explanation of why slugs need to stay stable."
+                      rows={6}
+                      value={commentBody}
+                    />
+                  </label>
+
+                  <button
+                    className="primary-button"
+                    disabled={savingComment || commentBody.trim().length < 10}
+                    onClick={handleSaveComment}
+                    type="button"
+                  >
+                    {savingComment ? 'Saving...' : 'Save note'}
+                  </button>
+
+                  <div className="note-list">
+                    {lessonDetail.comments.length === 0 ? (
+                      <p className="empty-state">No notes yet for this lesson.</p>
+                    ) : (
+                      lessonDetail.comments.map((comment) => (
+                        <article key={comment.id} className="note-card">
+                          <div className="note-card__header">
+                            <span className={`note-state note-${comment.understandingState}`}>
+                              {noteLabels[comment.understandingState]}
+                            </span>
+                            <small>{formatDate(comment.createdAt)}</small>
+                          </div>
+                          <p>{comment.body}</p>
+                        </article>
+                      ))
+                    )}
+                  </div>
+                </article>
+
+                <article className="content-card">
+                  <div className="section-heading">
+                    <h4>Open Brain capture</h4>
+                    <span className="muted">
+                      Capture only the durable learning artifacts worth resurfacing later.
+                    </span>
+                  </div>
+
+                  {lessonDetail.brainBridge.reason ? (
+                    <p className="empty-state">{lessonDetail.brainBridge.reason}</p>
+                  ) : (
+                    <>
+                      <label className="field">
+                        <span>Artifact type</span>
+                        <select
+                          onChange={(event) =>
+                            setArtifactType(event.target.value as LearningArtifactKind)
+                          }
+                          value={artifactType}
+                        >
+                          {Object.entries(artifactLabels).map(([value, label]) => (
+                            <option key={value} value={value}>
+                              {label}
+                            </option>
+                          ))}
+                        </select>
+                      </label>
+
+                      <label className="field">
+                        <span>Capture text</span>
+                        <textarea
+                          onChange={(event) => setArtifactBody(event.target.value)}
+                          placeholder={artifactPlaceholders[artifactType]}
+                          rows={5}
+                          value={artifactBody}
+                        />
+                      </label>
+
+                      <button
+                        className="primary-button"
+                        disabled={
+                          capturingArtifact ||
+                          (artifactType !== 'summary' && artifactBody.trim().length < 10)
+                        }
+                        onClick={handleCaptureArtifact}
+                        type="button"
+                      >
+                        {capturingArtifact ? 'Capturing...' : 'Send to Open Brain'}
+                      </button>
+
+                      {captureMessage ? (
+                        <p className="capture-message">{captureMessage}</p>
+                      ) : null}
+                    </>
+                  )}
+                </article>
+
+                <article className="content-card">
+                  <div className="section-heading">
+                    <h4>Related thoughts</h4>
+                    <span className="muted">
+                      Prior context from `thoughts` that overlaps this lesson.
+                    </span>
+                  </div>
+
+                  <div className="related-list">
+                    {lessonDetail.relatedThoughts.length === 0 ? (
+                      <p className="empty-state">
+                        No related thoughts surfaced for this lesson yet.
+                      </p>
+                    ) : (
+                      lessonDetail.relatedThoughts.map((thought) => (
+                        <article key={thought.id} className="thought-card">
+                          <div className="thought-card__meta">
+                            <span className="meta-pill">
+                              {(thought.similarity * 100).toFixed(1)}% match
+                            </span>
+                            <span className="muted">{formatDate(thought.createdAt)}</span>
+                          </div>
+                          <p>{thought.content}</p>
+                        </article>
+                      ))
+                    )}
+                  </div>
+                </article>
+
+                <article className="content-card">
+                  <div className="section-heading">
+                    <h4>Related research</h4>
+                    <span className="muted">Open the underlying source notes at any time.</span>
+                  </div>
+
+                  <div className="related-list">
+                    {lessonDetail.relatedResearch.map((document) => (
+                      <button
+                        key={document.slug}
+                        className="related-card"
+                        onClick={() => handleResearchSelect(document.slug)}
+                        type="button"
+                      >
+                        <strong>{document.title}</strong>
+                        <p>{document.summary}</p>
+                      </button>
+                    ))}
+                  </div>
+                </article>
+              </section>
+            </div>
+          )
+        ) : researchLoading || !researchDetail ? (
+          <PanelLoader label="Loading research..." />
+        ) : (
+          <section className="content-card content-card--wide">
+            <div className="lesson-header">
+              <div>
+                <p className="eyebrow">Research library · {researchDetail.category}</p>
+                <h3>{researchDetail.title}</h3>
+                <p className="content-card__summary">{researchDetail.summary}</p>
+              </div>
+
+              {selectedLessonSummary ? (
+                <button
+                  className="secondary-button"
+                  onClick={() => handleLessonSelect(selectedLessonSummary.slug)}
+                  type="button"
+                >
+                  Back to lesson
+                </button>
+              ) : null}
+            </div>
+
+            <div className="research-meta">
+              <span className="meta-pill">{researchDetail.sourcePath}</span>
+              {researchDetail.sourceUrl ? (
+                <a
+                  className="secondary-link"
+                  href={researchDetail.sourceUrl}
+                  rel="noreferrer"
+                  target="_blank"
+                >
+                  Open source link
+                </a>
+              ) : null}
+            </div>
+
+            <div className="markdown-body">
+              <ReactMarkdown>{researchDetail.content}</ReactMarkdown>
+            </div>
+          </section>
+        )}
+      </main>
+    </div>
+  )
+}
+
+function MetricCard({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="metric-card">
+      <span>{label}</span>
+      <strong>{value}</strong>
+    </div>
+  )
+}
+
+function PanelLoader({ label }: { label: string }) {
+  return (
+    <div className="panel-loader">
+      <div className="panel-loader__pulse" />
+      <p>{label}</p>
+    </div>
+  )
+}
+
+export default App

--- a/recipes/repo-learning-coach/src/index.css
+++ b/recipes/repo-learning-coach/src/index.css
@@ -1,0 +1,43 @@
+@import url('https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600&family=IBM+Plex+Sans:wght@400;500;600;700&display=swap');
+
+:root {
+  color-scheme: light;
+  font-family: 'IBM Plex Sans', 'Avenir Next', 'Segoe UI', sans-serif;
+  line-height: 1.5;
+  font-weight: 400;
+  color: #152033;
+  background:
+    radial-gradient(circle at top left, rgba(252, 222, 179, 0.65), transparent 26%),
+    radial-gradient(circle at top right, rgba(171, 220, 214, 0.5), transparent 25%),
+    linear-gradient(180deg, #fbf8f2 0%, #f2efe8 100%);
+  font-synthesis: none;
+  text-rendering: optimizeLegibility;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html,
+body,
+#root {
+  min-height: 100%;
+}
+
+body {
+  margin: 0;
+}
+
+button,
+input,
+select,
+textarea {
+  font: inherit;
+}
+
+code,
+pre {
+  font-family: 'IBM Plex Mono', 'SFMono-Regular', 'Menlo', monospace;
+}

--- a/recipes/repo-learning-coach/src/lib/api.ts
+++ b/recipes/repo-learning-coach/src/lib/api.ts
@@ -1,0 +1,76 @@
+import type {
+  BootstrapData,
+  CaptureResult,
+  LearningArtifactKind,
+  LessonDetail,
+  LessonStatus,
+  QuizResult,
+  ResearchDocumentDetail,
+  UnderstandingState,
+} from './types'
+
+const requestJson = async <T>(input: RequestInfo, init?: RequestInit) => {
+  const response = await fetch(input, {
+    headers: {
+      'Content-Type': 'application/json',
+      ...(init?.headers ?? {}),
+    },
+    ...init,
+  })
+
+  if (!response.ok) {
+    const payload = (await response.json().catch(() => null)) as
+      | { error?: string }
+      | null
+    throw new Error(payload?.error ?? 'Request failed.')
+  }
+
+  return (await response.json()) as T
+}
+
+export const fetchBootstrap = () => requestJson<BootstrapData>('/api/bootstrap')
+
+export const fetchLessonDetail = (slug: string) =>
+  requestJson<LessonDetail>(`/api/lessons/${slug}`)
+
+export const fetchResearchDocument = (slug: string) =>
+  requestJson<ResearchDocumentDetail>(`/api/research/${slug}`)
+
+export const saveLessonProgress = (
+  slug: string,
+  status: LessonStatus,
+  confidence: number,
+) =>
+  requestJson<LessonDetail>(`/api/lessons/${slug}/progress`, {
+    method: 'POST',
+    body: JSON.stringify({ status, confidence }),
+  })
+
+export const addLessonComment = (
+  slug: string,
+  body: string,
+  understandingState: UnderstandingState,
+) =>
+  requestJson<LessonDetail>(`/api/lessons/${slug}/comments`, {
+    method: 'POST',
+    body: JSON.stringify({ body, understandingState }),
+  })
+
+export const captureLessonArtifact = (
+  slug: string,
+  kind: LearningArtifactKind,
+  content: string,
+) =>
+  requestJson<CaptureResult>(`/api/lessons/${slug}/capture`, {
+    method: 'POST',
+    body: JSON.stringify({ kind, content }),
+  })
+
+export const submitQuiz = (
+  quizId: string,
+  answers: Array<{ questionId: string; selectedOption: string }>,
+) =>
+  requestJson<QuizResult>(`/api/quizzes/${quizId}/submit`, {
+    method: 'POST',
+    body: JSON.stringify({ answers }),
+  })

--- a/recipes/repo-learning-coach/src/lib/types.ts
+++ b/recipes/repo-learning-coach/src/lib/types.ts
@@ -1,0 +1,141 @@
+export type LessonStatus = 'not_started' | 'in_progress' | 'completed'
+
+export type UnderstandingState =
+  | 'clear'
+  | 'unsure'
+  | 'confused'
+  | 'want_more_depth'
+  | 'want_examples'
+
+export type LearningArtifactKind = 'takeaway' | 'confusion' | 'summary'
+
+export type BrainBridgeState = {
+  enabled: boolean
+  reason: string | null
+}
+
+export type LessonSummary = {
+  slug: string
+  title: string
+  stage: string
+  difficulty: string
+  orderIndex: number
+  estimatedMinutes: number
+  summary: string
+  status: LessonStatus
+  confidence: number
+  quizAverage: number
+  quizBest: number
+  followUpCount: number
+}
+
+export type ResearchDocumentSummary = {
+  slug: string
+  title: string
+  summary: string
+  category: string
+}
+
+export type RelatedThoughtSummary = {
+  id: string
+  content: string
+  createdAt: string
+  similarity: number
+  metadata: Record<string, unknown>
+}
+
+export type BootstrapData = {
+  project: {
+    slug: string
+    title: string
+    description: string
+    audience: string
+  }
+  dashboard: {
+    totalLessons: number
+    completedLessons: number
+    averageQuizScore: number
+    attemptCount: number
+    followUpCount: number
+    nextRecommendedLesson: string | null
+  }
+  lessons: LessonSummary[]
+  researchDocuments: ResearchDocumentSummary[]
+  brainBridge: BrainBridgeState
+}
+
+export type LessonDetail = {
+  lesson: {
+    slug: string
+    title: string
+    stage: string
+    difficulty: string
+    orderIndex: number
+    estimatedMinutes: number
+    summary: string
+    goals: string[]
+    content: string
+    status: LessonStatus
+    confidence: number
+    quizAverage: number
+    quizBest: number
+    lastViewedAt: string | null
+    completedAt: string | null
+  }
+  quiz: {
+    id: string
+    title: string
+    passingScore: number
+    questions: Array<{
+      id: string
+      orderIndex: number
+      prompt: string
+      options: string[]
+      explanation: string
+    }>
+    recentAttempts: Array<{
+      id: string
+      score: number
+      totalQuestions: number
+      createdAt: string
+    }>
+  }
+  comments: Array<{
+    id: string
+    body: string
+    understandingState: UnderstandingState
+    createdAt: string
+  }>
+  relatedResearch: ResearchDocumentSummary[]
+  relatedThoughts: RelatedThoughtSummary[]
+  brainBridge: BrainBridgeState
+}
+
+export type ResearchDocumentDetail = {
+  slug: string
+  title: string
+  summary: string
+  category: string
+  content: string
+  sourcePath: string
+  sourceUrl: string | null
+}
+
+export type QuizResult = {
+  score: number
+  totalQuestions: number
+  correctCount: number
+  results: Array<{
+    questionId: string
+    prompt: string
+    selectedOption: string
+    correctOption: string
+    explanation: string
+    isCorrect: boolean
+  }>
+}
+
+export type CaptureResult = {
+  thoughtId: string
+  message: string
+}

--- a/recipes/repo-learning-coach/src/main.tsx
+++ b/recipes/repo-learning-coach/src/main.tsx
@@ -1,0 +1,10 @@
+import { StrictMode } from 'react'
+import { createRoot } from 'react-dom/client'
+import './index.css'
+import App from './App.tsx'
+
+createRoot(document.getElementById('root')!).render(
+  <StrictMode>
+    <App />
+  </StrictMode>,
+)

--- a/recipes/repo-learning-coach/tsconfig.app.json
+++ b/recipes/repo-learning-coach/tsconfig.app.json
@@ -1,0 +1,25 @@
+{
+  "compilerOptions": {
+    "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.app.tsbuildinfo",
+    "target": "es2023",
+    "lib": ["ES2023", "DOM", "DOM.Iterable"],
+    "module": "esnext",
+    "types": ["vite/client"],
+    "skipLibCheck": true,
+
+    /* Bundler mode */
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "verbatimModuleSyntax": true,
+    "moduleDetection": "force",
+    "noEmit": true,
+    "jsx": "react-jsx",
+
+    /* Linting */
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "erasableSyntaxOnly": true,
+    "noFallthroughCasesInSwitch": true
+  },
+  "include": ["src"]
+}

--- a/recipes/repo-learning-coach/tsconfig.json
+++ b/recipes/repo-learning-coach/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "files": [],
+  "references": [
+    { "path": "./tsconfig.app.json" },
+    { "path": "./tsconfig.node.json" },
+    { "path": "./tsconfig.server.json" }
+  ]
+}

--- a/recipes/repo-learning-coach/tsconfig.node.json
+++ b/recipes/repo-learning-coach/tsconfig.node.json
@@ -1,0 +1,24 @@
+{
+  "compilerOptions": {
+    "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.node.tsbuildinfo",
+    "target": "es2023",
+    "lib": ["ES2023"],
+    "module": "esnext",
+    "types": ["node"],
+    "skipLibCheck": true,
+
+    /* Bundler mode */
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "verbatimModuleSyntax": true,
+    "moduleDetection": "force",
+    "noEmit": true,
+
+    /* Linting */
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "erasableSyntaxOnly": true,
+    "noFallthroughCasesInSwitch": true
+  },
+  "include": ["vite.config.ts"]
+}

--- a/recipes/repo-learning-coach/tsconfig.server.json
+++ b/recipes/repo-learning-coach/tsconfig.server.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.server.tsbuildinfo",
+    "target": "es2023",
+    "lib": ["ES2023"],
+    "module": "esnext",
+    "types": ["node"],
+    "skipLibCheck": true,
+    "moduleResolution": "bundler",
+    "allowSyntheticDefaultImports": true,
+    "esModuleInterop": true,
+    "verbatimModuleSyntax": true,
+    "moduleDetection": "force",
+    "noEmit": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "erasableSyntaxOnly": true,
+    "noFallthroughCasesInSwitch": true
+  },
+  "include": ["server/**/*.ts"]
+}

--- a/recipes/repo-learning-coach/vite.config.ts
+++ b/recipes/repo-learning-coach/vite.config.ts
@@ -1,0 +1,12 @@
+import { defineConfig } from 'vite'
+import react from '@vitejs/plugin-react'
+
+// https://vite.dev/config/
+export default defineConfig({
+  plugins: [react()],
+  server: {
+    proxy: {
+      '/api': 'http://localhost:8787',
+    },
+  },
+})


### PR DESCRIPTION
## What changed
- added a new `recipes/repo-learning-coach/` contribution that ports the learning prototype into an OB1-compatible recipe
- replaced the original local SQLite design with a Supabase-backed schema, Express server layer, markdown-driven content importer, and local React app
- added an Open Brain bridge for related-thought retrieval and explicit capture of durable learning artifacts into `thoughts`
- documented the full setup flow, file/content contract, and future dashboard extraction path

## Why it changed
The original prototype had a useful learning UX, but it was shaped like a standalone local product rather than an OB1 contribution. This recipe keeps the UX and translates the architecture into something that fits OB1: local app, Supabase tables in the existing Open Brain project, and a narrow integration path into `thoughts`.

## Impact
Users can now run a repo-specific onboarding and learning app from markdown content while keeping durable takeaways connected to their existing Open Brain memory loop.

## Validation
- `npm run lint`
- `npm run build`
- metadata JSON parse check
- text sweep for leftover SQLite / Vibe Coach / local MCP references

## Notes
- I did not run `npm run sync` or a live app session against Supabase/OpenRouter because the required environment variables and services were not configured in this workspace.
