### PR TITLE
[recipes] Add work operating model activation workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ Standalone capabilities that make your Open Brain smarter.
 | [Life Engine](recipes/life-engine/) | Self-improving personal assistant — calendar, habits, health, proactive briefings via Telegram or Discord | [@justfinethanku](https://github.com/justfinethanku) |
 | [Life Engine Video](recipes/life-engine-video/) | Add-on that renders Life Engine briefings as short animated videos with voiceover | [@justfinethanku](https://github.com/justfinethanku) |
 | [Daily Digest](recipes/daily-digest/) | Automated daily summary of recent thoughts delivered via email or Slack | OB1 Team |
+| [Work Operating Model Activation](recipes/work-operating-model-activation/) | Conversation-first workflow that turns tacit work patterns into structured Open Brain records and agent-ready operating files | [@jonathanedwards](https://github.com/jonathanedwards) |
 | [Research-to-Decision Workflow](recipes/research-to-decision-workflow/) | Composition recipe that chains canonical skills into operator and investor research, synthesis, meeting, and memo workflows | [@NateBJones](https://github.com/NateBJones) |
 
 ### [`/skills`](skills/) — Agent Skills
@@ -106,6 +107,7 @@ Plain-text skill packs you can drop into Claude Code, Codex, or other AI clients
 | [Meeting Synthesis Skill Pack](skills/meeting-synthesis/) | Converts meeting notes or transcripts into decisions, action items, risks, and follow-up artifacts | [@NateBJones](https://github.com/NateBJones) |
 | [Panning for Gold Skill Pack](skills/panning-for-gold/) | Turns brain dumps and transcripts into evaluated idea inventories | [@jaredirish](https://github.com/jaredirish) |
 | [Claudeception Skill Pack](skills/claudeception/) | Extracts reusable lessons from work sessions into new skills | [@jaredirish](https://github.com/jaredirish) |
+| [Work Operating Model Skill Pack](skills/work-operating-model/) | Runs a five-layer elicitation interview and saves the approved operating model into Open Brain | [@jonathanedwards](https://github.com/jonathanedwards) |
 
 ### [`/dashboards`](dashboards/) — Frontend Templates
 

--- a/recipes/README.md
+++ b/recipes/README.md
@@ -9,6 +9,7 @@ Step-by-step builds that add a new capability to your Open Brain. Follow the ins
 | [Email History Import](email-history-import/) | Pull your Gmail archive into searchable thoughts |
 | [ChatGPT Conversation Import](chatgpt-conversation-import/) | Ingest your ChatGPT data export |
 | [Daily Digest](daily-digest/) | Automated summary of recent thoughts via email or Slack |
+| [Work Operating Model Activation](work-operating-model-activation/) | Interview-driven workflow that stores how you actually work and generates agent-ready operating files |
 | [Research-to-Decision Workflow](research-to-decision-workflow/) | Compose canonical skills into operator and investor paths for analysis, synthesis, meetings, and decision documents |
 
 ## Contributing

--- a/recipes/work-operating-model-activation/README.md
+++ b/recipes/work-operating-model-activation/README.md
@@ -1,0 +1,190 @@
+# Work Operating Model Activation
+
+> A conversation-first workflow that interviews you about how your work actually runs, stores the answers as structured Open Brain data, and generates agent-ready operating files.
+
+## What It Does
+
+This recipe adds a dedicated MCP server plus schema for a 45-minute elicitation workflow. The interview runs in five fixed layers:
+
+1. operating rhythms
+2. recurring decisions
+3. dependencies
+4. institutional knowledge
+5. friction
+
+Each approved layer is saved into structured tables, summarized into one durable Open Brain thought through your existing core connector, and made available for later querying and export generation.
+
+This recipe depends on the canonical [Work Operating Model skill](../../skills/work-operating-model/), which owns the interview behavior. The recipe owns the data model, remote MCP server, and export snapshots.
+
+## Prerequisites
+
+- Working Open Brain setup ([guide](../../docs/01-getting-started.md))
+- Existing core Open Brain connector with `search_thoughts` and `capture_thought`
+- AI client that supports reusable skills or prompt packs
+- Supabase CLI installed and linked to your project
+- Canonical [Work Operating Model skill](../../skills/work-operating-model/)
+
+## Credential Tracker
+
+```text
+WORK OPERATING MODEL ACTIVATION -- CREDENTIAL TRACKER
+----------------------------------------------------
+
+FROM YOUR OPEN BRAIN SETUP
+  Project URL:           ____________
+  Secret key:            ____________
+  Project ref:           ____________
+  MCP Access Key:        ____________
+  Core Open Brain tools available:  yes / no
+
+GENERATED DURING SETUP
+  Default User ID:       ____________
+  Function URL:          ____________
+  MCP Connection URL:    ____________
+  Current profile version: ____________
+
+----------------------------------------------------
+```
+
+## Steps
+
+### 1. Install the skill dependency
+
+Follow the installation steps in the [Work Operating Model skill](../../skills/work-operating-model/). The skill handles the interview, confirmation gates, contradiction pass, and summary-thought capture.
+
+### 2. Run the schema
+
+Open your Supabase SQL Editor and run [`schema.sql`](./schema.sql):
+
+```text
+https://supabase.com/dashboard/project/YOUR_PROJECT_ID/sql/new
+```
+
+This creates:
+
+- `operating_model_profiles`
+- `operating_model_sessions`
+- `operating_model_layer_checkpoints`
+- `operating_model_entries`
+- `operating_model_exports`
+
+It also adds the helper RPC functions `operating_model_start_session()` and `operating_model_save_layer()` for atomic session and layer persistence.
+
+### 3. Generate your default user ID
+
+This recipe is single-user on purpose. Generate one UUID and reuse it for future sessions:
+
+```bash
+uuidgen | tr '[:upper:]' '[:lower:]'
+```
+
+Save it to your credential tracker, then set it in Supabase:
+
+```bash
+supabase secrets set DEFAULT_USER_ID=your-generated-uuid
+```
+
+### 4. Deploy the MCP server
+
+Follow the [Deploy an Edge Function](../../primitives/deploy-edge-function/) guide using these values:
+
+| Setting | Value |
+|---------|-------|
+| Function name | `work-operating-model-mcp` |
+| Download path | `recipes/work-operating-model-activation` |
+
+This function uses:
+
+- `SUPABASE_URL`
+- `SUPABASE_SERVICE_ROLE_KEY`
+- `MCP_ACCESS_KEY`
+- `DEFAULT_USER_ID`
+
+### 5. Connect it to your AI client
+
+Use the [Remote MCP Connection](../../primitives/remote-mcp/) pattern.
+
+| Setting | Value |
+|---------|-------|
+| Connector name | `Work Operating Model` |
+| URL | Your function URL with the same MCP key pattern you use for your other OB1 servers |
+
+Keep your core Open Brain connector enabled too. This recipe stores structured data in its own tables, but the skill still uses the base `search_thoughts` and `capture_thought` tools for hints and summary memory writes.
+
+### 6. Start the interview
+
+With both connectors enabled and the skill installed, prompt your AI client:
+
+```text
+Use the Work Operating Model workflow to interview me and build my operating model.
+```
+
+The skill should:
+
+1. call `start_operating_model_session`
+2. run the five layers in order
+3. show a checkpoint summary after each layer
+4. wait for your confirmation before saving
+5. save the layer with `save_operating_model_layer`
+6. capture one summary thought through your core Open Brain connector
+7. run a contradiction pass
+8. call `generate_operating_model_exports`
+
+### 7. Review the exports
+
+At the end of a successful run, the MCP server stores and returns:
+
+- `operating-model.json`
+- `USER.md`
+- `SOUL.md`
+- `HEARTBEAT.md`
+- `schedule-recommendations.json`
+
+These are stored in `operating_model_exports`, so they still exist even if your client cannot write files locally.
+
+## Available MCP Tools
+
+1. `start_operating_model_session`
+   Create or resume the active interview run. Returns profile status, session status, completed layers, pending layer, session checkpoints, and latest approved checkpoints.
+
+2. `save_operating_model_layer`
+   Atomically upserts the approved layer checkpoint plus canonical entries for that layer, then advances the session to the next layer or review state.
+
+3. `query_operating_model`
+   Reads the latest operating model or a filtered slice by `layer`, `keyword`, `cadence`, `stakeholder`, `unresolved_only`, or `friction_priority`.
+
+4. `generate_operating_model_exports`
+   Renders and stores the final JSON/markdown artifacts after all five layers are approved.
+
+## Expected Outcome
+
+When this recipe is working correctly:
+
+- a first session creates version `1` of a structured operating model
+- pausing after layer 2 and restarting later resumes at the correct pending layer
+- each approved layer writes one checkpoint plus canonical entries into the recipe tables
+- the skill captures six summary thoughts in your core Open Brain:
+  - one per layer
+  - one final synthesis
+- `query_operating_model` can find things like `Monday planning block`, `finance email dependency`, or `handoff friction`
+- `generate_operating_model_exports` returns all five artifact blobs even if no local files are written
+
+## Troubleshooting
+
+**Issue: `start_operating_model_session` says no environment variable is configured**
+Solution: Verify `DEFAULT_USER_ID` was set with `supabase secrets set DEFAULT_USER_ID=...` and redeploy the function if needed.
+
+**Issue: The skill can see the recipe connector but not `search_thoughts` or `capture_thought`**
+Solution: This recipe does not replace the core Open Brain server. Re-enable your base connector alongside this one.
+
+**Issue: Export generation fails with missing layers**
+Solution: At least one approved checkpoint must exist for each of the five layers. Resume the session and finish the missing layer summaries before exporting.
+
+**Issue: Querying by friction priority returns nothing**
+Solution: `friction_priority` reads from `details.priority`, so the saved friction entries need `low`, `medium`, or `high` in that field.
+
+## Next Steps
+
+- Feed `USER.md`, `SOUL.md`, and `HEARTBEAT.md` into any agent platform that uses operating files.
+- Re-run the workflow quarterly or after a major role change to create a new version.
+- Use the [MCP Tool Audit & Optimization Guide](../../docs/05-tool-audit.md) once you add this server so your capture/query/admin tool surface stays manageable.

--- a/recipes/work-operating-model-activation/deno.json
+++ b/recipes/work-operating-model-activation/deno.json
@@ -1,0 +1,9 @@
+{
+  "imports": {
+    "@hono/mcp": "npm:@hono/mcp@0.1.1",
+    "@modelcontextprotocol/sdk": "npm:@modelcontextprotocol/sdk@1.24.3",
+    "@supabase/supabase-js": "npm:@supabase/supabase-js@2.47.10",
+    "hono": "npm:hono@4.9.2",
+    "zod": "npm:zod@4.1.13"
+  }
+}

--- a/recipes/work-operating-model-activation/index.ts
+++ b/recipes/work-operating-model-activation/index.ts
@@ -1,0 +1,862 @@
+import "jsr:@supabase/functions-js/edge-runtime.d.ts";
+
+import { StreamableHTTPTransport } from "@hono/mcp";
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { createClient } from "@supabase/supabase-js";
+import { Hono } from "hono";
+import { z } from "zod";
+
+const SUPABASE_URL = Deno.env.get("SUPABASE_URL");
+const SUPABASE_SERVICE_ROLE_KEY = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY");
+const MCP_ACCESS_KEY = Deno.env.get("MCP_ACCESS_KEY");
+const DEFAULT_USER_ID = Deno.env.get("DEFAULT_USER_ID");
+
+if (!SUPABASE_URL || !SUPABASE_SERVICE_ROLE_KEY || !MCP_ACCESS_KEY || !DEFAULT_USER_ID) {
+  throw new Error(
+    "Missing one or more required environment variables: SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY, MCP_ACCESS_KEY, DEFAULT_USER_ID"
+  );
+}
+
+const supabase = createClient(SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY);
+const app = new Hono();
+
+const LAYERS = [
+  "operating_rhythms",
+  "recurring_decisions",
+  "dependencies",
+  "institutional_knowledge",
+  "friction",
+] as const;
+
+const ARTIFACTS = [
+  "operating-model.json",
+  "USER.md",
+  "SOUL.md",
+  "HEARTBEAT.md",
+  "schedule-recommendations.json",
+] as const;
+
+type Layer = (typeof LAYERS)[number];
+
+type OperatingModelEntry = {
+  title: string;
+  summary: string;
+  cadence?: string | null;
+  trigger?: string | null;
+  inputs: string[];
+  stakeholders: string[];
+  constraints: string[];
+  details: Record<string, unknown>;
+  source_confidence: "confirmed" | "synthesized";
+  status: "active" | "unresolved" | "superseded";
+  last_validated_at?: string | null;
+};
+
+type SessionRecord = {
+  id: string;
+  profile_id: string;
+  profile_version: number;
+  session_name: string | null;
+  status: string;
+  current_layer: string;
+  completed_layers: string[] | null;
+  created_at: string;
+  updated_at: string;
+  completed_at: string | null;
+};
+
+type ProfileRecord = {
+  id: string;
+  current_version: number;
+  status: string;
+};
+
+type CheckpointRecord = {
+  id: string;
+  layer: Layer;
+  checkpoint_summary: string;
+  normalized_payload: Record<string, unknown>;
+  profile_version: number;
+  last_validated_at: string;
+};
+
+type EntryRow = {
+  id: string;
+  layer: Layer;
+  title: string;
+  summary: string;
+  cadence: string | null;
+  trigger: string | null;
+  inputs: string[] | null;
+  stakeholders: string[] | null;
+  constraints: string[] | null;
+  details: Record<string, unknown> | null;
+  source_confidence: "confirmed" | "synthesized";
+  status: "active" | "unresolved" | "superseded";
+  last_validated_at: string;
+  entry_order: number;
+};
+
+const baseEntrySchema = z.object({
+  title: z.string().min(3).describe("Short label for this operating-model entry."),
+  summary: z.string().min(10).describe("Self-contained explanation of the pattern, decision, dependency, knowledge area, or friction."),
+  cadence: z.string().optional().nullable().describe("When this recurs, such as daily, weekly, monthly, quarter-end, or ad hoc."),
+  trigger: z.string().optional().nullable().describe("What event, time, or condition causes this to matter."),
+  inputs: z.array(z.string()).default([]).describe("Inputs needed to execute or reason about this entry."),
+  stakeholders: z.array(z.string()).default([]).describe("People, teams, or systems involved in this entry."),
+  constraints: z.array(z.string()).default([]).describe("Constraints, guardrails, or realities that shape this entry."),
+  details: z.record(z.string(), z.any()).default({}).describe("Layer-specific detail payload."),
+  source_confidence: z.enum(["confirmed", "synthesized"]).default("confirmed").describe("Use confirmed for explicit user statements and synthesized for patterns inferred from multiple examples."),
+  status: z.enum(["active", "unresolved", "superseded"]).default("active").describe("Use unresolved when the user flagged uncertainty or contradiction that still needs clarification."),
+  last_validated_at: z.string().optional().nullable().describe("ISO timestamp for the last user confirmation. Omit to default to now."),
+});
+
+const timeWindowSchema = z.object({
+  label: z.string().optional(),
+  days: z.array(z.string()).optional(),
+  start: z.string().optional(),
+  end: z.string().optional(),
+  notes: z.string().optional(),
+});
+
+const layerDetailValidators: Record<Layer, z.ZodTypeAny> = {
+  operating_rhythms: z.object({
+    time_windows: z.array(z.union([z.string(), timeWindowSchema])).min(1),
+    energy_pattern: z.string().min(3),
+    interruptions: z.array(z.string()).default([]),
+    non_calendar_reality: z.string().min(3),
+  }),
+  recurring_decisions: z.object({
+    decision_name: z.string().min(3),
+    decision_inputs: z.array(z.string()).min(1),
+    thresholds: z.array(z.string()).default([]),
+    escalation_rule: z.string().min(3),
+    reversible: z.union([z.boolean(), z.string()]),
+  }),
+  dependencies: z.object({
+    dependency_owner: z.string().min(2),
+    deliverable: z.string().min(3),
+    needed_by: z.string().min(2),
+    failure_impact: z.string().min(3),
+    fallback: z.string().min(3),
+  }),
+  institutional_knowledge: z.object({
+    knowledge_area: z.string().min(3),
+    why_it_matters: z.string().min(3),
+    where_it_lives: z.string().min(3),
+    who_else_knows: z.array(z.string()).default([]),
+    risk_if_missing: z.string().min(3),
+  }),
+  friction: z.object({
+    frequency: z.string().min(2),
+    time_cost: z.string().min(2),
+    current_workaround: z.string().min(3),
+    systems_involved: z.array(z.string()).default([]),
+    automation_candidate: z.union([z.boolean(), z.string()]),
+    priority: z.enum(["low", "medium", "high"]).optional(),
+  }),
+};
+
+const server = new McpServer({
+  name: "work-operating-model-activation",
+  version: "1.0.0",
+});
+
+function jsonText(payload: unknown) {
+  return JSON.stringify(payload, null, 2);
+}
+
+function normalizeStringList(values: string[] | null | undefined): string[] {
+  return Array.from(
+    new Set((values ?? []).map((value) => value.trim()).filter(Boolean))
+  );
+}
+
+function normalizeEntry(layer: Layer, entry: z.infer<typeof baseEntrySchema>): OperatingModelEntry {
+  layerDetailValidators[layer].parse(entry.details);
+
+  return {
+    title: entry.title.trim(),
+    summary: entry.summary.trim(),
+    cadence: entry.cadence?.trim() || null,
+    trigger: entry.trigger?.trim() || null,
+    inputs: normalizeStringList(entry.inputs),
+    stakeholders: normalizeStringList(entry.stakeholders),
+    constraints: normalizeStringList(entry.constraints),
+    details: entry.details,
+    source_confidence: entry.source_confidence,
+    status: entry.status,
+    last_validated_at: entry.last_validated_at ?? null,
+  };
+}
+
+function renderSectionHeading(title: string): string {
+  return `## ${title}\n`;
+}
+
+function renderEntries(entries: EntryRow[]): string {
+  if (entries.length === 0) {
+    return "- None captured yet.\n";
+  }
+
+  return entries
+    .map((entry) => {
+      const lines = [`- ${entry.title}: ${entry.summary}`];
+      if (entry.cadence) lines.push(`  Cadence: ${entry.cadence}`);
+      if (entry.trigger) lines.push(`  Trigger: ${entry.trigger}`);
+      if (entry.stakeholders?.length) lines.push(`  Stakeholders: ${entry.stakeholders.join(", ")}`);
+      if (entry.constraints?.length) lines.push(`  Constraints: ${entry.constraints.join(", ")}`);
+      return lines.join("\n");
+    })
+    .join("\n");
+}
+
+function groupEntries(entries: EntryRow[]): Record<Layer, EntryRow[]> {
+  const grouped = {
+    operating_rhythms: [],
+    recurring_decisions: [],
+    dependencies: [],
+    institutional_knowledge: [],
+    friction: [],
+  } as Record<Layer, EntryRow[]>;
+  for (const entry of entries) {
+    grouped[entry.layer].push(entry);
+  }
+  for (const layer of LAYERS) {
+    grouped[layer].sort((a, b) => a.entry_order - b.entry_order);
+  }
+  return grouped;
+}
+
+function cadenceBucket(cadence: string | null | undefined): "daily" | "weekly" | "monthly" | "event_driven" {
+  const value = (cadence ?? "").toLowerCase();
+  if (value.includes("month") || value.includes("quarter")) return "monthly";
+  if (value.includes("week")) return "weekly";
+  if (value.includes("day") || value.includes("morning") || value.includes("afternoon") || value.includes("evening")) {
+    return "daily";
+  }
+  return "event_driven";
+}
+
+function buildScheduleRecommendations(grouped: Record<Layer, EntryRow[]>, version: number, sessionId: string) {
+  const recommendations = {
+    generated_at: new Date().toISOString(),
+    profile_version: version,
+    session_id: sessionId,
+    daily: [] as Array<Record<string, unknown>>,
+    weekly: [] as Array<Record<string, unknown>>,
+    monthly: [] as Array<Record<string, unknown>>,
+    event_driven: [] as Array<Record<string, unknown>>,
+  };
+
+  for (const entry of grouped.operating_rhythms) {
+    const bucket = cadenceBucket(entry.cadence);
+    recommendations[bucket].push({
+      name: entry.title,
+      cadence: entry.cadence ?? "event-driven",
+      trigger: entry.trigger ?? "Use the recorded operating rhythm as the trigger.",
+      rationale: entry.summary,
+      source_layers: ["operating_rhythms"],
+    });
+  }
+
+  for (const entry of grouped.dependencies) {
+    const details = entry.details ?? {};
+    recommendations.event_driven.push({
+      name: `Check dependency: ${entry.title}`,
+      cadence: entry.cadence ?? "event-driven",
+      trigger: entry.trigger ?? String(details.needed_by ?? "Before the dependent work starts"),
+      rationale: String(details.failure_impact ?? entry.summary),
+      source_layers: ["dependencies"],
+    });
+  }
+
+  return recommendations;
+}
+
+function buildOperatingModelJson(
+  profile: ProfileRecord,
+  session: SessionRecord,
+  checkpoints: CheckpointRecord[],
+  grouped: Record<Layer, EntryRow[]>
+) {
+  return {
+    generated_at: new Date().toISOString(),
+    profile_id: profile.id,
+    profile_status: profile.status,
+    profile_version: session.profile_version,
+    session_id: session.id,
+    session_status: session.status,
+    layers: Object.fromEntries(
+      LAYERS.map((layer) => [
+        layer,
+        {
+          checkpoint_summary:
+            checkpoints.find((checkpoint) => checkpoint.layer === layer)?.checkpoint_summary ?? "",
+          entries: grouped[layer].map((entry) => ({
+            title: entry.title,
+            summary: entry.summary,
+            cadence: entry.cadence,
+            trigger: entry.trigger,
+            inputs: entry.inputs ?? [],
+            stakeholders: entry.stakeholders ?? [],
+            constraints: entry.constraints ?? [],
+            details: entry.details ?? {},
+            source_confidence: entry.source_confidence,
+            status: entry.status,
+            last_validated_at: entry.last_validated_at,
+          })),
+        },
+      ])
+    ),
+  };
+}
+
+function buildUserMarkdown(
+  session: SessionRecord,
+  checkpoints: CheckpointRecord[],
+  grouped: Record<Layer, EntryRow[]>
+): string {
+  const lines = [
+    "# USER",
+    "",
+    `Profile version: ${session.profile_version}`,
+    `Generated from session: ${session.id}`,
+    "",
+    renderSectionHeading("Operating Rhythms"),
+    checkpoints.find((item) => item.layer === "operating_rhythms")?.checkpoint_summary ?? "",
+    "",
+    renderEntries(grouped.operating_rhythms),
+    "",
+    renderSectionHeading("Recurring Decisions"),
+    checkpoints.find((item) => item.layer === "recurring_decisions")?.checkpoint_summary ?? "",
+    "",
+    renderEntries(grouped.recurring_decisions),
+    "",
+    renderSectionHeading("Dependencies"),
+    checkpoints.find((item) => item.layer === "dependencies")?.checkpoint_summary ?? "",
+    "",
+    renderEntries(grouped.dependencies),
+    "",
+    renderSectionHeading("Institutional Knowledge"),
+    checkpoints.find((item) => item.layer === "institutional_knowledge")?.checkpoint_summary ?? "",
+    "",
+    renderEntries(grouped.institutional_knowledge),
+    "",
+    renderSectionHeading("Friction"),
+    checkpoints.find((item) => item.layer === "friction")?.checkpoint_summary ?? "",
+    "",
+    renderEntries(grouped.friction),
+    "",
+  ];
+
+  return lines.join("\n");
+}
+
+function buildSoulMarkdown(checkpoints: CheckpointRecord[], grouped: Record<Layer, EntryRow[]>): string {
+  const decisionHeuristics = grouped.recurring_decisions
+    .map((entry) => {
+      const details = entry.details ?? {};
+      return `- ${details.decision_name ?? entry.title}: use ${Array.isArray(details.decision_inputs) ? details.decision_inputs.join(", ") : "the recorded inputs"} before acting. Escalate when ${details.escalation_rule ?? entry.status}.`;
+    })
+    .join("\n");
+
+  const boundaries = [
+    ...grouped.dependencies.map((entry) => `- Respect dependency timing for ${entry.title}.`),
+    ...grouped.friction
+      .filter((entry) => entry.status === "unresolved")
+      .map((entry) => `- Treat ${entry.title} as unresolved. Ask before automating around it.`),
+  ].join("\n");
+
+  const knowledge = grouped.institutional_knowledge
+    .map((entry) => `- ${entry.title}: ${entry.summary}`)
+    .join("\n");
+
+  return [
+    "# SOUL",
+    "",
+    "## Mandate",
+    checkpoints.find((item) => item.layer === "recurring_decisions")?.checkpoint_summary ??
+      "Help the operator work in line with their actual patterns, not their idealized calendar.",
+    "",
+    "## Boundaries",
+    boundaries || "- Default to asking for confirmation when an item is unresolved or time-sensitive.",
+    "",
+    "## Decision Heuristics",
+    decisionHeuristics || "- No recurring decision heuristics captured yet.",
+    "",
+    "## Knowledge To Respect",
+    knowledge || "- No unique institutional knowledge captured yet.",
+    "",
+    "## Quality Bar",
+    "Prefer concrete, triggerable help. Use the user's real rhythms, explicit dependencies, and known friction before proposing action.",
+    "",
+  ].join("\n");
+}
+
+function buildHeartbeatMarkdown(grouped: Record<Layer, EntryRow[]>, scheduleRecommendations: ReturnType<typeof buildScheduleRecommendations>): string {
+  const buildRecommendationList = (items: Array<Record<string, unknown>>) =>
+    items.length === 0
+      ? "- None captured.\n"
+      : items
+          .map(
+            (item) =>
+              `- ${String(item.name)}\n  Trigger: ${String(item.trigger)}\n  Why: ${String(item.rationale)}`
+          )
+          .join("\n");
+
+  const dependencyChecks = grouped.dependencies
+    .map((entry) => {
+      const details = entry.details ?? {};
+      return `- ${entry.title}: need ${String(details.deliverable ?? "the recorded dependency")} from ${String(details.dependency_owner ?? "the dependency owner")} by ${String(details.needed_by ?? entry.trigger ?? "the required time")}.`;
+    })
+    .join("\n");
+
+  return [
+    "# HEARTBEAT",
+    "",
+    "## Daily Checks",
+    buildRecommendationList(scheduleRecommendations.daily),
+    "",
+    "## Weekly Checks",
+    buildRecommendationList(scheduleRecommendations.weekly),
+    "",
+    "## Monthly Checks",
+    buildRecommendationList(scheduleRecommendations.monthly),
+    "",
+    "## Event-Driven Checks",
+    buildRecommendationList(scheduleRecommendations.event_driven),
+    "",
+    "## Dependency Watch",
+    dependencyChecks || "- No dependency watches captured yet.",
+    "",
+  ].join("\n");
+}
+
+async function getProfile(userId: string): Promise<ProfileRecord | null> {
+  const { data, error } = await supabase
+    .from("operating_model_profiles")
+    .select("id, current_version, status")
+    .eq("user_id", userId)
+    .single();
+
+  if (error) {
+    if (error.code === "PGRST116") return null;
+    throw new Error(`Failed to load profile: ${error.message}`);
+  }
+
+  return data as ProfileRecord;
+}
+
+async function getLatestSession(userId: string): Promise<SessionRecord | null> {
+  const { data, error } = await supabase
+    .from("operating_model_sessions")
+    .select("id, profile_id, profile_version, session_name, status, current_layer, completed_layers, created_at, updated_at, completed_at")
+    .eq("user_id", userId)
+    .order("created_at", { ascending: false })
+    .limit(1)
+    .maybeSingle();
+
+  if (error) {
+    throw new Error(`Failed to load latest session: ${error.message}`);
+  }
+
+  return (data as SessionRecord | null) ?? null;
+}
+
+async function getSessionById(sessionId: string): Promise<SessionRecord> {
+  const { data, error } = await supabase
+    .from("operating_model_sessions")
+    .select("id, profile_id, profile_version, session_name, status, current_layer, completed_layers, created_at, updated_at, completed_at")
+    .eq("id", sessionId)
+    .single();
+
+  if (error) {
+    throw new Error(`Failed to load session: ${error.message}`);
+  }
+
+  return data as SessionRecord;
+}
+
+async function getSessionForVersion(userId: string, version: number): Promise<SessionRecord | null> {
+  const { data, error } = await supabase
+    .from("operating_model_sessions")
+    .select("id, profile_id, profile_version, session_name, status, current_layer, completed_layers, created_at, updated_at, completed_at")
+    .eq("user_id", userId)
+    .eq("profile_version", version)
+    .order("created_at", { ascending: false })
+    .limit(1)
+    .maybeSingle();
+
+  if (error) {
+    throw new Error(`Failed to load session for version ${version}: ${error.message}`);
+  }
+
+  return (data as SessionRecord | null) ?? null;
+}
+
+async function getCheckpoints(sessionId: string): Promise<CheckpointRecord[]> {
+  const { data, error } = await supabase
+    .from("operating_model_layer_checkpoints")
+    .select("id, layer, checkpoint_summary, normalized_payload, profile_version, last_validated_at")
+    .eq("session_id", sessionId)
+    .eq("status", "approved")
+    .order("updated_at", { ascending: true });
+
+  if (error) {
+    throw new Error(`Failed to load checkpoints: ${error.message}`);
+  }
+
+  return (data as CheckpointRecord[]) ?? [];
+}
+
+async function getEntries(sessionId: string): Promise<EntryRow[]> {
+  const { data, error } = await supabase
+    .from("operating_model_entries")
+    .select("id, layer, title, summary, cadence, trigger, inputs, stakeholders, constraints, details, source_confidence, status, last_validated_at, entry_order")
+    .eq("session_id", sessionId)
+    .order("entry_order", { ascending: true });
+
+  if (error) {
+    throw new Error(`Failed to load entries: ${error.message}`);
+  }
+
+  return (data as EntryRow[]) ?? [];
+}
+
+async function resolveVersion(userId: string, requestedVersion?: number): Promise<{
+  profile: ProfileRecord | null;
+  session: SessionRecord | null;
+  version: number | null;
+}> {
+  const profile = await getProfile(userId);
+
+  if (requestedVersion) {
+    const session = await getSessionForVersion(userId, requestedVersion);
+    return { profile, session, version: session?.profile_version ?? requestedVersion };
+  }
+
+  const latestSession = await getLatestSession(userId);
+  if (latestSession && (!profile || latestSession.profile_version >= profile.current_version)) {
+    return { profile, session: latestSession, version: latestSession.profile_version };
+  }
+
+  if (profile && profile.current_version > 0) {
+    const session = await getSessionForVersion(userId, profile.current_version);
+    return { profile, session, version: profile.current_version };
+  }
+
+  return { profile, session: latestSession, version: latestSession?.profile_version ?? null };
+}
+
+server.tool(
+  "start_operating_model_session",
+  "Start the work operating model interview or resume the latest in-progress session. Use this before asking layer questions so the agent knows whether it is resuming or beginning fresh.",
+  {
+    session_name: z.string().optional().describe("Optional label for this run, such as 'April 2026 operating model refresh'."),
+  },
+  async ({ session_name }) => {
+    try {
+      const { data, error } = await supabase.rpc("operating_model_start_session", {
+        p_user_id: DEFAULT_USER_ID,
+        p_session_name: session_name ?? null,
+      });
+
+      if (error) {
+        throw new Error(`Failed to start or resume session: ${error.message}`);
+      }
+
+      return {
+        content: [{ type: "text", text: jsonText(data) }],
+      };
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      return {
+        content: [{ type: "text", text: jsonText({ error: message }) }],
+        isError: true,
+      };
+    }
+  }
+);
+
+server.tool(
+  "save_operating_model_layer",
+  "Persist an approved layer checkpoint after the user confirms it. Use this only after you have shown a checkpoint summary, received explicit confirmation, and normalized the layer into canonical entries.",
+  {
+    session_id: z.string().uuid().describe("The active operating-model session ID returned by start_operating_model_session."),
+    layer: z.enum(LAYERS).describe("Which of the five layers you are saving."),
+    checkpoint_summary: z.string().min(20).describe("Approved layer summary shown to the user before saving."),
+    entries: z.array(baseEntrySchema).min(1).describe("Canonical structured entries for this layer."),
+  },
+  async ({ session_id, layer, checkpoint_summary, entries }) => {
+    try {
+      const normalizedEntries = entries.map((entry) => normalizeEntry(layer, entry));
+
+      const { data, error } = await supabase.rpc("operating_model_save_layer", {
+        p_session_id: session_id,
+        p_layer: layer,
+        p_checkpoint_summary: checkpoint_summary.trim(),
+        p_entries: normalizedEntries,
+      });
+
+      if (error) {
+        throw new Error(`Failed to save layer: ${error.message}`);
+      }
+
+      return {
+        content: [{ type: "text", text: jsonText(data) }],
+      };
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      return {
+        content: [{ type: "text", text: jsonText({ error: message }) }],
+        isError: true,
+      };
+    }
+  }
+);
+
+server.tool(
+  "query_operating_model",
+  "Read the current operating model or a filtered slice of it. Use this during contradiction checks, resume flows, or when you need the latest structured profile by layer, keyword, cadence, stakeholder, unresolved status, or friction priority.",
+  {
+    layer: z.enum(LAYERS).optional().describe("Restrict results to one layer."),
+    keyword: z.string().optional().describe("Keyword to match against title, summary, trigger, arrays, and detail text."),
+    cadence: z.string().optional().describe("Filter to entries whose cadence mentions this text."),
+    stakeholder: z.string().optional().describe("Filter to entries that involve this stakeholder."),
+    unresolved_only: z.boolean().optional().describe("Only return unresolved entries."),
+    friction_priority: z.enum(["low", "medium", "high"]).optional().describe("Only meaningful for the friction layer. Filters on details.priority."),
+    profile_version: z.number().int().positive().optional().describe("Read a specific version instead of the latest available version."),
+  },
+  async ({ layer, keyword, cadence, stakeholder, unresolved_only, friction_priority, profile_version }) => {
+    try {
+      const resolved = await resolveVersion(DEFAULT_USER_ID, profile_version);
+
+      if (!resolved.session || !resolved.version) {
+        return {
+          content: [{ type: "text", text: jsonText({ message: "No operating model profile has been started yet." }) }],
+        };
+      }
+
+      const checkpoints = await getCheckpoints(resolved.session.id);
+      const entries = await getEntries(resolved.session.id);
+
+      let filtered = entries;
+
+      if (layer) {
+        filtered = filtered.filter((entry) => entry.layer === layer);
+      }
+
+      if (cadence) {
+        const needle = cadence.toLowerCase();
+        filtered = filtered.filter((entry) => (entry.cadence ?? "").toLowerCase().includes(needle));
+      }
+
+      if (stakeholder) {
+        const needle = stakeholder.toLowerCase();
+        filtered = filtered.filter((entry) =>
+          (entry.stakeholders ?? []).some((item) => item.toLowerCase().includes(needle))
+        );
+      }
+
+      if (unresolved_only) {
+        filtered = filtered.filter((entry) => entry.status === "unresolved");
+      }
+
+      if (friction_priority) {
+        filtered = filtered.filter(
+          (entry) =>
+            entry.layer === "friction" &&
+            String((entry.details ?? {}).priority ?? "").toLowerCase() === friction_priority
+        );
+      }
+
+      if (keyword) {
+        const needle = keyword.toLowerCase();
+        filtered = filtered.filter((entry) => {
+          const haystack = [
+            entry.title,
+            entry.summary,
+            entry.cadence ?? "",
+            entry.trigger ?? "",
+            ...(entry.inputs ?? []),
+            ...(entry.stakeholders ?? []),
+            ...(entry.constraints ?? []),
+            JSON.stringify(entry.details ?? {}),
+          ]
+            .join(" ")
+            .toLowerCase();
+
+          return haystack.includes(needle);
+        });
+      }
+
+      const response = {
+        profile_status: resolved.profile?.status ?? "draft",
+        profile_version: resolved.version,
+        session_id: resolved.session.id,
+        session_status: resolved.session.status,
+        completed_layers: resolved.session.completed_layers ?? [],
+        pending_layer: resolved.session.current_layer,
+        checkpoint_count: checkpoints.length,
+        entry_count: filtered.length,
+        checkpoints,
+        entries: filtered,
+      };
+
+      return {
+        content: [{ type: "text", text: jsonText(response) }],
+      };
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      return {
+        content: [{ type: "text", text: jsonText({ error: message }) }],
+        isError: true,
+      };
+    }
+  }
+);
+
+server.tool(
+  "generate_operating_model_exports",
+  "Render and store the canonical operating-model exports after all five layers are approved and contradictions are resolved. Use this at the end of the workflow to return JSON and markdown artifacts.",
+  {
+    session_id: z.string().uuid().optional().describe("Optional session ID to export. Defaults to the latest active or completed session."),
+    final_review_notes: z.string().optional().describe("Optional notes from the final contradiction pass to store with the export metadata."),
+  },
+  async ({ session_id, final_review_notes }) => {
+    try {
+      const session = session_id
+        ? await getSessionById(session_id)
+        : (await resolveVersion(DEFAULT_USER_ID)).session;
+
+      if (!session) {
+        throw new Error("No operating-model session is available to export.");
+      }
+
+      const profile = await getProfile(DEFAULT_USER_ID);
+      if (!profile) {
+        throw new Error("No operating-model profile found.");
+      }
+
+      const checkpoints = await getCheckpoints(session.id);
+      const completedLayerSet = new Set(checkpoints.map((item) => item.layer));
+      const missingLayers = LAYERS.filter((layer) => !completedLayerSet.has(layer));
+      if (missingLayers.length > 0) {
+        throw new Error(`Cannot generate exports yet. Missing approved layers: ${missingLayers.join(", ")}`);
+      }
+
+      const entries = await getEntries(session.id);
+      const grouped = groupEntries(entries);
+      const scheduleRecommendations = buildScheduleRecommendations(grouped, session.profile_version, session.id);
+      const operatingModelJson = buildOperatingModelJson(profile, session, checkpoints, grouped);
+      const exportsMap: Record<(typeof ARTIFACTS)[number], string> = {
+        "operating-model.json": jsonText(operatingModelJson),
+        "USER.md": buildUserMarkdown(session, checkpoints, grouped),
+        "SOUL.md": buildSoulMarkdown(checkpoints, grouped),
+        "HEARTBEAT.md": buildHeartbeatMarkdown(grouped, scheduleRecommendations),
+        "schedule-recommendations.json": jsonText(scheduleRecommendations),
+      };
+
+      const upsertRows = ARTIFACTS.map((artifactName) => ({
+        profile_id: session.profile_id,
+        session_id: session.id,
+        user_id: DEFAULT_USER_ID,
+        profile_version: session.profile_version,
+        artifact_name: artifactName,
+        content: exportsMap[artifactName],
+        content_type: artifactName.endsWith(".json") ? "application/json" : "text/markdown",
+        metadata: {
+          generated_at: new Date().toISOString(),
+          final_review_notes: final_review_notes ?? null,
+        },
+      }));
+
+      const { error: exportError } = await supabase
+        .from("operating_model_exports")
+        .upsert(upsertRows, { onConflict: "session_id,artifact_name" });
+
+      if (exportError) {
+        throw new Error(`Failed to store exports: ${exportError.message}`);
+      }
+
+      const { error: sessionError } = await supabase
+        .from("operating_model_sessions")
+        .update({
+          status: "completed",
+          current_layer: "complete",
+          completed_at: new Date().toISOString(),
+        })
+        .eq("id", session.id);
+
+      if (sessionError) {
+        throw new Error(`Failed to finalize session: ${sessionError.message}`);
+      }
+
+      const { error: profileError } = await supabase
+        .from("operating_model_profiles")
+        .update({
+          current_version: session.profile_version,
+          status: "active",
+        })
+        .eq("id", profile.id);
+
+      if (profileError) {
+        throw new Error(`Failed to update profile version: ${profileError.message}`);
+      }
+
+      return {
+        content: [
+          {
+            type: "text",
+            text: jsonText({
+              session_id: session.id,
+              profile_version: session.profile_version,
+              exports: exportsMap,
+            }),
+          },
+        ],
+      };
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      return {
+        content: [{ type: "text", text: jsonText({ error: message }) }],
+        isError: true,
+      };
+    }
+  }
+);
+
+app.get("/health", (c) =>
+  c.json({ status: "ok", service: "Work Operating Model Activation MCP", version: "1.0.0" })
+);
+
+app.all("*", async (c) => {
+  if (!c.req.header("accept")?.includes("text/event-stream")) {
+    const headers = new Headers(c.req.raw.headers);
+    headers.set("Accept", "application/json, text/event-stream");
+    const patched = new Request(c.req.raw.url, {
+      method: c.req.raw.method,
+      headers,
+      body: c.req.raw.body,
+      // @ts-ignore Deno stream request compatibility
+      duplex: "half",
+    });
+    Object.defineProperty(c.req, "raw", { value: patched, writable: true });
+  }
+
+  const key =
+    c.req.query("key") ||
+    c.req.header("x-brain-key") ||
+    c.req.header("x-access-key");
+
+  if (!key || key !== MCP_ACCESS_KEY) {
+    return c.json({ error: "Unauthorized" }, 401);
+  }
+
+  const transport = new StreamableHTTPTransport();
+  await server.connect(transport);
+  return transport.handleRequest(c);
+});
+
+Deno.serve(app.fetch);

--- a/recipes/work-operating-model-activation/metadata.json
+++ b/recipes/work-operating-model-activation/metadata.json
@@ -1,0 +1,21 @@
+{
+  "name": "Work Operating Model Activation",
+  "description": "Conversation-first workflow for eliciting a user's operating rhythms, recurring decisions, dependencies, institutional knowledge, and friction into structured Open Brain data plus agent-ready exports.",
+  "category": "recipes",
+  "author": {
+    "name": "Jonathan Edwards",
+    "github": "jonathanedwards"
+  },
+  "version": "1.0.0",
+  "requires": {
+    "open_brain": true,
+    "services": ["Supabase"],
+    "tools": ["Supabase CLI", "AI client with MCP support and reusable skills/prompts"]
+  },
+  "requires_skills": ["work-operating-model"],
+  "tags": ["workflow", "operating-model", "interview", "agent-config", "mcp", "activation"],
+  "difficulty": "intermediate",
+  "estimated_time": "45 minutes",
+  "created": "2026-04-14",
+  "updated": "2026-04-14"
+}

--- a/recipes/work-operating-model-activation/schema.sql
+++ b/recipes/work-operating-model-activation/schema.sql
@@ -1,0 +1,622 @@
+-- ============================================
+-- Work Operating Model Activation
+-- ============================================
+-- Structured storage for conversation-first work elicitation.
+-- This recipe stores one durable profile per user, versioned sessions,
+-- approved layer checkpoints, canonical entries, and export snapshots.
+--
+-- Run this in your Supabase SQL Editor.
+-- ============================================
+
+CREATE OR REPLACE FUNCTION update_work_operating_model_updated_at()
+RETURNS TRIGGER AS $$
+BEGIN
+  NEW.updated_at = now();
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TABLE IF NOT EXISTS operating_model_profiles (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id UUID NOT NULL UNIQUE,
+  current_version INTEGER NOT NULL DEFAULT 0 CHECK (current_version >= 0),
+  status TEXT NOT NULL DEFAULT 'draft'
+    CHECK (status IN ('draft', 'active', 'archived')),
+  notes TEXT,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE TABLE IF NOT EXISTS operating_model_sessions (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  profile_id UUID NOT NULL REFERENCES operating_model_profiles(id) ON DELETE CASCADE,
+  user_id UUID NOT NULL,
+  profile_version INTEGER NOT NULL CHECK (profile_version > 0),
+  session_name TEXT,
+  status TEXT NOT NULL DEFAULT 'in_progress'
+    CHECK (status IN ('in_progress', 'review_ready', 'completed', 'abandoned')),
+  current_layer TEXT NOT NULL DEFAULT 'operating_rhythms'
+    CHECK (current_layer IN (
+      'operating_rhythms',
+      'recurring_decisions',
+      'dependencies',
+      'institutional_knowledge',
+      'friction',
+      'review',
+      'complete'
+    )),
+  completed_layers TEXT[] NOT NULL DEFAULT '{}',
+  resume_metadata JSONB NOT NULL DEFAULT '{}'::jsonb,
+  started_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  completed_at TIMESTAMPTZ,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE TABLE IF NOT EXISTS operating_model_layer_checkpoints (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  profile_id UUID NOT NULL REFERENCES operating_model_profiles(id) ON DELETE CASCADE,
+  session_id UUID NOT NULL REFERENCES operating_model_sessions(id) ON DELETE CASCADE,
+  user_id UUID NOT NULL,
+  profile_version INTEGER NOT NULL CHECK (profile_version > 0),
+  layer TEXT NOT NULL
+    CHECK (layer IN (
+      'operating_rhythms',
+      'recurring_decisions',
+      'dependencies',
+      'institutional_knowledge',
+      'friction'
+    )),
+  checkpoint_summary TEXT NOT NULL,
+  normalized_payload JSONB NOT NULL DEFAULT '{}'::jsonb,
+  status TEXT NOT NULL DEFAULT 'approved'
+    CHECK (status IN ('draft', 'approved', 'superseded')),
+  approved_at TIMESTAMPTZ,
+  last_validated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  UNIQUE (session_id, layer)
+);
+
+CREATE TABLE IF NOT EXISTS operating_model_entries (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  profile_id UUID NOT NULL REFERENCES operating_model_profiles(id) ON DELETE CASCADE,
+  session_id UUID NOT NULL REFERENCES operating_model_sessions(id) ON DELETE CASCADE,
+  checkpoint_id UUID NOT NULL REFERENCES operating_model_layer_checkpoints(id) ON DELETE CASCADE,
+  user_id UUID NOT NULL,
+  profile_version INTEGER NOT NULL CHECK (profile_version > 0),
+  layer TEXT NOT NULL
+    CHECK (layer IN (
+      'operating_rhythms',
+      'recurring_decisions',
+      'dependencies',
+      'institutional_knowledge',
+      'friction'
+    )),
+  entry_order INTEGER NOT NULL DEFAULT 0,
+  title TEXT NOT NULL,
+  summary TEXT NOT NULL,
+  cadence TEXT,
+  trigger TEXT,
+  inputs TEXT[] NOT NULL DEFAULT '{}',
+  stakeholders TEXT[] NOT NULL DEFAULT '{}',
+  constraints TEXT[] NOT NULL DEFAULT '{}',
+  details JSONB NOT NULL DEFAULT '{}'::jsonb,
+  source_confidence TEXT NOT NULL DEFAULT 'confirmed'
+    CHECK (source_confidence IN ('confirmed', 'synthesized')),
+  status TEXT NOT NULL DEFAULT 'active'
+    CHECK (status IN ('active', 'unresolved', 'superseded')),
+  last_validated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE TABLE IF NOT EXISTS operating_model_exports (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  profile_id UUID NOT NULL REFERENCES operating_model_profiles(id) ON DELETE CASCADE,
+  session_id UUID NOT NULL REFERENCES operating_model_sessions(id) ON DELETE CASCADE,
+  user_id UUID NOT NULL,
+  profile_version INTEGER NOT NULL CHECK (profile_version > 0),
+  artifact_name TEXT NOT NULL
+    CHECK (artifact_name IN (
+      'operating-model.json',
+      'USER.md',
+      'SOUL.md',
+      'HEARTBEAT.md',
+      'schedule-recommendations.json'
+    )),
+  content TEXT NOT NULL,
+  content_type TEXT NOT NULL,
+  metadata JSONB NOT NULL DEFAULT '{}'::jsonb,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  UNIQUE (session_id, artifact_name)
+);
+
+CREATE INDEX IF NOT EXISTS idx_omp_user_status
+  ON operating_model_profiles(user_id, status);
+
+CREATE INDEX IF NOT EXISTS idx_oms_user_status_version
+  ON operating_model_sessions(user_id, status, profile_version DESC);
+
+CREATE INDEX IF NOT EXISTS idx_oms_completed_layers
+  ON operating_model_sessions USING GIN (completed_layers);
+
+CREATE INDEX IF NOT EXISTS idx_omc_session_layer
+  ON operating_model_layer_checkpoints(session_id, layer);
+
+CREATE INDEX IF NOT EXISTS idx_omc_user_version
+  ON operating_model_layer_checkpoints(user_id, profile_version DESC, layer);
+
+CREATE INDEX IF NOT EXISTS idx_ome_user_version_layer
+  ON operating_model_entries(user_id, profile_version DESC, layer, entry_order);
+
+CREATE INDEX IF NOT EXISTS idx_ome_stakeholders
+  ON operating_model_entries USING GIN (stakeholders);
+
+CREATE INDEX IF NOT EXISTS idx_ome_inputs
+  ON operating_model_entries USING GIN (inputs);
+
+CREATE INDEX IF NOT EXISTS idx_ome_details
+  ON operating_model_entries USING GIN (details);
+
+CREATE INDEX IF NOT EXISTS idx_omx_session_artifact
+  ON operating_model_exports(session_id, artifact_name);
+
+ALTER TABLE operating_model_profiles ENABLE ROW LEVEL SECURITY;
+ALTER TABLE operating_model_sessions ENABLE ROW LEVEL SECURITY;
+ALTER TABLE operating_model_layer_checkpoints ENABLE ROW LEVEL SECURITY;
+ALTER TABLE operating_model_entries ENABLE ROW LEVEL SECURITY;
+ALTER TABLE operating_model_exports ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS operating_model_profiles_user_policy ON operating_model_profiles;
+CREATE POLICY operating_model_profiles_user_policy ON operating_model_profiles
+  FOR ALL
+  USING (auth.uid() = user_id)
+  WITH CHECK (auth.uid() = user_id);
+
+DROP POLICY IF EXISTS operating_model_sessions_user_policy ON operating_model_sessions;
+CREATE POLICY operating_model_sessions_user_policy ON operating_model_sessions
+  FOR ALL
+  USING (auth.uid() = user_id)
+  WITH CHECK (auth.uid() = user_id);
+
+DROP POLICY IF EXISTS operating_model_layer_checkpoints_user_policy ON operating_model_layer_checkpoints;
+CREATE POLICY operating_model_layer_checkpoints_user_policy ON operating_model_layer_checkpoints
+  FOR ALL
+  USING (auth.uid() = user_id)
+  WITH CHECK (auth.uid() = user_id);
+
+DROP POLICY IF EXISTS operating_model_entries_user_policy ON operating_model_entries;
+CREATE POLICY operating_model_entries_user_policy ON operating_model_entries
+  FOR ALL
+  USING (auth.uid() = user_id)
+  WITH CHECK (auth.uid() = user_id);
+
+DROP POLICY IF EXISTS operating_model_exports_user_policy ON operating_model_exports;
+CREATE POLICY operating_model_exports_user_policy ON operating_model_exports
+  FOR ALL
+  USING (auth.uid() = user_id)
+  WITH CHECK (auth.uid() = user_id);
+
+GRANT SELECT, INSERT, UPDATE, DELETE ON TABLE public.operating_model_profiles TO service_role;
+GRANT SELECT, INSERT, UPDATE, DELETE ON TABLE public.operating_model_sessions TO service_role;
+GRANT SELECT, INSERT, UPDATE, DELETE ON TABLE public.operating_model_layer_checkpoints TO service_role;
+GRANT SELECT, INSERT, UPDATE, DELETE ON TABLE public.operating_model_entries TO service_role;
+GRANT SELECT, INSERT, UPDATE, DELETE ON TABLE public.operating_model_exports TO service_role;
+
+DROP TRIGGER IF EXISTS update_operating_model_profiles_updated_at ON operating_model_profiles;
+CREATE TRIGGER update_operating_model_profiles_updated_at
+  BEFORE UPDATE ON operating_model_profiles
+  FOR EACH ROW
+  EXECUTE FUNCTION update_work_operating_model_updated_at();
+
+DROP TRIGGER IF EXISTS update_operating_model_sessions_updated_at ON operating_model_sessions;
+CREATE TRIGGER update_operating_model_sessions_updated_at
+  BEFORE UPDATE ON operating_model_sessions
+  FOR EACH ROW
+  EXECUTE FUNCTION update_work_operating_model_updated_at();
+
+DROP TRIGGER IF EXISTS update_operating_model_layer_checkpoints_updated_at ON operating_model_layer_checkpoints;
+CREATE TRIGGER update_operating_model_layer_checkpoints_updated_at
+  BEFORE UPDATE ON operating_model_layer_checkpoints
+  FOR EACH ROW
+  EXECUTE FUNCTION update_work_operating_model_updated_at();
+
+DROP TRIGGER IF EXISTS update_operating_model_entries_updated_at ON operating_model_entries;
+CREATE TRIGGER update_operating_model_entries_updated_at
+  BEFORE UPDATE ON operating_model_entries
+  FOR EACH ROW
+  EXECUTE FUNCTION update_work_operating_model_updated_at();
+
+DROP TRIGGER IF EXISTS update_operating_model_exports_updated_at ON operating_model_exports;
+CREATE TRIGGER update_operating_model_exports_updated_at
+  BEFORE UPDATE ON operating_model_exports
+  FOR EACH ROW
+  EXECUTE FUNCTION update_work_operating_model_updated_at();
+
+CREATE OR REPLACE FUNCTION operating_model_next_layer(p_completed_layers TEXT[])
+RETURNS TEXT AS $$
+DECLARE
+  v_layers TEXT[] := ARRAY[
+    'operating_rhythms',
+    'recurring_decisions',
+    'dependencies',
+    'institutional_knowledge',
+    'friction'
+  ];
+  v_layer TEXT;
+BEGIN
+  FOREACH v_layer IN ARRAY v_layers LOOP
+    IF NOT v_layer = ANY(COALESCE(p_completed_layers, ARRAY[]::TEXT[])) THEN
+      RETURN v_layer;
+    END IF;
+  END LOOP;
+
+  RETURN 'review';
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE OR REPLACE FUNCTION operating_model_start_session(
+  p_user_id UUID,
+  p_session_name TEXT DEFAULT NULL
+)
+RETURNS JSONB AS $$
+DECLARE
+  v_profile operating_model_profiles%ROWTYPE;
+  v_session operating_model_sessions%ROWTYPE;
+  v_session_checkpoints JSONB;
+  v_latest_checkpoints JSONB;
+  v_next_version INTEGER;
+BEGIN
+  INSERT INTO operating_model_profiles (user_id)
+  VALUES (p_user_id)
+  ON CONFLICT (user_id) DO UPDATE
+    SET updated_at = now()
+  RETURNING * INTO v_profile;
+
+  SELECT *
+  INTO v_session
+  FROM operating_model_sessions
+  WHERE user_id = p_user_id
+    AND status IN ('in_progress', 'review_ready')
+  ORDER BY created_at DESC
+  LIMIT 1;
+
+  IF v_session.id IS NULL THEN
+    v_next_version := GREATEST(v_profile.current_version, 0) + 1;
+
+    INSERT INTO operating_model_sessions (
+      profile_id,
+      user_id,
+      profile_version,
+      session_name,
+      status,
+      current_layer
+    )
+    VALUES (
+      v_profile.id,
+      p_user_id,
+      v_next_version,
+      p_session_name,
+      'in_progress',
+      'operating_rhythms'
+    )
+    RETURNING * INTO v_session;
+
+    UPDATE operating_model_profiles
+      SET status = 'draft',
+          updated_at = now()
+    WHERE id = v_profile.id
+    RETURNING * INTO v_profile;
+  END IF;
+
+  SELECT COALESCE(
+    jsonb_agg(
+      jsonb_build_object(
+        'layer', c.layer,
+        'checkpoint_summary', c.checkpoint_summary,
+        'normalized_payload', c.normalized_payload,
+        'last_validated_at', c.last_validated_at,
+        'profile_version', c.profile_version
+      )
+      ORDER BY array_position(
+        ARRAY[
+          'operating_rhythms',
+          'recurring_decisions',
+          'dependencies',
+          'institutional_knowledge',
+          'friction'
+        ],
+        c.layer
+      )
+    ),
+    '[]'::jsonb
+  )
+  INTO v_session_checkpoints
+  FROM operating_model_layer_checkpoints c
+  WHERE c.session_id = v_session.id
+    AND c.status = 'approved';
+
+  SELECT COALESCE(
+    jsonb_agg(
+      jsonb_build_object(
+        'layer', ranked.layer,
+        'checkpoint_summary', ranked.checkpoint_summary,
+        'normalized_payload', ranked.normalized_payload,
+        'last_validated_at', ranked.last_validated_at,
+        'profile_version', ranked.profile_version
+      )
+      ORDER BY array_position(
+        ARRAY[
+          'operating_rhythms',
+          'recurring_decisions',
+          'dependencies',
+          'institutional_knowledge',
+          'friction'
+        ],
+        ranked.layer
+      )
+    ),
+    '[]'::jsonb
+  )
+  INTO v_latest_checkpoints
+  FROM (
+    SELECT DISTINCT ON (layer)
+      layer,
+      checkpoint_summary,
+      normalized_payload,
+      last_validated_at,
+      profile_version
+    FROM operating_model_layer_checkpoints
+    WHERE user_id = p_user_id
+      AND status = 'approved'
+    ORDER BY layer, profile_version DESC, approved_at DESC NULLS LAST, updated_at DESC
+  ) ranked;
+
+  RETURN jsonb_build_object(
+    'profile_id', v_profile.id,
+    'profile_status', v_profile.status,
+    'current_version', v_profile.current_version,
+    'session_id', v_session.id,
+    'session_status', v_session.status,
+    'session_version', v_session.profile_version,
+    'completed_layers', to_jsonb(COALESCE(v_session.completed_layers, ARRAY[]::TEXT[])),
+    'pending_layer', COALESCE(v_session.current_layer, operating_model_next_layer(v_session.completed_layers)),
+    'session_checkpoints', v_session_checkpoints,
+    'latest_checkpoints', v_latest_checkpoints
+  );
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE OR REPLACE FUNCTION operating_model_save_layer(
+  p_session_id UUID,
+  p_layer TEXT,
+  p_checkpoint_summary TEXT,
+  p_entries JSONB
+)
+RETURNS JSONB AS $$
+DECLARE
+  v_session operating_model_sessions%ROWTYPE;
+  v_profile operating_model_profiles%ROWTYPE;
+  v_checkpoint_id UUID;
+  v_completed_layers TEXT[];
+  v_pending_layer TEXT;
+  v_saved_entries JSONB;
+  v_layers TEXT[] := ARRAY[
+    'operating_rhythms',
+    'recurring_decisions',
+    'dependencies',
+    'institutional_knowledge',
+    'friction'
+  ];
+BEGIN
+  IF NOT p_layer = ANY(v_layers) THEN
+    RAISE EXCEPTION 'Invalid layer: %', p_layer;
+  END IF;
+
+  IF jsonb_typeof(COALESCE(p_entries, '[]'::jsonb)) <> 'array' THEN
+    RAISE EXCEPTION 'Entries payload must be a JSON array';
+  END IF;
+
+  SELECT *
+  INTO v_session
+  FROM operating_model_sessions
+  WHERE id = p_session_id
+  FOR UPDATE;
+
+  IF v_session.id IS NULL THEN
+    RAISE EXCEPTION 'Session not found';
+  END IF;
+
+  IF v_session.status NOT IN ('in_progress', 'review_ready') THEN
+    RAISE EXCEPTION 'Session is not editable in status %', v_session.status;
+  END IF;
+
+  SELECT *
+  INTO v_profile
+  FROM operating_model_profiles
+  WHERE id = v_session.profile_id
+  FOR UPDATE;
+
+  INSERT INTO operating_model_layer_checkpoints (
+    profile_id,
+    session_id,
+    user_id,
+    profile_version,
+    layer,
+    checkpoint_summary,
+    normalized_payload,
+    status,
+    approved_at,
+    last_validated_at
+  )
+  VALUES (
+    v_profile.id,
+    v_session.id,
+    v_session.user_id,
+    v_session.profile_version,
+    p_layer,
+    p_checkpoint_summary,
+    jsonb_build_object(
+      'layer', p_layer,
+      'checkpoint_summary', p_checkpoint_summary,
+      'entries', COALESCE(p_entries, '[]'::jsonb)
+    ),
+    'approved',
+    now(),
+    now()
+  )
+  ON CONFLICT (session_id, layer) DO UPDATE
+    SET checkpoint_summary = EXCLUDED.checkpoint_summary,
+        normalized_payload = EXCLUDED.normalized_payload,
+        status = 'approved',
+        approved_at = now(),
+        last_validated_at = now(),
+        updated_at = now()
+  RETURNING id INTO v_checkpoint_id;
+
+  DELETE FROM operating_model_entries
+  WHERE session_id = v_session.id
+    AND layer = p_layer;
+
+  INSERT INTO operating_model_entries (
+    profile_id,
+    session_id,
+    checkpoint_id,
+    user_id,
+    profile_version,
+    layer,
+    entry_order,
+    title,
+    summary,
+    cadence,
+    trigger,
+    inputs,
+    stakeholders,
+    constraints,
+    details,
+    source_confidence,
+    status,
+    last_validated_at
+  )
+  SELECT
+    v_profile.id,
+    v_session.id,
+    v_checkpoint_id,
+    v_session.user_id,
+    v_session.profile_version,
+    p_layer,
+    src.ordinality::INTEGER,
+    TRIM(src.entry->>'title'),
+    TRIM(src.entry->>'summary'),
+    NULLIF(TRIM(src.entry->>'cadence'), ''),
+    NULLIF(TRIM(src.entry->>'trigger'), ''),
+    COALESCE(
+      ARRAY(
+        SELECT jsonb_array_elements_text(COALESCE(src.entry->'inputs', '[]'::jsonb))
+      ),
+      ARRAY[]::TEXT[]
+    ),
+    COALESCE(
+      ARRAY(
+        SELECT jsonb_array_elements_text(COALESCE(src.entry->'stakeholders', '[]'::jsonb))
+      ),
+      ARRAY[]::TEXT[]
+    ),
+    COALESCE(
+      ARRAY(
+        SELECT jsonb_array_elements_text(COALESCE(src.entry->'constraints', '[]'::jsonb))
+      ),
+      ARRAY[]::TEXT[]
+    ),
+    COALESCE(src.entry->'details', '{}'::jsonb),
+    COALESCE(NULLIF(src.entry->>'source_confidence', ''), 'confirmed'),
+    COALESCE(NULLIF(src.entry->>'status', ''), 'active'),
+    COALESCE(
+      NULLIF(src.entry->>'last_validated_at', '')::timestamptz,
+      now()
+    )
+  FROM jsonb_array_elements(COALESCE(p_entries, '[]'::jsonb)) WITH ORDINALITY AS src(entry, ordinality);
+
+  SELECT ARRAY(
+    SELECT item
+    FROM unnest(COALESCE(v_session.completed_layers, ARRAY[]::TEXT[]) || ARRAY[p_layer]) AS item
+    GROUP BY item
+    ORDER BY array_position(v_layers, item)
+  )
+  INTO v_completed_layers;
+
+  v_pending_layer := operating_model_next_layer(v_completed_layers);
+
+  UPDATE operating_model_sessions
+    SET completed_layers = v_completed_layers,
+        current_layer = CASE
+          WHEN v_pending_layer = 'review' THEN 'review'
+          ELSE v_pending_layer
+        END,
+        status = CASE
+          WHEN v_pending_layer = 'review' THEN 'review_ready'
+          ELSE 'in_progress'
+        END,
+        resume_metadata = resume_metadata || jsonb_build_object(
+          'last_saved_layer', p_layer,
+          'last_saved_at', now()
+        ),
+        updated_at = now()
+  WHERE id = v_session.id
+  RETURNING * INTO v_session;
+
+  UPDATE operating_model_profiles
+    SET status = 'draft',
+        updated_at = now()
+  WHERE id = v_profile.id;
+
+  SELECT COALESCE(
+    jsonb_agg(
+      jsonb_build_object(
+        'title', e.title,
+        'summary', e.summary,
+        'cadence', e.cadence,
+        'trigger', e.trigger,
+        'inputs', to_jsonb(e.inputs),
+        'stakeholders', to_jsonb(e.stakeholders),
+        'constraints', to_jsonb(e.constraints),
+        'details', e.details,
+        'source_confidence', e.source_confidence,
+        'status', e.status,
+        'last_validated_at', e.last_validated_at
+      )
+      ORDER BY e.entry_order
+    ),
+    '[]'::jsonb
+  )
+  INTO v_saved_entries
+  FROM operating_model_entries e
+  WHERE e.session_id = v_session.id
+    AND e.layer = p_layer;
+
+  RETURN jsonb_build_object(
+    'session_id', v_session.id,
+    'session_status', v_session.status,
+    'session_version', v_session.profile_version,
+    'layer', p_layer,
+    'checkpoint_summary', p_checkpoint_summary,
+    'completed_layers', to_jsonb(v_completed_layers),
+    'pending_layer', CASE
+      WHEN v_pending_layer = 'review' THEN 'review'
+      ELSE v_pending_layer
+    END,
+    'entries', v_saved_entries
+  );
+END;
+$$ LANGUAGE plpgsql;
+
+GRANT EXECUTE ON FUNCTION public.operating_model_next_layer(TEXT[]) TO service_role;
+GRANT EXECUTE ON FUNCTION public.operating_model_start_session(UUID, TEXT) TO service_role;
+GRANT EXECUTE ON FUNCTION public.operating_model_save_layer(UUID, TEXT, TEXT, JSONB) TO service_role;
+
+-- Verification
+-- SELECT table_name FROM information_schema.tables
+-- WHERE table_name LIKE 'operating_model_%'
+-- ORDER BY table_name;

--- a/skills/README.md
+++ b/skills/README.md
@@ -13,6 +13,7 @@ Reusable AI client skills and prompt packs for Open Brain workflows. These are t
 | [Heavy File Ingestion Skill Pack](heavy-file-ingestion/) | Converts PDFs, decks, spreadsheets, and other bulky files into markdown, CSV, and a cheap structural index before analysis | [@NateBJones](https://github.com/NateBJones) |
 | [Panning for Gold Skill Pack](panning-for-gold/) | Turns brain dumps and transcripts into evaluated idea inventories | [@jaredirish](https://github.com/jaredirish) |
 | [Claudeception Skill Pack](claudeception/) | Extracts reusable lessons from work sessions into new skills | [@jaredirish](https://github.com/jaredirish) |
+| [Work Operating Model Skill Pack](work-operating-model/) | Runs a five-layer work elicitation interview and turns the approved result into structured Open Brain records plus exports | [@jonathanedwards](https://github.com/jonathanedwards) |
 
 ## How Skills Differ From Recipes
 

--- a/skills/work-operating-model/README.md
+++ b/skills/work-operating-model/README.md
@@ -1,0 +1,86 @@
+# Work Operating Model
+
+> Reusable interviewer skill that turns a user's tacit work patterns into structured Open Brain records and agent-ready exports.
+
+## What It Does
+
+This skill runs a strict, five-layer elicitation interview:
+
+1. operating rhythms
+2. recurring decisions
+3. dependencies
+4. institutional knowledge
+5. friction
+
+It resumes or starts a session, interviews through concrete recent examples, confirms each checkpoint before saving, writes one summary thought per approved layer through the base Open Brain connector, runs a final contradiction pass, and generates export artifacts.
+
+If you want the schema, MCP server, and setup instructions, use the paired [Work Operating Model Activation recipe](../../recipes/work-operating-model-activation/).
+
+## Supported Clients
+
+- Claude Code
+- Codex
+- Cursor
+- Any client that supports reusable prompt packs plus MCP tools
+
+## Prerequisites
+
+- Working Open Brain setup with `search_thoughts` and `capture_thought` available ([guide](../../docs/01-getting-started.md))
+- The [Work Operating Model Activation recipe](../../recipes/work-operating-model-activation/) installed and connected
+- AI client that supports reusable skills or equivalent system instructions
+
+## Installation
+
+1. Copy [`SKILL.md`](./SKILL.md) into your client's reusable-instructions location.
+2. Reload or restart the client.
+3. Verify the client can see:
+   - your core Open Brain search/capture tools
+   - `start_operating_model_session`
+   - `save_operating_model_layer`
+   - `query_operating_model`
+   - `generate_operating_model_exports`
+
+For Claude Code, a common install path is:
+
+```bash
+mkdir -p ~/.claude/skills/work-operating-model
+cp skills/work-operating-model/SKILL.md ~/.claude/skills/work-operating-model/SKILL.md
+```
+
+## Trigger Conditions
+
+- “Help me document how I actually work”
+- “Interview me for my operating model”
+- “Build my USER.md / SOUL.md / HEARTBEAT.md from a conversation”
+- “I want to figure out what I actually do all day”
+- Starting the paired recipe in a client that supports skills
+
+## Expected Outcome
+
+When the skill is loaded and the paired recipe is connected, the client should:
+
+- create or resume a session
+- interview in the fixed five-layer order
+- show a checkpoint summary before every save
+- only persist confirmed or explicitly synthesized patterns
+- capture one summary thought per layer plus one final synthesis thought
+- return `operating-model.json`, `USER.md`, `SOUL.md`, `HEARTBEAT.md`, and `schedule-recommendations.json`
+
+## Troubleshooting
+
+**Issue: The skill starts asking broad abstract questions**
+Solution: Restore the “recent concrete examples first” rule from the skill. The workflow should anchor on last week or last month before synthesizing patterns.
+
+**Issue: The skill saves unconfirmed hints from search**
+Solution: It should not. Search results are hints only. They must be confirmed or reframed by the user before persistence.
+
+**Issue: The skill cannot find the paired MCP tools**
+Solution: Confirm the recipe connector is enabled. The skill needs both the recipe server and the base Open Brain connector.
+
+## Notes for Other Clients
+
+Tool names may be namespaced in some clients. Keep the behavior the same even if the visible tool IDs differ:
+
+- identify the base search/capture tools that write to core Open Brain
+- identify the four recipe tools that manage the operating model
+- use those actual names in your environment rather than hard-coding a prefix

--- a/skills/work-operating-model/SKILL.md
+++ b/skills/work-operating-model/SKILL.md
@@ -1,0 +1,294 @@
+---
+name: work-operating-model
+description: |
+  Conversation-first workflow for turning tacit work patterns into a structured
+  operating model. Use when the user wants to map how their work actually runs,
+  generate USER.md / SOUL.md / HEARTBEAT.md artifacts, or build an agent-ready
+  model of rhythms, recurring decisions, dependencies, institutional knowledge,
+  and friction. Requires base Open Brain search/capture tools plus the paired
+  Work Operating Model recipe MCP tools.
+author: Jonathan Edwards
+version: 1.0.0
+---
+
+# Work Operating Model
+
+## Purpose
+
+The first job is not to automate the user. It is to help them see and describe how their work actually runs.
+
+Your job is to:
+
+1. interview the user through five fixed layers
+2. convert the approved results into canonical structured entries
+3. save each layer only after explicit confirmation
+4. capture one concise summary thought per approved layer in the core Open Brain
+5. run a contradiction pass
+6. generate the final exports
+
+## Required Tools
+
+Before doing anything else, identify the actual tool names available in the current environment for:
+
+- the base Open Brain search tool, usually `search_thoughts`
+- the base Open Brain capture tool, usually `capture_thought`
+- `start_operating_model_session`
+- `save_operating_model_layer`
+- `query_operating_model`
+- `generate_operating_model_exports`
+
+If any of the recipe tools are missing, stop and say so clearly.
+If the base search/capture tools are missing, stop and say so clearly.
+
+Do not assume the exact tool prefix. Use the names exposed in the current client.
+
+## Non-Negotiable Rules
+
+1. Use this fixed layer order:
+   - operating rhythms
+   - recurring decisions
+   - dependencies
+   - institutional knowledge
+   - friction
+
+2. Start concrete, not abstract.
+   - Ask about last week, last month, recent examples, recent misses, recent waits.
+   - Do not open with “what do you do all day?”
+
+3. Search results are hints, not facts.
+   - You may use the base search tool before a layer starts.
+   - Treat everything retrieved as tentative context.
+   - Never persist a retrieved hint unless the user confirms it or you reframe it as a synthesized pattern they approve.
+
+4. Save only after explicit confirmation.
+   - Show a checkpoint summary first.
+   - Ask for confirmation or corrections.
+   - Only then call `save_operating_model_layer`.
+
+5. Persist lean memory.
+   - One summary thought per approved layer.
+   - One final synthesis thought after export generation.
+   - Do not capture one thought per atomic entry.
+
+6. Use `source_confidence` honestly.
+   - `confirmed`: the user explicitly said or approved it as written.
+   - `synthesized`: you abstracted a pattern from multiple concrete examples and the user approved that synthesis.
+
+7. Do not silently smooth contradictions.
+   - Surface them in the final review.
+   - If they materially affect a saved layer, revise and resave that layer before export generation.
+
+## Workflow
+
+### Phase 1: Session Start
+
+1. Call `start_operating_model_session`.
+2. Summarize:
+   - whether this is a fresh session or a resume
+   - completed layers
+   - pending layer
+   - any existing checkpoints worth carrying forward
+3. If resuming, continue from the pending layer.
+4. If fresh, begin with `operating_rhythms`.
+
+### Phase 2: Layer Interview
+
+For each layer:
+
+1. Run a small, focused memory check with the base search tool.
+   - Use 2-4 narrow queries.
+   - Example for rhythms: “Monday planning”, “end of week review”, “calendar overload”
+   - Example for dependencies: “waiting on finance”, “blocked by email”, “handoff”
+2. Present any useful hints as tentative:
+   - “I found a few hints from prior context. I’m treating these as prompts, not facts.”
+3. Ask for recent concrete examples.
+4. Convert the response into canonical entries.
+5. Show a checkpoint summary with the strongest patterns and unresolved items.
+6. Ask for confirmation or corrections.
+7. After confirmation, call `save_operating_model_layer`.
+8. Immediately capture one concise summary thought through the base `capture_thought` tool.
+
+### Phase 3: Final Review
+
+After all five layers are saved:
+
+1. Call `query_operating_model`.
+2. Compare the layers for contradictions:
+   - rhythms vs dependencies
+   - recurring decisions vs institutional knowledge
+   - friction vs the claimed operating rhythm
+3. Present contradictions or tensions explicitly.
+4. If corrections are needed, revise the affected layer and resave it.
+
+### Phase 4: Export Generation
+
+1. Once the model is internally consistent, call `generate_operating_model_exports`.
+2. Capture one final synthesis thought through the base capture tool.
+3. Present the returned artifacts:
+   - `operating-model.json`
+   - `USER.md`
+   - `SOUL.md`
+   - `HEARTBEAT.md`
+   - `schedule-recommendations.json`
+
+## Canonical Entry Contract
+
+Every saved entry must include:
+
+- `title`
+- `summary`
+- `cadence`
+- `trigger`
+- `inputs[]`
+- `stakeholders[]`
+- `constraints[]`
+- `details`
+- `source_confidence`
+- `status`
+- `last_validated_at`
+
+Layer-specific `details` must match these shapes:
+
+### `operating_rhythms`
+
+- `time_windows[]`
+- `energy_pattern`
+- `interruptions[]`
+- `non_calendar_reality`
+
+### `recurring_decisions`
+
+- `decision_name`
+- `decision_inputs[]`
+- `thresholds[]`
+- `escalation_rule`
+- `reversible`
+
+### `dependencies`
+
+- `dependency_owner`
+- `deliverable`
+- `needed_by`
+- `failure_impact`
+- `fallback`
+
+### `institutional_knowledge`
+
+- `knowledge_area`
+- `why_it_matters`
+- `where_it_lives`
+- `who_else_knows`
+- `risk_if_missing`
+
+### `friction`
+
+- `frequency`
+- `time_cost`
+- `current_workaround`
+- `systems_involved[]`
+- `automation_candidate`
+- `priority` when known (`low`, `medium`, or `high`)
+
+## Interview Guidance By Layer
+
+### 1. Operating Rhythms
+
+Ask about:
+
+- what their days actually feel like
+- what gets front-loaded or deferred
+- when they can do deep work
+- what interrupts the ideal plan
+- what repeats weekly or monthly even when it is not formally scheduled
+
+Strong prompt pattern:
+
+- “Walk me through a real Monday from the last two weeks.”
+- “Where does your calendar lie to you?”
+- “When are you actually good for deep work versus admin or reactive work?”
+
+### 2. Recurring Decisions
+
+Ask about:
+
+- repeated judgment calls
+- what inputs they look at
+- what thresholds matter
+- when they escalate
+- which decisions are reversible
+
+Strong prompt pattern:
+
+- “What decisions do you make over and over where the answer depends on context, not a checklist?”
+- “What do you look at before you decide?”
+
+### 3. Dependencies
+
+Ask about:
+
+- people or systems they wait on
+- the timing windows that matter
+- what gets blocked
+- fallback behavior when something is late
+
+Strong prompt pattern:
+
+- “What part of your week depends on someone else sending, approving, or clarifying something?”
+- “What breaks when that doesn’t happen on time?”
+
+### 4. Institutional Knowledge
+
+Ask about:
+
+- what they know that is not written down
+- what context only they carry
+- where key knowledge actually lives
+- what would break if they disappeared for two weeks
+
+Strong prompt pattern:
+
+- “What do you know that your team relies on but nobody has really documented?”
+- “What mistakes would a smart new hire make because the real context is still in your head?”
+
+### 5. Friction
+
+Ask about:
+
+- recurring annoyances
+- repeated re-explanations
+- broken handoffs
+- tools that force duplicate work
+- annoying waits that steal time or quality
+
+Strong prompt pattern:
+
+- “What keeps eating 10-20 minutes at a time?”
+- “Where do you keep doing work the hard way because the systems never quite line up?”
+
+## Checkpoint Format
+
+Every layer checkpoint should contain:
+
+1. a short layer summary
+2. 2-5 canonical entries
+3. explicit unresolved items when present
+4. the exact approval ask
+
+Good approval ask:
+
+“This is the operating-rhythms model I’d save right now. Correct anything that’s off, especially the deep-work window and the Friday compression pattern. If this looks right, I’ll save it and move to recurring decisions.”
+
+## Summary Thought Pattern
+
+After each approved layer, capture one thought like this:
+
+`Operating model layer complete: operating rhythms. Real pattern: Monday is for intake and prioritization, Tuesday-Thursday carry the real build work, Friday compresses into follow-ups and cleanup. Deep work window is late morning when interruptions are lowest. Key non-calendar reality: the week shape depends heavily on inbox and approvals landing on time.`
+
+Final synthesis thought should summarize the full operating model, not repeat all entries.
+
+## Tone
+
+Be direct, practical, and specific.
+No generic productivity advice.
+No fake certainty.
+Keep momentum moving without bulldozing confirmation.

--- a/skills/work-operating-model/metadata.json
+++ b/skills/work-operating-model/metadata.json
@@ -1,0 +1,20 @@
+{
+  "name": "Work Operating Model",
+  "description": "Standalone skill pack for interviewing a user about how their work actually runs, saving the approved model into structured Open Brain tables, and generating agent-ready exports.",
+  "category": "skills",
+  "author": {
+    "name": "Jonathan Edwards",
+    "github": "jonathanedwards"
+  },
+  "version": "1.0.0",
+  "requires": {
+    "open_brain": true,
+    "services": [],
+    "tools": ["AI client with reusable skills/prompts and MCP support"]
+  },
+  "tags": ["skill", "operating-model", "interview", "workflow", "agent-config"],
+  "difficulty": "intermediate",
+  "estimated_time": "10 minutes",
+  "created": "2026-04-14",
+  "updated": "2026-04-14"
+}


### PR DESCRIPTION
## Summary
- add the Work Operating Model Activation recipe with schema, MCP server, and export generation
- add the paired Work Operating Model skill pack for the five-layer elicitation workflow
- index both contributions in the top-level recipes and skills listings

## Validation
- deno check --config deno.json index.ts
- node -e "for (const file of ['recipes/work-operating-model-activation/metadata.json','skills/work-operating-model/metadata.json']) JSON.parse(require('fs').readFileSync(file,'utf8')); console.log('metadata ok')"