### PR TITLE
[skills] Add install prompt to weekly signal diff README

### DIFF
--- a/skills/weekly-signal-diff/README.md
+++ b/skills/weekly-signal-diff/README.md
@@ -47,6 +47,30 @@ companies for any fast-moving market and keep the same structural-diff process.
    use the Perplexity Sonar family for the retrieval pass and keep the final
    digest structure consistent every week.
 
+If you want an agent to do the installation for you, copy and paste this:
+
+```text
+Install the Weekly Signal Diff skill for me from this repository.
+
+Source files:
+- skills/weekly-signal-diff/SKILL.md
+- skills/weekly-signal-diff/references/starter-universe.md
+- skills/weekly-signal-diff/references/live-search-upgrade.md
+
+What I want you to do:
+1. Detect which AI client or agent environment we are in.
+2. Create the correct reusable-skill folder for that client.
+3. Copy the skill file and the full references folder into that location.
+4. Preserve the folder name as `weekly-signal-diff`.
+5. Tell me exactly where you installed it.
+6. Give me the shortest possible reload step if this client needs one.
+7. Give me one test prompt I can run immediately.
+
+If the client has no native skill folder, put the contents somewhere easy to
+reuse and tell me exactly how to paste or load it into that client's reusable
+instructions feature.
+```
+
 For Claude Code, a common install path is:
 
 ```bash


### PR DESCRIPTION
## Contribution Type

- [x] Skill (`/skills`)
- [ ] Recipe (`/recipes`)
- [ ] Schema (`/schemas`)
- [ ] Dashboard (`/dashboards`)
- [ ] Integration (`/integrations`)
- [ ] Repo improvement (docs, CI, templates)

## What does this do?

Adds a copy-paste prompt to the `weekly-signal-diff` README so a user can hand the installation off to their agent. The prompt tells the agent to detect the client environment, copy the skill and references into the right reusable-skill location, report where it installed the files, and provide a reload step plus a test prompt.

## Requirements

No new runtime requirements. This is a README improvement inside the existing skill folder.

## Testing

- Ran targeted markdownlint on `skills/weekly-signal-diff/**/*.md`
- Re-ran README completeness and internal link checks for the skill folder
- Cleared `git diff --check`

## Checklist

- [x] I've read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] My contribution has a `README.md` with prerequisites, step-by-step instructions, and expected outcome
- [x] My `metadata.json` has all required fields
- [x] If my contribution depends on a skill or primitive, I declared it in metadata.json and linked it in the README
- [ ] I tested this on my own Open Brain instance
- [x] No credentials, API keys, or secrets are included
