### PR TITLE
[skills] Add weekly signal diff skill pack

### DIFF
--- a/skills/weekly-signal-diff/README.md
+++ b/skills/weekly-signal-diff/README.md
@@ -1,0 +1,107 @@
+# Weekly Signal Diff
+
+> Standalone skill pack for turning a week's worth of market noise into a
+> personalized structural diff.
+
+## What It Does
+
+This skill runs a weekly scan across a suggested universe of categories and
+companies, then reweights the analysis using what Open Brain already knows
+about the user. It produces a `diff, not digest`: what changed, why it
+matters, and what to watch next.
+
+The default starter universe is AI-first because that is where the original
+use case came from, but the logic is universal. You can swap the categories and
+companies for any fast-moving market and keep the same structural-diff process.
+
+## Supported Clients
+
+- Claude Code
+- Codex
+- Cursor
+- Other AI clients that support reusable prompt packs, rules, or custom
+  instructions
+
+## Prerequisites
+
+- Working Open Brain setup if you want memory search and capture
+  ([guide](../../docs/01-getting-started.md))
+- AI client that supports reusable skills, rules, or custom instructions
+- One of:
+  - live web access in the client
+  - a user-provided weekly source set
+- Optional upgrade for automated live-search runs: OpenRouter access to the
+  Perplexity Sonar family
+  ([OpenRouter model page](https://openrouter.ai/perplexity/sonar/api))
+
+## Installation
+
+1. Copy [`SKILL.md`](./SKILL.md) into your client's reusable-instructions
+   location.
+2. Keep the [`references/`](./references/) folder alongside it if you want the
+   starter universe and live-search notes available to the client.
+3. Restart or reload the client so it picks up the skill.
+4. Test it with a prompt like:
+   `Run my weekly signal diff on AI infrastructure and tell me what changed this week that matters for a solo builder.`
+5. Optional: wire it into your weekly automation. If OpenRouter is available,
+   use the Perplexity Sonar family for the retrieval pass and keep the final
+   digest structure consistent every week.
+
+For Claude Code, a common install path is:
+
+```bash
+mkdir -p ~/.claude/skills/weekly-signal-diff/references
+cp skills/weekly-signal-diff/SKILL.md ~/.claude/skills/weekly-signal-diff/SKILL.md
+cp -R skills/weekly-signal-diff/references ~/.claude/skills/weekly-signal-diff/references
+```
+
+If your client does not support native skill folders, paste the contents of
+[`SKILL.md`](./SKILL.md) into that client's reusable prompt or project-rules
+feature and keep the reference files nearby.
+
+## Trigger Conditions
+
+- "Run my weekly signal diff"
+- "What changed this week that matters to me?"
+- "Track AI this week"
+- "Turn this week's news into structural shifts"
+- "Give me the signal, not the headlines"
+- Weekly automated digests or review rituals
+
+## Expected Outcome
+
+When installed and invoked correctly, the skill should produce:
+
+- a coverage note explaining what was scanned
+- 3-7 structural shifts instead of a long news list
+- user-specific implications pulled from Open Brain memory
+- a watchlist for next week
+- optional capture of the weekly digest back into Open Brain
+
+## Troubleshooting
+
+**Issue: The output reads like a news summary**
+Solution: Keep the structural questions intact. The skill should filter for
+constraint shifts, leverage shifts, broken assumptions, and exposed
+dependencies.
+
+**Issue: The final diff feels generic**
+Solution: Check that the client actually searched Open Brain first. This skill
+gets sharper when it can pull active projects, recurring interests, and prior
+digests before ranking the week's news.
+
+**Issue: The scan fixates on the default 30-company list**
+Solution: Treat the starter universe as a bootstrap layer. Replace or re-rank
+the suggested companies and categories using the user's actual focus areas.
+
+**Issue: The live-search results are shallow or stale**
+Solution: If OpenRouter is available, upgrade the retrieval pass to a
+Perplexity Sonar search model and constrain domains or freshness when needed.
+See [references/live-search-upgrade.md](./references/live-search-upgrade.md).
+
+## Notes for Other Clients
+
+This skill is portable because the logic is procedural. Any client that can
+load reusable instructions and access either Open Brain or a weekly source set
+can run it. If the client has no live search, feed it a source packet and ask
+for the same structural-diff output.

--- a/skills/weekly-signal-diff/SKILL.md
+++ b/skills/weekly-signal-diff/SKILL.md
@@ -55,7 +55,7 @@ the strongest search mode the environment supports.
      personal awareness, operator strategy, investor tracking, or content prep.
    - If the user says nothing, default to a 7-day operator-style review.
 
-2. Pull Open Brain context first.
+1. Pull Open Brain context first.
    - Search for active projects, current priorities, recurring entities, recent
      captures, and the last 2-4 weekly digests.
    - Tool names vary by client. Use the available Open Brain search, list, and
@@ -64,7 +64,7 @@ the strongest search mode the environment supports.
      keep revisiting, what they are worried about, and what they are trying to
      learn.
 
-3. Build the watchlist.
+1. Build the watchlist.
    - Start from the suggested 10-category / 30-company starter universe if the
      user has not defined a watchlist.
    - Treat the starter list as a scaffold, not a contract.
@@ -75,7 +75,7 @@ the strongest search mode the environment supports.
    - Preserve some baseline discovery. Personalization should shape the scan,
      not collapse it into only known favorites.
 
-4. Gather the week's evidence.
+1. Gather the week's evidence.
    - Prefer fresh, source-backed information with links or citations.
    - If live search is available, perform a broad sweep first, then targeted
      follow-ups on the top candidate shifts.
@@ -84,7 +84,7 @@ the strongest search mode the environment supports.
    - Ignore pure announcement theater unless it changes economics,
      distribution, regulation, dependency, geography, or buyer behavior.
 
-5. Ask the structural questions on every candidate signal.
+1. Ask the structural questions on every candidate signal.
    - What constraint shifted?
    - Who gained or lost leverage?
    - What got cheaper, harder, faster, or more defensible?
@@ -94,13 +94,13 @@ the strongest search mode the environment supports.
    - Why does this matter for the user's actual projects, workflows, or market
      view?
 
-6. Score before writing.
+1. Score before writing.
    - Keep only the few signals that represent real change.
    - A good weekly diff usually has 3-7 structural shifts.
    - Merge duplicates, drop weak stories, and explicitly label speculation as
      speculation.
 
-7. Produce the weekly diff.
+1. Produce the weekly diff.
 
 Use this default structure:
 
@@ -115,7 +115,7 @@ Use this default structure:
 - `Watch next` — entities, constraints, or questions to monitor
 - `Actions` — optional follow-ups, only if the evidence supports them
 
-8. Capture the durable output.
+1. Capture the durable output.
    - Save the final digest back into Open Brain when capture tools are
      available.
    - Prefer one durable weekly summary plus separate captures only for truly

--- a/skills/weekly-signal-diff/SKILL.md
+++ b/skills/weekly-signal-diff/SKILL.md
@@ -1,0 +1,158 @@
+---
+name: weekly-signal-diff
+description: |
+  Use when the user wants a weekly structural diff on AI, software, or another
+  fast-moving market. Starts from 10 suggested categories and 30 suggested
+  companies when no watchlist exists, then adapts the scan using Open Brain
+  memory, current priorities, and prior digests. Best for prompts like "run my
+  weekly signal diff", "what changed this week that matters to me", "track this
+  market", or "turn this week's news into structural shifts". Optional live
+  search upgrade: if OpenRouter access is available, prefer the Perplexity
+  Sonar family for fresh web-grounded retrieval with citations.
+author: Jonathan Edwards
+version: 1.0.0
+---
+
+# Weekly Signal Diff
+
+## Problem
+
+A wall of news does not tell the user what structurally changed. Most weekly
+roundups over-index on headlines, underweight economics and dependency shifts,
+and ignore what the user actually cares about. This skill turns a noisy week
+into a small set of structural changes, weighted by Open Brain memory.
+
+## When to Use
+
+- Weekly market review or Sunday/Friday ritual
+- "Run my weekly signal diff"
+- "What changed this week that matters to me?"
+- "Track this market and tell me the structural shifts"
+- "Turn this pile of news into a decision-grade diff"
+- Ongoing automation that writes a weekly digest back to Open Brain
+
+## Required Context
+
+Gather as much as the environment allows:
+
+- the user's active projects, bets, and recurring interests
+- prior weekly digests or adjacent summaries stored in Open Brain
+- the desired freshness window (default: last 7 days)
+- any preferred outlets, banned sources, or explicit watchlist entities
+
+If the user has not provided categories or companies, read
+[references/starter-universe.md](references/starter-universe.md) and use it as
+a bootstrap layer only.
+
+If live web access is available and the user wants current coverage, read
+[references/live-search-upgrade.md](references/live-search-upgrade.md) and use
+the strongest search mode the environment supports.
+
+## Process
+
+1. Establish the frame.
+   - Confirm the topic space, freshness window, and whether the goal is
+     personal awareness, operator strategy, investor tracking, or content prep.
+   - If the user says nothing, default to a 7-day operator-style review.
+
+2. Pull Open Brain context first.
+   - Search for active projects, current priorities, recurring entities, recent
+     captures, and the last 2-4 weekly digests.
+   - Tool names vary by client. Use the available Open Brain search, list, and
+     capture tools in the environment rather than assuming fixed names.
+   - Extract a short relevance profile: what the user is building, what they
+     keep revisiting, what they are worried about, and what they are trying to
+     learn.
+
+3. Build the watchlist.
+   - Start from the suggested 10-category / 30-company starter universe if the
+     user has not defined a watchlist.
+   - Treat the starter list as a scaffold, not a contract.
+   - Re-rank or replace items using Open Brain context:
+     - promote companies, categories, or themes the user mentions often
+     - demote low-signal items
+     - add personal-priority entities even if they are outside the starter set
+   - Preserve some baseline discovery. Personalization should shape the scan,
+     not collapse it into only known favorites.
+
+4. Gather the week's evidence.
+   - Prefer fresh, source-backed information with links or citations.
+   - If live search is available, perform a broad sweep first, then targeted
+     follow-ups on the top candidate shifts.
+   - If live search is not available, work from the user's provided sources and
+     say that the diff is source-bounded.
+   - Ignore pure announcement theater unless it changes economics,
+     distribution, regulation, dependency, geography, or buyer behavior.
+
+5. Ask the structural questions on every candidate signal.
+   - What constraint shifted?
+   - Who gained or lost leverage?
+   - What got cheaper, harder, faster, or more defensible?
+   - What dependency got exposed?
+   - What business model or pricing assumption weakened?
+   - What changed in regulation, geography, or distribution?
+   - Why does this matter for the user's actual projects, workflows, or market
+     view?
+
+6. Score before writing.
+   - Keep only the few signals that represent real change.
+   - A good weekly diff usually has 3-7 structural shifts.
+   - Merge duplicates, drop weak stories, and explicitly label speculation as
+     speculation.
+
+7. Produce the weekly diff.
+
+Use this default structure:
+
+- `Coverage note` — what was scanned, how it was personalized, and the date
+  window
+- `Structural shifts` — 3-7 items, each with:
+  - what changed
+  - why it matters in general
+  - why it matters to this user
+  - supporting evidence or citations
+- `What changed from last week` — new, rising, fading, or resolved themes
+- `Watch next` — entities, constraints, or questions to monitor
+- `Actions` — optional follow-ups, only if the evidence supports them
+
+8. Capture the durable output.
+   - Save the final digest back into Open Brain when capture tools are
+     available.
+   - Prefer one durable weekly summary plus separate captures only for truly
+     important follow-up items.
+   - Include provenance: week ending date, topic scope, and major entities
+     covered.
+
+## Output
+
+When this skill works correctly, the user gets:
+
+- a concise weekly structural diff instead of a headline roundup
+- a clear explanation of why the shifts matter to them specifically
+- citations or source links when live search is available
+- a durable weekly digest saved back into Open Brain for future comparison
+
+## Guardrails
+
+- The goal is `diff, not digest`.
+- Do not force all 30 suggested companies into the final output. They are there
+  to prevent blank-page syndrome, not to create fake coverage.
+- Do not mistake product launches, benchmark screenshots, or funding headlines
+  for structural change unless they move a real constraint.
+- Keep general market analysis separate from personalized implications.
+- If evidence is thin, say the week was thin.
+- If the environment lacks live search, be explicit about the freshness
+  limitation.
+- If the user's interests are unclear, use the starter universe and explain
+  that it is a bootstrap pass.
+
+## Notes for Other Clients
+
+- This skill is portable across Claude Code, Codex, Cursor, and similar clients
+  because the core behavior is procedural.
+- Adapt Open Brain tool names to the local environment.
+- For scheduled runs, pair the skill with the user's automation system and keep
+  the same structure every week so diffs stay comparable.
+- If OpenRouter is available, prefer a Perplexity Sonar web-search model for
+  the retrieval pass, then use the local AI client or model to do the actual
+  synthesis if that split is more ergonomic.

--- a/skills/weekly-signal-diff/metadata.json
+++ b/skills/weekly-signal-diff/metadata.json
@@ -1,0 +1,27 @@
+{
+  "name": "Weekly Signal Diff",
+  "description": "Standalone skill pack for turning a week's worth of market or AI news into a personalized structural diff using Open Brain memory, a suggested starter universe, and optional live web search.",
+  "category": "skills",
+  "author": {
+    "name": "Jonathan Edwards",
+    "github": "justfinethanku"
+  },
+  "version": "1.0.0",
+  "requires": {
+    "open_brain": true,
+    "services": ["Optional: OpenRouter (Perplexity Sonar family) for live search"],
+    "tools": ["Claude Code or similar AI coding tool with reusable skills/system prompts"]
+  },
+  "tags": [
+    "weekly-review",
+    "signal-diff",
+    "market-intelligence",
+    "news",
+    "openrouter",
+    "research"
+  ],
+  "difficulty": "intermediate",
+  "estimated_time": "15 minutes",
+  "created": "2026-04-13",
+  "updated": "2026-04-13"
+}

--- a/skills/weekly-signal-diff/references/live-search-upgrade.md
+++ b/skills/weekly-signal-diff/references/live-search-upgrade.md
@@ -1,0 +1,57 @@
+# Live Search Upgrade
+
+Use this file only when the environment supports current web retrieval and the
+user wants fresh, source-backed coverage.
+
+## Preferred Upgrade Path
+
+For OB1 users with OpenRouter access, prefer the Perplexity Sonar family for
+the retrieval pass. Start with the strongest Sonar search tier available in the
+user's account. Use the plain Sonar tier as the lowest-cost fallback when
+budget matters more than depth.
+
+Useful references:
+
+- [OpenRouter: Perplexity Sonar](https://openrouter.ai/perplexity/sonar/api)
+- [Perplexity Sonar docs](https://docs.perplexity.ai/docs/sonar/models/sonar)
+- [Perplexity search filters](https://docs.perplexity.ai/docs/grounded-llm/chat-completions/filters/academic-filter)
+
+## Retrieval Pattern
+
+Run the search in two passes:
+
+1. Broad sweep
+   - scan the last 7 days across the suggested categories and high-priority
+     entities
+   - return only source-backed developments with links or citations
+   - shortlist the stories that look like structural change
+
+2. Targeted follow-up
+   - deepen only the top 3-7 candidate shifts
+   - tighten recency, domain filters, or entity filters when needed
+   - pull enough evidence to explain both the general impact and the personal
+     relevance
+
+## What to Ask the Search Layer For
+
+Prefer prompts or search instructions that request:
+
+- a 7-day freshness window unless the user says otherwise
+- cited links or explicit source URLs
+- domain filters when the user trusts a specific set of outlets
+- one-paragraph explanations of why each result matters
+- rejection of results that are just launch noise or funding theater
+
+## Automation Notes
+
+For scheduled runs:
+
+- keep the retrieval and synthesis structure consistent every week
+- store the final digest back in Open Brain so next week's run has something to
+  diff against
+- track the week-ending date in the saved summary
+- if cost matters, use a cheaper broad sweep and spend extra search depth only
+  on the top candidate shifts
+
+The search layer finds the evidence. Open Brain decides what matters to this
+user. Keep those roles separate.

--- a/skills/weekly-signal-diff/references/starter-universe.md
+++ b/skills/weekly-signal-diff/references/starter-universe.md
@@ -1,0 +1,52 @@
+# Starter Universe
+
+Use this file only when the user has not already defined a watchlist. The list
+below is a bootstrap scaffold, not a hard requirement.
+
+Rules for using it:
+
+- Start here only if the user has not provided categories, companies, or a
+  source packet.
+- Treat the categories and companies as suggested defaults.
+- Re-rank, replace, or expand the list using Open Brain memory before you write
+  the final diff.
+- Preserve some baseline discovery. Do not personalize so aggressively that the
+  scan stops surfacing new signal.
+- If the user is tracking a non-AI sector, reuse the same pattern:
+  10 suggested categories with 3 suggested entities in each lane.
+
+## Suggested Categories and Companies
+
+| Category | Suggested Companies |
+| -------- | ------------------- |
+| Frontier labs | OpenAI, Anthropic, Google DeepMind |
+| Open model ecosystem | Meta AI, Mistral, Hugging Face |
+| Search and answer interfaces | Perplexity, Glean, You.com |
+| Developer tooling and agents | Cursor, Replit, Cognition |
+| Cloud AI platforms | Microsoft Azure AI, Google Cloud, AWS |
+| Data and model infrastructure | Databricks, Snowflake, Together AI |
+| Enterprise software incumbents | Salesforce, Atlassian, ServiceNow |
+| Productivity and knowledge tools | Notion, Canva, Grammarly |
+| Creative media generation | Runway, ElevenLabs, Pika |
+| Robotics and embodied AI | Figure, Wayve, Physical Intelligence |
+
+## Re-Ranking Heuristics
+
+Promote an entity or category when:
+
+- it shows up repeatedly in the user's projects or captures
+- it affects a toolchain the user depends on
+- it competes with, supplies, or constrains something the user is building
+- it appeared in the last digest and has unresolved momentum
+
+Demote or replace an entity or category when:
+
+- it has low connection to the user's actual work
+- it generates plenty of headlines but little structural change
+- the user's niche clearly lives elsewhere
+
+## Coverage Note Template
+
+Use wording like this at the top of the weekly diff:
+
+`This week's scan started from 10 suggested categories and 30 suggested companies, then reweighted coverage using Open Brain context around [focus areas].`


### PR DESCRIPTION
## Contribution Type

- [x] Skill (`/skills`)
- [ ] Recipe (`/recipes`)
- [ ] Schema (`/schemas`)
- [ ] Dashboard (`/dashboards`)
- [ ] Integration (`/integrations`)
- [ ] Repo improvement (docs, CI, templates)

## What does this do?

Adds a universal `weekly-signal-diff` skill pack for turning a week's worth of market or AI news into a structural diff instead of a summary. The skill starts from 10 suggested categories and 30 suggested companies as a bootstrap scaffold, then reweights the analysis using Open Brain memory, recent priorities, and prior digests. It also includes an optional live-search upgrade path for OpenRouter users who want to use the Perplexity Sonar family for current, source-backed retrieval.

## Requirements

- Working Open Brain setup if the user wants memory search and capture
- AI client with reusable skills, rules, or system prompts
- Live web access or a user-provided weekly source set
- Optional: OpenRouter access to the Perplexity Sonar family for stronger automated search

## Testing

- Ran local metadata schema validation with `check-jsonschema`
- Ran a local subset of the OB1 PR gate checks: folder scope, required files, skill artifact presence, README completeness, file-size checks, and internal link resolution
- Reviewed the staged diff and cleared `git diff --check`
- Did not execute the skill against a live Open Brain connector from this environment, so the PR keeps the testing note honest about that limitation

## Checklist

- [x] I've read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] My contribution has a `README.md` with prerequisites, step-by-step instructions, and expected outcome
- [x] My `metadata.json` has all required fields
- [x] If my contribution depends on a skill or primitive, I declared it in metadata.json and linked it in the README
- [ ] I tested this on my own Open Brain instance
- [x] No credentials, API keys, or secrets are included
