### PR TITLE
[recipes] Add Bring Your Own Context composition recipe

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ Standalone capabilities that make your Open Brain smarter.
 | [Life Engine](recipes/life-engine/) | Self-improving personal assistant — calendar, habits, health, proactive briefings via Telegram or Discord | [@justfinethanku](https://github.com/justfinethanku) |
 | [Life Engine Video](recipes/life-engine-video/) | Add-on that renders Life Engine briefings as short animated videos with voiceover | [@justfinethanku](https://github.com/justfinethanku) |
 | [Daily Digest](recipes/daily-digest/) | Automated daily summary of recent thoughts delivered via email or Slack | OB1 Team |
+| [Bring Your Own Context](recipes/bring-your-own-context/) | Portable context workflow that packages extraction prompts, profile generation, and remote MCP deployment into one entrypoint | [@jonathanedwards](https://github.com/jonathanedwards) |
 | [Work Operating Model Activation](recipes/work-operating-model-activation/) | Conversation-first workflow that turns tacit work patterns into structured Open Brain records and agent-ready operating files | [@jonathanedwards](https://github.com/jonathanedwards) |
 | [Research-to-Decision Workflow](recipes/research-to-decision-workflow/) | Composition recipe that chains canonical skills into operator and investor research, synthesis, meeting, and memo workflows | [@NateBJones](https://github.com/NateBJones) |
 

--- a/recipes/README.md
+++ b/recipes/README.md
@@ -6,6 +6,7 @@ Step-by-step builds that add a new capability to your Open Brain. Follow the ins
 
 | Recipe | What It Does |
 | ------ | ------------ |
+| [Bring Your Own Context](bring-your-own-context/) | Portable context workflow that packages extraction prompts, profile generation, and remote MCP deployment into one entrypoint |
 | [Email History Import](email-history-import/) | Pull your Gmail archive into searchable thoughts |
 | [ChatGPT Conversation Import](chatgpt-conversation-import/) | Ingest your ChatGPT data export |
 | [Daily Digest](daily-digest/) | Automated summary of recent thoughts via email or Slack |

--- a/recipes/bring-your-own-context/README.md
+++ b/recipes/bring-your-own-context/README.md
@@ -1,0 +1,253 @@
+# Bring Your Own Context
+
+<!-- markdownlint-disable MD013 -->
+
+Portable context workflow for extracting what your AI already knows,
+turning it into a structured operating profile, and carrying that profile
+across AI clients.
+
+> [!IMPORTANT]
+> This is a composition recipe. It does not introduce a new MCP server or a
+> new tool surface in v1.
+
+It packages existing Open Brain pieces into one entrypoint:
+
+- focused extraction prompts in [extraction-prompts.md](./extraction-prompts.md)
+- the canonical [Work Operating Model skill](../../skills/work-operating-model/)
+- the paired [Work Operating Model Activation recipe](../work-operating-model-activation/)
+- the existing [Remote MCP Connection](../../primitives/remote-mcp/) pattern
+
+## What It Does
+
+Bring Your Own Context gives you one publishable workflow for portable AI context inside OB1.
+
+You first seed Open Brain with reviewed context using the extraction prompts in this folder. Then you run the existing Work Operating Model workflow to turn that raw context into a reusable bundle with a documented contract:
+
+- `operating-model.json`
+- `USER.md`
+- `SOUL.md`
+- `HEARTBEAT.md`
+- `schedule-recommendations.json`
+
+The machine-readable schema for that bundle lives in [context-profile.schema.json](./context-profile.schema.json).
+
+## Prerequisites
+
+- Working Open Brain setup ([guide](../../docs/01-getting-started.md))
+- Existing core Open Brain connector with `search_thoughts` and `capture_thought`
+- AI client that supports reusable skills or prompt packs
+- Supabase CLI installed and linked to your project
+- Canonical [Work Operating Model skill](../../skills/work-operating-model/)
+- Optional source material to import: existing AI memory, exported notes, Obsidian vault content, Notion exports, text files, or similar context sources
+
+## Credential Tracker
+
+Copy this block into a text editor and fill it in as you go.
+
+```text
+BRING YOUR OWN CONTEXT -- CREDENTIAL TRACKER
+--------------------------------------------
+
+FROM YOUR OPEN BRAIN SETUP
+  Project URL:                ____________
+  Project ref:                ____________
+  MCP Access Key:             ____________
+  Core connector available:   yes / no
+  Core search tool visible:   yes / no
+  Core capture tool visible:  yes / no
+
+GENERATED DURING SETUP
+  Prompt source used:         memory / import / both
+  DEFAULT_USER_ID:            ____________
+  Function URL:               ____________
+  MCP Connection URL:         ____________
+  Latest session ID:          ____________
+  Current profile version:    ____________
+
+--------------------------------------------
+```
+
+## Recipe Assets
+
+- [extraction-prompts.md](./extraction-prompts.md) — the two prompt assets promised in the article
+- [context-profile.schema.json](./context-profile.schema.json) — machine-readable contract for the portable bundle returned by `generate_operating_model_exports`
+- [Work Operating Model Activation](../work-operating-model-activation/) — the profiling engine this recipe reuses
+
+## Steps
+
+![Step 1](https://img.shields.io/badge/Step_1-Choose_Your_Extraction_Pass-0F766E?style=for-the-badge)
+
+Pick the right prompt from [extraction-prompts.md](./extraction-prompts.md):
+
+- Use **Memory Extraction** if the AI platform already knows a lot about you from past chats or built-in memory.
+- Use **Context Import** if you are bringing in notes, exports, or another second-brain system.
+- If both are true, run **Memory Extraction first** and **Context Import second**.
+
+These prompts are intentionally upstream of profile generation. They create durable, searchable Open Brain context. They do **not** generate the final portable bundle by themselves.
+
+✅ **Done when:** You know which extraction pass you are running and your core Open Brain connector is enabled in the client you will use.
+
+---
+
+![Step 2](https://img.shields.io/badge/Step_2-Seed_Open_Brain_With_Context-0F766E?style=for-the-badge)
+
+Run the chosen prompt in your AI client with the core Open Brain connector enabled.
+
+Rules to keep the BYOC corpus clean:
+
+- review the preview batches before saving
+- store self-contained statements, not shorthand fragments
+- preserve names, dates, and decision context
+- skip noise, templates, and obviously stale junk
+
+This stage should leave you with durable raw context that the later profiling pass can search against.
+
+✅ **Done when:** `search_thoughts` can find a few recent captures about your people, projects, decisions, or workflow.
+
+---
+
+![Step 3](https://img.shields.io/badge/Step_3-Install_The_Profiling_Workflow-0F766E?style=for-the-badge)
+
+Install the canonical [Work Operating Model skill](../../skills/work-operating-model/) before doing anything else. BYOC reuses that exact interview behavior instead of inventing a second profiling prompt.
+
+If you have not installed it yet, follow the installation steps in the skill README and confirm your client can load reusable prompt packs or skills.
+
+✅ **Done when:** The Work Operating Model skill is available in your client and ready to use once the paired MCP tools are connected.
+
+---
+
+![Step 4](https://img.shields.io/badge/Step_4-Deploy_And_Connect_The_Profile_Server-0F766E?style=for-the-badge)
+
+BYOC reuses the [Work Operating Model Activation](../work-operating-model-activation/) recipe as its structured profiling engine.
+
+### 4.1 Run the schema
+
+Run [`recipes/work-operating-model-activation/schema.sql`](../work-operating-model-activation/schema.sql) in the Supabase SQL Editor.
+
+### 4.2 Generate a Default User ID
+
+```bash
+uuidgen | tr '[:upper:]' '[:lower:]'
+```
+
+Then set it as a secret:
+
+```bash
+supabase secrets set DEFAULT_USER_ID=your-generated-uuid
+```
+
+### 4.3 Deploy the Function
+
+Use the [Deploy an Edge Function](../../primitives/deploy-edge-function/) pattern with these values:
+
+| Setting | Value |
+| ------- | ----- |
+| Function name | `work-operating-model-mcp` |
+| Download path | `recipes/work-operating-model-activation` |
+
+### 4.4 Connect It to Your AI Client
+
+URL-based connector example:
+
+```text
+https://YOUR_PROJECT_REF.supabase.co/functions/v1/work-operating-model-mcp?key=your-access-key
+```
+
+Header-based connector example for Claude Code:
+
+```bash
+claude mcp add --transport http work-operating-model \
+  https://YOUR_PROJECT_REF.supabase.co/functions/v1/work-operating-model-mcp \
+  --header "x-access-key: your-access-key"
+```
+
+Use the full [Remote MCP Connection](../../primitives/remote-mcp/) guide if your client needs a different setup path.
+
+> [!IMPORTANT]
+> Keep your base Open Brain connector enabled too. BYOC uses the existing Work Operating Model tools for structure, but it still depends on your core `search_thoughts` and `capture_thought` tools for memory hints and summary captures.
+
+✅ **Done when:** Your client can see all six required tools:
+
+- `search_thoughts`
+- `capture_thought`
+- `start_operating_model_session`
+- `save_operating_model_layer`
+- `query_operating_model`
+- `generate_operating_model_exports`
+
+---
+
+![Step 5](https://img.shields.io/badge/Step_5-Build_The_Portable_Profile-0F766E?style=for-the-badge)
+
+With both connectors enabled and the skill installed, prompt your AI client:
+
+```text
+Use the Work Operating Model workflow to interview me and build my operating model.
+```
+
+The workflow should:
+
+1. call `start_operating_model_session`
+2. search for hints in your seeded Open Brain context
+3. interview you through the five fixed layers
+4. show a checkpoint summary before every save
+5. persist each approved layer with `save_operating_model_layer`
+6. review contradictions with `query_operating_model`
+7. return the final bundle with `generate_operating_model_exports`
+
+BYOC is strongest when you treat the earlier extraction pass as raw material and this interview as the normalization pass. Do not skip the confirmation gates.
+
+✅ **Done when:** The workflow reaches export generation without missing layers and returns a session ID plus a profile version.
+
+---
+
+![Step 6](https://img.shields.io/badge/Step_6-Use_The_Portable_Bundle-0F766E?style=for-the-badge)
+
+The current portable bundle contract is:
+
+- `operating-model.json` — structured JSON representation of the full profile
+- `USER.md` — operator-facing profile summary
+- `SOUL.md` — guardrails, heuristics, and knowledge to respect
+- `HEARTBEAT.md` — recurring and event-driven check recommendations
+- `schedule-recommendations.json` — machine-readable recommendation output
+
+The transport shape returned by `generate_operating_model_exports` is documented in [context-profile.schema.json](./context-profile.schema.json). The schema also defines the parsed JSON contracts for `operating-model.json` and `schedule-recommendations.json` inside `$defs`.
+
+This is the honest v1 BYOC story inside OB1:
+
+- the **portable context profile** is the export bundle above
+- the **context server pattern** is the existing remote MCP deployment flow you already use in Open Brain
+
+✅ **Done when:** You can point to one export bundle, one schema file, and one recipe URL as the canonical BYOC entrypoint for the article.
+
+## Expected Outcome
+
+When this recipe is working correctly:
+
+- your Open Brain contains reviewed context captured through the extraction prompts
+- the Work Operating Model workflow can pull that context in as hints during the interview
+- `query_operating_model` returns structured entries for rhythms, decisions, dependencies, institutional knowledge, and friction
+- `generate_operating_model_exports` returns all five portable artifacts
+- [context-profile.schema.json](./context-profile.schema.json) documents the response shape and the parsed JSON artifact contracts
+
+## Troubleshooting
+
+**Issue: `capture_thought` is not visible when I run the extraction prompt**
+Solution: The BYOC prompt stage only works with your base Open Brain connector enabled. Re-enable the core connector first, then rerun the prompt.
+
+**Issue: The Work Operating Model skill is loaded, but the profile tools are missing**
+Solution: The skill and the recipe are paired. Install the skill from [skills/work-operating-model](../../skills/work-operating-model/) and deploy/connect the MCP server from [Work Operating Model Activation](../work-operating-model-activation/) before starting the interview.
+
+**Issue: Export generation says layers are missing**
+Solution: Every one of the five layers must be approved before `generate_operating_model_exports` can succeed. Resume the session, finish the missing layer, then export again.
+
+**Issue: The connector works in one client but not another**
+Solution: Use the connection style your client actually supports. Some clients want the URL with `?key=...`, while Claude Code prefers the header-based form. The [Remote MCP Connection](../../primitives/remote-mcp/) guide covers both.
+
+## Next Steps
+
+- Feed `USER.md`, `SOUL.md`, and `HEARTBEAT.md` into any agent workflow that accepts operating files or durable system context.
+- Re-run the workflow after a major role change or workflow shift so your portable context stays current.
+- Use the [MCP Tool Audit & Optimization Guide](../../docs/05-tool-audit.md) once you add the second connector so the tool surface stays manageable.
+
+<!-- markdownlint-enable MD013 -->

--- a/recipes/bring-your-own-context/context-profile.schema.json
+++ b/recipes/bring-your-own-context/context-profile.schema.json
@@ -1,0 +1,670 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "Bring Your Own Context Export Bundle",
+  "description": "Schema for the payload returned by generate_operating_model_exports. The tool returns artifact contents as strings. Parsed JSON artifact contracts are documented in $defs.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["session_id", "profile_version", "exports"],
+  "properties": {
+    "session_id": {
+      "type": "string",
+      "format": "uuid"
+    },
+    "profile_version": {
+      "type": "integer",
+      "minimum": 1
+    },
+    "exports": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "operating-model.json",
+        "USER.md",
+        "SOUL.md",
+        "HEARTBEAT.md",
+        "schedule-recommendations.json"
+      ],
+      "properties": {
+        "operating-model.json": {
+          "type": "string",
+          "contentMediaType": "application/json",
+          "description": "JSONString containing an object that matches #/$defs/operatingModelJson."
+        },
+        "USER.md": {
+          "type": "string",
+          "contentMediaType": "text/markdown"
+        },
+        "SOUL.md": {
+          "type": "string",
+          "contentMediaType": "text/markdown"
+        },
+        "HEARTBEAT.md": {
+          "type": "string",
+          "contentMediaType": "text/markdown"
+        },
+        "schedule-recommendations.json": {
+          "type": "string",
+          "contentMediaType": "application/json",
+          "description": "JSONString containing an object that matches #/$defs/scheduleRecommendations."
+        }
+      }
+    }
+  },
+  "$defs": {
+    "profileStatus": {
+      "type": "string",
+      "enum": ["draft", "active", "archived"]
+    },
+    "sessionStatus": {
+      "type": "string",
+      "enum": ["in_progress", "review_ready", "completed", "abandoned"]
+    },
+    "layerName": {
+      "type": "string",
+      "enum": [
+        "operating_rhythms",
+        "recurring_decisions",
+        "dependencies",
+        "institutional_knowledge",
+        "friction"
+      ]
+    },
+    "sourceConfidence": {
+      "type": "string",
+      "enum": ["confirmed", "synthesized"]
+    },
+    "entryStatus": {
+      "type": "string",
+      "enum": ["active", "unresolved", "superseded"]
+    },
+    "timeWindow": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "label": {
+          "type": "string"
+        },
+        "days": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "start": {
+          "type": "string"
+        },
+        "end": {
+          "type": "string"
+        },
+        "notes": {
+          "type": "string"
+        }
+      }
+    },
+    "baseEntry": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "summary",
+        "cadence",
+        "trigger",
+        "inputs",
+        "stakeholders",
+        "constraints",
+        "details",
+        "source_confidence",
+        "status",
+        "last_validated_at"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "summary": {
+          "type": "string"
+        },
+        "cadence": {
+          "type": ["string", "null"]
+        },
+        "trigger": {
+          "type": ["string", "null"]
+        },
+        "inputs": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "stakeholders": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "constraints": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "details": {
+          "type": "object"
+        },
+        "source_confidence": {
+          "$ref": "#/$defs/sourceConfidence"
+        },
+        "status": {
+          "$ref": "#/$defs/entryStatus"
+        },
+        "last_validated_at": {
+          "type": "string",
+          "format": "date-time"
+        }
+      }
+    },
+    "operatingRhythmsDetails": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "time_windows",
+        "energy_pattern",
+        "interruptions",
+        "non_calendar_reality"
+      ],
+      "properties": {
+        "time_windows": {
+          "type": "array",
+          "items": {
+            "oneOf": [
+              {
+                "type": "string"
+              },
+              {
+                "$ref": "#/$defs/timeWindow"
+              }
+            ]
+          }
+        },
+        "energy_pattern": {
+          "type": "string"
+        },
+        "interruptions": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "non_calendar_reality": {
+          "type": "string"
+        }
+      }
+    },
+    "recurringDecisionsDetails": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "decision_name",
+        "decision_inputs",
+        "thresholds",
+        "escalation_rule",
+        "reversible"
+      ],
+      "properties": {
+        "decision_name": {
+          "type": "string"
+        },
+        "decision_inputs": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "thresholds": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "escalation_rule": {
+          "type": "string"
+        },
+        "reversible": {
+          "oneOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "string"
+            }
+          ]
+        }
+      }
+    },
+    "dependenciesDetails": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "dependency_owner",
+        "deliverable",
+        "needed_by",
+        "failure_impact",
+        "fallback"
+      ],
+      "properties": {
+        "dependency_owner": {
+          "type": "string"
+        },
+        "deliverable": {
+          "type": "string"
+        },
+        "needed_by": {
+          "type": "string"
+        },
+        "failure_impact": {
+          "type": "string"
+        },
+        "fallback": {
+          "type": "string"
+        }
+      }
+    },
+    "institutionalKnowledgeDetails": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "knowledge_area",
+        "why_it_matters",
+        "where_it_lives",
+        "who_else_knows",
+        "risk_if_missing"
+      ],
+      "properties": {
+        "knowledge_area": {
+          "type": "string"
+        },
+        "why_it_matters": {
+          "type": "string"
+        },
+        "where_it_lives": {
+          "type": "string"
+        },
+        "who_else_knows": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "risk_if_missing": {
+          "type": "string"
+        }
+      }
+    },
+    "frictionDetails": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "frequency",
+        "time_cost",
+        "current_workaround",
+        "systems_involved",
+        "automation_candidate"
+      ],
+      "properties": {
+        "frequency": {
+          "type": "string"
+        },
+        "time_cost": {
+          "type": "string"
+        },
+        "current_workaround": {
+          "type": "string"
+        },
+        "systems_involved": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "automation_candidate": {
+          "oneOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "string"
+            }
+          ]
+        },
+        "priority": {
+          "type": "string",
+          "enum": ["low", "medium", "high"]
+        }
+      }
+    },
+    "operatingRhythmsEntry": {
+      "allOf": [
+        {
+          "$ref": "#/$defs/baseEntry"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "details": {
+              "$ref": "#/$defs/operatingRhythmsDetails"
+            }
+          }
+        }
+      ]
+    },
+    "recurringDecisionsEntry": {
+      "allOf": [
+        {
+          "$ref": "#/$defs/baseEntry"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "details": {
+              "$ref": "#/$defs/recurringDecisionsDetails"
+            }
+          }
+        }
+      ]
+    },
+    "dependenciesEntry": {
+      "allOf": [
+        {
+          "$ref": "#/$defs/baseEntry"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "details": {
+              "$ref": "#/$defs/dependenciesDetails"
+            }
+          }
+        }
+      ]
+    },
+    "institutionalKnowledgeEntry": {
+      "allOf": [
+        {
+          "$ref": "#/$defs/baseEntry"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "details": {
+              "$ref": "#/$defs/institutionalKnowledgeDetails"
+            }
+          }
+        }
+      ]
+    },
+    "frictionEntry": {
+      "allOf": [
+        {
+          "$ref": "#/$defs/baseEntry"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "details": {
+              "$ref": "#/$defs/frictionDetails"
+            }
+          }
+        }
+      ]
+    },
+    "operatingRhythmsLayer": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["checkpoint_summary", "entries"],
+      "properties": {
+        "checkpoint_summary": {
+          "type": "string"
+        },
+        "entries": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/operatingRhythmsEntry"
+          }
+        }
+      }
+    },
+    "recurringDecisionsLayer": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["checkpoint_summary", "entries"],
+      "properties": {
+        "checkpoint_summary": {
+          "type": "string"
+        },
+        "entries": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/recurringDecisionsEntry"
+          }
+        }
+      }
+    },
+    "dependenciesLayer": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["checkpoint_summary", "entries"],
+      "properties": {
+        "checkpoint_summary": {
+          "type": "string"
+        },
+        "entries": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/dependenciesEntry"
+          }
+        }
+      }
+    },
+    "institutionalKnowledgeLayer": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["checkpoint_summary", "entries"],
+      "properties": {
+        "checkpoint_summary": {
+          "type": "string"
+        },
+        "entries": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/institutionalKnowledgeEntry"
+          }
+        }
+      }
+    },
+    "frictionLayer": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["checkpoint_summary", "entries"],
+      "properties": {
+        "checkpoint_summary": {
+          "type": "string"
+        },
+        "entries": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/frictionEntry"
+          }
+        }
+      }
+    },
+    "operatingModelJson": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "generated_at",
+        "profile_id",
+        "profile_status",
+        "profile_version",
+        "session_id",
+        "session_status",
+        "layers"
+      ],
+      "properties": {
+        "generated_at": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "profile_id": {
+          "type": "string",
+          "format": "uuid"
+        },
+        "profile_status": {
+          "$ref": "#/$defs/profileStatus"
+        },
+        "profile_version": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "session_id": {
+          "type": "string",
+          "format": "uuid"
+        },
+        "session_status": {
+          "$ref": "#/$defs/sessionStatus"
+        },
+        "layers": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "operating_rhythms",
+            "recurring_decisions",
+            "dependencies",
+            "institutional_knowledge",
+            "friction"
+          ],
+          "properties": {
+            "operating_rhythms": {
+              "$ref": "#/$defs/operatingRhythmsLayer"
+            },
+            "recurring_decisions": {
+              "$ref": "#/$defs/recurringDecisionsLayer"
+            },
+            "dependencies": {
+              "$ref": "#/$defs/dependenciesLayer"
+            },
+            "institutional_knowledge": {
+              "$ref": "#/$defs/institutionalKnowledgeLayer"
+            },
+            "friction": {
+              "$ref": "#/$defs/frictionLayer"
+            }
+          }
+        }
+      }
+    },
+    "scheduleRecommendation": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["name", "cadence", "trigger", "rationale", "source_layers"],
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "cadence": {
+          "type": "string"
+        },
+        "trigger": {
+          "type": "string"
+        },
+        "rationale": {
+          "type": "string"
+        },
+        "source_layers": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/layerName"
+          }
+        }
+      }
+    },
+    "scheduleRecommendations": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "generated_at",
+        "profile_version",
+        "session_id",
+        "daily",
+        "weekly",
+        "monthly",
+        "event_driven"
+      ],
+      "properties": {
+        "generated_at": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "profile_version": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "session_id": {
+          "type": "string",
+          "format": "uuid"
+        },
+        "daily": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/scheduleRecommendation"
+          }
+        },
+        "weekly": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/scheduleRecommendation"
+          }
+        },
+        "monthly": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/scheduleRecommendation"
+          }
+        },
+        "event_driven": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/scheduleRecommendation"
+          }
+        }
+      }
+    },
+    "portableBundleParsed": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "operating-model.json",
+        "USER.md",
+        "SOUL.md",
+        "HEARTBEAT.md",
+        "schedule-recommendations.json"
+      ],
+      "properties": {
+        "operating-model.json": {
+          "$ref": "#/$defs/operatingModelJson"
+        },
+        "USER.md": {
+          "type": "string"
+        },
+        "SOUL.md": {
+          "type": "string"
+        },
+        "HEARTBEAT.md": {
+          "type": "string"
+        },
+        "schedule-recommendations.json": {
+          "$ref": "#/$defs/scheduleRecommendations"
+        }
+      }
+    }
+  }
+}

--- a/recipes/bring-your-own-context/extraction-prompts.md
+++ b/recipes/bring-your-own-context/extraction-prompts.md
@@ -1,0 +1,142 @@
+# Bring Your Own Context Extraction Prompts
+
+<!-- markdownlint-disable MD013 -->
+
+Use these prompts at the front of the Bring Your Own Context workflow.
+
+They are intentionally focused on **context extraction and ingestion**, not profile synthesis. Run them first to seed Open Brain with durable context, then use the [Work Operating Model workflow](../work-operating-model-activation/) to normalize that context into the final portable bundle.
+
+## Which Prompt To Use
+
+- Use **Prompt 1: Memory Extraction** when the AI platform already has useful memory about you.
+- Use **Prompt 2: Context Import** when you are migrating notes, exports, or another second-brain system.
+- If both are true, run **Prompt 1 first** and **Prompt 2 second**.
+
+## Prompt 1: Memory Extraction
+
+**Job:** Pulls everything your current AI already knows about you into Open Brain as reviewed, self-contained statements.
+
+**Use it when:** Claude, ChatGPT, Gemini, or another AI already has real history about your projects, people, preferences, and recurring decisions.
+
+**What it should not do:** This prompt should not generate `USER.md`, `SOUL.md`, `HEARTBEAT.md`, or any final profile artifact. Its job is to seed Open Brain with durable raw context only.
+
+````text
+<role>
+You are a portable-context extraction assistant. Your job is to extract everything you already know about the user from memory and conversation history, organize it into clean knowledge chunks, and save each approved chunk to their Open Brain using the capture_thought MCP tool.
+</role>
+
+<context-gathering>
+1. First, confirm the Open Brain MCP server is connected by checking for the capture_thought tool. If it is not available, stop and say: "I can't find the capture_thought tool. Make sure your Open Brain connector is enabled before running this prompt."
+
+2. Pull up everything you already know about the user from memory and conversation history. Look for:
+   - people
+   - active and recent projects
+   - tool preferences
+   - workflow habits
+   - repeated decisions and constraints
+   - business context
+   - personal context that would actually be useful later
+
+3. Organize what you find into these categories:
+   - People
+   - Projects
+   - Preferences
+   - Decisions
+   - Recurring topics
+   - Professional context
+   - Personal context
+
+4. Present the organized results to the user before saving anything. Say how many items you found and walk them through the categories.
+
+5. Ask what they want to skip, edit, or keep. Wait for approval before saving.
+</context-gathering>
+
+<execution>
+For each approved item:
+
+- save it as a clear standalone statement
+- preserve names, dates, and why the detail matters
+- avoid shorthand fragments that only make sense in the current chat
+
+Good format:
+"Sarah Chen is my direct report. She focuses on backend architecture, joined the team in March, and has talked about moving to the ML team."
+
+Bad format:
+"Sarah - DR - backend - ML maybe"
+
+Save in small batches. After each batch, confirm what was saved and what category is next.
+</execution>
+
+<guardrails>
+- Only extract context that genuinely exists in memory or prior conversation history.
+- If something looks stale, flag it before saving.
+- Do not invent missing details.
+- Do not generate final profile artifacts in this step.
+- If the capture_thought tool errors, stop and report the error.
+</guardrails>
+````
+
+## Prompt 2: Context Import
+
+**Job:** Migrates notes, exports, and other external context sources into Open Brain as clean, self-contained statements.
+
+**Use it when:** You are importing Notion, Obsidian, Apple Notes, text files, AI exports, meeting notes, or anything else that already contains useful context.
+
+**What it should not do:** This prompt should not act like the Work Operating Model interviewer. It is an ingestion pass, not the final normalization pass.
+
+````text
+<role>
+You are a portable-context import assistant. Your job is to help the user move existing notes, exports, and context from another system into Open Brain. You should turn each approved chunk into a clean, standalone thought that will still make sense to a different AI later.
+</role>
+
+<context-gathering>
+1. First, confirm the Open Brain MCP server is connected by checking for the capture_thought tool. If it is not available, stop and say: "I can't find the capture_thought tool. Make sure your Open Brain connector is enabled before running this prompt."
+
+2. Ask what source the user is importing from and what kind of material it contains.
+
+3. Ask the user to paste a manageable batch or describe the export structure.
+
+4. Before saving anything, inspect the material and split it into logical chunks:
+   - one short note = one chunk
+   - one long note with multiple distinct ideas = multiple chunks
+   - one database row = one chunk turned into readable prose
+   - one meeting note = one chunk per meaningful decision, action, or finding
+
+5. Show the first preview batch before saving. Wait for approval or corrections.
+</context-gathering>
+
+<execution>
+For each approved chunk:
+
+- transform it into a standalone statement
+- preserve names, dates, and linked context that matter for later retrieval
+- remove formatting artifacts from the original source
+- save each chunk individually with capture_thought
+
+After each batch:
+- report how many thoughts were saved
+- say how many remain in the current batch
+- ask for the next batch if more source material exists
+</execution>
+
+<guardrails>
+- Do not invent context that is not actually present.
+- Preserve the meaning of the original material even if you rewrite the format.
+- Skip empty templates, headers with no content, and structural noise.
+- Warn the user before processing very large imports that may create meaningful API cost.
+- Do not generate final profile artifacts in this step.
+- If the capture_thought tool errors, stop and report the error.
+</guardrails>
+````
+
+## After The Prompt Pass
+
+Once the extraction stage is complete:
+
+1. keep your core Open Brain connector enabled
+2. connect the [Work Operating Model Activation](../work-operating-model-activation/) recipe
+3. run the BYOC interview to turn the raw context into a portable profile bundle
+
+That second stage is where `USER.md`, `SOUL.md`, `HEARTBEAT.md`, and the structured profile export are generated.
+
+<!-- markdownlint-enable MD013 -->

--- a/recipes/bring-your-own-context/metadata.json
+++ b/recipes/bring-your-own-context/metadata.json
@@ -1,0 +1,22 @@
+{
+  "name": "Bring Your Own Context",
+  "description": "Portable context workflow that packages extraction prompts, the Work Operating Model profile flow, and remote MCP deployment into one reusable Open Brain recipe.",
+  "category": "recipes",
+  "author": {
+    "name": "Jonathan Edwards",
+    "github": "jonathanedwards"
+  },
+  "version": "1.0.0",
+  "requires": {
+    "open_brain": true,
+    "services": ["Supabase"],
+    "tools": ["Supabase CLI", "AI client with MCP support and reusable skills/prompts"]
+  },
+  "requires_skills": ["work-operating-model"],
+  "requires_primitives": ["deploy-edge-function", "remote-mcp"],
+  "tags": ["byoc", "portable-context", "operating-model", "mcp", "prompts"],
+  "difficulty": "intermediate",
+  "estimated_time": "1 hour",
+  "created": "2026-04-14",
+  "updated": "2026-04-14"
+}

--- a/recipes/work-operating-model-activation/README.md
+++ b/recipes/work-operating-model-activation/README.md
@@ -2,6 +2,9 @@
 
 > A conversation-first workflow that interviews you about how your work actually runs, stores the answers as structured Open Brain data, and generates agent-ready operating files.
 
+> [!NOTE]
+> If you are coming from the Bring Your Own Context post or want the article-friendly entrypoint, start with [Bring Your Own Context](../bring-your-own-context/). This recipe is the structured profiling engine that BYOC uses under the hood.
+
 ## What It Does
 
 This recipe adds a dedicated MCP server plus schema for a 45-minute elicitation workflow. The interview runs in five fixed layers:
@@ -14,7 +17,7 @@ This recipe adds a dedicated MCP server plus schema for a 45-minute elicitation 
 
 Each approved layer is saved into structured tables, summarized into one durable Open Brain thought through your existing core connector, and made available for later querying and export generation.
 
-This recipe depends on the canonical [Work Operating Model skill](../../skills/work-operating-model/), which owns the interview behavior. The recipe owns the data model, remote MCP server, and export snapshots.
+This recipe depends on the canonical [Work Operating Model skill](../../skills/work-operating-model/), which owns the interview behavior. The recipe owns the data model, remote MCP server, and export snapshots. The higher-level [Bring Your Own Context](../bring-your-own-context/) recipe packages this workflow together with context extraction prompts and the portable bundle contract.
 
 ## Prerequisites
 

--- a/recipes/work-operating-model-activation/README.md
+++ b/recipes/work-operating-model-activation/README.md
@@ -1,7 +1,6 @@
 # Work Operating Model Activation
 
 > A conversation-first workflow that interviews you about how your work actually runs, stores the answers as structured Open Brain data, and generates agent-ready operating files.
-
 > [!NOTE]
 > If you are coming from the Bring Your Own Context post or want the article-friendly entrypoint, start with [Bring Your Own Context](../bring-your-own-context/). This recipe is the structured profiling engine that BYOC uses under the hood.
 


### PR DESCRIPTION
## What changed

This PR adds a new `Bring Your Own Context` composition recipe that packages the existing OB1 context extraction, profile generation, and remote MCP deployment flow into one article-friendly entrypoint.

It adds:

- `recipes/bring-your-own-context/README.md`
- `recipes/bring-your-own-context/extraction-prompts.md`
- `recipes/bring-your-own-context/context-profile.schema.json`
- `recipes/bring-your-own-context/metadata.json`

It also adds discoverability links from the root recipes listings and points the existing Work Operating Model Activation recipe back to the BYOC entrypoint.

## Why it changed

The new post promises publish-time tooling for extracting prompts, profile specs, and implementation guidance around a portable AI context server. The strongest OB1 version of that promise is a composition recipe built from the existing Work Operating Model and remote MCP primitives rather than a second overlapping server stack.

## User impact

Users now have one canonical entrypoint for the BYOC workflow:

- run extraction prompts to seed Open Brain with durable context
- reuse the existing Work Operating Model workflow to normalize that context
- export a documented portable bundle consisting of `operating-model.json`, `USER.md`, `SOUL.md`, `HEARTBEAT.md`, and `schedule-recommendations.json`

## Validation

- Parsed `recipes/bring-your-own-context/metadata.json`
- Parsed `recipes/bring-your-own-context/context-profile.schema.json`
- Ran `npx markdownlint-cli2 recipes/bring-your-own-context/README.md recipes/bring-your-own-context/extraction-prompts.md`
- Verified the schema export keys match the `ARTIFACTS` list in `recipes/work-operating-model-activation/index.ts`
- Verified the local links in the new BYOC docs resolve

## Live testing

Not yet tested against a live Open Brain instance in this push. This PR currently includes static validation and documentation/schema alignment checks only.
