### PR TITLE
[docs] Introduce required/optional OB1 compatibility contract

### DIFF
--- a/.github/metadata.schema.json
+++ b/.github/metadata.schema.json
@@ -57,9 +57,9 @@
       "required": ["open_brain"],
       "properties": {
         "open_brain": {
-          "type": "boolean",
-          "const": true,
-          "description": "Must be true. All contributions require an Open Brain setup."
+          "type": "string",
+          "enum": ["required", "optional"],
+          "description": "Open Brain compatibility. 'required' = contribution depends on the core Open Brain setup (Supabase + pgvector + MCP). 'optional' = contribution is useful on its own; Open Brain integration is additive."
         },
         "services": {
           "type": "array",

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -162,7 +162,7 @@ Every contribution needs a `metadata.json` file. Here's the template:
   },
   "version": "1.0.0",
   "requires": {
-    "open_brain": true,
+    "open_brain": "required",
     "services": ["Gmail API"],
     "tools": ["Node.js 18+"]
   },
@@ -175,9 +175,15 @@ Every contribution needs a `metadata.json` file. Here's the template:
 }
 ```
 
-**Required fields:** `name`, `description`, `category`, `author` (with `name`), `version`, `requires.open_brain` (must be `true`), `tags` (at least 1), `difficulty` (one of: `beginner`, `intermediate`, `advanced`), `estimated_time`
+**Required fields:** `name`, `description`, `category`, `author` (with `name`), `version`, `requires.open_brain` (either `"required"` or `"optional"`), `tags` (at least 1), `difficulty` (one of: `beginner`, `intermediate`, `advanced`), `estimated_time`
 
 **Optional fields:** `author.github`, `requires.services`, `requires.tools`, `requires_skills`, `created`, `updated`
+
+**`requires.open_brain` values:**
+- `"required"` — contribution depends on the core Open Brain setup (Supabase + pgvector + MCP). Recipes, primitives, extensions, schemas, dashboards, and most integrations use this.
+- `"optional"` — contribution is useful on its own. Any Open Brain hooks are additive, not required. Most skills in `skills/` that are reusable outside OB1 should use this.
+
+If you are unsure, default to `"required"`. Use `"optional"` only if a user with no Open Brain setup could still get real value from the contribution.
 
 **Additional structured dependency fields:**
 - `requires_skills` — array of skill slugs this contribution depends on (e.g., `["auto-capture"]`). Use this when the reusable behavior lives in `skills/<slug>/`
@@ -199,7 +205,7 @@ Example for an extension:
   },
   "version": "1.0.0",
   "requires": {
-    "open_brain": true,
+    "open_brain": "required",
     "services": [],
     "tools": ["Node.js 18+"]
   },
@@ -226,7 +232,7 @@ Example for a recipe that depends on a reusable skill:
   },
   "version": "1.0.0",
   "requires": {
-    "open_brain": true,
+    "open_brain": "required",
     "services": [],
     "tools": ["Claude Code or similar AI coding tool"]
   },

--- a/README.md
+++ b/README.md
@@ -98,6 +98,8 @@ Standalone capabilities that make your Open Brain smarter.
 
 Plain-text skill packs you can drop into Claude Code, Codex, or other AI clients that support reusable prompts/rules. These are the canonical reusable building blocks that recipes and other contributions can depend on.
 
+Most skills are useful on their own — Open Brain integration is **optional** for them, not required. A few (like `auto-capture`, `autodream-brain-sync`, `weekly-signal-diff`, and `work-operating-model`) are tightly coupled to a running Open Brain. See each skill's `metadata.json` (`requires.open_brain: "required" | "optional"`) or the [`skills/` README](skills/) for the full compatibility table.
+
 | Skill | What It Does | Contributor |
 | ----- | ------------ | ----------- |
 | [Auto-Capture Skill Pack](skills/auto-capture/) | Captures ACT NOW items and session summaries to Open Brain when a session ends | [@jaredirish](https://github.com/jaredirish) |

--- a/dashboards/_template/metadata.json
+++ b/dashboards/_template/metadata.json
@@ -8,11 +8,16 @@
   },
   "version": "1.0.0",
   "requires": {
-    "open_brain": true,
+    "open_brain": "required",
     "services": [],
-    "tools": ["Node.js 18+"]
+    "tools": [
+      "Node.js 18+"
+    ]
   },
-  "tags": ["tag1", "tag2"],
+  "tags": [
+    "tag1",
+    "tag2"
+  ],
   "difficulty": "beginner",
   "estimated_time": "20 minutes",
   "created": "2026-03-11",

--- a/dashboards/open-brain-dashboard-next/metadata.json
+++ b/dashboards/open-brain-dashboard-next/metadata.json
@@ -8,9 +8,11 @@
   },
   "version": "1.1.0",
   "requires": {
-    "open_brain": true,
+    "open_brain": "required",
     "services": [],
-    "tools": ["Node.js 18+"]
+    "tools": [
+      "Node.js 18+"
+    ]
   },
   "tags": [
     "dashboard",

--- a/dashboards/open-brain-dashboard/metadata.json
+++ b/dashboards/open-brain-dashboard/metadata.json
@@ -8,7 +8,7 @@
   },
   "version": "1.0.0",
   "requires": {
-    "open_brain": true,
+    "open_brain": "required",
     "services": [],
     "tools": [
       "Node.js 18+"

--- a/extensions/_template/AGENT_SPEC.md
+++ b/extensions/_template/AGENT_SPEC.md
@@ -51,7 +51,7 @@ Must validate against `/.github/metadata.schema.json`. Required fields:
   },
   "version": "1.0.0",
   "requires": {
-    "open_brain": true,
+    "open_brain": "required",
     "services": [],
     "tools": ["Supabase CLI"]
   },

--- a/extensions/_template/metadata.json
+++ b/extensions/_template/metadata.json
@@ -8,13 +8,21 @@
   },
   "version": "1.0.0",
   "requires": {
-    "open_brain": true,
+    "open_brain": "required",
     "services": [],
-    "tools": ["Supabase CLI"]
+    "tools": [
+      "Supabase CLI"
+    ]
   },
-  "requires_primitives": ["deploy-edge-function", "remote-mcp"],
+  "requires_primitives": [
+    "deploy-edge-function",
+    "remote-mcp"
+  ],
   "learning_order": 1,
-  "tags": ["tag1", "tag2"],
+  "tags": [
+    "tag1",
+    "tag2"
+  ],
   "difficulty": "beginner",
   "estimated_time": "45 minutes"
 }

--- a/extensions/family-calendar/metadata.json
+++ b/extensions/family-calendar/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "Kid Logistics / Family Calendar",
-  "description": "Multi-person family scheduling — activities, important dates, and conflict detection across the whole household.",
+  "description": "Multi-person family scheduling \u2014 activities, important dates, and conflict detection across the whole household.",
   "category": "extensions",
   "author": {
     "name": "Nate B. Jones",
@@ -8,13 +8,24 @@
   },
   "version": "1.0.0",
   "requires": {
-    "open_brain": true,
+    "open_brain": "required",
     "services": [],
-    "tools": ["Supabase CLI"]
+    "tools": [
+      "Supabase CLI"
+    ]
   },
-  "requires_primitives": ["deploy-edge-function", "remote-mcp"],
+  "requires_primitives": [
+    "deploy-edge-function",
+    "remote-mcp"
+  ],
   "learning_order": 3,
-  "tags": ["family", "calendar", "scheduling", "kids", "logistics"],
+  "tags": [
+    "family",
+    "calendar",
+    "scheduling",
+    "kids",
+    "logistics"
+  ],
   "difficulty": "intermediate",
   "estimated_time": "45 minutes",
   "created": "2026-03-12",

--- a/extensions/home-maintenance/metadata.json
+++ b/extensions/home-maintenance/metadata.json
@@ -8,13 +8,23 @@
   },
   "version": "1.0.0",
   "requires": {
-    "open_brain": true,
+    "open_brain": "required",
     "services": [],
-    "tools": ["Supabase CLI"]
+    "tools": [
+      "Supabase CLI"
+    ]
   },
-  "requires_primitives": ["deploy-edge-function", "remote-mcp"],
+  "requires_primitives": [
+    "deploy-edge-function",
+    "remote-mcp"
+  ],
   "learning_order": 2,
-  "tags": ["home", "maintenance", "scheduling", "tracking"],
+  "tags": [
+    "home",
+    "maintenance",
+    "scheduling",
+    "tracking"
+  ],
   "difficulty": "beginner",
   "estimated_time": "30 minutes",
   "created": "2026-03-12",

--- a/extensions/household-knowledge/metadata.json
+++ b/extensions/household-knowledge/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "Household Knowledge Base",
-  "description": "Store and retrieve household facts — paint colors, appliance details, vendor contacts, measurements, and more.",
+  "description": "Store and retrieve household facts \u2014 paint colors, appliance details, vendor contacts, measurements, and more.",
   "category": "extensions",
   "author": {
     "name": "Nate B. Jones",
@@ -8,13 +8,23 @@
   },
   "version": "1.0.0",
   "requires": {
-    "open_brain": true,
+    "open_brain": "required",
     "services": [],
-    "tools": ["Supabase CLI"]
+    "tools": [
+      "Supabase CLI"
+    ]
   },
-  "requires_primitives": ["deploy-edge-function", "remote-mcp"],
+  "requires_primitives": [
+    "deploy-edge-function",
+    "remote-mcp"
+  ],
   "learning_order": 1,
-  "tags": ["household", "home", "knowledge-base", "beginner"],
+  "tags": [
+    "household",
+    "home",
+    "knowledge-base",
+    "beginner"
+  ],
   "difficulty": "beginner",
   "estimated_time": "30 minutes",
   "created": "2026-03-12",

--- a/extensions/job-hunt/metadata.json
+++ b/extensions/job-hunt/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "Job Hunt Pipeline",
-  "description": "Complete job search management — companies, applications, interviews, and pipeline analytics with CRM integration.",
+  "description": "Complete job search management \u2014 companies, applications, interviews, and pipeline analytics with CRM integration.",
   "category": "extensions",
   "author": {
     "name": "Nate B. Jones",
@@ -8,13 +8,26 @@
   },
   "version": "1.0.0",
   "requires": {
-    "open_brain": true,
+    "open_brain": "required",
     "services": [],
-    "tools": ["Supabase CLI"]
+    "tools": [
+      "Supabase CLI"
+    ]
   },
-  "requires_primitives": ["deploy-edge-function", "remote-mcp", "rls"],
+  "requires_primitives": [
+    "deploy-edge-function",
+    "remote-mcp",
+    "rls"
+  ],
   "learning_order": 6,
-  "tags": ["job-hunt", "career", "pipeline", "interviews", "applications", "rls"],
+  "tags": [
+    "job-hunt",
+    "career",
+    "pipeline",
+    "interviews",
+    "applications",
+    "rls"
+  ],
   "difficulty": "advanced",
   "estimated_time": "1 hour",
   "created": "2026-03-12",

--- a/extensions/meal-planning/metadata.json
+++ b/extensions/meal-planning/metadata.json
@@ -8,13 +8,26 @@
   },
   "version": "1.0.0",
   "requires": {
-    "open_brain": true,
+    "open_brain": "required",
     "services": [],
-    "tools": ["Supabase CLI"]
+    "tools": [
+      "Supabase CLI"
+    ]
   },
-  "requires_primitives": ["deploy-edge-function", "remote-mcp", "rls", "shared-mcp"],
+  "requires_primitives": [
+    "deploy-edge-function",
+    "remote-mcp",
+    "rls",
+    "shared-mcp"
+  ],
   "learning_order": 4,
-  "tags": ["meal-planning", "recipes", "shopping", "sharing", "rls"],
+  "tags": [
+    "meal-planning",
+    "recipes",
+    "shopping",
+    "sharing",
+    "rls"
+  ],
   "difficulty": "intermediate",
   "estimated_time": "1 hour",
   "created": "2026-03-12",

--- a/extensions/professional-crm/metadata.json
+++ b/extensions/professional-crm/metadata.json
@@ -8,13 +8,25 @@
   },
   "version": "1.0.0",
   "requires": {
-    "open_brain": true,
+    "open_brain": "required",
     "services": [],
-    "tools": ["Supabase CLI"]
+    "tools": [
+      "Supabase CLI"
+    ]
   },
-  "requires_primitives": ["deploy-edge-function", "remote-mcp", "rls"],
+  "requires_primitives": [
+    "deploy-edge-function",
+    "remote-mcp",
+    "rls"
+  ],
   "learning_order": 5,
-  "tags": ["crm", "contacts", "networking", "professional", "rls"],
+  "tags": [
+    "crm",
+    "contacts",
+    "networking",
+    "professional",
+    "rls"
+  ],
   "difficulty": "intermediate",
   "estimated_time": "45 minutes",
   "created": "2026-03-12",

--- a/integrations/_template/metadata.json
+++ b/integrations/_template/metadata.json
@@ -8,11 +8,14 @@
   },
   "version": "1.0.0",
   "requires": {
-    "open_brain": true,
+    "open_brain": "required",
     "services": [],
     "tools": []
   },
-  "tags": ["tag1", "tag2"],
+  "tags": [
+    "tag1",
+    "tag2"
+  ],
   "difficulty": "intermediate",
   "estimated_time": "30 minutes",
   "created": "2026-03-11",

--- a/integrations/discord-capture/metadata.json
+++ b/integrations/discord-capture/metadata.json
@@ -7,11 +7,21 @@
   },
   "version": "1.0.0",
   "requires": {
-    "open_brain": true,
-    "services": ["Discord API", "OpenRouter"],
-    "tools": ["Supabase CLI"]
+    "open_brain": "required",
+    "services": [
+      "Discord API",
+      "OpenRouter"
+    ],
+    "tools": [
+      "Supabase CLI"
+    ]
   },
-  "tags": ["discord", "capture", "bot", "messaging"],
+  "tags": [
+    "discord",
+    "capture",
+    "bot",
+    "messaging"
+  ],
   "difficulty": "intermediate",
   "estimated_time": "30 minutes",
   "created": "2026-03-11",

--- a/integrations/kubernetes-deployment/metadata.json
+++ b/integrations/kubernetes-deployment/metadata.json
@@ -8,11 +8,26 @@
   },
   "version": "1.0.0",
   "requires": {
-    "open_brain": true,
-    "services": ["Kubernetes", "PostgreSQL", "pgvector"],
-    "tools": ["kubectl", "Docker"]
+    "open_brain": "required",
+    "services": [
+      "Kubernetes",
+      "PostgreSQL",
+      "pgvector"
+    ],
+    "tools": [
+      "kubectl",
+      "Docker"
+    ]
   },
-  "tags": ["kubernetes", "k8s", "self-hosted", "postgresql", "pgvector", "deployment", "infrastructure"],
+  "tags": [
+    "kubernetes",
+    "k8s",
+    "self-hosted",
+    "postgresql",
+    "pgvector",
+    "deployment",
+    "infrastructure"
+  ],
   "difficulty": "advanced",
   "estimated_time": "60 minutes",
   "created": "2026-03-22",

--- a/integrations/slack-capture/metadata.json
+++ b/integrations/slack-capture/metadata.json
@@ -8,11 +8,20 @@
   },
   "version": "1.0.0",
   "requires": {
-    "open_brain": true,
-    "services": ["Slack"],
-    "tools": ["Supabase CLI"]
+    "open_brain": "required",
+    "services": [
+      "Slack"
+    ],
+    "tools": [
+      "Supabase CLI"
+    ]
   },
-  "tags": ["slack", "capture", "integration", "messaging"],
+  "tags": [
+    "slack",
+    "capture",
+    "integration",
+    "messaging"
+  ],
   "difficulty": "beginner",
   "estimated_time": "15 minutes",
   "created": "2026-03-12",

--- a/primitives/_template/metadata.json
+++ b/primitives/_template/metadata.json
@@ -8,11 +8,14 @@
   },
   "version": "1.0.0",
   "requires": {
-    "open_brain": true,
+    "open_brain": "required",
     "services": [],
     "tools": []
   },
-  "tags": ["tag1", "tag2"],
+  "tags": [
+    "tag1",
+    "tag2"
+  ],
   "difficulty": "intermediate",
   "estimated_time": "20 minutes"
 }

--- a/primitives/deploy-edge-function/metadata.json
+++ b/primitives/deploy-edge-function/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "Deploy an Edge Function",
-  "description": "How to deploy any Open Brain extension as a Supabase Edge Function — create, configure, and deploy in 5 steps.",
+  "description": "How to deploy any Open Brain extension as a Supabase Edge Function \u2014 create, configure, and deploy in 5 steps.",
   "category": "primitives",
   "author": {
     "name": "Nate B. Jones",
@@ -8,11 +8,19 @@
   },
   "version": "1.0.0",
   "requires": {
-    "open_brain": true,
-    "services": ["Supabase CLI"],
+    "open_brain": "required",
+    "services": [
+      "Supabase CLI"
+    ],
     "tools": []
   },
-  "tags": ["deployment", "edge-function", "supabase", "mcp", "deno"],
+  "tags": [
+    "deployment",
+    "edge-function",
+    "supabase",
+    "mcp",
+    "deno"
+  ],
   "difficulty": "beginner",
   "estimated_time": "10 minutes",
   "created": "2026-03-13",

--- a/primitives/remote-mcp/metadata.json
+++ b/primitives/remote-mcp/metadata.json
@@ -8,11 +8,18 @@
   },
   "version": "1.0.0",
   "requires": {
-    "open_brain": true,
+    "open_brain": "required",
     "services": [],
     "tools": []
   },
-  "tags": ["mcp", "remote", "connection", "claude", "chatgpt", "cursor"],
+  "tags": [
+    "mcp",
+    "remote",
+    "connection",
+    "claude",
+    "chatgpt",
+    "cursor"
+  ],
   "difficulty": "beginner",
   "estimated_time": "5 minutes",
   "created": "2026-03-13",

--- a/primitives/rls/metadata.json
+++ b/primitives/rls/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "Row Level Security (RLS)",
-  "description": "Reusable guide to PostgreSQL Row Level Security — the foundation for multi-user and shared-access extensions.",
+  "description": "Reusable guide to PostgreSQL Row Level Security \u2014 the foundation for multi-user and shared-access extensions.",
   "category": "primitives",
   "author": {
     "name": "Nate B. Jones",
@@ -8,11 +8,16 @@
   },
   "version": "1.0.0",
   "requires": {
-    "open_brain": true,
+    "open_brain": "required",
     "services": [],
     "tools": []
   },
-  "tags": ["security", "postgresql", "multi-user", "rls"],
+  "tags": [
+    "security",
+    "postgresql",
+    "multi-user",
+    "rls"
+  ],
   "difficulty": "intermediate",
   "estimated_time": "20 minutes"
 }

--- a/primitives/shared-mcp/metadata.json
+++ b/primitives/shared-mcp/metadata.json
@@ -8,11 +8,18 @@
   },
   "version": "1.0.0",
   "requires": {
-    "open_brain": true,
+    "open_brain": "required",
     "services": [],
-    "tools": ["Node.js 18+"]
+    "tools": [
+      "Node.js 18+"
+    ]
   },
-  "tags": ["mcp", "sharing", "multi-user", "collaboration"],
+  "tags": [
+    "mcp",
+    "sharing",
+    "multi-user",
+    "collaboration"
+  ],
   "difficulty": "intermediate",
   "estimated_time": "30 minutes"
 }

--- a/primitives/troubleshooting/metadata.json
+++ b/primitives/troubleshooting/metadata.json
@@ -8,11 +8,16 @@
   },
   "version": "1.0.0",
   "requires": {
-    "open_brain": true,
+    "open_brain": "required",
     "services": [],
     "tools": []
   },
-  "tags": ["troubleshooting", "debugging", "errors", "help"],
+  "tags": [
+    "troubleshooting",
+    "debugging",
+    "errors",
+    "help"
+  ],
   "difficulty": "beginner",
   "estimated_time": "5 minutes",
   "created": "2026-03-13",

--- a/recipes/_template/metadata.json
+++ b/recipes/_template/metadata.json
@@ -8,12 +8,15 @@
   },
   "version": "1.0.0",
   "requires": {
-    "open_brain": true,
+    "open_brain": "required",
     "services": [],
     "tools": []
   },
   "requires_skills": [],
-  "tags": ["tag1", "tag2"],
+  "tags": [
+    "tag1",
+    "tag2"
+  ],
   "difficulty": "beginner",
   "estimated_time": "15 minutes",
   "created": "2026-03-11",

--- a/recipes/adaptive-capture-classification/metadata.json
+++ b/recipes/adaptive-capture-classification/metadata.json
@@ -8,9 +8,13 @@
   },
   "version": "1.0.0",
   "requires": {
-    "open_brain": true,
-    "services": ["Any OpenAI-compatible LLM gateway (OpenRouter, Ollama, etc.)"],
-    "tools": ["Supabase CLI or Supabase Studio"]
+    "open_brain": "required",
+    "services": [
+      "Any OpenAI-compatible LLM gateway (OpenRouter, Ollama, etc.)"
+    ],
+    "tools": [
+      "Supabase CLI or Supabase Studio"
+    ]
   },
   "tags": [
     "classification",
@@ -23,7 +27,7 @@
     "feedback-loop"
   ],
   "difficulty": "intermediate",
-  "estimated_time": "60–90 minutes",
+  "estimated_time": "60\u201390 minutes",
   "created": "2026-03-31",
   "updated": "2026-03-31"
 }

--- a/recipes/auto-capture/metadata.json
+++ b/recipes/auto-capture/metadata.json
@@ -8,12 +8,22 @@
   },
   "version": "1.0.0",
   "requires": {
-    "open_brain": true,
+    "open_brain": "required",
     "services": [],
-    "tools": ["Claude Code or similar AI coding tool with reusable skills/system prompts"]
+    "tools": [
+      "Claude Code or similar AI coding tool with reusable skills/system prompts"
+    ]
   },
-  "requires_skills": ["auto-capture"],
-  "tags": ["capture", "auto-save", "session-close", "workflow", "skill"],
+  "requires_skills": [
+    "auto-capture"
+  ],
+  "tags": [
+    "capture",
+    "auto-save",
+    "session-close",
+    "workflow",
+    "skill"
+  ],
   "difficulty": "beginner",
   "estimated_time": "10 minutes",
   "created": "2026-03-15",

--- a/recipes/bring-your-own-context/metadata.json
+++ b/recipes/bring-your-own-context/metadata.json
@@ -8,13 +8,29 @@
   },
   "version": "1.0.0",
   "requires": {
-    "open_brain": true,
-    "services": ["Supabase"],
-    "tools": ["Supabase CLI", "AI client with MCP support and reusable skills/prompts"]
+    "open_brain": "required",
+    "services": [
+      "Supabase"
+    ],
+    "tools": [
+      "Supabase CLI",
+      "AI client with MCP support and reusable skills/prompts"
+    ]
   },
-  "requires_skills": ["work-operating-model"],
-  "requires_primitives": ["deploy-edge-function", "remote-mcp"],
-  "tags": ["byoc", "portable-context", "operating-model", "mcp", "prompts"],
+  "requires_skills": [
+    "work-operating-model"
+  ],
+  "requires_primitives": [
+    "deploy-edge-function",
+    "remote-mcp"
+  ],
+  "tags": [
+    "byoc",
+    "portable-context",
+    "operating-model",
+    "mcp",
+    "prompts"
+  ],
   "difficulty": "intermediate",
   "estimated_time": "1 hour",
   "created": "2026-04-14",

--- a/recipes/chatgpt-conversation-import/metadata.json
+++ b/recipes/chatgpt-conversation-import/metadata.json
@@ -8,11 +8,21 @@
   },
   "version": "2.0.0",
   "requires": {
-    "open_brain": true,
-    "services": ["OpenRouter"],
-    "tools": ["Python 3.10+"]
+    "open_brain": "required",
+    "services": [
+      "OpenRouter"
+    ],
+    "tools": [
+      "Python 3.10+"
+    ]
   },
-  "tags": ["chatgpt", "import", "conversations", "migration", "knowledge-extraction"],
+  "tags": [
+    "chatgpt",
+    "import",
+    "conversations",
+    "migration",
+    "knowledge-extraction"
+  ],
   "difficulty": "beginner",
   "estimated_time": "20 minutes",
   "created": "2026-03-10",

--- a/recipes/claudeception/metadata.json
+++ b/recipes/claudeception/metadata.json
@@ -8,11 +8,21 @@
   },
   "version": "1.0.0",
   "requires": {
-    "open_brain": true,
+    "open_brain": "required",
     "services": [],
-    "tools": ["Claude Code"]
+    "tools": [
+      "Claude Code"
+    ]
   },
-  "tags": ["skills", "learning", "extraction", "meta", "self-improving", "knowledge", "continuous-learning"],
+  "tags": [
+    "skills",
+    "learning",
+    "extraction",
+    "meta",
+    "self-improving",
+    "knowledge",
+    "continuous-learning"
+  ],
   "difficulty": "intermediate",
   "estimated_time": "10 minutes",
   "created": "2026-03-19",

--- a/recipes/content-fingerprint-dedup/metadata.json
+++ b/recipes/content-fingerprint-dedup/metadata.json
@@ -8,11 +8,17 @@
   },
   "version": "1.0.0",
   "requires": {
-    "open_brain": true,
+    "open_brain": "required",
     "services": [],
     "tools": []
   },
-  "tags": ["deduplication", "fingerprint", "sha256", "import", "data-quality"],
+  "tags": [
+    "deduplication",
+    "fingerprint",
+    "sha256",
+    "import",
+    "data-quality"
+  ],
   "difficulty": "beginner",
   "estimated_time": "5 minutes",
   "created": "2026-03-16",

--- a/recipes/daily-digest/metadata.json
+++ b/recipes/daily-digest/metadata.json
@@ -8,11 +8,23 @@
   },
   "version": "1.0.0",
   "requires": {
-    "open_brain": true,
-    "services": ["Gmail MCP"],
-    "tools": ["Claude Code or Claude Desktop"]
+    "open_brain": "required",
+    "services": [
+      "Gmail MCP"
+    ],
+    "tools": [
+      "Claude Code or Claude Desktop"
+    ]
   },
-  "tags": ["digest", "summary", "email", "automation", "scheduled-task", "gmail", "claude-code"],
+  "tags": [
+    "digest",
+    "summary",
+    "email",
+    "automation",
+    "scheduled-task",
+    "gmail",
+    "claude-code"
+  ],
   "difficulty": "beginner",
   "estimated_time": "10 minutes",
   "created": "2026-03-25",

--- a/recipes/email-history-import/metadata.json
+++ b/recipes/email-history-import/metadata.json
@@ -8,11 +8,20 @@
   },
   "version": "1.0.0",
   "requires": {
-    "open_brain": true,
-    "services": ["Gmail API"],
-    "tools": ["Deno"]
+    "open_brain": "required",
+    "services": [
+      "Gmail API"
+    ],
+    "tools": [
+      "Deno"
+    ]
   },
-  "tags": ["email", "gmail", "import", "history"],
+  "tags": [
+    "email",
+    "gmail",
+    "import",
+    "history"
+  ],
   "difficulty": "intermediate",
   "estimated_time": "30 minutes",
   "created": "2026-03-10",

--- a/recipes/fingerprint-dedup-backfill/metadata.json
+++ b/recipes/fingerprint-dedup-backfill/metadata.json
@@ -8,11 +8,19 @@
   },
   "version": "1.0.0",
   "requires": {
-    "open_brain": true,
+    "open_brain": "required",
     "services": [],
-    "tools": ["Node.js 18+"]
+    "tools": [
+      "Node.js 18+"
+    ]
   },
-  "tags": ["deduplication", "fingerprint", "backfill", "data-quality", "cleanup"],
+  "tags": [
+    "deduplication",
+    "fingerprint",
+    "backfill",
+    "data-quality",
+    "cleanup"
+  ],
   "difficulty": "beginner",
   "estimated_time": "15 minutes",
   "created": "2026-03-22",

--- a/recipes/google-activity-import/metadata.json
+++ b/recipes/google-activity-import/metadata.json
@@ -8,11 +8,25 @@
   },
   "version": "1.0.0",
   "requires": {
-    "open_brain": true,
-    "services": ["OpenRouter"],
-    "tools": ["Node.js 18+"]
+    "open_brain": "required",
+    "services": [
+      "OpenRouter"
+    ],
+    "tools": [
+      "Node.js 18+"
+    ]
   },
-  "tags": ["google", "takeout", "import", "search-history", "gmail", "maps", "youtube", "chrome", "activity"],
+  "tags": [
+    "google",
+    "takeout",
+    "import",
+    "search-history",
+    "gmail",
+    "maps",
+    "youtube",
+    "chrome",
+    "activity"
+  ],
   "difficulty": "beginner",
   "estimated_time": "15 minutes",
   "created": "2026-03-16",

--- a/recipes/grok-export-import/metadata.json
+++ b/recipes/grok-export-import/metadata.json
@@ -8,11 +8,22 @@
   },
   "version": "1.0.0",
   "requires": {
-    "open_brain": true,
-    "services": ["OpenRouter API", "Supabase"],
-    "tools": ["Node.js 18+"]
+    "open_brain": "required",
+    "services": [
+      "OpenRouter API",
+      "Supabase"
+    ],
+    "tools": [
+      "Node.js 18+"
+    ]
   },
-  "tags": ["import", "grok", "xai", "conversations", "ai-history"],
+  "tags": [
+    "import",
+    "grok",
+    "xai",
+    "conversations",
+    "ai-history"
+  ],
   "difficulty": "beginner",
   "estimated_time": "15 minutes",
   "created": "2026-03-15",

--- a/recipes/infographic-generator/metadata.json
+++ b/recipes/infographic-generator/metadata.json
@@ -8,11 +8,23 @@
   },
   "version": "1.0.0",
   "requires": {
-    "open_brain": true,
-    "services": ["Gemini API (free tier)"],
-    "tools": ["Claude Code or similar AI coding tool", "Python 3.10+"]
+    "open_brain": "required",
+    "services": [
+      "Gemini API (free tier)"
+    ],
+    "tools": [
+      "Claude Code or similar AI coding tool",
+      "Python 3.10+"
+    ]
   },
-  "tags": ["infographic", "visualization", "image-generation", "gemini", "research", "content"],
+  "tags": [
+    "infographic",
+    "visualization",
+    "image-generation",
+    "gemini",
+    "research",
+    "content"
+  ],
   "difficulty": "intermediate",
   "estimated_time": "15 minutes",
   "created": "2026-03-18",

--- a/recipes/instagram-import/metadata.json
+++ b/recipes/instagram-import/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "Instagram Import",
-  "description": "Import Instagram data exports — DM conversations, comments, and post captions — into Open Brain as searchable thoughts.",
+  "description": "Import Instagram data exports \u2014 DM conversations, comments, and post captions \u2014 into Open Brain as searchable thoughts.",
   "category": "recipes",
   "author": {
     "name": "Alan Shurafa",
@@ -8,11 +8,22 @@
   },
   "version": "1.0.0",
   "requires": {
-    "open_brain": true,
-    "services": ["OpenRouter API", "Supabase"],
-    "tools": ["Node.js 18+"]
+    "open_brain": "required",
+    "services": [
+      "OpenRouter API",
+      "Supabase"
+    ],
+    "tools": [
+      "Node.js 18+"
+    ]
   },
-  "tags": ["import", "instagram", "meta", "social-media", "messages"],
+  "tags": [
+    "import",
+    "instagram",
+    "meta",
+    "social-media",
+    "messages"
+  ],
   "difficulty": "intermediate",
   "estimated_time": "20 minutes",
   "created": "2026-03-15",

--- a/recipes/journals-blogger-import/metadata.json
+++ b/recipes/journals-blogger-import/metadata.json
@@ -8,11 +8,22 @@
   },
   "version": "1.0.0",
   "requires": {
-    "open_brain": true,
-    "services": ["OpenRouter API", "Supabase"],
-    "tools": ["Node.js 18+"]
+    "open_brain": "required",
+    "services": [
+      "OpenRouter API",
+      "Supabase"
+    ],
+    "tools": [
+      "Node.js 18+"
+    ]
   },
-  "tags": ["import", "blogger", "journal", "blog", "atom-xml"],
+  "tags": [
+    "import",
+    "blogger",
+    "journal",
+    "blog",
+    "atom-xml"
+  ],
   "difficulty": "beginner",
   "estimated_time": "15 minutes",
   "created": "2026-03-15",

--- a/recipes/life-engine-video/metadata.json
+++ b/recipes/life-engine-video/metadata.json
@@ -8,7 +8,7 @@
   },
   "version": "1.0.0",
   "requires": {
-    "open_brain": true,
+    "open_brain": "required",
     "services": [
       "supabase",
       "elevenlabs",

--- a/recipes/life-engine/metadata.json
+++ b/recipes/life-engine/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "Life Engine",
-  "description": "A self-improving, time-aware personal assistant that runs in the background via Claude Code's /loop command. Checks your calendar, surfaces relevant knowledge from Open Brain, tracks habits and health, and delivers proactive briefings via Telegram or Discord — adapting to your life over time.",
+  "description": "A self-improving, time-aware personal assistant that runs in the background via Claude Code's /loop command. Checks your calendar, surfaces relevant knowledge from Open Brain, tracks habits and health, and delivers proactive briefings via Telegram or Discord \u2014 adapting to your life over time.",
   "category": "recipes",
   "author": {
     "name": "Jonathan Edwards",
@@ -8,7 +8,7 @@
   },
   "version": "1.1.0",
   "requires": {
-    "open_brain": true,
+    "open_brain": "required",
     "services": [
       "supabase",
       "google-calendar",

--- a/recipes/live-retrieval/metadata.json
+++ b/recipes/live-retrieval/metadata.json
@@ -8,11 +8,21 @@
   },
   "version": "1.0.0",
   "requires": {
-    "open_brain": true,
+    "open_brain": "required",
     "services": [],
-    "tools": ["Claude Code"]
+    "tools": [
+      "Claude Code"
+    ]
   },
-  "tags": ["retrieval", "context", "search", "live", "read", "flywheel", "proactive"],
+  "tags": [
+    "retrieval",
+    "context",
+    "search",
+    "live",
+    "read",
+    "flywheel",
+    "proactive"
+  ],
   "difficulty": "beginner",
   "estimated_time": "5 minutes",
   "created": "2026-03-19",

--- a/recipes/local-ollama-embeddings/metadata.json
+++ b/recipes/local-ollama-embeddings/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "Local Embeddings via Ollama",
-  "description": "Generate embeddings locally using Ollama and insert thoughts into Supabase — no cloud API key needed for the embedding step.",
+  "description": "Generate embeddings locally using Ollama and insert thoughts into Supabase \u2014 no cloud API key needed for the embedding step.",
   "category": "recipes",
   "author": {
     "name": "Sam Rogers",
@@ -8,11 +8,20 @@
   },
   "version": "1.0.0",
   "requires": {
-    "open_brain": true,
+    "open_brain": "required",
     "services": [],
-    "tools": ["Python 3.10+", "Ollama"]
+    "tools": [
+      "Python 3.10+",
+      "Ollama"
+    ]
   },
-  "tags": ["ollama", "embeddings", "local", "offline", "privacy"],
+  "tags": [
+    "ollama",
+    "embeddings",
+    "local",
+    "offline",
+    "privacy"
+  ],
   "difficulty": "intermediate",
   "estimated_time": "30 minutes",
   "created": "2026-03-14",

--- a/recipes/ob-graph/metadata.json
+++ b/recipes/ob-graph/metadata.json
@@ -8,9 +8,14 @@
   },
   "version": "1.0.0",
   "requires": {
-    "open_brain": true,
-    "services": ["Supabase"],
-    "tools": ["Supabase CLI", "Deno"]
+    "open_brain": "required",
+    "services": [
+      "Supabase"
+    ],
+    "tools": [
+      "Supabase CLI",
+      "Deno"
+    ]
   },
   "tags": [
     "graph",

--- a/recipes/obsidian-vault-import/metadata.json
+++ b/recipes/obsidian-vault-import/metadata.json
@@ -8,11 +8,22 @@
   },
   "version": "1.0.0",
   "requires": {
-    "open_brain": true,
-    "services": ["OpenRouter"],
-    "tools": ["Python 3.10+"]
+    "open_brain": "required",
+    "services": [
+      "OpenRouter"
+    ],
+    "tools": [
+      "Python 3.10+"
+    ]
   },
-  "tags": ["obsidian", "import", "migration", "vault", "markdown", "pkm"],
+  "tags": [
+    "obsidian",
+    "import",
+    "migration",
+    "vault",
+    "markdown",
+    "pkm"
+  ],
   "difficulty": "intermediate",
   "estimated_time": "20 minutes setup + ~16 min per 1000 thoughts",
   "created": "2026-03-13",

--- a/recipes/panning-for-gold/metadata.json
+++ b/recipes/panning-for-gold/metadata.json
@@ -8,11 +8,23 @@
   },
   "version": "2.0.0",
   "requires": {
-    "open_brain": true,
-    "services": ["OpenRouter"],
-    "tools": ["Claude Code or similar AI coding tool"]
+    "open_brain": "required",
+    "services": [
+      "OpenRouter"
+    ],
+    "tools": [
+      "Claude Code or similar AI coding tool"
+    ]
   },
-  "tags": ["brain-dump", "transcript", "extraction", "evaluation", "voice", "processing", "skill"],
+  "tags": [
+    "brain-dump",
+    "transcript",
+    "extraction",
+    "evaluation",
+    "voice",
+    "processing",
+    "skill"
+  ],
   "difficulty": "intermediate",
   "estimated_time": "20 minutes",
   "created": "2026-03-13",

--- a/recipes/perplexity-conversation-import/metadata.json
+++ b/recipes/perplexity-conversation-import/metadata.json
@@ -8,11 +8,22 @@
   },
   "version": "1.0.0",
   "requires": {
-    "open_brain": true,
-    "services": ["OpenRouter"],
-    "tools": ["Python 3.10+"]
+    "open_brain": "required",
+    "services": [
+      "OpenRouter"
+    ],
+    "tools": [
+      "Python 3.10+"
+    ]
   },
-  "tags": ["perplexity", "import", "conversations", "memory", "migration", "summarization"],
+  "tags": [
+    "perplexity",
+    "import",
+    "conversations",
+    "memory",
+    "migration",
+    "summarization"
+  ],
   "difficulty": "beginner",
   "estimated_time": "20 minutes",
   "created": "2026-03-22",

--- a/recipes/repo-learning-coach/metadata.json
+++ b/recipes/repo-learning-coach/metadata.json
@@ -7,9 +7,13 @@
   },
   "version": "1.0.0",
   "requires": {
-    "open_brain": true,
-    "services": ["OpenRouter"],
-    "tools": ["Node.js 18+"]
+    "open_brain": "required",
+    "services": [
+      "OpenRouter"
+    ],
+    "tools": [
+      "Node.js 18+"
+    ]
   },
   "tags": [
     "learning",

--- a/recipes/research-to-decision-workflow/metadata.json
+++ b/recipes/research-to-decision-workflow/metadata.json
@@ -8,9 +8,11 @@
   },
   "version": "1.0.0",
   "requires": {
-    "open_brain": true,
+    "open_brain": "required",
     "services": [],
-    "tools": ["Claude Code or similar AI coding tool with reusable skills/system prompts"]
+    "tools": [
+      "Claude Code or similar AI coding tool with reusable skills/system prompts"
+    ]
   },
   "requires_skills": [
     "competitive-analysis",
@@ -19,7 +21,13 @@
     "research-synthesis",
     "meeting-synthesis"
   ],
-  "tags": ["workflow", "decision-support", "diligence", "memo", "skill-composition"],
+  "tags": [
+    "workflow",
+    "decision-support",
+    "diligence",
+    "memo",
+    "skill-composition"
+  ],
   "difficulty": "intermediate",
   "estimated_time": "20 minutes",
   "created": "2026-03-31",

--- a/recipes/schema-aware-routing/metadata.json
+++ b/recipes/schema-aware-routing/metadata.json
@@ -8,9 +8,13 @@
   },
   "version": "1.0.0",
   "requires": {
-    "open_brain": true,
-    "services": ["OpenAI-compatible API (LLM + embeddings)"],
-    "tools": ["Node.js 18+ or Deno"]
+    "open_brain": "required",
+    "services": [
+      "OpenAI-compatible API (LLM + embeddings)"
+    ],
+    "tools": [
+      "Node.js 18+ or Deno"
+    ]
   },
   "tags": [
     "ingestion",

--- a/recipes/source-filtering/metadata.json
+++ b/recipes/source-filtering/metadata.json
@@ -8,11 +8,21 @@
   },
   "version": "1.0.0",
   "requires": {
-    "open_brain": true,
-    "services": ["OpenRouter"],
-    "tools": ["Deno 1.40+"]
+    "open_brain": "required",
+    "services": [
+      "OpenRouter"
+    ],
+    "tools": [
+      "Deno 1.40+"
+    ]
   },
-  "tags": ["source", "filtering", "metadata", "backfill", "search"],
+  "tags": [
+    "source",
+    "filtering",
+    "metadata",
+    "backfill",
+    "search"
+  ],
   "difficulty": "beginner",
   "estimated_time": "15 minutes",
   "created": "2026-03-13",

--- a/recipes/vercel-neon-telegram/metadata.json
+++ b/recipes/vercel-neon-telegram/metadata.json
@@ -8,11 +8,26 @@
   },
   "version": "1.0.0",
   "requires": {
-    "open_brain": true,
-    "services": ["Neon Postgres", "Vercel", "OpenAI API", "Telegram"],
-    "tools": ["Node.js 18+"]
+    "open_brain": "required",
+    "services": [
+      "Neon Postgres",
+      "Vercel",
+      "OpenAI API",
+      "Telegram"
+    ],
+    "tools": [
+      "Node.js 18+"
+    ]
   },
-  "tags": ["vercel", "neon", "telegram", "alternative-architecture", "mcp", "next-js", "pgvector"],
+  "tags": [
+    "vercel",
+    "neon",
+    "telegram",
+    "alternative-architecture",
+    "mcp",
+    "next-js",
+    "pgvector"
+  ],
   "difficulty": "intermediate",
   "estimated_time": "1 hour",
   "created": "2026-03-14",

--- a/recipes/work-operating-model-activation/metadata.json
+++ b/recipes/work-operating-model-activation/metadata.json
@@ -8,12 +8,26 @@
   },
   "version": "1.0.0",
   "requires": {
-    "open_brain": true,
-    "services": ["Supabase"],
-    "tools": ["Supabase CLI", "AI client with MCP support and reusable skills/prompts"]
+    "open_brain": "required",
+    "services": [
+      "Supabase"
+    ],
+    "tools": [
+      "Supabase CLI",
+      "AI client with MCP support and reusable skills/prompts"
+    ]
   },
-  "requires_skills": ["work-operating-model"],
-  "tags": ["workflow", "operating-model", "interview", "agent-config", "mcp", "activation"],
+  "requires_skills": [
+    "work-operating-model"
+  ],
+  "tags": [
+    "workflow",
+    "operating-model",
+    "interview",
+    "agent-config",
+    "mcp",
+    "activation"
+  ],
   "difficulty": "intermediate",
   "estimated_time": "45 minutes",
   "created": "2026-04-14",

--- a/recipes/x-twitter-import/metadata.json
+++ b/recipes/x-twitter-import/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "X/Twitter Import",
-  "description": "Import X (Twitter) data exports — tweets, DMs, and Grok chats — into Open Brain as searchable thoughts.",
+  "description": "Import X (Twitter) data exports \u2014 tweets, DMs, and Grok chats \u2014 into Open Brain as searchable thoughts.",
   "category": "recipes",
   "author": {
     "name": "Alan Shurafa",
@@ -8,11 +8,22 @@
   },
   "version": "1.0.0",
   "requires": {
-    "open_brain": true,
-    "services": ["OpenRouter API", "Supabase"],
-    "tools": ["Node.js 18+"]
+    "open_brain": "required",
+    "services": [
+      "OpenRouter API",
+      "Supabase"
+    ],
+    "tools": [
+      "Node.js 18+"
+    ]
   },
-  "tags": ["import", "twitter", "x", "tweets", "social-media"],
+  "tags": [
+    "import",
+    "twitter",
+    "x",
+    "tweets",
+    "social-media"
+  ],
   "difficulty": "intermediate",
   "estimated_time": "20 minutes",
   "created": "2026-03-15",

--- a/schemas/_template/metadata.json
+++ b/schemas/_template/metadata.json
@@ -8,11 +8,14 @@
   },
   "version": "1.0.0",
   "requires": {
-    "open_brain": true,
+    "open_brain": "required",
     "services": [],
     "tools": []
   },
-  "tags": ["tag1", "tag2"],
+  "tags": [
+    "tag1",
+    "tag2"
+  ],
   "difficulty": "beginner",
   "estimated_time": "10 minutes",
   "created": "2026-03-11",

--- a/schemas/workflow-status/metadata.json
+++ b/schemas/workflow-status/metadata.json
@@ -8,11 +8,16 @@
   },
   "version": "1.0.0",
   "requires": {
-    "open_brain": true,
+    "open_brain": "required",
     "services": [],
     "tools": []
   },
-  "tags": ["workflow", "kanban", "status", "tasks"],
+  "tags": [
+    "workflow",
+    "kanban",
+    "status",
+    "tasks"
+  ],
   "difficulty": "beginner",
   "estimated_time": "5 minutes",
   "created": "2026-03-31",

--- a/skills/README.md
+++ b/skills/README.md
@@ -1,19 +1,28 @@
 # Skills
 
-Reusable AI client skills and prompt packs for Open Brain workflows. These are the canonical home for reusable agent behavior: install the file, reload your client, and reuse the behavior across projects or other contributions.
+Reusable AI client skills and prompt packs. These are the canonical home for reusable agent behavior: install the file, reload your client, and reuse the behavior across projects or other contributions.
 
-| Skill | What It Does | Contributor |
-| ----- | ------------ | ----------- |
-| [Auto-Capture Skill Pack](auto-capture/) | Captures ACT NOW items and session summaries to Open Brain when a session ends | [@jaredirish](https://github.com/jaredirish) |
-| [Competitive Analysis Skill Pack](competitive-analysis/) | Builds competitor briefs, pricing comparisons, market maps, and strategic recommendations | [@NateBJones](https://github.com/NateBJones) |
-| [Financial Model Review Skill Pack](financial-model-review/) | Reviews an existing model for assumption quality, structural risk, and scenario gaps | [@NateBJones](https://github.com/NateBJones) |
-| [Deal Memo Drafting Skill Pack](deal-memo-drafting/) | Turns existing diligence materials into structured deal, IC, or partnership memos | [@NateBJones](https://github.com/NateBJones) |
-| [Research Synthesis Skill Pack](research-synthesis/) | Synthesizes source sets into findings, contradictions, confidence markers, and next questions | [@NateBJones](https://github.com/NateBJones) |
-| [Meeting Synthesis Skill Pack](meeting-synthesis/) | Converts meeting notes or transcripts into decisions, action items, risks, and follow-up artifacts | [@NateBJones](https://github.com/NateBJones) |
-| [Heavy File Ingestion Skill Pack](heavy-file-ingestion/) | Converts PDFs, decks, spreadsheets, and other bulky files into markdown, CSV, and a cheap structural index before analysis | [@NateBJones](https://github.com/NateBJones) |
-| [Panning for Gold Skill Pack](panning-for-gold/) | Turns brain dumps and transcripts into evaluated idea inventories | [@jaredirish](https://github.com/jaredirish) |
-| [Aiception Skill Pack (formerly Claudeception)](claudeception/) | Extracts reusable lessons from work sessions into new skills | [@jaredirish](https://github.com/jaredirish) |
-| [Work Operating Model Skill Pack](work-operating-model/) | Runs a five-layer work elicitation interview and turns the approved result into structured Open Brain records plus exports | [@jonathanedwards](https://github.com/jonathanedwards) |
+Most skills here are useful on their own — Open Brain integration is additive. A few are tightly coupled to a running Open Brain and need the core setup to be meaningful. The **Works without OB1?** column makes that distinction explicit.
+
+| Skill | What It Does | Works without OB1? | Contributor |
+| ----- | ------------ | ------------------ | ----------- |
+| [Auto-Capture Skill Pack](auto-capture/) | Captures ACT NOW items and session summaries to Open Brain when a session ends | ❌ Required | [@jaredirish](https://github.com/jaredirish) |
+| [Autodream Brain Sync](autodream-brain-sync/) | Syncs Claude Code's local memory saves to Open Brain so memories are accessible from all AI clients and devices | ❌ Required | [@jaredirish](https://github.com/jaredirish) |
+| [Weekly Signal Diff](weekly-signal-diff/) | Weekly scan that reweights a category/company universe using what Open Brain already knows about the user | ❌ Required | [@NateBJones](https://github.com/NateBJones) |
+| [Work Operating Model Skill Pack](work-operating-model/) | Runs a five-layer elicitation interview and saves the approved operating model into structured Open Brain tables plus exports | ❌ Required | [@jonathanedwards](https://github.com/jonathanedwards) |
+| [Competitive Analysis Skill Pack](competitive-analysis/) | Builds competitor briefs, pricing comparisons, market maps, and strategic recommendations | ✅ Yes | [@NateBJones](https://github.com/NateBJones) |
+| [Financial Model Review Skill Pack](financial-model-review/) | Reviews an existing model for assumption quality, structural risk, and scenario gaps | ✅ Yes | [@NateBJones](https://github.com/NateBJones) |
+| [Deal Memo Drafting Skill Pack](deal-memo-drafting/) | Turns existing diligence materials into structured deal, IC, or partnership memos | ✅ Yes | [@NateBJones](https://github.com/NateBJones) |
+| [Research Synthesis Skill Pack](research-synthesis/) | Synthesizes source sets into findings, contradictions, confidence markers, and next questions | ✅ Yes | [@NateBJones](https://github.com/NateBJones) |
+| [Meeting Synthesis Skill Pack](meeting-synthesis/) | Converts meeting notes or transcripts into decisions, action items, risks, and follow-up artifacts | ✅ Yes | [@NateBJones](https://github.com/NateBJones) |
+| [Heavy File Ingestion Skill Pack](heavy-file-ingestion/) | Converts PDFs, decks, spreadsheets, and other bulky files into markdown, CSV, and a cheap structural index before analysis | ✅ Yes | [@NateBJones](https://github.com/NateBJones) |
+| [Panning for Gold Skill Pack](panning-for-gold/) | Turns brain dumps and transcripts into evaluated idea inventories | ✅ Yes | [@jaredirish](https://github.com/jaredirish) |
+| [Aiception Skill Pack (formerly Claudeception)](claudeception/) | Extracts reusable lessons from work sessions into new skills | ✅ Yes | [@jaredirish](https://github.com/jaredirish) |
+| [N Agentic Harnesses Skill Pack](n-agentic-harnesses/) | Teaches an agent to select and adapt the right harness for a given job across different AI clients | ✅ Yes | [@NateBJones](https://github.com/NateBJones) |
+
+**Compatibility legend:**
+- ❌ **Required** — depends on the core Open Brain setup (Supabase + pgvector + MCP). Install Open Brain first, then this skill.
+- ✅ **Yes** — works on its own with any supported AI client. If you also run Open Brain, the skill's outputs can be captured as thoughts, but nothing about the skill itself requires it.
 
 ## How Skills Differ From Recipes
 
@@ -26,3 +35,5 @@ Reusable AI client skills and prompt packs for Open Brain workflows. These are t
 ## Contributing
 
 Skills are open for community contributions. Keep them plain-text and reviewable: submit `SKILL.md`, `*.skill.md`, or `*-skill.md` files, not zipped exports. See [CONTRIBUTING.md](../CONTRIBUTING.md) for the full requirements.
+
+Each skill's `metadata.json` must declare `requires.open_brain` as either `"required"` or `"optional"`. Use `"optional"` if the skill gives value with no Open Brain setup; use `"required"` if the skill's core behavior calls Open Brain tools or depends on Open Brain data shapes.

--- a/skills/_template/metadata.json
+++ b/skills/_template/metadata.json
@@ -8,11 +8,15 @@
   },
   "version": "1.0.0",
   "requires": {
-    "open_brain": true,
+    "open_brain": "required",
     "services": [],
     "tools": []
   },
-  "tags": ["skill", "prompt", "workflow"],
+  "tags": [
+    "skill",
+    "prompt",
+    "workflow"
+  ],
   "difficulty": "beginner",
   "estimated_time": "10 minutes",
   "created": "2026-03-27",

--- a/skills/auto-capture/metadata.json
+++ b/skills/auto-capture/metadata.json
@@ -8,11 +8,19 @@
   },
   "version": "1.0.0",
   "requires": {
-    "open_brain": true,
+    "open_brain": "required",
     "services": [],
-    "tools": ["AI client with reusable skills, rules, or custom instructions"]
+    "tools": [
+      "AI client with reusable skills, rules, or custom instructions"
+    ]
   },
-  "tags": ["skill", "capture", "session-close", "workflow", "open-brain"],
+  "tags": [
+    "skill",
+    "capture",
+    "session-close",
+    "workflow",
+    "open-brain"
+  ],
   "difficulty": "beginner",
   "estimated_time": "5 minutes",
   "created": "2026-03-31",

--- a/skills/autodream-brain-sync/metadata.json
+++ b/skills/autodream-brain-sync/metadata.json
@@ -8,11 +8,18 @@
   },
   "version": "1.0.0",
   "requires": {
-    "open_brain": true,
+    "open_brain": "required",
     "services": [],
-    "tools": ["mcp__open-brain__capture_thought"]
+    "tools": [
+      "mcp__open-brain__capture_thought"
+    ]
   },
-  "tags": ["memory", "autodream", "sync", "multi-client"],
+  "tags": [
+    "memory",
+    "autodream",
+    "sync",
+    "multi-client"
+  ],
   "difficulty": "beginner",
   "estimated_time": "5 minutes",
   "created": "2026-03-31",

--- a/skills/claudeception/metadata.json
+++ b/skills/claudeception/metadata.json
@@ -8,11 +8,19 @@
   },
   "version": "2.0.0",
   "requires": {
-    "open_brain": true,
+    "open_brain": "optional",
     "services": [],
-    "tools": ["Claude Code or similar AI client with reusable skills/prompts"]
+    "tools": [
+      "Claude Code or similar AI client with reusable skills/prompts"
+    ]
   },
-  "tags": ["skill", "learning", "meta", "knowledge", "workflow"],
+  "tags": [
+    "skill",
+    "learning",
+    "meta",
+    "knowledge",
+    "workflow"
+  ],
   "difficulty": "intermediate",
   "estimated_time": "5 minutes",
   "created": "2026-03-27",

--- a/skills/competitive-analysis/metadata.json
+++ b/skills/competitive-analysis/metadata.json
@@ -8,11 +8,19 @@
   },
   "version": "1.0.0",
   "requires": {
-    "open_brain": true,
+    "open_brain": "optional",
     "services": [],
-    "tools": ["Claude Code or similar AI coding tool with reusable skills/system prompts"]
+    "tools": [
+      "Claude Code or similar AI coding tool with reusable skills/system prompts"
+    ]
   },
-  "tags": ["competitive-analysis", "strategy", "positioning", "pricing", "market-research"],
+  "tags": [
+    "competitive-analysis",
+    "strategy",
+    "positioning",
+    "pricing",
+    "market-research"
+  ],
   "difficulty": "intermediate",
   "estimated_time": "10 minutes",
   "created": "2026-03-31",

--- a/skills/deal-memo-drafting/metadata.json
+++ b/skills/deal-memo-drafting/metadata.json
@@ -8,11 +8,19 @@
   },
   "version": "1.0.0",
   "requires": {
-    "open_brain": true,
+    "open_brain": "optional",
     "services": [],
-    "tools": ["Claude Code or similar AI coding tool with reusable skills/system prompts"]
+    "tools": [
+      "Claude Code or similar AI coding tool with reusable skills/system prompts"
+    ]
   },
-  "tags": ["deal-memo", "investment-memo", "diligence", "ic-memo", "decision-doc"],
+  "tags": [
+    "deal-memo",
+    "investment-memo",
+    "diligence",
+    "ic-memo",
+    "decision-doc"
+  ],
   "difficulty": "intermediate",
   "estimated_time": "10 minutes",
   "created": "2026-03-31",

--- a/skills/financial-model-review/metadata.json
+++ b/skills/financial-model-review/metadata.json
@@ -8,11 +8,19 @@
   },
   "version": "1.0.0",
   "requires": {
-    "open_brain": true,
+    "open_brain": "optional",
     "services": [],
-    "tools": ["Claude Code or similar AI coding tool with reusable skills/system prompts"]
+    "tools": [
+      "Claude Code or similar AI coding tool with reusable skills/system prompts"
+    ]
   },
-  "tags": ["financial-model", "forecast-review", "diligence", "assumptions", "finance"],
+  "tags": [
+    "financial-model",
+    "forecast-review",
+    "diligence",
+    "assumptions",
+    "finance"
+  ],
   "difficulty": "intermediate",
   "estimated_time": "10 minutes",
   "created": "2026-03-31",

--- a/skills/heavy-file-ingestion/metadata.json
+++ b/skills/heavy-file-ingestion/metadata.json
@@ -8,11 +8,22 @@
   },
   "version": "1.0.0",
   "requires": {
-    "open_brain": true,
+    "open_brain": "optional",
     "services": [],
-    "tools": ["Python 3.10+", "uv or pip", "AI client with reusable skills/prompts"]
+    "tools": [
+      "Python 3.10+",
+      "uv or pip",
+      "AI client with reusable skills/prompts"
+    ]
   },
-  "tags": ["skill", "file-conversion", "markdown", "pdf", "spreadsheet", "token-efficiency"],
+  "tags": [
+    "skill",
+    "file-conversion",
+    "markdown",
+    "pdf",
+    "spreadsheet",
+    "token-efficiency"
+  ],
   "difficulty": "intermediate",
   "estimated_time": "10 minutes",
   "created": "2026-03-31",

--- a/skills/meeting-synthesis/metadata.json
+++ b/skills/meeting-synthesis/metadata.json
@@ -8,11 +8,19 @@
   },
   "version": "1.0.0",
   "requires": {
-    "open_brain": true,
+    "open_brain": "optional",
     "services": [],
-    "tools": ["Claude Code or similar AI coding tool with reusable skills/system prompts"]
+    "tools": [
+      "Claude Code or similar AI coding tool with reusable skills/system prompts"
+    ]
   },
-  "tags": ["meeting", "meeting-notes", "transcript", "actions", "synthesis"],
+  "tags": [
+    "meeting",
+    "meeting-notes",
+    "transcript",
+    "actions",
+    "synthesis"
+  ],
   "difficulty": "intermediate",
   "estimated_time": "10 minutes",
   "created": "2026-03-31",

--- a/skills/n-agentic-harnesses/metadata.json
+++ b/skills/n-agentic-harnesses/metadata.json
@@ -8,11 +8,21 @@
   },
   "version": "1.0.0",
   "requires": {
-    "open_brain": true,
+    "open_brain": "optional",
     "services": [],
-    "tools": ["AI client with reusable skills/prompts", "Ability to install the bundled references directory"]
+    "tools": [
+      "AI client with reusable skills/prompts",
+      "Ability to install the bundled references directory"
+    ]
   },
-  "tags": ["agentic-harness", "agents", "workflow", "architecture", "evaluation", "memory"],
+  "tags": [
+    "agentic-harness",
+    "agents",
+    "workflow",
+    "architecture",
+    "evaluation",
+    "memory"
+  ],
   "difficulty": "advanced",
   "estimated_time": "10 minutes",
   "created": "2026-04-02",

--- a/skills/panning-for-gold/metadata.json
+++ b/skills/panning-for-gold/metadata.json
@@ -8,11 +8,19 @@
   },
   "version": "2.0.0",
   "requires": {
-    "open_brain": true,
+    "open_brain": "optional",
     "services": [],
-    "tools": ["Claude Code or similar AI client with reusable skills/prompts"]
+    "tools": [
+      "Claude Code or similar AI client with reusable skills/prompts"
+    ]
   },
-  "tags": ["skill", "brain-dump", "transcript", "evaluation", "workflow"],
+  "tags": [
+    "skill",
+    "brain-dump",
+    "transcript",
+    "evaluation",
+    "workflow"
+  ],
   "difficulty": "intermediate",
   "estimated_time": "5 minutes",
   "created": "2026-03-27",

--- a/skills/research-synthesis/metadata.json
+++ b/skills/research-synthesis/metadata.json
@@ -8,11 +8,19 @@
   },
   "version": "1.0.0",
   "requires": {
-    "open_brain": true,
+    "open_brain": "optional",
     "services": [],
-    "tools": ["Claude Code or similar AI coding tool with reusable skills/system prompts"]
+    "tools": [
+      "Claude Code or similar AI coding tool with reusable skills/system prompts"
+    ]
   },
-  "tags": ["research", "synthesis", "diligence", "evidence", "decision-support"],
+  "tags": [
+    "research",
+    "synthesis",
+    "diligence",
+    "evidence",
+    "decision-support"
+  ],
   "difficulty": "intermediate",
   "estimated_time": "10 minutes",
   "created": "2026-03-31",

--- a/skills/weekly-signal-diff/metadata.json
+++ b/skills/weekly-signal-diff/metadata.json
@@ -8,9 +8,13 @@
   },
   "version": "1.0.0",
   "requires": {
-    "open_brain": true,
-    "services": ["Optional: OpenRouter (Perplexity Sonar family) for live search"],
-    "tools": ["Claude Code or similar AI coding tool with reusable skills/system prompts"]
+    "open_brain": "required",
+    "services": [
+      "Optional: OpenRouter (Perplexity Sonar family) for live search"
+    ],
+    "tools": [
+      "Claude Code or similar AI coding tool with reusable skills/system prompts"
+    ]
   },
   "tags": [
     "weekly-review",

--- a/skills/work-operating-model/metadata.json
+++ b/skills/work-operating-model/metadata.json
@@ -8,11 +8,19 @@
   },
   "version": "1.0.0",
   "requires": {
-    "open_brain": true,
+    "open_brain": "required",
     "services": [],
-    "tools": ["AI client with reusable skills/prompts and MCP support"]
+    "tools": [
+      "AI client with reusable skills/prompts and MCP support"
+    ]
   },
-  "tags": ["skill", "operating-model", "interview", "workflow", "agent-config"],
+  "tags": [
+    "skill",
+    "operating-model",
+    "interview",
+    "workflow",
+    "agent-config"
+  ],
   "difficulty": "intermediate",
   "estimated_time": "10 minutes",
   "created": "2026-04-14",


### PR DESCRIPTION
## Summary
- **Breaking schema change.** `requires.open_brain` migrates from the boolean const `true` to a string enum: `"required" | "optional"`.
- Bulk-migrates every existing `metadata.json` (66 files total) to the new shape and reclassifies the nine standalone skill packs as `"optional"`.
- Rewrites `skills/README.md` with a new **Works without OB1?** column and a compatibility legend. Adds a one-paragraph note under the skills section of the root `README.md`.

## Why this change
The old contract forced every contribution to declare `open_brain: true`, which overstated the dependency. Many skills in `skills/` (competitive-analysis, deal-memo-drafting, financial-model-review, meeting-synthesis, research-synthesis, heavy-file-ingestion, n-agentic-harnesses, panning-for-gold, claudeception) are genuinely useful on their own — Open Brain hooks are additive, not required.

The new contract lets the upcoming community catalog (PR2) and the public `/ob1` directory on natejones.com (separate repo) surface that distinction accurately instead of overselling the dependency.

## Classification decisions in this PR
- **All** recipes, primitives, extensions, schemas, dashboards, and integrations → `"required"`. Nothing in those categories works without the core OB1 stack in v1.
- **Skills declared `"required"`** (4): `auto-capture`, `autodream-brain-sync`, `weekly-signal-diff`, `work-operating-model` — each explicitly calls OB1 MCP tools or depends on OB1 data shapes.
- **Skills declared `"optional"`** (9): `claudeception`, `competitive-analysis`, `deal-memo-drafting`, `financial-model-review`, `heavy-file-ingestion`, `meeting-synthesis`, `n-agentic-harnesses`, `panning-for-gold`, `research-synthesis`.

## Files changed
- `.github/metadata.schema.json` — enum swap, description updated
- `CONTRIBUTING.md` — documents the new contract + both values
- `extensions/_template/AGENT_SPEC.md` — template sample updated
- `README.md` — short note under `/skills` explaining the split
- `skills/README.md` — new column, legend, and contributing guidance
- 66 × `metadata.json` — bulk migration to `"required"` or `"optional"`

## Follow-up PR
PR2 ships the catalog generator script plus the committed `resources/ob1-catalog.json` artifact and a gate drift check. PR2 depends on this contract landing first.

## In-flight contribution branches
Any open PR whose `metadata.json` still sets `open_brain: true` will fail the `Metadata valid` check after this merges. Maintainer-side fix on merge is the expected remediation (contributor volume is low). We should post a short note on the repo discussion / Discord once this lands so active contributors can rebase.

## Test plan
- [x] `check-jsonschema --schemafile .github/metadata.schema.json <every metadata.json>` passes locally (all 66 files)
- [x] Gate workflow skips contribution checks for `[docs]`-tagged PRs (line 75 in `ob1-gate.yml`)
- [ ] Post-merge: verify catalog generator in PR2 ingests every contribution cleanly
- [ ] Post-merge: check that any currently open contribution PR gets a clear failure message pointing at this migration

🤖 Generated with [Claude Code](https://claude.com/claude-code)