### PR TITLE
[docs] Add OB1 catalog generator + committed ob1-catalog.json

### DIFF
--- a/.github/workflows/ob1-gate.yml
+++ b/.github/workflows/ob1-gate.yml
@@ -31,6 +31,29 @@ jobs:
       - name: Install metadata schema validator
         run: python3 -m pip install check-jsonschema
 
+      - name: Check catalog is not stale
+        id: catalog_check
+        # Only run if any contribution content or metadata changed — a doc-only
+        # or workflow-only PR cannot invalidate the catalog.
+        run: |
+          set +e
+          changed=$(git diff --name-only origin/main...HEAD)
+          if echo "$changed" | grep -qE '^(recipes|schemas|dashboards|integrations|skills|primitives|extensions)/[^_].*/(README\.md|metadata\.json)$' \
+            || echo "$changed" | grep -qE '^scripts/build_catalog\.py$' \
+            || echo "$changed" | grep -qE '^resources/ob1-catalog\.json$'; then
+            python3 scripts/build_catalog.py --check
+            rc=$?
+            if [ "$rc" -ne 0 ]; then
+              echo "catalog_stale=true" >> $GITHUB_OUTPUT
+              echo "::error::resources/ob1-catalog.json is stale. Run \`python3 scripts/build_catalog.py\` and commit the result."
+              exit "$rc"
+            fi
+            echo "catalog_stale=false" >> $GITHUB_OUTPUT
+          else
+            echo "catalog check skipped (no contribution or generator changes)"
+            echo "catalog_stale=false" >> $GITHUB_OUTPUT
+          fi
+
       - name: Get changed files
         id: changed
         run: |

--- a/recipes/email-history-import/README.md
+++ b/recipes/email-history-import/README.md
@@ -100,7 +100,7 @@ deno run --allow-net --allow-read --allow-write --allow-env pull-gmail.ts --list
 4. **Deduplicate** via sync-log (tracks Gmail message IDs already imported)
 5. **Embed** content via OpenRouter (`text-embedding-3-small`)
 6. **Classify** via LLM (topics, type, people, action items)
-7. **Upsert** into Supabase with SHA-256 [content fingerprint](../../primitives/content-fingerprint-dedup/README.md) — re-running produces zero duplicates
+7. **Upsert** into Supabase with SHA-256 [content fingerprint](../content-fingerprint-dedup/README.md) — re-running produces zero duplicates
 
 ### What gets filtered out
 
@@ -115,7 +115,7 @@ Each imported email becomes one row in the `thoughts` table:
 - `content`: Email body with context prefix (`[Email from X | Subject: Y | Date: Z]`)
 - `embedding`: 1536-dim vector for semantic search (truncated to 8K chars)
 - `metadata`: LLM-extracted topics, type, people, action items, plus `source: "gmail"`, `gmail_id`, `gmail_labels`, `gmail_thread_id`
-- `content_fingerprint`: Normalized SHA-256 hash for dedup (see [content fingerprint primitive](../../primitives/content-fingerprint-dedup/README.md))
+- `content_fingerprint`: Normalized SHA-256 hash for dedup (see [content fingerprint primitive](../content-fingerprint-dedup/README.md))
 
 ## Troubleshooting
 

--- a/resources/ob1-catalog.json
+++ b/resources/ob1-catalog.json
@@ -1,0 +1,3068 @@
+{
+  "schema_version": "1.0.0",
+  "generated_from": {
+    "repo": "NateBJones-Projects/OB1",
+    "branch": "main"
+  },
+  "categories": [
+    {
+      "slug": "recipes",
+      "site_path": "/ob1/recipes",
+      "count": 29,
+      "required_count": 29,
+      "optional_count": 0
+    },
+    {
+      "slug": "schemas",
+      "site_path": "/ob1/schemas",
+      "count": 1,
+      "required_count": 1,
+      "optional_count": 0
+    },
+    {
+      "slug": "dashboards",
+      "site_path": "/ob1/dashboards",
+      "count": 2,
+      "required_count": 2,
+      "optional_count": 0
+    },
+    {
+      "slug": "integrations",
+      "site_path": "/ob1/integrations",
+      "count": 3,
+      "required_count": 3,
+      "optional_count": 0
+    },
+    {
+      "slug": "skills",
+      "site_path": "/ob1/skills",
+      "count": 13,
+      "required_count": 4,
+      "optional_count": 9
+    },
+    {
+      "slug": "primitives",
+      "site_path": "/ob1/primitives",
+      "count": 5,
+      "required_count": 5,
+      "optional_count": 0
+    },
+    {
+      "slug": "extensions",
+      "site_path": "/ob1/extensions",
+      "count": 6,
+      "required_count": 6,
+      "optional_count": 0
+    }
+  ],
+  "entries": [
+    {
+      "slug": "adaptive-capture-classification",
+      "category": "recipes",
+      "site_path": "/ob1/recipes/adaptive-capture-classification",
+      "name": "Adaptive Capture Classification",
+      "description": "Adds confidence gating and a per-type learning loop to OB1's capture flow. The classifier reports a confidence score; a threshold gates whether to auto-classify or ask the user; every user response nudges the threshold up or down. Includes optional A/B model comparison and spell correction learning tables.",
+      "author": {
+        "name": "Matthew Hardy",
+        "github": "mjh756"
+      },
+      "version": "1.0.0",
+      "tags": [
+        "classification",
+        "confidence",
+        "learning",
+        "capture",
+        "thresholds",
+        "a/b-testing",
+        "spell-correction",
+        "feedback-loop"
+      ],
+      "difficulty": "intermediate",
+      "estimated_time": "60–90 minutes",
+      "created": "2026-03-31",
+      "updated": "2026-03-31",
+      "learning_order": null,
+      "compatibility": {
+        "open_brain": "required"
+      },
+      "requirements": {
+        "services": [
+          "Any OpenAI-compatible LLM gateway (OpenRouter, Ollama, etc.)"
+        ],
+        "tools": [
+          "Supabase CLI or Supabase Studio"
+        ]
+      },
+      "dependencies": {
+        "skills": [],
+        "primitives": []
+      },
+      "reverse_dependencies": {
+        "skills": [],
+        "primitives": []
+      },
+      "urls": {
+        "github_folder": "https://github.com/NateBJones-Projects/OB1/tree/main/recipes/adaptive-capture-classification",
+        "github_readme": "https://github.com/NateBJones-Projects/OB1/blob/main/recipes/adaptive-capture-classification/README.md"
+      },
+      "readme_markdown": "# Adaptive Capture Classification\n\n## What This Does\n\nOB1's `capture` MCP tool classifies your input once and moves on — there is no mechanism to\ntell it when it got the type wrong. This recipe adds a learning loop on top of the existing capture flow: the\nclassifier reports a confidence score, a per-type threshold gates whether to auto-classify or\nask for confirmation, and every user response nudges that threshold up or down. Over time the\nsystem learns which capture types it can reliably auto-classify for you and becomes\nprogressively less intrusive.\n\n## Difficulty\n\nIntermediate\n\n## Prerequisites\n\n- Open Brain setup complete with the `thoughts` table populated\n- An AI gateway configured (OpenRouter, Ollama, or any OpenAI-compatible endpoint)\n- Access to run SQL migrations against your Supabase project (Supabase Studio or CLI)\n- A capture interface you control — CLI script, Telegram bot, n8n workflow, or similar\n  (this recipe is interface-agnostic; the gating logic sits between your interface and the\n  OB1 `capture` MCP call)\n- A trusted server-side environment for the reference implementation below\n  (`capture-with-gating.ts` uses `SUPABASE_SERVICE_ROLE_KEY`, not a browser-safe anon key)\n\n## What You'll Learn\n\n- How to add confidence scoring to LLM classification without changing your existing schema\n- How to implement adaptive per-type thresholds that improve from user feedback\n- How to run A/B model comparisons on live captures to choose between models empirically\n- How to build a spell/typo correction layer that learns from user corrections\n\n---\n\n## Setup\n\n### Step 1: Run the schema migration\n\nRun `schema.sql` against your Supabase project. This creates four tables alongside your\nexisting OB1 schema — nothing existing is modified.\n\n**Supabase Studio:** open the SQL editor, paste the contents of `schema.sql`, and run it.\n\n**Supabase CLI:**\n```bash\nsupabase migration new adaptive_capture_classification\n# paste the contents of schema.sql into the generated migration file\nsupabase db push\n```\n\n✅ **Done when:** the four tables appear in your Supabase Studio table list:\n`correction_learnings`, `classification_outcomes`, `capture_thresholds`, `ab_comparisons`.\n\n---\n\n### Step 2: Configure your capture types\n\nIn `classifier_prompt.md`, edit the `{types}` list to match your Open Brain schema. OB1's\ncanonical types are:\n\n```json\n[\"idea\", \"task\", \"person_note\", \"reference\", \"decision\", \"lesson\", \"meeting\", \"journal\"]\n```\n\nRemove types you don't use, but do not add values outside this list unless you have added\ncorresponding type support to your `thoughts` table. The classifier and threshold system\nwill adapt to whatever list you set — per-type rows in `capture_thresholds` are created on\nfirst use.\n\n---\n\n### Step 3: Add a user context string\n\nThe classifier prompt includes a `{user_context}` slot. Fill this in with a short description\nof your active projects and any domain vocabulary the classifier might otherwise misread as\ntypos or generic words. Store this string wherever your capture interface loads configuration.\n\nExample:\n```\nMaya is a product designer in San Francisco. Active projects: Onboarding v3, Design System\naudit, Q2 mobile app. Domain terms: Figma, Lottie, handoff, A11y, WCAG.\n```\n\n---\n\n### Step 4: Wrap your capture call with the gating logic\n\n> [!NOTE]\n> This recipe provides a pseudocode description of the gating pattern plus a minimal\n> TypeScript reference implementation (`capture-with-gating.ts`). You will need to adapt\n> the implementation to your own capture interface — the logic is intentionally kept\n> separate from any specific bot, CLI, or workflow framework.\n\nReplace your current direct call to the OB1 `capture` MCP tool with the following pattern.\n\n```\nCONSTANTS:\n    DEFAULT_THRESHOLD  = 0.75\n    THRESHOLD_MIN      = 0.50\n    THRESHOLD_MAX      = 0.95\n    THRESHOLD_NUDGE    = 0.02\n    CONSISTENCY_CUTOFF = 9       # re-run classifier if confidence below this\n    CONSISTENCY_FACTOR = 0.6     # multiply confidence if two runs disagree on type\n\nFUNCTION process_capture(raw_text, hint_type=null, hint_project=null):\n\n    # --- 1. Classify ---\n    result = call_llm(\n        system_prompt = SYSTEM_PROMPT,           # from classifier_prompt.md\n        user_prompt   = USER_TEMPLATE.format(\n            user_context = USER_CONTEXT,\n            content      = raw_text,\n            types        = CAPTURE_TYPES,\n            type_note    = \"\" if hint_type is null\n                           else ' — you MUST use \"{hint_type}\" for this field'\n        ),\n        temperature = 0.1\n    )\n    classified = parse_json(result)              # fields: type, title, tags, project,\n                                                 # due_date, confidence (0–10)\n\n    # --- 2. Optional consistency check ---\n    if hint_type is null and classified.confidence < CONSISTENCY_CUTOFF:\n        second = call_llm(same prompt)\n        if second.type != classified.type:\n            classified.confidence = round(classified.confidence * CONSISTENCY_FACTOR)\n\n    # --- 3. Look up learned threshold ---\n    threshold = get_threshold(classified.type)   # SELECT from capture_thresholds\n\n    # --- 4. Gate: auto-classify or ask? ---\n    if hint_type is not null or (classified.confidence / 10) >= threshold:\n        auto_classify = true\n    else:\n        auto_classify = false\n\n    # --- 5. Record outcome (user_accepted filled in later) ---\n    outcome_id = insert_outcome(\n        model          = model_name,\n        item_type      = classified.type,\n        confidence     = classified.confidence,\n        auto_classified = auto_classify\n    )\n\n    return { classified, auto_classify, outcome_id }\n\n\nFUNCTION complete_capture(outcome_id, classified, accepted, user_correction=null):\n\n    # --- 6. Write to OB1 ---\n    if accepted:\n        call_ob1_capture(\n            content  = classified.title,\n            type     = classified.type,\n            tags     = classified.tags,\n            project  = classified.project,\n            due_date = classified.due_date\n        )\n\n    # --- 7. Record feedback and adjust threshold ---\n    update_outcome(outcome_id, user_accepted=accepted, user_correction=user_correction)\n    adjust_threshold(classified.type, accepted=accepted)\n\n\nFUNCTION adjust_threshold(item_type, accepted):\n    current = get_threshold(item_type)\n    # Lower threshold when accepted (auto-classify was correct → be more aggressive)\n    # Raise threshold when rejected (auto-classify was wrong → be more conservative)\n    delta = -THRESHOLD_NUDGE if accepted else +THRESHOLD_NUDGE\n    new_val = clamp(current + delta, THRESHOLD_MIN, THRESHOLD_MAX)\n    upsert_threshold(item_type, new_val)\n```\n\n---\n\n### Step 5: Add confirmation handling to your interface\n\nWhen `auto_classify` is `false`, prompt the user to confirm or correct. The minimum viable\nconfirmation loop is:\n\n```\nShow:    \"I think this is a [type]: [title]. Confidence: [n]/10. Correct? [Yes] [No] [Pick type]\"\n\nOn Yes:  complete_capture(outcome_id, classified, accepted=true)\nOn No:   complete_capture(outcome_id, classified, accepted=false)\nOn Pick: re-run classification with hint_type = user_chosen_type\n         complete_capture(outcome_id, new_classified, accepted=true, user_correction=user_chosen_type)\n```\n\nFor CLI interfaces, a simple y/n prompt is sufficient. For Telegram or Slack, an inline\nkeyboard with type buttons works well.\n\n---\n\n### Step 6 (optional): Enable A/B model comparison\n\nIf you want to empirically compare two models before committing to one as your default,\nrun both classifiers in parallel on the same capture and ask the user to pick the better\nresult. Store the outcome in `ab_comparisons`.\n\n```\nmodel_a_result = classify(text, model=\"model-a\")\nmodel_b_result = classify(text, model=\"model-b\")\n\ncompare_id = insert_ab_compare(model_a_result, model_b_result)\n\nShow both results to user, ask: \"Which is better? [A] [B] [Both] [Neither]\"\n\nupdate_ab_compare(compare_id, winner=user_choice)\n```\n\nQuery `ab_comparisons` to see win rates:\n```sql\nSELECT\n    model_a,\n    model_b,\n    COUNT(*) AS total,\n    SUM(CASE WHEN winner = 'a'       THEN 1 ELSE 0 END) AS wins_a,\n    SUM(CASE WHEN winner = 'b'       THEN 1 ELSE 0 END) AS wins_b,\n    AVG(time_ms_a) AS avg_ms_a,\n    AVG(time_ms_b) AS avg_ms_b\nFROM ab_comparisons\nWHERE winner IS NOT NULL\nGROUP BY model_a, model_b;\n```\n\n---\n\n## How to Use It\n\nOnce wired up, your capture flow works like this:\n\n**High-confidence capture** — the classifier returns confidence 8/10 and the current\nthreshold for `task` is 0.75. It auto-classifies, writes to OB1, and silently nudges the\n`task` threshold down by 0.02 (the system is performing well — it can be slightly more\naggressive next time).\n\n**Low-confidence capture** — the classifier returns confidence 5/10 for `note` but the\nthreshold is 0.75. You get a confirmation prompt. If you accept, the threshold nudges down.\nIf you correct it to `decision`, the threshold for `note` nudges up (you were right to ask)\nand the correction is recorded.\n\n**Checking learned thresholds:**\n```sql\nSELECT item_type, threshold, sample_count, updated_at\nFROM capture_thresholds\nORDER BY sample_count DESC;\n```\n\n**Checking model accuracy:**\n```sql\nSELECT\n    model,\n    COUNT(*) AS outcomes,\n    ROUND(AVG(CASE WHEN user_accepted THEN 1.0 ELSE 0.0 END), 3) AS accuracy\nFROM classification_outcomes\nWHERE user_accepted IS NOT NULL\nGROUP BY model;\n```\n\n---\n\n## Example\n\n**Capture:** \"need to call alex re thursday meeting\"\n\n**Classifier output:**\n```json\n{\n  \"type\": \"task\",\n  \"title\": \"Call Alex re Thursday meeting\",\n  \"tags\": [\"comms\", \"meeting\"],\n  \"project\": null,\n  \"due_date\": null,\n  \"confidence\": 9\n}\n```\n\n**Current `task` threshold:** 0.75\n\n**Decision:** 9/10 = 0.90 ≥ 0.75 → auto-classify. Written to OB1 immediately with no prompt.\n`task` threshold nudges to 0.73.\n\n---\n\n**Capture:** \"alex thursday\"\n\n**Classifier output:**\n```json\n{\n  \"type\": \"task\",\n  \"title\": \"Follow up with Alex on Thursday\",\n  \"tags\": [\"comms\"],\n  \"project\": null,\n  \"due_date\": null,\n  \"confidence\": 5\n}\n```\n\n**Decision:** 5/10 = 0.50 < 0.75 → confirmation prompt shown.\n\nUser taps **Yes** → written to OB1, `task` threshold nudges to 0.73.\nUser taps **Decision** → re-classified as `decision`, written to OB1, `task` threshold\nnudges to 0.77 (auto-classify was wrong for this type — raise the bar slightly).\n\n---\n\n## Notes\n\n**The threshold floor is 0.50.** Even a perfectly performing classifier will never\nauto-classify captures where the LLM reports less than 50% confidence. Captures that\nconsistently fall below the floor for a given type are inherently ambiguous — the right\nresponse is to always ask.\n\n**The threshold ceiling is 0.95.** The classifier is never treated as infallible.\nThis preserves occasional confirmation prompts even for types the system handles well,\nwhich catches model drift and keeps the feedback loop alive.\n\n**Thresholds are per-type, not global.** `task` captures may auto-classify aggressively\n(threshold 0.60) while `decision` captures — which carry more consequence — stay\nconservative (threshold 0.85). The system finds this balance from your corrections\nwithout manual tuning.\n\n**The spell correction tables (`correction_learnings`) are optional.** If your capture\ninterface already handles typos, or your users type accurately, skip this table entirely.\nThe rest of the recipe functions without it. If you do use it, see `classifier_prompt.md`\nfor guidance on domain vocabulary that should never be flagged as misspellings.\n\n**This recipe does not modify the OB1 `thoughts` table or any existing schema.** All four\ntables are additive. Rolling back means dropping the four tables; nothing else is affected.\n\n## Troubleshooting\n\n**All captures are being asked for confirmation.**\nThe thresholds start at 0.75 and the classifier may report conservative confidence scores\ninitially. This is expected — the system needs 10–20 captures per type before thresholds\nsettle. If confidence scores are consistently low (< 5), check your `{user_context}` string;\na missing or vague context causes the classifier to hedge on `project` and `type` fields,\nwhich drags confidence down.\n\n**The classifier keeps choosing the wrong type.**\nAdd an explicit type hint at capture time for captures where you know the type. A hint\nlocks the type field (confidence is set to 10 automatically) and the other metadata fields\nare still inferred. This trains the threshold without polluting the accuracy stats with\ncases where classification was genuinely ambiguous.\n\n**Threshold for a type is stuck near the ceiling.**\nThis means the auto-classifier has been wrong more often than right for that type. Check\nyour `classification_outcomes` rows for that type — look at `confidence` values alongside\n`user_accepted`. If confidence is consistently high but `user_accepted` is false, your\ncapture vocabulary for that type may be ambiguous or your type definitions may overlap. A\nrevised `{types}` list or a clearer user context string usually resolves this.\n"
+    },
+    {
+      "slug": "auto-capture",
+      "category": "recipes",
+      "site_path": "/ob1/recipes/auto-capture",
+      "name": "Auto-Capture Protocol",
+      "description": "Workflow guidance for using the reusable Auto-Capture skill to store ACT NOW items and session summaries in Open Brain at session close.",
+      "author": {
+        "name": "Jared Irish",
+        "github": "jaredirish"
+      },
+      "version": "1.0.0",
+      "tags": [
+        "capture",
+        "auto-save",
+        "session-close",
+        "workflow",
+        "skill"
+      ],
+      "difficulty": "beginner",
+      "estimated_time": "10 minutes",
+      "created": "2026-03-15",
+      "updated": "2026-03-31",
+      "learning_order": null,
+      "compatibility": {
+        "open_brain": "required"
+      },
+      "requirements": {
+        "services": [],
+        "tools": [
+          "Claude Code or similar AI coding tool with reusable skills/system prompts"
+        ]
+      },
+      "dependencies": {
+        "skills": [
+          "auto-capture"
+        ],
+        "primitives": []
+      },
+      "reverse_dependencies": {
+        "skills": [],
+        "primitives": []
+      },
+      "urls": {
+        "github_folder": "https://github.com/NateBJones-Projects/OB1/tree/main/recipes/auto-capture",
+        "github_readme": "https://github.com/NateBJones-Projects/OB1/blob/main/recipes/auto-capture/README.md"
+      },
+      "readme_markdown": "# Auto-Capture Protocol\n\n*The write side of the Open Brain flywheel*\n\nAutomatically capture evaluated ideas and session summaries to Open Brain when a work session ends. No manual step. No toggle. The system closes its own loop.\n\n## What It Does\n\nThis recipe teaches you how to use the reusable [Auto-Capture skill](/ob1/skills/auto-capture) as part of an Open Brain workflow. The skill handles the behavior at session close; this recipe defines what should get captured, what should not, and how the captures compose with [Panning for Gold](/ob1/recipes/panning-for-gold).\n\n> [!NOTE]\n> This is a behavioral workflow, not a background service, hook, or daemon. Your AI client follows the protocol when session-end conditions are met.\n\nTogether with [Panning for Gold](/ob1/recipes/panning-for-gold), Auto-Capture creates the write side of a knowledge flywheel:\n\n```text\nBrainstorm / Work Session\n    |\n    v\nPanning for Gold (evaluate + triage)\n    |\n    v\nAuto-Capture (store to Open Brain)\n    |\n    v\nFuture sessions find these via search_thoughts\n```\n\n## Prerequisites\n\n- Working Open Brain setup ([guide](https://github.com/NateBJones-Projects/OB1/blob/main/docs/01-getting-started.md))\n- Claude Code or another AI coding tool that supports reusable skills/system prompts\n- The canonical [Auto-Capture skill pack](/ob1/skills/auto-capture)\n- Open Brain MCP tools connected so capture is available\n- Recommended: [Panning for Gold](/ob1/recipes/panning-for-gold) for evaluating raw input before capture\n\n### Credential Tracker\n\n```text\nFrom your existing Open Brain setup:\n- Project URL: _______________\n- Open Brain MCP server connected: yes / no\n- Open Brain capture tool available: yes / no\n- Open Brain search tool available: yes / no\n\nNo additional credentials needed for this recipe.\n```\n\n## Steps\n\n1. **Install the skill dependency**\n\n   Follow the installation steps in the [Auto-Capture skill pack](/ob1/skills/auto-capture). The canonical prompt lives there.\n\n2. **Confirm your Open Brain tools are available**\n\n   Verify your AI client can see the Open Brain capture tool. If your setup also exposes search, keep that enabled so the skill can avoid obvious duplicates.\n\n3. **Use it at the right point in the workflow**\n\n   Run Auto-Capture when a session is genuinely ending and you already have evaluated outputs. The best fit is:\n\n   - after a Panning for Gold run produces ACT NOW items\n   - after a work session ends with clear decisions or next actions\n   - when you want the most valuable outputs stored before you lose context\n\n4. **Verify the captures**\n\n   End a short session with one or two clear ACT NOW items, then confirm that:\n\n   - each ACT NOW item was captured separately\n   - one session summary was captured\n   - the captures are searchable in a later session\n\n## What Gets Captured\n\n### 1. Each ACT NOW item\n\nCapture each high-value item as its own thought. Each one should include:\n\n- what the idea or decision is\n- why it matters\n- concrete next actions\n- provenance when available\n\nExample:\n\n```text\nACT NOW: Switch the webhook pipeline to queue-based backoff. This handles burst traffic more reliably than the current retry flow and reduces dropped events during spikes. Next actions: (1) prototype the queue worker, (2) benchmark it against the current handler, (3) test with a 10x burst replay. Origin: 2026-03-14 API redesign session, thread #7.\n```\n\n### 2. One session summary\n\nCapture one summary that records the session's themes and the number of important items that emerged.\n\nExample:\n\n```text\nWork session: API redesign brainstorm. 24 threads reviewed, 3 ACT NOW items, 5 research threads, 16 parked. Main themes: queue-based retries, webhook durability, client SDK versioning. Full context lives in docs/brainstorming/2026-03-14-api-redesign-gold-found.md.\n```\n\n## What Does Not Get Captured\n\n- Raw brainstorming or transcript text\n- Parked or killed items\n- Obvious duplicates of thoughts that are already in Open Brain\n\n## Capture Quality Checklist\n\nBefore a capture is considered done, make sure it is:\n\n- self-contained enough to understand months later\n- specific about the decision or next action\n- explicit about why it matters\n- grounded with provenance when available\n\n## How This Composes with Panning for Gold\n\nPanning for Gold and Auto-Capture solve different parts of the same problem:\n\n| Workflow Piece | Role |\n| --- | --- |\n| [Panning for Gold](/ob1/recipes/panning-for-gold) | Extracts and evaluates threads from messy raw input |\n| [Auto-Capture skill](/ob1/skills/auto-capture) | Stores the highest-value outputs at session close |\n| This recipe | Defines the OB1 workflow, capture rules, and expected outputs |\n\n## Expected Outcome\n\nWhen working correctly, you should see:\n\n- one searchable Open Brain thought per ACT NOW item\n- one searchable Open Brain thought for the session summary\n- no raw-noise captures cluttering the database\n- a clean handoff from evaluation workflows like [Panning for Gold](/ob1/recipes/panning-for-gold) into durable Open Brain memory\n\n## Troubleshooting\n\n**Issue: The skill fires, but nothing appears in Open Brain**\nSolution: Verify your Open Brain capture tool is connected and callable in the current client. Test it manually before relying on the recipe.\n\n**Issue: Captures are too generic to be useful later**\nSolution: Tighten the capture content. Preserve the decision, the reason it matters, and concrete next actions. Generic wrap-ups do not search well.\n\n**Issue: Duplicate thoughts appear after using this with Panning for Gold**\nSolution: Keep the workflow boundary clean. Panning for Gold should evaluate; Auto-Capture should persist the final high-value outputs. If both are storing the same payload, make the capture step the single source of persistence.\n"
+    },
+    {
+      "slug": "bring-your-own-context",
+      "category": "recipes",
+      "site_path": "/ob1/recipes/bring-your-own-context",
+      "name": "Bring Your Own Context",
+      "description": "Portable context workflow that packages extraction prompts, the Work Operating Model profile flow, and remote MCP deployment into one reusable Open Brain recipe.",
+      "author": {
+        "name": "Jonathan Edwards",
+        "github": "jonathanedwards"
+      },
+      "version": "1.0.0",
+      "tags": [
+        "byoc",
+        "portable-context",
+        "operating-model",
+        "mcp",
+        "prompts"
+      ],
+      "difficulty": "intermediate",
+      "estimated_time": "1 hour",
+      "created": "2026-04-14",
+      "updated": "2026-04-14",
+      "learning_order": null,
+      "compatibility": {
+        "open_brain": "required"
+      },
+      "requirements": {
+        "services": [
+          "Supabase"
+        ],
+        "tools": [
+          "Supabase CLI",
+          "AI client with MCP support and reusable skills/prompts"
+        ]
+      },
+      "dependencies": {
+        "skills": [
+          "work-operating-model"
+        ],
+        "primitives": [
+          "deploy-edge-function",
+          "remote-mcp"
+        ]
+      },
+      "reverse_dependencies": {
+        "skills": [],
+        "primitives": []
+      },
+      "urls": {
+        "github_folder": "https://github.com/NateBJones-Projects/OB1/tree/main/recipes/bring-your-own-context",
+        "github_readme": "https://github.com/NateBJones-Projects/OB1/blob/main/recipes/bring-your-own-context/README.md"
+      },
+      "readme_markdown": "# Bring Your Own Context\n\n<!-- markdownlint-disable MD013 -->\n\nPortable context workflow for extracting what your AI already knows,\nturning it into a structured operating profile, and carrying that profile\nacross AI clients.\n\n> [!IMPORTANT]\n> This is a composition recipe. It does not introduce a new MCP server or a\n> new tool surface in v1.\n\nIt packages existing Open Brain pieces into one entrypoint:\n\n- focused extraction prompts in [extraction-prompts.md](https://github.com/NateBJones-Projects/OB1/blob/main/recipes/bring-your-own-context/extraction-prompts.md)\n- the canonical [Work Operating Model skill](/ob1/skills/work-operating-model)\n- the paired [Work Operating Model Activation recipe](/ob1/recipes/work-operating-model-activation)\n- the existing [Remote MCP Connection](/ob1/primitives/remote-mcp) pattern\n\n## What It Does\n\nBring Your Own Context gives you one publishable workflow for portable AI context inside OB1.\n\nYou first seed Open Brain with reviewed context using the extraction prompts in this folder. Then you run the existing Work Operating Model workflow to turn that raw context into a reusable bundle with a documented contract:\n\n- `operating-model.json`\n- `USER.md`\n- `SOUL.md`\n- `HEARTBEAT.md`\n- `schedule-recommendations.json`\n\nThe machine-readable schema for that bundle lives in [context-profile.schema.json](https://github.com/NateBJones-Projects/OB1/blob/main/recipes/bring-your-own-context/context-profile.schema.json).\n\n## Prerequisites\n\n- Working Open Brain setup ([guide](https://github.com/NateBJones-Projects/OB1/blob/main/docs/01-getting-started.md))\n- Existing core Open Brain connector with `search_thoughts` and `capture_thought`\n- AI client that supports reusable skills or prompt packs\n- Supabase CLI installed and linked to your project\n- Canonical [Work Operating Model skill](/ob1/skills/work-operating-model)\n- Optional source material to import: existing AI memory, exported notes, Obsidian vault content, Notion exports, text files, or similar context sources\n\n## Credential Tracker\n\nCopy this block into a text editor and fill it in as you go.\n\n```text\nBRING YOUR OWN CONTEXT -- CREDENTIAL TRACKER\n--------------------------------------------\n\nFROM YOUR OPEN BRAIN SETUP\n  Project URL:                ____________\n  Project ref:                ____________\n  MCP Access Key:             ____________\n  Core connector available:   yes / no\n  Core search tool visible:   yes / no\n  Core capture tool visible:  yes / no\n\nGENERATED DURING SETUP\n  Prompt source used:         memory / import / both\n  DEFAULT_USER_ID:            ____________\n  Function URL:               ____________\n  MCP Connection URL:         ____________\n  Latest session ID:          ____________\n  Current profile version:    ____________\n\n--------------------------------------------\n```\n\n## Recipe Assets\n\n- [extraction-prompts.md](https://github.com/NateBJones-Projects/OB1/blob/main/recipes/bring-your-own-context/extraction-prompts.md) — the two prompt assets promised in the article\n- [context-profile.schema.json](https://github.com/NateBJones-Projects/OB1/blob/main/recipes/bring-your-own-context/context-profile.schema.json) — machine-readable contract for the portable bundle returned by `generate_operating_model_exports`\n- [Work Operating Model Activation](/ob1/recipes/work-operating-model-activation) — the profiling engine this recipe reuses\n\n## Steps\n\n![Step 1](https://img.shields.io/badge/Step_1-Choose_Your_Extraction_Pass-0F766E?style=for-the-badge)\n\nPick the right prompt from [extraction-prompts.md](https://github.com/NateBJones-Projects/OB1/blob/main/recipes/bring-your-own-context/extraction-prompts.md):\n\n- Use **Memory Extraction** if the AI platform already knows a lot about you from past chats or built-in memory.\n- Use **Context Import** if you are bringing in notes, exports, or another second-brain system.\n- If both are true, run **Memory Extraction first** and **Context Import second**.\n\nThese prompts are intentionally upstream of profile generation. They create durable, searchable Open Brain context. They do **not** generate the final portable bundle by themselves.\n\n✅ **Done when:** You know which extraction pass you are running and your core Open Brain connector is enabled in the client you will use.\n\n---\n\n![Step 2](https://img.shields.io/badge/Step_2-Seed_Open_Brain_With_Context-0F766E?style=for-the-badge)\n\nRun the chosen prompt in your AI client with the core Open Brain connector enabled.\n\nRules to keep the BYOC corpus clean:\n\n- review the preview batches before saving\n- store self-contained statements, not shorthand fragments\n- preserve names, dates, and decision context\n- skip noise, templates, and obviously stale junk\n\nThis stage should leave you with durable raw context that the later profiling pass can search against.\n\n✅ **Done when:** `search_thoughts` can find a few recent captures about your people, projects, decisions, or workflow.\n\n---\n\n![Step 3](https://img.shields.io/badge/Step_3-Install_The_Profiling_Workflow-0F766E?style=for-the-badge)\n\nInstall the canonical [Work Operating Model skill](/ob1/skills/work-operating-model) before doing anything else. BYOC reuses that exact interview behavior instead of inventing a second profiling prompt.\n\nIf you have not installed it yet, follow the installation steps in the skill README and confirm your client can load reusable prompt packs or skills.\n\n✅ **Done when:** The Work Operating Model skill is available in your client and ready to use once the paired MCP tools are connected.\n\n---\n\n![Step 4](https://img.shields.io/badge/Step_4-Deploy_And_Connect_The_Profile_Server-0F766E?style=for-the-badge)\n\nBYOC reuses the [Work Operating Model Activation](/ob1/recipes/work-operating-model-activation) recipe as its structured profiling engine.\n\n### 4.1 Run the schema\n\nRun [`recipes/work-operating-model-activation/schema.sql`](https://github.com/NateBJones-Projects/OB1/blob/main/recipes/work-operating-model-activation/schema.sql) in the Supabase SQL Editor.\n\n### 4.2 Generate a Default User ID\n\n```bash\nuuidgen | tr '[:upper:]' '[:lower:]'\n```\n\nThen set it as a secret:\n\n```bash\nsupabase secrets set DEFAULT_USER_ID=your-generated-uuid\n```\n\n### 4.3 Deploy the Function\n\nUse the [Deploy an Edge Function](/ob1/primitives/deploy-edge-function) pattern with these values:\n\n| Setting | Value |\n| ------- | ----- |\n| Function name | `work-operating-model-mcp` |\n| Download path | `recipes/work-operating-model-activation` |\n\n### 4.4 Connect It to Your AI Client\n\nURL-based connector example:\n\n```text\nhttps://YOUR_PROJECT_REF.supabase.co/functions/v1/work-operating-model-mcp?key=your-access-key\n```\n\nHeader-based connector example for Claude Code:\n\n```bash\nclaude mcp add --transport http work-operating-model \\\n  https://YOUR_PROJECT_REF.supabase.co/functions/v1/work-operating-model-mcp \\\n  --header \"x-access-key: your-access-key\"\n```\n\nUse the full [Remote MCP Connection](/ob1/primitives/remote-mcp) guide if your client needs a different setup path.\n\n> [!IMPORTANT]\n> Keep your base Open Brain connector enabled too. BYOC uses the existing Work Operating Model tools for structure, but it still depends on your core `search_thoughts` and `capture_thought` tools for memory hints and summary captures.\n\n✅ **Done when:** Your client can see all six required tools:\n\n- `search_thoughts`\n- `capture_thought`\n- `start_operating_model_session`\n- `save_operating_model_layer`\n- `query_operating_model`\n- `generate_operating_model_exports`\n\n---\n\n![Step 5](https://img.shields.io/badge/Step_5-Build_The_Portable_Profile-0F766E?style=for-the-badge)\n\nWith both connectors enabled and the skill installed, prompt your AI client:\n\n```text\nUse the Work Operating Model workflow to interview me and build my operating model.\n```\n\nThe workflow should:\n\n1. call `start_operating_model_session`\n2. search for hints in your seeded Open Brain context\n3. interview you through the five fixed layers\n4. show a checkpoint summary before every save\n5. persist each approved layer with `save_operating_model_layer`\n6. review contradictions with `query_operating_model`\n7. return the final bundle with `generate_operating_model_exports`\n\nBYOC is strongest when you treat the earlier extraction pass as raw material and this interview as the normalization pass. Do not skip the confirmation gates.\n\n✅ **Done when:** The workflow reaches export generation without missing layers and returns a session ID plus a profile version.\n\n---\n\n![Step 6](https://img.shields.io/badge/Step_6-Use_The_Portable_Bundle-0F766E?style=for-the-badge)\n\nThe current portable bundle contract is:\n\n- `operating-model.json` — structured JSON representation of the full profile\n- `USER.md` — operator-facing profile summary\n- `SOUL.md` — guardrails, heuristics, and knowledge to respect\n- `HEARTBEAT.md` — recurring and event-driven check recommendations\n- `schedule-recommendations.json` — machine-readable recommendation output\n\nThe transport shape returned by `generate_operating_model_exports` is documented in [context-profile.schema.json](https://github.com/NateBJones-Projects/OB1/blob/main/recipes/bring-your-own-context/context-profile.schema.json). The schema also defines the parsed JSON contracts for `operating-model.json` and `schedule-recommendations.json` inside `$defs`.\n\nThis is the honest v1 BYOC story inside OB1:\n\n- the **portable context profile** is the export bundle above\n- the **context server pattern** is the existing remote MCP deployment flow you already use in Open Brain\n\n✅ **Done when:** You can point to one export bundle, one schema file, and one recipe URL as the canonical BYOC entrypoint for the article.\n\n## Expected Outcome\n\nWhen this recipe is working correctly:\n\n- your Open Brain contains reviewed context captured through the extraction prompts\n- the Work Operating Model workflow can pull that context in as hints during the interview\n- `query_operating_model` returns structured entries for rhythms, decisions, dependencies, institutional knowledge, and friction\n- `generate_operating_model_exports` returns all five portable artifacts\n- [context-profile.schema.json](https://github.com/NateBJones-Projects/OB1/blob/main/recipes/bring-your-own-context/context-profile.schema.json) documents the response shape and the parsed JSON artifact contracts\n\n## Troubleshooting\n\n**Issue: `capture_thought` is not visible when I run the extraction prompt**\nSolution: The BYOC prompt stage only works with your base Open Brain connector enabled. Re-enable the core connector first, then rerun the prompt.\n\n**Issue: The Work Operating Model skill is loaded, but the profile tools are missing**\nSolution: The skill and the recipe are paired. Install the skill from [skills/work-operating-model](/ob1/skills/work-operating-model) and deploy/connect the MCP server from [Work Operating Model Activation](/ob1/recipes/work-operating-model-activation) before starting the interview.\n\n**Issue: Export generation says layers are missing**\nSolution: Every one of the five layers must be approved before `generate_operating_model_exports` can succeed. Resume the session, finish the missing layer, then export again.\n\n**Issue: The connector works in one client but not another**\nSolution: Use the connection style your client actually supports. Some clients want the URL with `?key=...`, while Claude Code prefers the header-based form. The [Remote MCP Connection](/ob1/primitives/remote-mcp) guide covers both.\n\n## Next Steps\n\n- Feed `USER.md`, `SOUL.md`, and `HEARTBEAT.md` into any agent workflow that accepts operating files or durable system context.\n- Re-run the workflow after a major role change or workflow shift so your portable context stays current.\n- Use the [MCP Tool Audit & Optimization Guide](https://github.com/NateBJones-Projects/OB1/blob/main/docs/05-tool-audit.md) once you add the second connector so the tool surface stays manageable.\n\n<!-- markdownlint-enable MD013 -->\n"
+    },
+    {
+      "slug": "chatgpt-conversation-import",
+      "category": "recipes",
+      "site_path": "/ob1/recipes/chatgpt-conversation-import",
+      "name": "ChatGPT Conversation Import",
+      "description": "Parse your ChatGPT data export, resolve conversation branches, extract 2-5 typed thoughts per conversation via LLM knowledge extraction (decisions, preferences, learnings, context, brainstorms, references), and ingest them into Open Brain with enriched metadata and embeddings.",
+      "author": {
+        "name": "Matt Hallett",
+        "github": "matthallett1"
+      },
+      "version": "2.0.0",
+      "tags": [
+        "chatgpt",
+        "import",
+        "conversations",
+        "migration",
+        "knowledge-extraction"
+      ],
+      "difficulty": "beginner",
+      "estimated_time": "20 minutes",
+      "created": "2026-03-10",
+      "updated": "2026-04-10",
+      "learning_order": null,
+      "compatibility": {
+        "open_brain": "required"
+      },
+      "requirements": {
+        "services": [
+          "OpenRouter"
+        ],
+        "tools": [
+          "Python 3.10+"
+        ]
+      },
+      "dependencies": {
+        "skills": [],
+        "primitives": []
+      },
+      "reverse_dependencies": {
+        "skills": [],
+        "primitives": []
+      },
+      "urls": {
+        "github_folder": "https://github.com/NateBJones-Projects/OB1/tree/main/recipes/chatgpt-conversation-import",
+        "github_readme": "https://github.com/NateBJones-Projects/OB1/blob/main/recipes/chatgpt-conversation-import/README.md"
+      },
+      "readme_markdown": "# ChatGPT Conversation Import\n\n> Import your ChatGPT history into Open Brain as curated, searchable thoughts — not raw transcripts.\n\n## What It Does\n\nTakes your ChatGPT data export, resolves conversation branches, dispatches across 14 content types (text, voice transcripts, web search results, code execution output, and more), filters out trivial conversations using signal-based scoring, and uses an LLM to extract 2-5 distinct, typed thoughts per conversation. Each thought is classified as one of 6 types — decision, preference, learning, context, brainstorm, or reference — and loaded into your Open Brain with vector embeddings and enriched metadata. The result is semantically searchable knowledge extracted from every meaningful ChatGPT conversation you've ever had.\n\n## Prerequisites\n\n- Working Open Brain setup ([guide](https://github.com/NateBJones-Projects/OB1/blob/main/docs/01-getting-started.md))\n- Your ChatGPT data export (Settings → Data Controls → Export Data in ChatGPT)\n- Python 3.10+\n- Your Supabase project URL and service role key (from your credential tracker)\n- OpenRouter API key (for LLM extraction and embedding generation)\n\n## Credential Tracker\n\nCopy this block into a text editor and fill it in as you go.\n\n```text\nCHATGPT CONVERSATION IMPORT -- CREDENTIAL TRACKER\n--------------------------------------\n\nFROM YOUR OPEN BRAIN SETUP\n  Supabase Project URL:  ____________\n  Supabase Secret key:   ____________\n  OpenRouter API key:    ____________\n\nFILE LOCATION\n  Path to ChatGPT export:  ____________\n\n--------------------------------------\n```\n\n## Steps\n\n### 1. Export your data from ChatGPT\n\nGo to ChatGPT → Settings → Data Controls → Export Data. You'll receive an email with a download link within a few minutes. Download the zip file.\n\n### 2. Clone this recipe folder\n\n```bash\n# From the OB1 repo root\ncd recipes/chatgpt-conversation-import\n```\n\nOr copy the files (`import-chatgpt.py`, `requirements.txt`) into any working directory.\n\n### 3. Install dependencies\n\n```bash\npip install -r requirements.txt\n```\n\nThis installs `requests` — the only external dependency.\n\n### 4. Set your environment variables\n\n```bash\nexport SUPABASE_URL=https://YOUR_PROJECT_REF.supabase.co\nexport SUPABASE_SERVICE_ROLE_KEY=your-service-role-key-here\nexport OPENROUTER_API_KEY=sk-or-v1-your-key-here\n```\n\nAll three values come from your credential tracker. You can also copy `.env.example` to `.env` and fill it in, then run `export $(cat .env | xargs)`.\n\n### 5. Do a dry run first\n\n```bash\npython import-chatgpt.py path/to/chatgpt-export.zip --dry-run --limit 10\n```\n\nThis parses, filters, and extracts knowledge from 10 conversations without writing anything to your database. Review the output to see what would be imported and how the LLM distills each conversation into typed thoughts.\n\n### 6. Run the full import\n\n```bash\npython import-chatgpt.py path/to/chatgpt-export.zip\n```\n\nThe script will:\n1. Extract conversations from the zip (or directory), including sharded JSON files\n2. Resolve conversation branches by walking the `current_node` path\n3. Dispatch across 14 content types (extract text, skip model reasoning, strip code blocks)\n4. Filter out trivial conversations using signal-based scoring\n5. Detect session boundaries within long conversations (4h+ gaps)\n6. Extract 2-5 typed thoughts per conversation via LLM knowledge extraction\n7. Check for semantic duplicates against existing thoughts (0.92 similarity threshold)\n8. Generate a vector embedding for each thought (from the thought content, not the prefix)\n9. Insert each thought into your `thoughts` table with enriched metadata\n\nProgress prints to the console with ETA as it runs. A sync log (`chatgpt-sync-log.json`) tracks which conversations have been imported, so you can safely re-run the script after future exports without duplicating data. Conversations with new messages since the last import are automatically re-processed.\n\nOn Windows, the importer reads export JSON files as UTF-8 explicitly, so conversations containing non-ASCII characters won't depend on your system code page. The sync log is written next to [`import-chatgpt.py`](https://github.com/NateBJones-Projects/OB1/blob/main/recipes/chatgpt-conversation-import/import-chatgpt.py), not into whatever directory you launched the command from.\n\n### 7. Verify in your database\n\nOpen your Supabase dashboard → Table Editor → `thoughts`. You should see new rows with:\n- `content`: prefixed with `[ChatGPT: title | date]`, followed by a self-contained thought statement\n- `metadata`: includes `source: \"chatgpt\"`, thought `type`, `topics`, `people`, `confidence`, model, conversation URL, and more\n- `embedding`: a 1536-dimension vector (generated from the thought content, not the prefix)\n\n### 8. Test a search\n\nIn any MCP-connected AI (Claude Desktop, ChatGPT, etc.), ask:\n\n```\nSearch my brain for topics I discussed with ChatGPT about [something you know you talked about]\n```\n\n## Expected Outcome\n\nAfter a full import, your `thoughts` table contains distilled knowledge from every non-trivial ChatGPT conversation. Each thought is a standalone statement with type, topics, people, and confidence — not a raw transcript — that makes sense without the original conversation context.\n\nResults depend on export size, filtering, and model. Example from a real 2,300-conversation export:\n\n| Metric | gpt-4o-mini (default) | gpt-4o | With --focus |\n|--------|----------------------|--------|-------------|\n| Conversations scanned | 2,341 | 2,341 | 2,341 |\n| Filtered (single-turn, short) | ~1,000 (43%) | ~1,000 (43%) | ~1,000 (43%) |\n| Sent to LLM | ~1,300 | ~1,300 | ~300 |\n| Thoughts generated | ~800-1,500 | ~800-1,500 | ~250-400 |\n| Estimated API cost | ~$1.30 | ~$20 | ~$0.50-10 |\n\nUsing `--focus` reduces LLM calls significantly — conversations outside your focus areas return empty thoughts. Use `--model ollama` for $0.\n\nEach thought includes structured metadata:\n\n```json\n{\n  \"content\": \"[ChatGPT: Database Migration Strategy | 2025-09-15] Chose PostgreSQL over DynamoDB for the new order service. Key factors: complex joins for reporting, strong consistency requirements, existing team expertise. DynamoDB considered for write throughput but rejected due to access pattern limitations.\",\n  \"metadata\": {\n    \"source\": \"chatgpt\",\n    \"type\": \"decision\",\n    \"topics\": [\"database\", \"architecture\"],\n    \"people\": [],\n    \"confidence\": \"firm\",\n    \"chatgpt_model\": \"gpt-4o\",\n    \"chatgpt_message_count\": 34,\n    \"chatgpt_conversation_type\": \"technical_architecture\",\n    \"chatgpt_conversation_url\": \"https://chatgpt.com/c/abc-123\"\n  }\n}\n```\n\n## Thought Types\n\nThe LLM classifies each extracted thought into one of 6 types:\n\n| Type | What it captures | Example |\n|------|-----------------|---------|\n| `decision` | A choice made with reasoning | \"Chose PostgreSQL over DynamoDB for the order service. Needed complex joins for reporting.\" |\n| `preference` | Values, criteria, tastes revealed | \"For baby gear: prioritize stability on hardwood, easy cleaning, grows-with-child over brand.\" |\n| `learning` | Facts, patterns, insights discovered | \"Tungsten in X-ray machines: high atomic number produces X-rays efficiently when electrified.\" |\n| `context` | People, projects, situations | \"Platform team owns the API gateway and auth service. Infrastructure team handles deployments and monitoring.\" |\n| `brainstorm` | Ideas explored, strategies considered | \"For externalizing an internal product: start with design partner program, not public launch.\" |\n| `reference` | How-tos, recipes, reusable procedures | \"Carbon steel pan seasoning: scrub with steel wool, dry on stove, apply thin flaxseed oil layer.\" |\n\nEach thought also carries a `confidence` level: `firm` (clear conclusion), `tentative` (leaning toward), or `exploring` (still open).\n\n## How It Works\n\n### Three-stage pipeline\n\n**Stage 1: Parsing and Filtering** — Each conversation is parsed and scored before it reaches the LLM:\n\n- **Branch resolution**: Walks from `current_node` to root via parent pointers, producing the canonical conversation path (no interleaved regenerations from abandoned branches)\n- **Content type dispatch**: 14 content types are handled in three buckets — extract text from (text, multimodal_text, execution_output, web search, code), skip entirely (model reasoning/thoughts, reasoning_recap, system errors), and metadata only (tether_quote, custom instructions)\n- **Voice conversations**: Audio transcriptions are extracted from `multimodal_text` parts. Voice conversations are more substantive on average and are never auto-filtered\n- **Signal-based filtering**: Replaces regex title matching. Single-turn conversations are skipped. Conversations with 10+ messages are always processed. Borderline conversations (2-9 messages) are checked for word count and title presence, then the LLM decides\n\n**Stage 2: Knowledge Extraction** — Surviving conversations go to an LLM (gpt-4o-mini by default via OpenRouter) with a structured extraction prompt. The LLM returns 0-5 typed thoughts per conversation as JSON, each with content, type, topics, people, and confidence. For multi-day conversations, session boundaries are detected at 4h+ gaps and each session is extracted separately.\n\nThe LLM is instructed to:\n- Extract decisions with reasoning, including what was rejected and why\n- Capture preferences, criteria, and values\n- Record architectural and strategic choices (not code)\n- Preserve personal context that looks ephemeral but encodes life situation\n- Return empty for conversations that are just generic Q&A, creative tasks, or ephemeral lookups\n\n**Stage 3: Ingestion** — Each thought gets a vector embedding (text-embedding-3-small, 1536 dimensions) generated from the thought content itself (not the `[ChatGPT: title]` prefix). Before insertion, semantic deduplication checks for near-duplicates using `match_thoughts` RPC at a 0.92 similarity threshold. Each thought is inserted into your `thoughts` table with enriched metadata including model, conversation type, voice, and confidence.\n\n### Deduplication\n\nTwo layers of deduplication prevent redundant thoughts:\n\n1. **Sync log** (`chatgpt-sync-log.json`): Tracks each processed conversation by hash and `update_time`. Re-running the script after a new export only processes new conversations or conversations with new messages since the last import.\n2. **Semantic dedup**: Before inserting, each thought is checked against existing thoughts via `match_thoughts` at 0.92 similarity. This catches redundant thoughts when the same topic was discussed across multiple conversations.\n\n## `--store-conversations`\n\nThe `--store-conversations` flag enables an optional conversation history table that stores conversation-level metadata and pyramid summaries alongside the extracted thoughts.\n\n### What it does\n\nWhen enabled, each processed conversation is also stored in a `chatgpt_conversations` table with:\n- **Pyramid summaries** at 5 detail levels (8-word label, 16-word sentence, 32-word card, 64-word paragraph, 128-word full summary)\n- **HNSW-indexed embedding** of the 128-word summary for conversation-level semantic search\n- **Searchable arrays** for key topics and people mentioned\n- **Export metadata** including model, voice, custom GPT identifier, and conversation URL\n\n### What it enables\n\n- **Temporal browsing**: \"What was I working on in October?\" via `create_time` queries\n- **Source attribution**: Search thoughts, find a decision, follow `chatgpt_conversation_id` back to the full conversation summary and ChatGPT URL\n- **Progressive disclosure**: Use the 8-word summary for timelines, 32-word for dashboard cards, 128-word for full context\n- **Smarter re-imports**: Content hash detects conversations with changed content\n\n### How to set it up\n\n1. Open the Supabase SQL Editor in your project dashboard\n2. Paste and run the contents of `schema.sql` from this recipe folder\n3. Pass `--store-conversations` when running the import:\n\n```bash\npython import-chatgpt.py path/to/export.zip --store-conversations\n```\n\nThe pyramid summaries are generated in the same LLM call as the thought extraction, adding only ~200 extra output tokens per conversation (~$0.05 total for 1,400 conversations).\n\n## Options Reference\n\n| Flag | Description | Default |\n|------|-------------|---------|\n| `--dry-run` | Parse, filter, extract — but don't write to database | Off |\n| `--after YYYY-MM-DD` | Only process conversations created after this date | None |\n| `--before YYYY-MM-DD` | Only process conversations created before this date | None |\n| `--limit N` | Max conversations to process (0 = unlimited) | 0 |\n| `--min-messages N` | Minimum messages for a conversation to be processed | 2 |\n| `--min-words N` | Minimum word count for borderline conversations | 50 |\n| `--focus TOPICS` | Focus extraction on specific topics (preset or custom text — see below) | All topics |\n| `--store-conversations` | Also store conversation summaries with pyramid detail levels (requires `schema.sql`) | Off |\n| `--model openrouter` | LLM backend for extraction: `openrouter` or `ollama` | `openrouter` |\n| `--openrouter-model ID` | Which OpenRouter model to use | `openai/gpt-4o-mini` |\n| `--ollama-model NAME` | Which Ollama model to use (requires `--model ollama`) | `qwen3` |\n| `--raw` | Skip LLM extraction, ingest user messages as-is | Off |\n| `--verbose` | Print full thought text during processing | Off |\n| `--report FILE` | Write a markdown report of everything imported | None |\n| `--ingest-endpoint` | Use custom `INGEST_URL`/`INGEST_KEY` instead of Supabase direct insert | Off |\n\n### `--focus` — Topic Filtering\n\nBy default, the script extracts knowledge from all conversations. Use `--focus` to narrow extraction to specific domains, saving API cost and reducing noise from conversations you don't care about.\n\n**Presets** (one word, easy to remember):\n\n| Preset | Extracts | Skips |\n|--------|----------|-------|\n| `tech` | Architecture, engineering, system design, code patterns, infrastructure | Shopping, recipes, health, creative tasks |\n| `strategy` | Business strategy, product decisions, career, leadership, hiring | Shopping, recipes, technical details, creative |\n| `personal` | Family, health, relationships, values, home, personal finance | Work topics, technical details, shopping |\n| `creative` | Writing, design, art, content strategy, storytelling | Technical, business, shopping, health |\n| `all` | Everything (default behavior) | Only ephemeral lookups |\n\n**Examples with presets:**\n\n```bash\n# Only tech and engineering knowledge\npython import-chatgpt.py export.zip --focus tech\n\n# Only business and career decisions\npython import-chatgpt.py export.zip --focus strategy\n\n# Combine with date filter for recent tech decisions\npython import-chatgpt.py export.zip --focus tech --after 2025-01-01\n```\n\n**Custom focus** (any free-text description):\n\n```bash\n# Specific domains\npython import-chatgpt.py export.zip --focus \"AI/ML, prompt engineering, LLM architecture\"\n\n# Multiple interests\npython import-chatgpt.py export.zip --focus \"parenting, nutrition, home renovation\"\n\n# Very specific\npython import-chatgpt.py export.zip --focus \"AWS infrastructure, Kubernetes, CI/CD pipelines\"\n```\n\nWhen `--focus` is set, conversations outside your focus areas will return `{\"thoughts\": [], \"skip_reason\": \"off-topic\"}` — you still pay for the LLM call, but no thoughts are created. Combine with `--min-messages` to skip short conversations before they reach the LLM.\n\n### Using a local LLM (free, private)\n\nIf you don't want to send your conversations to OpenRouter, use Ollama for local extraction:\n\n```bash\n# Install Ollama and pull a model\nollama pull qwen3\n\n# Run with local LLM\npython import-chatgpt.py export.zip --model ollama --ollama-model qwen3\n```\n\nNote: embeddings still use OpenRouter (text-embedding-3-small) for Supabase direct insert mode. Only the extraction step runs locally.\n\n## Cost Estimates\n\nAll costs are via OpenRouter at current pricing. The v2 pipeline sends full dialogue (user + assistant messages) to the LLM and requests structured JSON extraction, which uses more input tokens but captures significantly more knowledge.\n\n| Component | Model | Cost |\n|-----------|-------|------|\n| Knowledge extraction | gpt-4o-mini | ~$0.15/1M input + $0.60/1M output |\n| Embeddings | text-embedding-3-small | ~$0.02/1M tokens |\n\n**Typical costs by export size (~$0.001/conversation):**\n\n| Export size | Processed | Thoughts | Est. cost |\n|-------------|-----------|----------|-----------|\n| 100 conversations | ~60 | ~180 | ~$0.06 |\n| 500 conversations | ~300 | ~900 | ~$0.30 |\n| 1000 conversations | ~600 | ~1,800 | ~$0.60 |\n| 5000 conversations | ~3,000 | ~9,000 | ~$3.00 |\n\nThese assume ~40% of conversations are filtered as trivial and ~3 thoughts per conversation. Add `--store-conversations` for ~$0.00004 extra per conversation (pyramid summaries in the same LLM call). Use `--model ollama` for $0 extraction cost (embeddings still use OpenRouter).\n\n## Troubleshooting\n\n**Issue: `conversations.json` not found in the export**\nSolution: ChatGPT exports come as a zip file. Make sure you've either (a) pointed the script at the zip file directly (`python import-chatgpt.py export.zip`), or (b) unzipped it and pointed at the directory. The script handles both formats automatically, including the multi-file format (`conversations-000.json`, `conversations-001.json`, etc.) used in large exports.\n\n**Issue: `OPENROUTER_API_KEY required` error**\nSolution: Make sure you've exported the environment variable in your current terminal session: `export OPENROUTER_API_KEY=sk-or-v1-...`. Environment variables don't persist between terminal windows.\n\n**Issue: Import is very slow**\nSolution: Each conversation requires one LLM call (knowledge extraction) and 1-3 embedding calls (one per thought) plus a dedup check per thought. For 500+ conversations, expect 15-30 minutes. Use `--limit 10` to test first, then run the full import. Progress prints to the console with ETA so you can track it.\n\n**Issue: Getting empty thoughts for most conversations**\nSolution: This is expected for many conversations — the LLM only extracts knowledge worth retrieving months from now. If too many conversations are returning empty, try lowering `--min-messages` (default 5) to allow shorter conversations through, or lowering `--min-words` (default 50) to relax the word count threshold. Use `--raw` if you want to import everything without LLM extraction.\n\n**Issue: JSON parse errors from LLM**\nSolution: This is normal occasionally — the LLM sometimes returns malformed JSON despite being asked for structured output. The script falls back to empty extraction for that conversation and continues. If it happens frequently with Ollama, try a different model (`--ollama-model llama3.1`).\n\n**Issue: Some conversations are missing after import**\nSolution: Conversations with fewer than 2 messages (single-turn) are always filtered. Untitled conversations with 5 or fewer messages are also filtered. Conversations with 10+ messages are always processed regardless of content. Run with `--dry-run --verbose` to see what's being filtered and why.\n\n**Issue: Want to re-import after a new ChatGPT export**\nSolution: Just run the script again pointing at your new export. The sync log (`chatgpt-sync-log.json`) next to `import-chatgpt.py` tracks which conversations have been processed and their `update_time`. Only new conversations and conversations with new messages will be re-processed. If you want to start fresh, delete that file.\n\n**Issue: `Failed to generate embedding` errors**\nSolution: Check that your OpenRouter API key is valid and has credits. Go to openrouter.ai/credits to verify your balance. The embedding model (text-embedding-3-small) costs $0.02 per million tokens — even a large import costs pennies.\n\n**Issue: How to use `--store-conversations`**\nSolution: You need to create the `chatgpt_conversations` table first. Open the Supabase SQL Editor, paste the contents of `schema.sql` from this recipe folder, and run it. Then pass `--store-conversations` on your next import run. The table stores conversation-level summaries and metadata — it is optional and the core thought import works without it.\n"
+    },
+    {
+      "slug": "claudeception",
+      "category": "recipes",
+      "site_path": "/ob1/recipes/claudeception",
+      "name": "Aiception (formerly Claudeception)",
+      "description": "Continuous learning system that extracts reusable knowledge from work sessions and creates new skills. Skills that create other skills. Integrates with Open Brain to search for existing knowledge before creating and capture new skills after.",
+      "author": {
+        "name": "Jared Irish",
+        "github": "jaredirish"
+      },
+      "version": "1.0.0",
+      "tags": [
+        "skills",
+        "learning",
+        "extraction",
+        "meta",
+        "self-improving",
+        "knowledge",
+        "continuous-learning"
+      ],
+      "difficulty": "intermediate",
+      "estimated_time": "10 minutes",
+      "created": "2026-03-19",
+      "updated": "2026-03-19",
+      "learning_order": null,
+      "compatibility": {
+        "open_brain": "required"
+      },
+      "requirements": {
+        "services": [],
+        "tools": [
+          "Claude Code"
+        ]
+      },
+      "dependencies": {
+        "skills": [],
+        "primitives": []
+      },
+      "reverse_dependencies": {
+        "skills": [],
+        "primitives": []
+      },
+      "urls": {
+        "github_folder": "https://github.com/NateBJones-Projects/OB1/tree/main/recipes/claudeception",
+        "github_readme": "https://github.com/NateBJones-Projects/OB1/blob/main/recipes/claudeception/README.md"
+      },
+      "readme_markdown": "# Aiception (Formerly Claudeception)\n\n<div align=\"center\">\n\n![Community Contribution](https://img.shields.io/badge/OB1_COMMUNITY-Approved_Contribution-2ea44f?style=for-the-badge&logo=github)\n\n**Created by [@jaredirish](https://github.com/jaredirish)**\n\n*Reviewed and merged by the Open Brain maintainer team — thank you for building the future of AI memory!*\n\n</div>\n\n*Skills that create other skills.*\n\nThe repo keeps the historical `claudeception` folder and recipe name for continuity, but the\nactual installable Claude Code skill should now be named `aiception`. Anthropic reserves\nskill names containing `claude` or `anthropic` in frontmatter, so the old installed name\nis no longer compatible.\n\nA continuous learning system that extracts reusable knowledge from work sessions and codifies it into new AI coding tool skills. When you discover something non-obvious (a debugging technique, a workaround, an error resolution), Aiception evaluates whether it's worth preserving and creates a structured skill file automatically.\n\n**This is the meta-skill.** Every other recipe in OB1 does a specific thing. This one creates new things from the act of working.\n\n## What It Does\n\nDuring normal work, Aiception watches for extractable knowledge:\n\n| Discovery Type | Example | What Gets Created |\n|----------------|---------|-------------------|\n| Non-obvious debugging | Spent 20 min finding that n8n Code node blocks `process.env` | Skill: \"n8n-code-node-sandbox-limits\" |\n| Error resolution | Misleading error led to wrong fix path | Skill with exact error message as trigger |\n| Workflow optimization | Found a 3-step process that replaces a 10-step one | Skill documenting the shortcut |\n| Tool integration | Discovered undocumented API behavior | Skill with the actual behavior documented |\n\nBefore creating, it searches Open Brain to check if the knowledge already exists. After creating, it captures the new skill to Open Brain so future sessions can find it.\n\n## Prerequisites\n\n- Working Open Brain setup ([guide](https://github.com/NateBJones-Projects/OB1/blob/main/docs/01-getting-started.md))\n- Claude Code installed and working\n- Open Brain MCP tools connected (`search_thoughts`, `capture_thought`)\n\n### Credential Tracker\n\n```\nFrom your existing Open Brain setup:\n- Project URL: _______________\n- Open Brain MCP server connected: yes / no\n\nNo additional credentials needed for this recipe.\n```\n\n## Steps\n\n### 1. Create the skill directory\n\n```bash\nmkdir -p ~/.claude/skills/aiception\n```\n\n### 2. Copy the skill file\n\n```bash\ncp claudeception.skill.md ~/.claude/skills/aiception/SKILL.md\n```\n\n### 3. Verify Claude Code picks up the skill\n\nRestart Claude Code. To verify, say \"what did we learn?\" or run `/aiception` at the end of a work session. Claude should reference the Aiception methodology.\n\n### 4. Work normally\n\nAiception fires automatically after tasks involving non-obvious investigation. You can also trigger it manually:\n\n- `/aiception` at end of session (retrospective mode)\n- \"save this as a skill\" after a discovery\n- \"what did we learn?\" to review the session\n\n### 5. Review created skills\n\nNew skills appear in `~/.claude/skills/[skill-name]/SKILL.md`. Each includes:\n- Problem description\n- Trigger conditions (exact error messages, symptoms)\n- Step-by-step solution\n- Verification steps\n- Quality gate checklist\n\n## Expected Outcome\n\nWhen working correctly, you should see:\n\n- After non-obvious debugging sessions, a prompt asking whether to extract the knowledge\n- Before creating a skill, an Open Brain search confirming no duplicate exists\n- New skill files appearing in `~/.claude/skills/` with structured content\n- After creation, the skill captured to Open Brain via `capture_thought`\n- In future sessions, the skill fires automatically when trigger conditions match\n\nA typical week of active development produces 1-3 new skills. Not every session produces one, and that's correct. Over-extraction is an anti-pattern.\n\n## Open Brain Integration\n\nAiception connects to Open Brain at two points:\n\n**Before creating (search):** Queries `search_thoughts` with keywords from the discovery. If related knowledge already exists in Open Brain, it updates the existing skill instead of creating a duplicate.\n\n**After creating (capture):** Saves the new skill to Open Brain via `capture_thought` with tags like `skill-created`, the skill name, and relevant domain tags. This means future sessions across any project can find the skill via semantic search.\n\n**Example flow:**\n\n```\nDiscovery: n8n Code node blocks process.env\n  -> search_thoughts(\"n8n code node sandbox process.env\")\n  -> No match found\n  -> Create skill: ~/.claude/skills/n8n-code-node-sandbox/SKILL.md\n  -> capture_thought(\"New skill created: n8n-code-node-sandbox.\n     n8n Code node v2 sandbox blocks process.env, fetch(), require().\n     Only pure JS transforms on $input/$json work.\")\n```\n\n## Adapting for Other Tools\n\nThe core pattern (discover, evaluate, extract, verify) works with any AI coding tool that supports custom instructions or skill files:\n\n- **Cursor:** Save to `.cursorrules` or project-level rules\n- **Windsurf:** Save to `.windsurfrules`\n- **Codex:** Save to `AGENTS.md` or codex instructions\n\nThe skill file format may differ, but the extraction process and quality criteria are universal.\n\n## Troubleshooting\n\n**Issue:** Aiception fires too often, creating low-value skills.\n**Solution:** Check the quality criteria in the skill file. A skill must be reusable, non-trivial, specific, and verified. If it only helps with one instance and won't recur, it's not a skill.\n\n**Issue:** Skills aren't being discovered in future sessions.\n**Solution:** Check the `description` field in the skill's frontmatter. It needs specific trigger conditions (error messages, symptoms, tool names) for Claude Code's semantic matching to surface it. Vague descriptions like \"helps with React\" won't match.\n\n**Issue:** Open Brain search returns nothing but a similar skill exists locally.\n**Solution:** The skill may have been created before Open Brain integration was added. Run `/aiception` in retrospective mode to capture existing skills to Open Brain.\n\n**Issue:** Too many skills accumulating (30+).\n**Solution:** Review the 5 least-recently-modified skills. If they haven't fired in 30+ days, either the trigger conditions are too narrow (update them) or the knowledge is no longer relevant (deprecate). Add a `deprecated: true` note to the frontmatter rather than deleting.\n\n---\n\n*The meta-skill. Skills that create other skills.*\n"
+    },
+    {
+      "slug": "content-fingerprint-dedup",
+      "category": "recipes",
+      "site_path": "/ob1/recipes/content-fingerprint-dedup",
+      "name": "Content Fingerprint Dedup",
+      "description": "SHA-256 content fingerprinting to prevent duplicate thoughts during bulk imports and multi-source capture.",
+      "author": {
+        "name": "Alan Shurafa",
+        "github": "alanshurafa"
+      },
+      "version": "1.0.0",
+      "tags": [
+        "deduplication",
+        "fingerprint",
+        "sha256",
+        "import",
+        "data-quality"
+      ],
+      "difficulty": "beginner",
+      "estimated_time": "5 minutes",
+      "created": "2026-03-16",
+      "updated": "2026-03-25",
+      "learning_order": null,
+      "compatibility": {
+        "open_brain": "required"
+      },
+      "requirements": {
+        "services": [],
+        "tools": []
+      },
+      "dependencies": {
+        "skills": [],
+        "primitives": []
+      },
+      "reverse_dependencies": {
+        "skills": [],
+        "primitives": []
+      },
+      "urls": {
+        "github_folder": "https://github.com/NateBJones-Projects/OB1/tree/main/recipes/content-fingerprint-dedup",
+        "github_readme": "https://github.com/NateBJones-Projects/OB1/blob/main/recipes/content-fingerprint-dedup/README.md"
+      },
+      "readme_markdown": "# Content Fingerprint Dedup\n\n> SHA-256 content fingerprinting to prevent duplicate thoughts during bulk imports and multi-source capture.\n\n## What It Is\n\nA `content_fingerprint` column on the `thoughts` table that stores a SHA-256 hash of normalized content, backed by a unique index. When you insert a thought, the database checks the fingerprint and either creates a new row or merges into the existing one. This makes every insert idempotent with zero runtime cost.\n\n## Why It Matters\n\nWithout dedup, bulk imports create duplicates. If you import the same ChatGPT export twice, you get double the rows. If Slack retries a webhook delivery (which it does on any timeout), you get two rows for the same message. If you capture from both a Chrome extension and the MCP server, overlapping content creates duplicates.\n\nContent fingerprint dedup solves all of that at the database level. Re-running any import produces zero new rows for content that already exists.\n\n## Prerequisites\n\n- Working Open Brain setup ([guide](https://github.com/NateBJones-Projects/OB1/blob/main/docs/01-getting-started.md))\n- The `thoughts` table must already exist\n\n## How It Works\n\nThe dedup chain has three parts:\n\n1. **Normalization** — Before hashing, content is lowercased, trimmed, and has all whitespace collapsed to single spaces. This means \"Hello  World\" and \"hello world\" produce the same fingerprint.\n\n2. **Fingerprinting** — The normalized string is hashed with SHA-256, producing a deterministic 64-character hex string.\n\n3. **Upsert** — An `INSERT ... ON CONFLICT (content_fingerprint) DO UPDATE` merges metadata into the existing row instead of creating a duplicate.\n\n```\nInput: \"  Hello   World  \"\n  → normalize: \"hello world\"\n  → SHA-256:   \"b94d27b9934d3e08a52e52d7da7dabfac484efe37a5380ee9088f7ace2efcde9\"\n  → INSERT or merge into existing row with that fingerprint\n```\n\n## Step-by-Step Guide\n\n### Step 1: Add the fingerprint column\n\nRun this in your Supabase SQL Editor:\n\n```sql\nALTER TABLE thoughts ADD COLUMN content_fingerprint TEXT;\n\nCREATE UNIQUE INDEX idx_thoughts_fingerprint\n  ON thoughts (content_fingerprint)\n  WHERE content_fingerprint IS NOT NULL;\n```\n\nThe partial index (`WHERE content_fingerprint IS NOT NULL`) means existing rows without fingerprints won't conflict with each other.\n\n### Step 2: Create the upsert RPC\n\n```sql\nCREATE OR REPLACE FUNCTION upsert_thought(p_content TEXT, p_payload JSONB DEFAULT '{}')\nRETURNS JSONB AS $$\nDECLARE\n  v_fingerprint TEXT;\n  v_result JSONB;\n  v_id UUID;\nBEGIN\n  v_fingerprint := encode(sha256(convert_to(\n    lower(trim(regexp_replace(p_content, '\\s+', ' ', 'g'))),\n    'UTF8'\n  )), 'hex');\n\n  INSERT INTO thoughts (content, content_fingerprint, metadata)\n  VALUES (p_content, v_fingerprint, COALESCE(p_payload->'metadata', '{}'::jsonb))\n  ON CONFLICT (content_fingerprint) WHERE content_fingerprint IS NOT NULL DO UPDATE\n  SET updated_at = now(),\n      metadata = thoughts.metadata || COALESCE(EXCLUDED.metadata, '{}'::jsonb)\n  RETURNING id INTO v_id;\n\n  v_result := jsonb_build_object('id', v_id, 'fingerprint', v_fingerprint);\n  RETURN v_result;\nEND;\n$$ LANGUAGE plpgsql;\n```\n\nNow call it from your Edge Function or import script:\n\n```sql\nSELECT upsert_thought('My thought content', '{\"metadata\": {\"source\": \"chatgpt\"}}'::jsonb);\n```\n\n### Step 3: Backfill existing rows (optional)\n\nIf you already have thoughts in the table, generate fingerprints for them:\n\n```sql\nUPDATE thoughts\nSET content_fingerprint = encode(sha256(convert_to(\n  lower(trim(regexp_replace(content, '\\s+', ' ', 'g'))),\n  'UTF8'\n)), 'hex')\nWHERE content_fingerprint IS NULL;\n```\n\nFor large tables (10K+ rows), batch the backfill to avoid long locks:\n\n```sql\nUPDATE thoughts\nSET content_fingerprint = encode(sha256(convert_to(\n  lower(trim(regexp_replace(content, '\\s+', ' ', 'g'))),\n  'UTF8'\n)), 'hex')\nWHERE id IN (\n  SELECT id FROM thoughts\n  WHERE content_fingerprint IS NULL\n  LIMIT 5000\n);\n-- Repeat until no rows remain\n```\n\n## Expected Outcome\n\nAfter completing this guide:\n\n- Every new thought gets a `content_fingerprint` on insert.\n- Inserting the same content twice updates the existing row instead of creating a duplicate.\n- Re-running any import produces **0 new rows** for already-imported content.\n- The unique index enforces the constraint at the database level — no application code can bypass it.\n\nVerify it works:\n\n```sql\n-- Insert twice, get the same ID back\nSELECT upsert_thought('Test dedup');\nSELECT upsert_thought('Test dedup');\n\n-- Should return 1, not 2\nSELECT count(*) FROM thoughts WHERE content LIKE 'Test dedup';\n```\n\n## Troubleshooting\n\n**Issue: \"duplicate key value violates unique constraint idx_thoughts_fingerprint\"**\nThis means you are inserting directly (not using `upsert_thought`) and the content already exists. Switch to calling `upsert_thought` instead of raw `INSERT`, or add your own `ON CONFLICT` clause.\n\n**Issue: Backfill is slow on large tables**\nUse the batched approach from Step 3. Run it in chunks of 5,000 rows. Each batch takes a few seconds on tables up to 100K rows.\n\n**Issue: Two different thoughts produce the same fingerprint**\nSHA-256 collisions are practically impossible (1 in 2^128). If you see this, the content is likely identical after normalization. Check for leading/trailing whitespace or casing differences in the original content.\n\n**Issue: content_fingerprint is NULL for some rows**\nRows inserted before fingerprint dedup was added will have NULL fingerprints. Run the backfill query from Step 3.\n\n## Works Well With\n\n- **[Email History Import](/ob1/recipes/email-history-import)** — Gmail import computes SHA-256 fingerprints on each email. With fingerprint dedup deployed, re-running an import produces zero duplicates.\n- All other import recipes (ChatGPT, Google Activity, etc.) become safely re-runnable.\n- Webhook-based capture (Slack, Telegram) is protected against retry-induced duplicates.\n- Multi-source capture (Chrome extension + MCP server) avoids cross-channel duplicates.\n\n## Scale Reference\n\nThis recipe has been tested against **75,000+ thoughts** across 9 sources (ChatGPT, Claude, Gemini, Grok, X/Twitter, Instagram, Google Activity, Limitless, Journals) with zero duplicates in production.\n\n## Further Reading\n\n- [PostgreSQL SHA-256 functions](https://www.postgresql.org/docs/current/functions-binarystring.html)\n- [Partial unique indexes](https://www.postgresql.org/docs/current/indexes-partial.html)\n- [INSERT ON CONFLICT (upsert)](https://www.postgresql.org/docs/current/sql-insert.html#SQL-ON-CONFLICT)\n"
+    },
+    {
+      "slug": "daily-digest",
+      "category": "recipes",
+      "site_path": "/ob1/recipes/daily-digest",
+      "name": "Daily Digest",
+      "description": "Automated daily summary of recent thoughts delivered via Gmail draft, powered by Claude Code scheduled tasks and Open Brain MCP. Zero infrastructure required.",
+      "author": {
+        "name": "Matt Hallett",
+        "github": "matthallett"
+      },
+      "version": "1.0.0",
+      "tags": [
+        "digest",
+        "summary",
+        "email",
+        "automation",
+        "scheduled-task",
+        "gmail",
+        "claude-code"
+      ],
+      "difficulty": "beginner",
+      "estimated_time": "10 minutes",
+      "created": "2026-03-25",
+      "updated": "2026-03-25",
+      "learning_order": null,
+      "compatibility": {
+        "open_brain": "required"
+      },
+      "requirements": {
+        "services": [
+          "Gmail MCP"
+        ],
+        "tools": [
+          "Claude Code or Claude Desktop"
+        ]
+      },
+      "dependencies": {
+        "skills": [],
+        "primitives": []
+      },
+      "reverse_dependencies": {
+        "skills": [],
+        "primitives": []
+      },
+      "urls": {
+        "github_folder": "https://github.com/NateBJones-Projects/OB1/tree/main/recipes/daily-digest",
+        "github_readme": "https://github.com/NateBJones-Projects/OB1/blob/main/recipes/daily-digest/README.md"
+      },
+      "readme_markdown": "# Daily Digest\n\n> Automated daily summary of your recent thoughts, delivered to your inbox.\n\n## What It Does\n\nQueries your most recent Open Brain thoughts, groups them by type and topic, and delivers a formatted summary. You wake up to a digest of everything your brain captured yesterday.\n\nThere are two approaches — pick the one that fits your setup:\n\n| Approach | Infrastructure | Difficulty | Auto-send? |\n| -------- | -------------- | ---------- | ---------- |\n| **Claude Code Scheduled Task** (below) | None — uses MCP tools you already have | Beginner | Draft only (one-tap send) |\n| **Supabase Edge Function** (planned) | Edge Function + pg_cron + email service | Intermediate | Full auto-send |\n\n---\n\n## Approach A: Claude Code Scheduled Task\n\nZero-infrastructure variant. If you already run Claude Code (or Claude Desktop's Code mode) with Open Brain MCP and Gmail MCP connected, this works today with no deployment.\n\n### Prerequisites\n\n- Working Open Brain setup ([guide](https://github.com/NateBJones-Projects/OB1/blob/main/docs/01-getting-started.md))\n- Claude Code or Claude Desktop (Code mode) with:\n  - Open Brain MCP connected\n  - Gmail MCP connected (for email delivery)\n\n### How It Works\n\nClaude Code has built-in scheduled tasks (visible in Claude Desktop under the **Scheduled** tab). You install a skill file — a prompt template — that tells Claude what to do on each run:\n\n1. Query Open Brain for thoughts from the last 24 hours\n2. Organize them into a scannable digest (grouped by type, with topic/people tags)\n3. Create a Gmail draft addressed to you\n\nClaude *is* the LLM — no OpenRouter key needed.\n\n### Steps\n\n![Step 1](https://img.shields.io/badge/Step_1-Install_the_Skill_File-1E88E5?style=for-the-badge)\n\nCopy the skill template into your Claude scheduled tasks directory:\n\n```bash\nmkdir -p ~/.claude/scheduled-tasks/daily-digest\ncp recipes/daily-digest/daily-digest-skill.md ~/.claude/scheduled-tasks/daily-digest/SKILL.md\n```\n\nThen open the file and replace `YOUR_EMAIL@example.com` with your actual email address.\n\n> [!IMPORTANT]\n> The skill file is a local prompt — it never gets committed to any repo. Your email stays on your machine.\n\n---\n\n![Step 2](https://img.shields.io/badge/Step_2-Create_the_Scheduled_Task-1E88E5?style=for-the-badge)\n\nIn any Claude Code session (or Claude Desktop Code mode), run:\n\n```\n/schedule\n```\n\nOr create it directly by telling Claude:\n\n> \"Create a scheduled task called daily-digest that runs every day at 7am using the skill file at ~/.claude/scheduled-tasks/daily-digest/SKILL.md\"\n\nThe task will appear in Claude Desktop's **Scheduled** tab.\n\n---\n\n![Step 3](https://img.shields.io/badge/Step_3-Test_Run_and_Approve_Tools-1E88E5?style=for-the-badge)\n\nClick **\"Run now\"** from the Scheduled tab to do an initial test. On the first run, Claude will ask for permission to use the Open Brain and Gmail MCP tools. Approve them once — future runs will remember.\n\n> [!TIP]\n> If you haven't captured any thoughts recently, the digest will say so. Capture a few test thoughts first via `capture_thought` to see the full format.\n\n---\n\n### Expected Outcome\n\nEvery morning, a Gmail draft appears in your inbox with:\n\n- A count of thoughts captured in the last 24 hours\n- Breakdown by type (observations, tasks, ideas, references, person notes)\n- Each thought's content (truncated), source, and topic/people tags\n- A summary header with top themes\n\nYou review the draft and hit send (or just read it).\n\n### Troubleshooting\n\n**Issue: Scheduled task never fires**\nSolution: Claude Code must be running (or Claude Desktop must be open) at the scheduled time. If your machine was asleep, the task fires on next launch.\n\n**Issue: Task pauses waiting for permissions**\nSolution: Run it manually once via the Scheduled tab and approve the MCP tool permissions. They persist for future runs.\n\n**Issue: \"No thoughts found\" every day**\nSolution: Check that your Open Brain MCP is connected and has recent data. Run `list_thoughts` manually in a Claude Code session to verify.\n\n**Issue: Gmail draft not appearing**\nSolution: Verify your Gmail MCP connector is working. Try `gmail_create_draft` manually in a Claude session to test.\n\n---\n\n## Approach B: Supabase Edge Function (Planned)\n\nA fully self-contained approach using a Supabase Edge Function, pg_cron trigger, and an email service (Resend or SendGrid) for true automated delivery without Claude running. This approach is not yet implemented — contributions welcome.\n\n### Prerequisites (planned)\n\n- Supabase CLI available ([Homebrew/Scoop/standalone binary or `npx supabase`](https://supabase.com/docs/guides/local-development/cli/getting-started); `npm i -g supabase` is not supported)\n- OpenRouter API key (for generating the summary)\n- Email service: Resend or SendGrid (free tier)\n\n### Credential Tracker (for future Edge Function approach)\n\n```text\nDAILY DIGEST -- CREDENTIAL TRACKER\n--------------------------------------\n\nFROM YOUR OPEN BRAIN SETUP\n  Supabase Project URL:  ____________\n  Supabase Secret key:   ____________\n  OpenRouter API key:    ____________\n\nDELIVERY METHOD\n  Email service (Resend/SendGrid): ____________\n  API key:                         ____________\n  Sender email:                    ____________\n\n--------------------------------------\n```\n"
+    },
+    {
+      "slug": "email-history-import",
+      "category": "recipes",
+      "site_path": "/ob1/recipes/email-history-import",
+      "name": "Email History Import",
+      "description": "Import your Gmail email history into Open Brain as searchable thoughts with sender, subject, and date metadata.",
+      "author": {
+        "name": "Matt Hallett",
+        "github": "matthallett"
+      },
+      "version": "1.0.0",
+      "tags": [
+        "email",
+        "gmail",
+        "import",
+        "history"
+      ],
+      "difficulty": "intermediate",
+      "estimated_time": "30 minutes",
+      "created": "2026-03-10",
+      "updated": "2026-03-10",
+      "learning_order": null,
+      "compatibility": {
+        "open_brain": "required"
+      },
+      "requirements": {
+        "services": [
+          "Gmail API"
+        ],
+        "tools": [
+          "Deno"
+        ]
+      },
+      "dependencies": {
+        "skills": [],
+        "primitives": []
+      },
+      "reverse_dependencies": {
+        "skills": [],
+        "primitives": []
+      },
+      "urls": {
+        "github_folder": "https://github.com/NateBJones-Projects/OB1/tree/main/recipes/email-history-import",
+        "github_readme": "https://github.com/NateBJones-Projects/OB1/blob/main/recipes/email-history-import/README.md"
+      },
+      "readme_markdown": "# Email History Import\n\n> Import your Gmail email history into Open Brain as searchable, embedded thoughts.\n\nYour email is full of decisions, commitments, and context that your AI has never seen. This recipe connects to Gmail, pulls the emails that matter (filtering out receipts, auto-replies, and noise), and loads them into your Open Brain. Once imported, your AI can recall what you said to someone three months ago, find that pricing discussion from last quarter, or surface commitments you forgot about.\n\n## What It Does\n\nPulls your Gmail history via the Gmail API and loads each email into Open Brain as a single thought. The script generates embeddings and extracts metadata (topics, people, action items) locally via OpenRouter, then inserts directly into Supabase with SHA-256 content fingerprint dedup.\n\n**One email = one thought.** No chunking, no parent/child relationships. This aligns with how the OB1 community handles long content (truncate for embedding, store full content).\n\n## Prerequisites\n\n- Working Open Brain setup ([guide](https://github.com/NateBJones-Projects/OB1/blob/main/docs/01-getting-started.md))\n- Deno runtime installed\n- Google Cloud project with Gmail API enabled\n- Gmail API OAuth credentials (Client ID + Client Secret)\n- OpenRouter API key (same one from your Open Brain setup)\n\n## Credential Tracker\n\nCopy this block into a text editor and fill it in as you go.\n\n```text\nEMAIL HISTORY IMPORT -- CREDENTIAL TRACKER\n--------------------------------------\n\nFROM YOUR OPEN BRAIN SETUP\n  Supabase Project URL:  ____________\n  Supabase Service Key:  ____________\n  OpenRouter API Key:    ____________\n\nGENERATED DURING SETUP\n  Google Cloud Project ID:     ____________\n  Gmail OAuth Client ID:       ____________.apps.googleusercontent.com\n  Gmail OAuth Client Secret:   ____________\n\n--------------------------------------\n```\n\n## Setup\n\n1. **Enable Gmail API** in your Google Cloud project\n2. **Create OAuth 2.0 credentials** (Desktop app type) and download as `credentials.json` into this folder\n3. **Set environment variables:**\n\n   ```bash\n   export SUPABASE_URL=https://YOUR_REF.supabase.co\n   export SUPABASE_SERVICE_ROLE_KEY=your-service-role-key\n   export OPENROUTER_API_KEY=sk-or-v1-your-key\n   ```\n\n4. **First run — authenticate:**\n\n   ```bash\n   deno run --allow-net --allow-read --allow-write --allow-env pull-gmail.ts --dry-run --limit=5\n   ```\n\n   This opens a browser window for OAuth consent. After authorizing, your token is cached in `token.json`.\n\n## Usage\n\n```bash\n# Dry run — see what would be imported\ndeno run --allow-net --allow-read --allow-write --allow-env pull-gmail.ts --dry-run\n\n# Import sent emails from the last 90 days\ndeno run --allow-net --allow-read --allow-write --allow-env pull-gmail.ts --window=90d --limit=500\n\n# Import starred emails\ndeno run --allow-net --allow-read --allow-write --allow-env pull-gmail.ts --labels=STARRED\n\n# List all Gmail labels\ndeno run --allow-net --allow-read --allow-write --allow-env pull-gmail.ts --list-labels\n```\n\n### Options\n\n| Flag | Default | Description |\n|------|---------|-------------|\n| `--window=` | `24h` | Time window: `24h`, `7d`, `30d`, `90d`, `1y`, `all` |\n| `--labels=` | `SENT` | Comma-separated Gmail labels |\n| `--limit=` | `50` | Max emails to process |\n| `--dry-run` | off | Preview without ingesting |\n| `--list-labels` | off | List all Gmail labels and exit |\n| `--ingest-endpoint` | off | Use `INGEST_URL`/`INGEST_KEY` instead of Supabase direct insert |\n\n### Ingestion modes\n\n**Default (Supabase direct insert)** — The script generates embeddings and extracts metadata via OpenRouter, then inserts directly into Supabase with content fingerprint dedup. Requires `SUPABASE_URL`, `SUPABASE_SERVICE_ROLE_KEY`, `OPENROUTER_API_KEY`. This matches the pattern used by the ChatGPT import and MCP server.\n\n**`--ingest-endpoint`** — POSTs to a custom Edge Function endpoint that handles embedding and metadata server-side. Requires `INGEST_URL` and `INGEST_KEY`. Use this if you have a custom ingest-thought function deployed.\n\n## How It Works\n\n1. **Fetch** emails from Gmail API by label and time window\n2. **Extract** body (base64 decode, HTML-to-text, strip quoted replies and signatures)\n3. **Filter** out noise (no-reply senders, receipts, auto-generated, <10 words)\n4. **Deduplicate** via sync-log (tracks Gmail message IDs already imported)\n5. **Embed** content via OpenRouter (`text-embedding-3-small`)\n6. **Classify** via LLM (topics, type, people, action items)\n7. **Upsert** into Supabase with SHA-256 [content fingerprint](/ob1/recipes/content-fingerprint-dedup) — re-running produces zero duplicates\n\n### What gets filtered out\n\n- Auto-generated emails (receipts, confirmations, password resets)\n- No-reply / notification senders\n- Emails with <10 words after cleanup\n- Quoted replies and email signatures are stripped before ingestion\n\n## Expected Outcome\n\nEach imported email becomes one row in the `thoughts` table:\n- `content`: Email body with context prefix (`[Email from X | Subject: Y | Date: Z]`)\n- `embedding`: 1536-dim vector for semantic search (truncated to 8K chars)\n- `metadata`: LLM-extracted topics, type, people, action items, plus `source: \"gmail\"`, `gmail_id`, `gmail_labels`, `gmail_thread_id`\n- `content_fingerprint`: Normalized SHA-256 hash for dedup (see [content fingerprint primitive](/ob1/recipes/content-fingerprint-dedup))\n\n## Troubleshooting\n\n**OAuth flow fails:** Make sure your redirect URI in Google Cloud Console is `http://localhost:3847/callback`.\n\n**No thoughts appear:** Check that `SUPABASE_SERVICE_ROLE_KEY` is your service role key (not the anon key). RLS blocks anon inserts.\n\n**Re-running imports the same emails:** The `sync-log.json` file tracks imported Gmail IDs. Delete it to re-import everything. Content fingerprints provide a second layer of dedup at the database level.\n\n**Embedding/metadata errors:** Verify your `OPENROUTER_API_KEY` has credits. The script calls OpenRouter for both embedding generation and metadata extraction.\n"
+    },
+    {
+      "slug": "fingerprint-dedup-backfill",
+      "category": "recipes",
+      "site_path": "/ob1/recipes/fingerprint-dedup-backfill",
+      "name": "Fingerprint Dedup Backfill",
+      "description": "Backfill content fingerprints on existing thoughts and safely remove duplicates discovered during the process.",
+      "author": {
+        "name": "Alan Shurafa",
+        "github": "alanshurafa"
+      },
+      "version": "1.0.0",
+      "tags": [
+        "deduplication",
+        "fingerprint",
+        "backfill",
+        "data-quality",
+        "cleanup"
+      ],
+      "difficulty": "beginner",
+      "estimated_time": "15 minutes",
+      "created": "2026-03-22",
+      "updated": "2026-03-22",
+      "learning_order": null,
+      "compatibility": {
+        "open_brain": "required"
+      },
+      "requirements": {
+        "services": [],
+        "tools": [
+          "Node.js 18+"
+        ]
+      },
+      "dependencies": {
+        "skills": [],
+        "primitives": []
+      },
+      "reverse_dependencies": {
+        "skills": [],
+        "primitives": []
+      },
+      "urls": {
+        "github_folder": "https://github.com/NateBJones-Projects/OB1/tree/main/recipes/fingerprint-dedup-backfill",
+        "github_readme": "https://github.com/NateBJones-Projects/OB1/blob/main/recipes/fingerprint-dedup-backfill/README.md"
+      },
+      "readme_markdown": "# Fingerprint Dedup Backfill\n\n<div align=\"center\">\n\n![Community Contribution](https://img.shields.io/badge/OB1_COMMUNITY-Approved_Contribution-2ea44f?style=for-the-badge&logo=github)\n\n**Created by [@alanshurafa](https://github.com/alanshurafa)**\n\n*Reviewed and merged by the Open Brain maintainer team — thank you for building the future of AI memory!*\n\n</div>\n\n> Backfill content fingerprints on existing thoughts and safely remove duplicates discovered during the process.\n\n## What It Does\n\nIf you imported thoughts before the [Content Fingerprint Dedup](/ob1/recipes/content-fingerprint-dedup) primitive was in place, those rows will have a NULL `content_fingerprint`. This recipe computes fingerprints for all existing rows and then identifies and removes duplicates — rows whose content already exists in the table under a properly fingerprinted copy.\n\nTwo scripts work together:\n\n1. **`backfill-fingerprints.mjs`** — Scans all NULL-fingerprint rows and patches each one with a computed SHA-256 fingerprint. Resumable via state file.\n\n2. **`delete-duplicates.mjs`** — Finds NULL-fingerprint rows whose content already has a fingerprinted copy in the table. Defaults to **report-only mode** (no deletions). Pass `--delete` to actually remove duplicates.\n\n## Prerequisites\n\n- Working Open Brain setup ([guide](https://github.com/NateBJones-Projects/OB1/blob/main/docs/01-getting-started.md))\n- [Content Fingerprint Dedup](/ob1/recipes/content-fingerprint-dedup) primitive applied (so `content_fingerprint` column exists)\n- Node.js 18+\n\n## Credential Tracker\n\nCopy this block into a text editor and fill it in as you go.\n\n```text\nFINGERPRINT DEDUP BACKFILL -- CREDENTIAL TRACKER\n--------------------------------------\n\nFROM YOUR OPEN BRAIN SETUP\n  Supabase URL:            ____________\n  Service role key:        ____________\n\n--------------------------------------\n```\n\n## Steps\n\n**1. Clone or download this recipe**\n\nCopy the recipe folder to your local machine.\n\n**2. Configure credentials**\n\nCopy `.env.example` to `.env` and fill in your Supabase credentials:\n\n```bash\ncp .env.example .env\n# Edit .env with your Supabase URL and service role key\n```\n\n**3. Run the backfill**\n\nThis computes and patches fingerprints for all rows where `content_fingerprint` is NULL:\n\n```bash\nnode backfill-fingerprints.mjs\n```\n\nThe script processes rows in batches of 1000, saving progress to `backfill-state.json` after each batch. If interrupted, it resumes from where it left off.\n\n**4. Generate a duplicate report**\n\nBefore deleting anything, see what would be removed:\n\n```bash\nnode delete-duplicates.mjs --report-only\n```\n\nThis scans remaining NULL-fingerprint rows, computes their fingerprints, and reports how many are duplicates of existing fingerprinted rows — without deleting anything.\n\n**5. Remove duplicates (when ready)**\n\nOnce you've reviewed the report and are satisfied:\n\n```bash\nnode delete-duplicates.mjs --delete\n```\n\n> [!CAUTION]\n> The `--delete` flag permanently removes rows. Make sure you've reviewed the report first. The script also backfills fingerprints on any genuine orphan rows (those with no existing duplicate).\n\n## Expected Outcome\n\nAfter running both scripts:\n\n- Every row in the `thoughts` table has a non-NULL `content_fingerprint`\n- No duplicate content exists (each unique fingerprint appears once)\n- The `content_fingerprint` unique constraint is now fully enforceable\n\nVerify with:\n\n```sql\n-- Count remaining NULL fingerprints (should be 0)\nselect count(*) from thoughts where content_fingerprint is null;\n\n-- Check for duplicate fingerprints (should return 0 rows)\nselect content_fingerprint, count(*) as copies\nfrom thoughts\nwhere content_fingerprint is not null\ngroup by content_fingerprint\nhaving count(*) > 1\nlimit 10;\n```\n\n## How the Fingerprint Is Computed\n\nThe normalization matches the [Content Fingerprint Dedup](/ob1/recipes/content-fingerprint-dedup) primitive exactly:\n\n1. Trim whitespace and collapse runs of whitespace to single spaces\n2. Lowercase\n3. Strip trailing punctuation (`.!?;:,`)\n4. Strip possessives (`'s` and `\\u2019s`)\n5. Strip trailing `s` from the last word if the word has 4+ characters\n6. SHA-256 hex digest of the result\n\nThis means \"The dog's toys.\" and \"the dogs toy\" produce the same fingerprint.\n\n## Troubleshooting\n\n**Issue: Script reports many \"duplicate\" PATCH errors (409 / 23505)**\nSolution: This means the computed fingerprint already exists on another row. The backfill script counts these but skips them — this is expected behavior. Run the cleanup script afterward to remove the duplicates.\n\n**Issue: Script hangs or times out on large tables**\nSolution: The scripts use cursor-based pagination and save state after each batch. If a request times out, the script retries after 5 seconds. For very large tables (100K+), expect the backfill to take 10-30 minutes.\n\n**Issue: `content_fingerprint` column doesn't exist**\nSolution: Apply the [Content Fingerprint Dedup](/ob1/recipes/content-fingerprint-dedup) primitive first. The column must exist before running these scripts.\n\n**Issue: Want to reset and start over**\nSolution: Delete the state file (`backfill-state.json` or `cleanup-state.json`) and run the script again. It will start from the beginning.\n"
+    },
+    {
+      "slug": "google-activity-import",
+      "category": "recipes",
+      "site_path": "/ob1/recipes/google-activity-import",
+      "name": "Google Activity Import",
+      "description": "Import your Google Search, Gmail, Maps, YouTube, and Chrome history from Google Takeout into Open Brain as searchable thoughts.",
+      "author": {
+        "name": "Alan Shurafa",
+        "github": "alanshurafa"
+      },
+      "version": "1.0.0",
+      "tags": [
+        "google",
+        "takeout",
+        "import",
+        "search-history",
+        "gmail",
+        "maps",
+        "youtube",
+        "chrome",
+        "activity"
+      ],
+      "difficulty": "beginner",
+      "estimated_time": "15 minutes",
+      "created": "2026-03-16",
+      "updated": "2026-03-16",
+      "learning_order": null,
+      "compatibility": {
+        "open_brain": "required"
+      },
+      "requirements": {
+        "services": [
+          "OpenRouter"
+        ],
+        "tools": [
+          "Node.js 18+"
+        ]
+      },
+      "dependencies": {
+        "skills": [],
+        "primitives": []
+      },
+      "reverse_dependencies": {
+        "skills": [],
+        "primitives": []
+      },
+      "urls": {
+        "github_folder": "https://github.com/NateBJones-Projects/OB1/tree/main/recipes/google-activity-import",
+        "github_readme": "https://github.com/NateBJones-Projects/OB1/blob/main/recipes/google-activity-import/README.md"
+      },
+      "readme_markdown": "# Google Activity Import\n\n<div align=\"center\">\n\n![Community Contribution](https://img.shields.io/badge/OB1_COMMUNITY-Approved_Contribution-2ea44f?style=for-the-badge&logo=github)\n\n**Created by [@alanshurafa](https://github.com/alanshurafa)**\n\n*Reviewed and merged by the Open Brain maintainer team — thank you for building the future of AI memory!*\n\n</div>\n\n> Import your Google Search, Gmail, Maps, YouTube, and Chrome history from Google Takeout into Open Brain as searchable thoughts.\n\n## What It Does\n\nTakes your Google Takeout data export, filters out noise (passive visits, trivial lookups, notifications), groups activity by day, uses an LLM to distill each day into 1-3 standalone thoughts, and loads them into your Open Brain with vector embeddings and metadata. The result is semantically searchable knowledge extracted from years of Google activity — your research patterns, decisions, habits, and interests.\n\n## Prerequisites\n\n- Working Open Brain setup ([guide](https://github.com/NateBJones-Projects/OB1/blob/main/docs/01-getting-started.md))\n- Your Google Takeout data export (see Step 1 below)\n- Node.js 18+\n- Your Supabase project URL and service role key (from your credential tracker)\n- OpenRouter API key (for LLM summarization and embedding generation)\n\n## Credential Tracker\n\nCopy this block into a text editor and fill it in as you go.\n\n```text\nGOOGLE ACTIVITY IMPORT -- CREDENTIAL TRACKER\n--------------------------------------\n\nFROM YOUR OPEN BRAIN SETUP\n  Supabase Project URL:  ____________\n  Supabase Secret key:   ____________\n  OpenRouter API key:    ____________\n\nFILE LOCATION\n  Path to Takeout folder:  ____________\n\n--------------------------------------\n```\n\n## Steps\n\n### 1. Request your data from Google Takeout\n\nGo to [takeout.google.com](https://takeout.google.com):\n\n1. Click **Deselect all** (top of the page)\n2. Scroll down and check **My Activity**\n3. Click **Multiple formats** and make sure it says **JSON** (not HTML)\n4. Click **Next step** → **Create export**\n5. Wait for the email (can take minutes to hours depending on size)\n6. Download and extract the zip file\n\nAfter extraction, you should have a folder structure like:\n\n```\nTakeout/\n  My Activity/\n    Search/\n      MyActivity.json\n    Gmail/\n      MyActivity.json\n    Maps/\n      MyActivity.json\n    YouTube/\n      MyActivity.json\n    Chrome/\n      MyActivity.json\n    ...\n```\n\n### 2. Navigate to this recipe folder\n\n```bash\n# From the OB1 repo root\ncd recipes/google-activity-import\n```\n\nOr copy the files (`import-google-activity.mjs`, `package.json`) into any working directory.\n\n### 3. Set your environment variables\n\n```bash\nexport SUPABASE_URL=https://YOUR_PROJECT_REF.supabase.co\nexport SUPABASE_SERVICE_ROLE_KEY=your-service-role-key-here\nexport OPENROUTER_API_KEY=sk-or-v1-your-key-here\n```\n\nAll three values come from your credential tracker. You can also copy `.env.example` to `.env` and fill it in, then run `export $(cat .env | xargs)`.\n\n### 4. Do a dry run first\n\n```bash\nnode import-google-activity.mjs ./path/to/Takeout/My\\ Activity --dry-run --limit 5\n```\n\nThis parses, filters, and summarizes 5 activity-days without writing anything to your database. Review the output to see what would be imported.\n\n### 5. Run the full import\n\n```bash\nnode import-google-activity.mjs ./path/to/Takeout/My\\ Activity\n```\n\nThe script will:\n1. Find all `MyActivity.json` files in the folder tree\n2. Filter to high-value categories (Search, Gmail, Maps, YouTube, Chrome)\n3. Remove noise entries (passive visits, notifications, trivial lookups)\n4. Group remaining entries by day\n5. Summarize each day's activity into 1-3 standalone thoughts via LLM\n6. Generate a vector embedding for each thought\n7. Insert each thought into your `thoughts` table\n\nProgress prints to the console. A sync log (`google-activity-sync-log.json`) tracks which days have been imported, so you can safely re-run the script after future Takeout exports without duplicating data.\n\n### 6. Verify in your database\n\nOpen your Supabase dashboard → Table Editor → `thoughts`. You should see new rows with:\n- `content`: prefixed with `[Google Search: 2024-06-15]` (or Gmail, Maps, etc.)\n- `metadata`: includes `source: \"google_activity\"`, category, date, entry count\n- `embedding`: a 1536-dimension vector\n\n### 7. Test a search\n\nIn any MCP-connected AI (Claude Desktop, ChatGPT, etc.), ask:\n\n```\nSearch my brain for things I researched about [topic you know you searched for]\n```\n\n## Expected Outcome\n\nAfter a full import, your `thoughts` table contains distilled knowledge from years of Google activity. Each thought is a standalone statement about your research patterns, decisions, or interests — not a raw list of searches.\n\nFrom a real production run with ~4 years of Google history:\n\n| Metric | Value |\n|--------|-------|\n| Total activity entries | 98,000+ |\n| After noise filtering | 42,000 |\n| Activity-days | 11,000+ |\n| Thoughts generated | ~8,000 |\n| Estimated API cost | ~$0.30 |\n\nThe filtering is aggressive by design — most Google activity is noise. The script keeps only entries with enough substance to reveal patterns worth remembering.\n\n## How It Works\n\n### Three-stage pipeline\n\n**Stage 1: Noise filtering** — Each activity entry passes through category-specific filters:\n\n| Category | Kept | Filtered |\n|----------|------|----------|\n| Search | All searches ≥10 chars | Notification counts |\n| Gmail | Email subjects ≥10 chars | Notification counts |\n| Maps | Searches, directions, navigation | Passive visits, views, opens |\n| YouTube | Searches, substantive watching | Short clips, passive visits |\n| Chrome | Page titles ≥15 chars | Very short titles |\n\n**Stage 2: Day grouping & summarization** — Surviving entries are grouped by date. Each day goes to an LLM (gpt-4o-mini via OpenRouter) with a tuned prompt. The LLM extracts 1-3 standalone thoughts per day, focusing on research patterns, decisions, and interests. Days with only trivial activity get empty summaries.\n\n**Stage 3: Ingestion** — Each thought gets a vector embedding (text-embedding-3-small, 1536 dimensions) and is inserted into your `thoughts` table with metadata linking back to the source category and date.\n\n### Deduplication\n\nThe sync log (`google-activity-sync-log.json`) stores a hash of each processed day's content, keyed by `category:date`. Re-running the script after a new Takeout export only processes:\n- New days that weren't in the previous export\n- Days whose content has changed (new entries appended)\n\nThis means you can download a fresh Takeout export every few months and re-run — only new activity gets imported.\n\n## Options Reference\n\n| Flag | Description | Default |\n|------|-------------|---------|\n| `--dry-run` | Parse, filter, summarize — don't write to database | Off |\n| `--limit N` | Max activity-days to process (0 = unlimited) | 0 |\n| `--after YYYY-MM-DD` | Only process activity after this date | None |\n| `--before YYYY-MM-DD` | Only process activity before this date | None |\n| `--categories LIST` | Comma-separated categories to process | Search,Gmail,Maps,YouTube,Chrome |\n| `--raw` | Skip LLM summarization, insert grouped entries as-is | Off |\n| `--verbose` | Print full thought text during processing | Off |\n\n### Processing specific categories\n\n```bash\n# Only import search history\nnode import-google-activity.mjs ./Takeout/My\\ Activity --categories Search\n\n# Only import search and Gmail\nnode import-google-activity.mjs ./Takeout/My\\ Activity --categories Search,Gmail\n```\n\n### Importing without LLM (free, private)\n\nIf you don't want to send your activity data to OpenRouter for summarization, use `--raw` mode:\n\n```bash\nnode import-google-activity.mjs ./Takeout/My\\ Activity --raw\n```\n\nThis inserts the grouped daily entries as-is (e.g., \"Google Search activity for 2024-06-15: Searched for X, Searched for Y...\"). Embeddings still use OpenRouter. The thoughts won't be as clean, but your raw activity data stays private.\n\n## Cost Estimates\n\nAll costs are via OpenRouter at current pricing.\n\n| Component | Model | Cost |\n|-----------|-------|------|\n| Summarization | gpt-4o-mini | ~$0.15/1M input + $0.60/1M output |\n| Embeddings | text-embedding-3-small | ~$0.02/1M tokens |\n\n**Typical costs by Takeout size:**\n\n| Takeout period | Activity-days | Thoughts | Est. cost |\n|----------------|---------------|----------|-----------|\n| 1 year | ~365 | ~200 | ~$0.01 |\n| 3 years | ~1,000 | ~600 | ~$0.04 |\n| 5 years | ~1,800 | ~1,200 | ~$0.07 |\n| All time (10yr+) | ~3,500 | ~2,500 | ~$0.15 |\n\nThese assume ~60% of days are filtered as trivial and ~1.5 thoughts per day on average.\n\n## Troubleshooting\n\n**Issue: \"No MyActivity.json files found\"**\nSolution: Make sure you selected **JSON** format (not HTML) when creating your Google Takeout export. The script looks for `MyActivity.json` files inside category subdirectories. If you see `MyActivity.html` files instead, re-create your Takeout with JSON format selected.\n\n**Issue: `OPENROUTER_API_KEY required` error**\nSolution: Make sure you've exported the environment variable in your current terminal session: `export OPENROUTER_API_KEY=sk-or-v1-...`. Environment variables don't persist between terminal windows.\n\n**Issue: Import is very slow**\nSolution: Each activity-day requires one LLM call (summarization) and 1-3 embedding calls. For 1,000+ days, expect 30-60 minutes. Use `--limit 10` to test first, then `--after 2024-01-01` to process recent activity, and expand the date range in later runs.\n\n**Issue: Most days return \"No thoughts extracted\"**\nSolution: This is expected. The LLM is deliberately selective — days with only routine searches or a single trivial lookup get empty summaries. Use `--raw` if you want to import everything without filtering.\n\n**Issue: Want to re-import after a new Takeout export**\nSolution: Just run the script again pointing at your new export. The sync log tracks which days have been processed by content hash. Only new or changed days will be imported. If you want to start completely fresh, delete `google-activity-sync-log.json`.\n\n**Issue: `Failed to generate embedding` errors**\nSolution: Check that your OpenRouter API key is valid and has credits. Go to openrouter.ai/credits to verify your balance. The embedding model (text-embedding-3-small) costs $0.02 per million tokens — even a large import costs pennies.\n\n**Issue: Want to import a category not in the default list**\nSolution: Use `--categories` to specify any category that has a `MyActivity.json` file. For example: `--categories \"Gemini Apps,Google Analytics\"`. Run without `--categories` first using `--dry-run` to see all available categories.\n"
+    },
+    {
+      "slug": "grok-export-import",
+      "category": "recipes",
+      "site_path": "/ob1/recipes/grok-export-import",
+      "name": "Grok Export Import",
+      "description": "Import xAI Grok conversation exports (JSON format with MongoDB-style dates) into Open Brain as searchable thoughts.",
+      "author": {
+        "name": "Alan Shurafa",
+        "github": "alanshurafa"
+      },
+      "version": "1.0.0",
+      "tags": [
+        "import",
+        "grok",
+        "xai",
+        "conversations",
+        "ai-history"
+      ],
+      "difficulty": "beginner",
+      "estimated_time": "15 minutes",
+      "created": "2026-03-15",
+      "updated": "2026-03-15",
+      "learning_order": null,
+      "compatibility": {
+        "open_brain": "required"
+      },
+      "requirements": {
+        "services": [
+          "OpenRouter API",
+          "Supabase"
+        ],
+        "tools": [
+          "Node.js 18+"
+        ]
+      },
+      "dependencies": {
+        "skills": [],
+        "primitives": []
+      },
+      "reverse_dependencies": {
+        "skills": [],
+        "primitives": []
+      },
+      "urls": {
+        "github_folder": "https://github.com/NateBJones-Projects/OB1/tree/main/recipes/grok-export-import",
+        "github_readme": "https://github.com/NateBJones-Projects/OB1/blob/main/recipes/grok-export-import/README.md"
+      },
+      "readme_markdown": "# Grok Export Import\n\n> Import xAI Grok conversation history into Open Brain as searchable thoughts.\n\n## What It Does\n\nParses xAI Grok conversation exports (JSON format with MongoDB-style dates) and imports each conversation as a thought with embeddings. Handles nested conversation/response structures and MongoDB date objects.\n\n## Prerequisites\n\n- Working Open Brain setup ([guide](https://github.com/NateBJones-Projects/OB1/blob/main/docs/01-getting-started.md))\n- **Grok data export** — JSON file from X/Grok\n- **Node.js 18+** installed\n- **OpenRouter API key** for embedding generation\n\n## Credential Tracker\n\n```text\nGROK EXPORT IMPORT -- CREDENTIAL TRACKER\n--------------------------------------\n\nFROM YOUR OPEN BRAIN SETUP\n  Supabase URL:          ____________\n  Service Role Key:      ____________\n\nFROM OPENROUTER\n  API Key:               ____________\n\n--------------------------------------\n```\n\n## Steps\n\n1. **Export your Grok data:**\n   - Request your data export from X (formerly Twitter)\n   - The Grok conversations are included in the data archive\n   - Find the Grok JSON file in the export\n\n2. **Copy this recipe folder** and install dependencies:\n\n   ```bash\n   cd grok-export-import\n   npm install\n   ```\n\n3. **Create `.env`** with your credentials (see `.env.example`):\n\n   ```env\n   SUPABASE_URL=https://your-project.supabase.co\n   SUPABASE_SERVICE_ROLE_KEY=your-service-role-key\n   OPENROUTER_API_KEY=sk-or-v1-your-key\n   ```\n\n4. **Preview what will be imported** (dry run):\n\n   ```bash\n   node import-grok.mjs /path/to/grok-export.json --dry-run\n   ```\n\n5. **Run the import:**\n\n   ```bash\n   node import-grok.mjs /path/to/grok-export.json\n   ```\n\n## Expected Outcome\n\nAfter running the import:\n- Each Grok conversation becomes a thought with `source_type: grok_import`\n- MongoDB-style dates (`$date.$numberLong`) are properly parsed to ISO timestamps\n- Running `search_thoughts` finds relevant Grok conversations\n\n**Scale reference:** Tested with 750+ Grok conversations imported successfully.\n\n## Troubleshooting\n\n**Issue: Date parsing errors**\nGrok uses MongoDB's `{$date: {$numberLong: \"...\"}}` format. The script handles this automatically. If you see wrong dates, check that the JSON file hasn't been modified.\n\n**Issue: \"conversations\" field not found**\nThe script looks for `parsed.conversations` first, then treats the root as an array. Different Grok export versions may structure the data differently.\n"
+    },
+    {
+      "slug": "infographic-generator",
+      "category": "recipes",
+      "site_path": "/ob1/recipes/infographic-generator",
+      "name": "Infographic Generator",
+      "description": "Turn research docs, Open Brain thoughts, and analysis into professional infographic images via Gemini's free-tier image generation API.",
+      "author": {
+        "name": "Jared Irish",
+        "github": "jaredirish"
+      },
+      "version": "1.0.0",
+      "tags": [
+        "infographic",
+        "visualization",
+        "image-generation",
+        "gemini",
+        "research",
+        "content"
+      ],
+      "difficulty": "intermediate",
+      "estimated_time": "15 minutes",
+      "created": "2026-03-18",
+      "updated": "2026-03-18",
+      "learning_order": null,
+      "compatibility": {
+        "open_brain": "required"
+      },
+      "requirements": {
+        "services": [
+          "Gemini API (free tier)"
+        ],
+        "tools": [
+          "Claude Code or similar AI coding tool",
+          "Python 3.10+"
+        ]
+      },
+      "dependencies": {
+        "skills": [],
+        "primitives": []
+      },
+      "reverse_dependencies": {
+        "skills": [],
+        "primitives": []
+      },
+      "urls": {
+        "github_folder": "https://github.com/NateBJones-Projects/OB1/tree/main/recipes/infographic-generator",
+        "github_readme": "https://github.com/NateBJones-Projects/OB1/blob/main/recipes/infographic-generator/README.md"
+      },
+      "readme_markdown": "# Infographic Generator\n\n*Turn research docs and Open Brain thoughts into professional infographic images*\n\nGenerate infographic images from any markdown document, research analysis, or Open Brain thought cluster using Gemini's free-tier image generation API. Auto-chunks content into logical segments, writes verbose image prompts, generates PNGs, and optionally captures prompts back to Open Brain for future retrieval.\n\n## What It Does\n\nTakes structured or unstructured content and runs a four-step process: **Analyze** the source for logical segments, **Chunk** into one-infographic-per-topic, **Prompt** with verbose image generation instructions (300+ words each with specific colors, layout, typography), and **Generate** actual PNG images via Gemini API. Prompts can be stored in Open Brain for future regeneration or adaptation.\n\n## Prerequisites\n\n- Working Open Brain setup ([guide](https://github.com/NateBJones-Projects/OB1/blob/main/docs/01-getting-started.md))\n- Claude Code (or another AI coding tool that supports skills/system prompts)\n- Open Brain MCP tools connected (`capture_thought`, `search_thoughts`)\n- Python 3.10+ installed\n- Gemini API key (free tier, get one at [ai.google.dev](https://ai.google.dev))\n\n### Credential Tracker\n\n```\nFrom your existing Open Brain setup:\n- Project URL: _______________\n- Open Brain MCP server connected: yes / no\n\nNew for this recipe:\n- Gemini API key: _______________ (from ai.google.dev, free tier works)\n```\n\n## Steps\n\n### 1. Create the skill directory\n\n```bash\nmkdir -p ~/.claude/skills/infographic-generator\n```\n\n### 2. Copy the skill and generation script\n\nCopy `infographic-generator.skill.md` and `generate.py` from this recipe:\n\n```bash\ncp infographic-generator.skill.md ~/.claude/skills/infographic-generator/SKILL.md\ncp generate.py ~/.claude/skills/infographic-generator/generate.py\nchmod +x ~/.claude/skills/infographic-generator/generate.py\n```\n\n### 3. Set up the Python environment\n\n```bash\ncd ~/.claude/skills/infographic-generator\npython3 -m venv .venv\nsource .venv/bin/activate\npip install google-genai Pillow\n```\n\n### 4. Set your Gemini API key\n\n```bash\nexport GEMINI_API_KEY=\"your-api-key-here\"\n```\n\nOr add it to your shell profile for persistence:\n\n```bash\necho 'export GEMINI_API_KEY=\"your-api-key-here\"' >> ~/.zshrc\n```\n\n### 5. Verify Claude Code picks up the skill\n\nRestart Claude Code. To verify, say \"make an infographic from this doc\" or \"visualize this research\" and confirm it references the Infographic Generator methodology.\n\n### 6. Generate your first infographic\n\nPoint the skill at any markdown file:\n\n```\nMake infographics from docs/research/my-analysis.md\n```\n\nOr use Open Brain as the source:\n\n```\nVisualize my thoughts about [topic]\n```\n\nThe skill will:\n1. Read and analyze the source content\n2. Chunk into logical segments (one infographic per major topic)\n3. Write verbose prompts with specific hex colors, layout types, and typography\n4. Save prompts to `./infographic-prompts/`\n5. Generate PNG images via Gemini API to `./media/`\n\n### 7. Review and iterate\n\nAfter generation, the skill shows each image. You can:\n\n```\nredo 3          # regenerate infographic #3\nredo 3 premium  # regenerate with higher quality model\n```\n\n### 8. (Optional) Capture prompts to Open Brain\n\nThe generated prompts are 300+ word rich text documents. Storing them in Open Brain makes them searchable across sessions:\n\n```\nSave these infographic prompts to Open Brain\n```\n\nFuture sessions can find them: `search_thoughts(\"infographic ROI analysis\")`\n\n## Expected Outcome\n\nWhen working correctly, you should see:\n\n- A prompt file saved to `./infographic-prompts/[source]-prompts.md` with one verbose prompt per content segment\n- PNG images saved to `./media/` with descriptive filenames\n- A manifest file at `./media/_latest_generation.json` linking filenames to titles\n- Each prompt includes specific hex colors, aspect ratio, layout type, typography specs, and \"what to avoid\" guidance\n\nA typical 2-page research doc yields 4-8 infographics. Generation takes 30-60 seconds per image on Gemini's free tier.\n\n## Open Brain Integration\n\nThis recipe connects to Open Brain in two ways:\n\n**As a source (read side):** Search Open Brain for thoughts on a topic, synthesize them, then generate infographics from the synthesis. \"Visualize my thoughts about MSP operations\" pulls relevant thoughts and creates visuals from them.\n\n**As storage (write side):** Generated prompts can be captured back to Open Brain. This creates a searchable library of visual templates. \"What infographic did I make for the deal structure?\" returns the prompt, which can be regenerated or adapted for new content.\n\nTogether with [Panning for Gold](/ob1/recipes/panning-for-gold) and Auto-Capture Protocol (PR [#42](https://github.com/NateBJones-Projects/OB1/pull/42)), this forms a complete capture-process-visualize flywheel (see [Issue #84](https://github.com/NateBJones-Projects/OB1/issues/84)).\n\n## Troubleshooting\n\n**Issue:** `GEMINI_API_KEY not set` error when generating.\n**Solution:** Ensure the environment variable is exported in your current shell session. Run `echo $GEMINI_API_KEY` to verify. If using Claude Code, the shell inherits from your profile, so add it to `~/.zshrc` or `~/.bashrc`.\n\n**Issue:** Gemini returns content policy errors for certain prompts.\n**Solution:** Some prompts trigger safety filters (surveillance themes, medical imagery, etc.). The script retries once automatically. If it still fails, the prompt is logged and skipped. You can manually edit the prompt to soften the language and use `--redo N` to regenerate just that image.\n\n**Issue:** Images have poor text rendering.\n**Solution:** Gemini's free tier (Flash) struggles with small text in infographics. Use `--premium` flag for better text rendering (uses a higher-quality model, may require a paid API key depending on your Gemini plan).\n\n**Issue:** Too many infographics generated from a short document.\n**Solution:** The skill chunks aggressively by default (one per section/topic). For shorter docs, tell the skill: \"Make 3 infographics max from this doc\" to constrain output.\n\n---\n\n*Part of the [Open Brain Flywheel](https://github.com/NateBJones-Projects/OB1/issues/84): capture, process, visualize.*\n"
+    },
+    {
+      "slug": "instagram-import",
+      "category": "recipes",
+      "site_path": "/ob1/recipes/instagram-import",
+      "name": "Instagram Import",
+      "description": "Import Instagram data exports — DM conversations, comments, and post captions — into Open Brain as searchable thoughts.",
+      "author": {
+        "name": "Alan Shurafa",
+        "github": "alanshurafa"
+      },
+      "version": "1.0.0",
+      "tags": [
+        "import",
+        "instagram",
+        "meta",
+        "social-media",
+        "messages"
+      ],
+      "difficulty": "intermediate",
+      "estimated_time": "20 minutes",
+      "created": "2026-03-15",
+      "updated": "2026-03-15",
+      "learning_order": null,
+      "compatibility": {
+        "open_brain": "required"
+      },
+      "requirements": {
+        "services": [
+          "OpenRouter API",
+          "Supabase"
+        ],
+        "tools": [
+          "Node.js 18+"
+        ]
+      },
+      "dependencies": {
+        "skills": [],
+        "primitives": []
+      },
+      "reverse_dependencies": {
+        "skills": [],
+        "primitives": []
+      },
+      "urls": {
+        "github_folder": "https://github.com/NateBJones-Projects/OB1/tree/main/recipes/instagram-import",
+        "github_readme": "https://github.com/NateBJones-Projects/OB1/blob/main/recipes/instagram-import/README.md"
+      },
+      "readme_markdown": "# Instagram Import\n\n<div align=\"center\">\n\n![Community Contribution](https://img.shields.io/badge/OB1_COMMUNITY-Approved_Contribution-2ea44f?style=for-the-badge&logo=github)\n\n**Created by [@alanshurafa](https://github.com/alanshurafa)**\n\n*Reviewed and merged by the Open Brain maintainer team — thank you for building the future of AI memory!*\n\n</div>\n\n> Import your Instagram data — DMs, comments, and post captions — into Open Brain.\n\n## What It Does\n\nParses Instagram's data export and imports three types of content as searchable thoughts:\n- **Messages** — DM conversations (minimum 3 messages per conversation)\n- **Comments** — Your comments on posts, batched together\n- **Posts** — Your post captions, batched together\n\nHandles Meta's double-encoded UTF-8 text (latin1 → UTF-8 conversion).\n\n## Prerequisites\n\n- Working Open Brain setup ([guide](https://github.com/NateBJones-Projects/OB1/blob/main/docs/01-getting-started.md))\n- **Instagram data export** — download from Instagram Settings\n- **Node.js 18+** installed\n- **OpenRouter API key** for embedding generation\n\n## Credential Tracker\n\n```text\nINSTAGRAM IMPORT -- CREDENTIAL TRACKER\n--------------------------------------\n\nFROM YOUR OPEN BRAIN SETUP\n  Supabase URL:          ____________\n  Service Role Key:      ____________\n\nFROM OPENROUTER\n  API Key:               ____________\n\n--------------------------------------\n```\n\n## Steps\n\n1. **Request your Instagram data:**\n   - Go to Instagram → Settings → Accounts Center → Your information and permissions → Download your information\n   - Select **JSON** format\n   - Download and extract the archive\n   - Look for the `your_instagram_activity/` folder\n\n2. **Copy this recipe folder** and install dependencies:\n\n   ```bash\n   cd instagram-import\n   npm install\n   ```\n\n3. **Create `.env`** with your credentials (see `.env.example`):\n\n   ```env\n   SUPABASE_URL=https://your-project.supabase.co\n   SUPABASE_SERVICE_ROLE_KEY=your-service-role-key\n   OPENROUTER_API_KEY=sk-or-v1-your-key\n   ```\n\n4. **Preview what will be imported** (dry run):\n\n   ```bash\n   node import-instagram.mjs /path/to/instagram-export --dry-run\n   ```\n\n5. **Import specific types only** (optional):\n\n   ```bash\n   node import-instagram.mjs /path/to/instagram-export --types messages\n   node import-instagram.mjs /path/to/instagram-export --types comments,posts\n   ```\n\n6. **Run the full import:**\n\n   ```bash\n   node import-instagram.mjs /path/to/instagram-export\n   ```\n\n## Expected Outcome\n\nAfter running the import:\n- DM conversations become thoughts tagged with `source_type: instagram_import`\n- Long conversations are capped at 200 messages per thought\n- Comments and captions are batched (50 comments or 30 captions per thought)\n- All content with `sensitivity_tier: personal`\n- Running `search_thoughts { query: \"that restaurant recommendation\" }` finds relevant DMs\n\n**Scale reference:** Tested with 502 Instagram items imported successfully.\n\n## Troubleshooting\n\n**Issue: \"Could not find your_instagram_activity directory\"**\nThe export structure varies by download method. Look inside your extracted archive for a folder named `your_instagram_activity`. If it's nested deeper, point the script at the parent folder.\n\n**Issue: Garbled text (wrong characters)**\nMeta exports encode text as latin1-interpreted UTF-8. The script fixes this automatically with `fixMetaEncoding()`. If text still looks wrong, the file may use a different encoding.\n\n**Issue: No messages found**\nDMs are in `your_instagram_activity/messages/inbox/`. Each conversation is in its own folder with `message_1.json`, `message_2.json`, etc. Check that this structure exists in your export.\n"
+    },
+    {
+      "slug": "journals-blogger-import",
+      "category": "recipes",
+      "site_path": "/ob1/recipes/journals-blogger-import",
+      "name": "Journals/Blogger Import",
+      "description": "Import blog posts from Google Blogger Atom XML exports into Open Brain as searchable thoughts.",
+      "author": {
+        "name": "Alan Shurafa",
+        "github": "alanshurafa"
+      },
+      "version": "1.0.0",
+      "tags": [
+        "import",
+        "blogger",
+        "journal",
+        "blog",
+        "atom-xml"
+      ],
+      "difficulty": "beginner",
+      "estimated_time": "15 minutes",
+      "created": "2026-03-15",
+      "updated": "2026-03-15",
+      "learning_order": null,
+      "compatibility": {
+        "open_brain": "required"
+      },
+      "requirements": {
+        "services": [
+          "OpenRouter API",
+          "Supabase"
+        ],
+        "tools": [
+          "Node.js 18+"
+        ]
+      },
+      "dependencies": {
+        "skills": [],
+        "primitives": []
+      },
+      "reverse_dependencies": {
+        "skills": [],
+        "primitives": []
+      },
+      "urls": {
+        "github_folder": "https://github.com/NateBJones-Projects/OB1/tree/main/recipes/journals-blogger-import",
+        "github_readme": "https://github.com/NateBJones-Projects/OB1/blob/main/recipes/journals-blogger-import/README.md"
+      },
+      "readme_markdown": "# Journals/Blogger Import\n\n<div align=\"center\">\n\n![Community Contribution](https://img.shields.io/badge/OB1_COMMUNITY-Approved_Contribution-2ea44f?style=for-the-badge&logo=github)\n\n**Created by [@alanshurafa](https://github.com/alanshurafa)**\n\n*Reviewed and merged by the Open Brain maintainer team — thank you for building the future of AI memory!*\n\n</div>\n\n> Import blog posts from Google Blogger Atom XML exports into Open Brain.\n\n## What It Does\n\nParses Google Blogger's Atom XML export format and imports blog posts and comments as thoughts with embeddings. Works with any standard Atom feed export. Blog posts are stored as `type: journal` thoughts.\n\n## Prerequisites\n\n- Working Open Brain setup ([guide](https://github.com/NateBJones-Projects/OB1/blob/main/docs/01-getting-started.md))\n- The **content-fingerprint-dedup** primitive installed (provides the `upsert_thought` RPC function used for deduplication)\n- **Blogger export files** — `.atom` files from Google Blogger\n- **Node.js 18+** installed\n- **OpenRouter API key** for embedding generation\n\n## Credential Tracker\n\n```text\nJOURNALS/BLOGGER IMPORT -- CREDENTIAL TRACKER\n--------------------------------------\n\nFROM YOUR OPEN BRAIN SETUP\n  Supabase URL:          ____________\n  Service Role Key:      ____________\n\nFROM OPENROUTER\n  API Key:               ____________\n\n--------------------------------------\n```\n\n## Steps\n\n1. **Export your blog data:**\n   - Go to your Blogger Dashboard → Settings → Manage Blog → Back up content\n   - Download the `.atom` file\n   - If you have multiple blogs, export each one\n\n2. **Place all `.atom` files in a folder:**\n\n   ```\n   blogger-exports/\n   ├── my-tech-blog.atom\n   ├── personal-journal.atom\n   └── travel-blog.atom\n   ```\n\n3. **Copy this recipe folder** and install dependencies:\n\n   ```bash\n   cd journals-blogger-import\n   npm install\n   ```\n\n4. **Create `.env`** with your credentials (see `.env.example`):\n\n   ```env\n   SUPABASE_URL=https://your-project.supabase.co\n   SUPABASE_SERVICE_ROLE_KEY=your-service-role-key\n   OPENROUTER_API_KEY=sk-or-v1-your-key\n   ```\n\n5. **Preview what will be imported** (dry run):\n\n   ```bash\n   node import-blogger.mjs /path/to/blogger-exports --dry-run\n   ```\n\n6. **Run the import:**\n\n   ```bash\n   node import-blogger.mjs /path/to/blogger-exports\n   ```\n\n## Expected Outcome\n\nAfter running the import:\n- Each blog post becomes a thought with `type: journal` and `source_type: blogger_import`\n- Post titles and publication dates are preserved\n- HTML content is stripped to plain text (line breaks preserved)\n- Blog comments are imported separately\n- Settings and template entries are automatically filtered out\n\n**Scale reference:** Tested with 3,000+ blog posts across multiple blogs imported successfully.\n\n## Troubleshooting\n\n**Issue: No entries found in .atom file**\nThe parser looks for `<entry>` tags with `kind#post` or `kind#comment` categories. Blogger settings and template entries are filtered out. If your Atom file uses a different schema, check the XML structure.\n\n**Issue: HTML tags appearing in imported text**\nThe HTML stripper handles common tags and entities. If you see raw HTML in your thoughts, the post may use unusual HTML structures. The content is still searchable.\n\n**Issue: Wrong dates on posts**\nThe parser uses the `<published>` tag from the Atom feed. If dates look wrong, check the timezone in your Blogger export settings.\n"
+    },
+    {
+      "slug": "life-engine",
+      "category": "recipes",
+      "site_path": "/ob1/recipes/life-engine",
+      "name": "Life Engine",
+      "description": "A self-improving, time-aware personal assistant that runs in the background via Claude Code's /loop command. Checks your calendar, surfaces relevant knowledge from Open Brain, tracks habits and health, and delivers proactive briefings via Telegram or Discord — adapting to your life over time.",
+      "author": {
+        "name": "Jonathan Edwards",
+        "github": "jonathanedwards"
+      },
+      "version": "1.1.0",
+      "tags": [
+        "loop",
+        "channels",
+        "proactive",
+        "calendar",
+        "telegram",
+        "discord",
+        "briefing",
+        "self-improving",
+        "habits",
+        "personal-assistant"
+      ],
+      "difficulty": "intermediate",
+      "estimated_time": "45-60 minutes",
+      "created": "2026-03-18",
+      "updated": "2026-04-01",
+      "learning_order": null,
+      "compatibility": {
+        "open_brain": "required"
+      },
+      "requirements": {
+        "services": [
+          "supabase",
+          "google-calendar",
+          "telegram",
+          "discord"
+        ],
+        "tools": [
+          "claude-code",
+          "supabase-mcp",
+          "google-calendar-mcp",
+          "telegram-channel-plugin or discord-channel-plugin",
+          "bun"
+        ]
+      },
+      "dependencies": {
+        "skills": [],
+        "primitives": []
+      },
+      "reverse_dependencies": {
+        "skills": [],
+        "primitives": []
+      },
+      "urls": {
+        "github_folder": "https://github.com/NateBJones-Projects/OB1/tree/main/recipes/life-engine",
+        "github_readme": "https://github.com/NateBJones-Projects/OB1/blob/main/recipes/life-engine/README.md"
+      },
+      "readme_markdown": "# 🧠 Life Engine\n\n> One loop. One skill. Claude figures out what matters right now.\n\nA self-improving, time-aware personal assistant that runs in the background via Claude Code's `/loop` command. It checks your calendar, surfaces relevant knowledge from your Open Brain, tracks habits and health check-ins, and delivers proactive briefings via Telegram or Discord — adapting to your life over time.\n\n**This isn't a calendar tool. It's not a reminder app. It's a personal AI engine that runs your day and gets better at it every week.**\n\n> [!IMPORTANT]\n> **This recipe requires [Claude Code](https://claude.ai/download).** It uses Claude Code-specific features — skills, the `/loop` command, and MCP server connections — that aren't available in other AI coding tools. If you're using a different agent, this one isn't for you (yet).\n\n> [!TIP]\n> **You don't have to set this up manually.** This guide is detailed enough that Claude Code can do most of the setup for you. If you'd rather not walk through every step yourself, skip to [Quick Setup with Claude Code](#quick-setup-with-claude-code) — paste one prompt and Claude handles the plugin install, skill file creation, schema setup, and permissions configuration. Come back to the step-by-step sections if you want to understand what it built or customize further.\n\n> [!NOTE]\n> **This will not be perfect on day one.** That's by design. Life Engine is built to iterate — your first morning briefing will be rough, your tenth will be dialed in, and by week four the system is suggesting its own improvements based on what you actually use. The value comes from the feedback loop between you and the agent, powered by the structured context your Open Brain provides. Treat the first run as a starting point, not a finished product.\n\n---\n\n## Quick Setup with Claude Code\n\nThis guide contains everything Claude Code needs to set up your entire Life Engine — the Telegram channel, skill files, database schema, and permissions config. Instead of walking through 8 steps manually, point Claude Code at this README and let it do the work.\n\n**Before you start**, you'll need:\n- Claude Code installed ([claude.ai/download](https://claude.ai/download))\n- A working Open Brain setup ([Getting Started Guide](https://github.com/NateBJones-Projects/OB1/blob/main/docs/01-getting-started.md))\n- Google Calendar MCP connected to Claude Code\n- [Bun](https://bun.sh/) installed (`brew install oven-sh/bun/bun`)\n- A Telegram or Discord account (whichever you want briefings delivered to)\n\n**Tell Claude Code:**\n\n> Read the Life Engine recipe at `~/path-to-ob1/recipes/life-engine/README.md` and set up my Life Engine end to end. I want to use **Telegram** *(or Discord)* as my messaging channel. Walk me through creating a bot if I don't have one yet. Install the channel plugin, configure it with my bot token, create the Life Engine skill file at `~/.claude/skills/life-engine/SKILL.md` using the full skill from `recipes/life-engine/life-engine-skill.md`, run the schema.sql in my Supabase SQL Editor, and configure permissions for unattended operation. Pause and walk me through any steps that need my phone or browser (bot creation, channel pairing). When everything is ready, test it with `/life-engine`.\n\n**What Claude Code will do:**\n1. Install and configure the Telegram channel plugin\n2. Create the skill file with the full Life Engine prompt\n3. Run the database schema in your Supabase project\n4. Set up permissions for unattended operation\n5. Pause for you to complete Telegram pairing (requires your phone)\n6. Run a test cycle to confirm everything works\n\nAfter setup, exit and relaunch with your channel (permissions are handled by `settings.json` — see Step 6):\n\n```bash\n# Telegram\nclaude --channels plugin:telegram@claude-plugins-official\n\n# Discord\nclaude --channels plugin:discord@claude-plugins-official\n```\n\nThen start your loop: `/loop 30m /life-engine`\n\nIf you want to understand each piece or customize the setup, continue with the step-by-step guide below.\n\n---\n\n## What It Does\n\nYou run one command:\n\n```\n/loop 30m /life-engine\n```\n\nEvery 30 minutes, Claude wakes up, checks the time, and decides what you need right now:\n\n| Time | What Happens |\n|------|-------------|\n| **7:00 AM** | Pulls your calendar, gives you a daily rundown, reminds you about your morning jog |\n| **9:30 AM** | You've got a 10am client call — queries your Open Brain for that client's history, past conversations, open items and sends you a briefing |\n| **12:00 PM** | No meetings for a bit — sends a quick check-in: \"How are you feeling? Quick update and I'll track it\" |\n| **3:00 PM** | \"Your afternoon is clear. Here's what's still on your plate\" |\n| **6:00 PM** | Day summary: meetings attended, tasks completed, habits tracked |\n\nThe key insight: **you don't build all of this on day one.**\n\nYou start simple — maybe it just checks your calendar and sends you a Telegram message. That's it. Then Claude starts learning. It notices patterns, suggests additions:\n\n- *\"Hey, you keep checking your Open Brain before client calls manually. Want me to add that to the skill?\"*\n- *\"You haven't used the weather check in 2 weeks. Want me to drop it?\"*\n- *\"I notice you have recurring Monday standups. Should I prep a summary of last week's notes every Monday morning?\"*\n\nThe skill evolves. Claude proposes changes, you approve them, and over time your Life Engine becomes something completely personalized that no one else's looks like.\n\n---\n\n## What You'll Learn\n\n- Using Claude Code's `/loop` command for recurring background tasks\n- Using Claude Code's **Channels** for real-time two-way Telegram messaging\n- Building time-aware Claude Code skills that adapt behavior based on context\n- Connecting multiple MCP integrations into a single cohesive workflow\n- Querying your Open Brain for contextual knowledge surfacing\n- Delivering proactive outputs via Telegram\n- Designing self-improving systems where Claude suggests its own enhancements\n\n---\n\n## Prerequisites\n\nBefore starting, you'll need:\n\n| Requirement | Status |\n|-------------|--------|\n| Working Open Brain setup ([Getting Started Guide](https://github.com/NateBJones-Projects/OB1/blob/main/docs/01-getting-started.md)) | ☐ |\n| Claude Code installed and working ([claude.ai/download](https://claude.ai/download)) | ☐ |\n| Google Calendar MCP connected to Claude Code | ☐ |\n| Telegram account + Bot created via [@BotFather](https://t.me/BotFather) | ☐ |\n| [Bun](https://bun.sh/) installed (`bun --version` to check) | ☐ |\n| Supabase project with Open Brain MCP deployed | ☐ |\n\n### Credential Tracker\n\nCopy this and fill it in as you go — you'll reference these values throughout setup.\n\n```\n# Open Brain\nSUPABASE_PROJECT_URL=\nSUPABASE_SERVICE_KEY=\nOB1_MCP_URL=\n\n# Telegram\nTELEGRAM_BOT_TOKEN=\n# (Chat ID is handled automatically via channel pairing — no need to look it up)\n\n# Google Calendar\n(Connected via Claude Code MCP settings)\n```\n\n---\n\n## Architecture Overview\n\n```\n┌─────────────────────────────────────────────────┐\n│                  Claude Code                     │\n│                                                  │\n│  claude --channels plugin:<platform>@...           │\n│  /loop 30m /life-engine                          │\n│       │                                          │\n│       ▼                                          │\n│  ┌─────────────┐                                 │\n│  │ /life-engine │ ◄── Claude Code Skill          │\n│  │   skill      │     (.claude/skills/)          │\n│  └──────┬──────┘                                 │\n│         │                                        │\n│    Checks time                                   │\n│    Decides action                                │\n│         │                                        │\n│    ┌────┼────────────┬──────────────┐            │\n│    ▼    ▼            ▼              ▼            │\n│  📅    🧠          💬           📊             │\n│  Google  Open Brain   Messaging    Life Engine   │\n│  Calendar (Supabase   Channel      Tables        │\n│  MCP      MCP)       (plugin)      (Supabase)    │\n│                                                  │\n└─────────────────────────────────────────────────┘\n```\n\n**Data flows:**\n1. **Calendar → Claude**: What's coming up?\n2. **Open Brain → Claude**: What do I know about it?\n3. **Claude → You**: Here's what you need (sent via Telegram or Discord channel).\n4. **You → Claude**: Replies pushed into the session in real time via channel.\n5. **Claude → Life Engine Tables**: Log habits, moods, improvements\n\n---\n\n## Step 1: Connect a Messaging Channel\n\nLife Engine needs a way to talk to you when you're away from the terminal. Claude Code's **Channels** feature provides built-in, two-way messaging — messages push into your session in real time with no custom server required. Pick whichever platform you already use.\n\n> [!NOTE]\n> Channels are a **research preview** feature. The `--channels` flag is not yet shown in `--help`, and the plugin syntax may evolve. See the [Channels documentation](https://code.claude.com/docs/en/channels) for the latest details.\n\n**First, install Bun** — all channel plugins require it:\n\n```bash\nbrew install oven-sh/bun/bun\n```\n\nVerify with `bun --version`.\n\nNow pick your platform:\n\n### Option A: Telegram (Recommended)\n\nTelegram is free, fast, works on every phone, and has the simplest bot setup.\n\n**1. Create a Telegram Bot**\n\n1. Open Telegram and message [@BotFather](https://t.me/BotFather)\n2. Send `/newbot`\n3. Give it a name (e.g., \"My Life Engine\")\n4. Give it a username (e.g., `my_life_engine_bot`)\n5. Copy the **bot token**\n\n**2. Install and Configure the Plugin**\n\nStart a Claude Code session and install the official Telegram plugin:\n\n```\n/plugin install telegram@claude-plugins-official\n/reload-plugins\n```\n\nThen configure it with your bot token:\n\n```\n/telegram:configure <YOUR_BOT_TOKEN>\n```\n\nThis writes your token to `~/.claude/channels/telegram/.env`.\n\n**3. Launch with Channels Enabled**\n\nExit your session and relaunch with the channel flag:\n\n```bash\nclaude --channels plugin:telegram@claude-plugins-official\n```\n\n**4. Pair Your Telegram Account**\n\n1. DM your bot on Telegram — send it any message (e.g., \"hello\")\n2. The bot replies with a **6-character pairing code**\n3. Back in Claude Code, approve the pairing:\n   ```\n   /telegram:access pair <code>\n   ```\n4. Lock down access so only your account can reach the session:\n   ```\n   /telegram:access policy allowlist\n   ```\n\n✅ **Checkpoint:** Send a test message to your bot on Telegram. Claude Code should receive it in the terminal and can reply back through the channel.\n\n### Option B: Discord\n\nIf you prefer Discord or already have a server, the setup is similar but requires a few extra steps in the Discord Developer Portal.\n\n**1. Create a Discord Bot**\n\n1. Go to the [Discord Developer Portal](https://discord.com/developers/applications) and click **New Application**\n2. In the **Bot** section, create a username, then click **Reset Token** and copy the token\n3. Under **Privileged Gateway Intents**, enable **Message Content Intent**\n\n**2. Invite the Bot to Your Server**\n\n1. Go to **OAuth2 > URL Generator**\n2. Select the `bot` scope and enable these permissions:\n   - View Channels\n   - Send Messages\n   - Send Messages in Threads\n   - Read Message History\n   - Attach Files\n   - Add Reactions\n3. Open the generated URL to add the bot to your server\n\n**3. Install and Configure the Plugin**\n\n```\n/plugin install discord@claude-plugins-official\n/reload-plugins\n/discord:configure <YOUR_BOT_TOKEN>\n```\n\n**4. Launch with Channels Enabled**\n\nExit your session and relaunch:\n\n```bash\nclaude --channels plugin:discord@claude-plugins-official\n```\n\n**5. Pair Your Discord Account**\n\n1. DM your bot on Discord — if it doesn't respond, make sure Claude Code is running with `--channels` from the previous step\n2. The bot replies with a **pairing code**\n3. Back in Claude Code:\n   ```\n   /discord:access pair <code>\n   /discord:access policy allowlist\n   ```\n\n✅ **Checkpoint:** Send a test message to your bot on Discord. Claude Code should receive it in the terminal and can reply back through the channel.\n\n### Channel Tools (Same for Both Platforms)\n\nAfter setup, the same three tools are available regardless of platform:\n\n| Tool | Purpose |\n|------|---------|\n| `reply` | Send text or files to a chat. Supports `text`, `chat_id`, optional `files` (array of absolute paths, max 50MB each), and `reply_to` (message ID). Auto-chunks long text. Images send as photos with preview. |\n| `react` | Add emoji reaction to a message. |\n| `edit_message` | Edit a previously sent bot message. Good for \"working…\" → result updates. |\n\n<details>\n<summary>Option C: Custom Telegram Bridge (for older Claude Code versions)</summary>\n\nIf your Claude Code version doesn't support `--channels`, you can use a lightweight bridge server instead.\n\n**1. Create a Telegram Bot** — same as Option A above.\n\n**2. Get Your Chat ID**\n\n1. Message your new bot (send anything — \"hello\")\n2. Visit: `https://api.telegram.org/bot<YOUR_BOT_TOKEN>/getUpdates`\n3. Find `\"chat\":{\"id\":XXXXXXX}` in the response\n4. Copy the **chat ID**\n\n**3. Set Up the Bridge Server**\n\n```bash\nmkdir ~/life-engine-telegram && cd ~/life-engine-telegram\n```\n\nCreate `bridge.js`:\n\n```javascript\n// Minimal Telegram bridge for Claude Code MCP\nimport { Telegraf } from 'telegraf';\nimport express from 'express';\n\nconst bot = new Telegraf(process.env.TELEGRAM_BOT_TOKEN);\nconst app = express();\napp.use(express.json());\n\nlet unreadMessages = [];\n\nbot.on('text', (ctx) => {\n  unreadMessages.push({\n    text: ctx.message.text,\n    from: ctx.message.from.first_name,\n    timestamp: new Date().toISOString()\n  });\n});\n\napp.get('/messages', (req, res) => {\n  res.json(unreadMessages.length === 0\n    ? { status: 'no_messages', messages: [] }\n    : { status: 'unread', messages: unreadMessages });\n});\n\napp.post('/messages/read', (req, res) => {\n  const count = unreadMessages.length;\n  unreadMessages = [];\n  res.json({ markedAsRead: count });\n});\n\napp.post('/reply', (req, res) => {\n  bot.telegram.sendMessage(process.env.TELEGRAM_CHAT_ID, req.body.message, {\n    parse_mode: 'Markdown'\n  });\n  res.json({ sent: true });\n});\n\napp.listen(3456, () => console.log('Telegram bridge running on :3456'));\nbot.launch();\n```\n\nCreate `package.json`:\n\n```json\n{\n  \"name\": \"life-engine-telegram\",\n  \"type\": \"module\",\n  \"dependencies\": {\n    \"telegraf\": \"^4.16.0\",\n    \"express\": \"^4.18.0\"\n  }\n}\n```\n\nInstall and run:\n\n```bash\nnpm install\nTELEGRAM_BOT_TOKEN=\"your_token\" TELEGRAM_CHAT_ID=\"your_chat_id\" node bridge.js\n```\n\nFor persistent operation, use `pm2` or create a `launchd` service (macOS).\n\n**4. Register as an MCP Server**\n\n```bash\nclaude mcp add telegram-bridge --transport http --url http://localhost:3456\n```\n\n**5. Add Telegram Polling**\n\nWith the custom bridge, you also need a companion skill to poll for incoming messages. Create `.claude/skills/check-telegram/SKILL.md`:\n\n```markdown\n# /check-telegram — Poll for Telegram Messages\n\nCheck for new Telegram messages from the user.\n\n1. Use the Telegram MCP tools to check for unread messages.\n2. If there are NO unread messages, say \"No new messages.\" and stop.\n3. If there ARE unread messages:\n   a. Read and understand what the user is asking for\n   b. Mark the messages as read\n   c. Take action on the request\n   d. Send your response back via Telegram\n   e. Keep responses concise and mobile-friendly\n```\n\nThen run it on a separate loop: `/loop 1m /check-telegram`\n\n</details>\n\n---\n\n## Step 2: Connect Google Calendar\n\nGoogle Calendar MCP gives Claude Code read access to your calendar events.\n\n### 2.1 Enable Google Calendar MCP\n\nIf you're using Claude Code with the Google Calendar MCP integration:\n\n1. Run `/mcp` in Claude Code\n2. Connect Google Calendar from the available integrations\n3. Authorize with your Google account\n\n### 2.2 Verify Calendar Access\n\nAsk Claude Code:\n\n```\nWhat's on my calendar for today?\n```\n\nIt should list your events using the `gcal_list_events` tool.\n\n✅ **Checkpoint:** Claude Code can see your calendar events.\n\n---\n\n## Step 3: Connect Your Open Brain\n\nYour Open Brain is already deployed as a remote MCP server from the Getting Started guide.\n\n### 3.1 Add Open Brain MCP to Claude Code\n\nIf not already connected:\n\n```bash\nclaude mcp add open-brain --transport http --url \"https://YOUR_PROJECT_REF.supabase.co/functions/v1/open-brain-mcp?key=YOUR_ACCESS_KEY\"\n```\n\n### 3.2 Verify Open Brain Access\n\nAsk Claude Code:\n\n```\nSearch my Open Brain for anything related to \"meetings\" or \"clients\"\n```\n\nIt should query your thoughts using semantic search.\n\n✅ **Checkpoint:** Claude Code can search your Open Brain.\n\n---\n\n## Step 4: Create the Life Engine Schema\n\nThe Life Engine needs its own tables to track habits, moods, check-ins, and skill evolution. This extends your Open Brain — it doesn't replace it.\n\n### 4.1 Run the Schema\n\nRun the included [`schema.sql`](https://github.com/NateBJones-Projects/OB1/blob/main/recipes/life-engine/schema.sql) file in your Supabase SQL Editor. It contains the full schema with CHECK constraints, table comments, GRANT statements for `service_role`, performance indexes, and an auto-update trigger.\n\n✅ **Checkpoint:** Run the verification query at the bottom of `schema.sql` — you should see 6 tables (`life_engine_habits`, `life_engine_habit_log`, `life_engine_checkins`, `life_engine_briefings`, `life_engine_evolution`, `life_engine_state`).\n\n---\n\n## Step 5: Build the Life Engine Skill\n\nThis is the core — a Claude Code skill that runs on every loop iteration.\n\n### 5.1 Create the Skill File\n\nCreate `.claude/skills/life-engine/SKILL.md` in your home directory (or project directory) and paste the full contents of [`life-engine-skill.md`](https://github.com/NateBJones-Projects/OB1/blob/main/recipes/life-engine/life-engine-skill.md) into it.\n\nThis file contains the complete Life Engine behavior: the 7-step core loop, time windows, message formats, self-improvement protocol, dynamic loop timing with automatic rescheduling, and all operational rules. It is the single source of truth for how Life Engine behaves — any customizations you make should be made there.\n\n✅ **Checkpoint:** The skill file exists at `.claude/skills/life-engine/SKILL.md` and matches the contents of `life-engine-skill.md`.\n\n> **Note:** In the previous version of this recipe, a separate `/check-telegram` polling skill was required to read incoming messages. With Channels, that's no longer needed — Telegram messages are pushed directly into your Claude Code session in real time. Claude reads and responds to them inline.\n\n---\n\n## Step 6: Configure Permissions for Unattended Operation\n\nLife Engine runs autonomously via `/loop`. If Claude encounters a tool it doesn't have permission to use, **the session pauses silently** until you approve it at the terminal. Nothing happens — no briefings, no check-ins, no Telegram responses — until you're back at the keyboard.\n\n> [!WARNING]\n> **This is the most common reason a Life Engine \"stops working.\"** You walk away, Claude hits one permission prompt, and everything freezes. Configure permissions before starting your first loop.\n\n### 6.1 Choose Your Approach\n\n| Approach | Best For | Risk Level |\n|----------|----------|------------|\n| **`settings.json` allowlist** *(recommended)* | Scoped permissions that persist across sessions | Low — scoped + persistent |\n| **`--allowedTools` (CLI flag)** | Same scoping, but must be re-typed each launch | Low — scoped |\n| **`--permission-mode auto`** | A middle ground — automatic but with some guardrails | Medium |\n| **`--dangerously-skip-permissions`** | Quick testing on a dedicated, trusted machine | High — bypasses ALL checks |\n\n### 6.2 Option A: settings.json Allowlist (Recommended)\n\nPre-approve only the specific tools Life Engine needs, persisted in your config so you don't have to re-type them every session. Create or update `.claude/settings.json`:\n\n```json\n{\n  \"permissions\": {\n    \"allow\": [\n      \"mcp__plugin_telegram_telegram__reply\",\n      \"mcp__plugin_telegram_telegram__react\",\n      \"mcp__plugin_telegram_telegram__edit_message\",\n      \"mcp__google-calendar__gcal_list_events\",\n      \"mcp__google-calendar__gcal_get_event\",\n      \"mcp__open-brain__search_thoughts\",\n      \"mcp__open-brain__list_thoughts\",\n      \"mcp__open-brain__thought_stats\",\n      \"mcp__open-brain__capture_thought\",\n      \"mcp__supabase__execute_sql\",\n      \"Bash(*)\",\n      \"CronCreate\",\n      \"CronDelete\"\n    ]\n  }\n}\n```\n\n> **Why `Bash(*)` instead of scoped patterns?** Life Engine uses `date` (date anchor) and `curl` (weather API) — both benign, read-only commands. Scoped patterns like `Bash(date *)` or `Bash(curl -s *api.open-meteo.com*)` are fragile because the LLM may vary its exact command syntax between runs, causing silent permission blocks. `Bash(*)` eliminates this fragility while MCP tools remain individually scoped above. Rule 11 (prompt injection guard) prevents dangerous Bash execution from external triggers.\n\nThen launch with just the channel flag:\n\n```bash\n# Telegram\nclaude --channels plugin:telegram@claude-plugins-official\n\n# Discord\nclaude --channels plugin:discord@claude-plugins-official\n```\n\n> **Note:** The exact tool names depend on how you named your MCP servers. Run `/mcp` in Claude Code to see your server names, then match them here. If you use Discord instead of Telegram, replace the `mcp__plugin_telegram_telegram__` entries with the corresponding Discord tool names.\n\n### 6.3 Option B: --allowedTools (CLI Flag)\n\nSame scoping as Option A, but passed on the command line instead of persisted in config. Useful if you want different permission sets for different sessions:\n\n```bash\nclaude --channels plugin:telegram@claude-plugins-official \\\n  --allowedTools \"mcp__plugin_telegram_telegram__reply \\\n    mcp__plugin_telegram_telegram__react \\\n    mcp__plugin_telegram_telegram__edit_message \\\n    mcp__google-calendar__gcal_list_events \\\n    mcp__google-calendar__gcal_get_event \\\n    mcp__open-brain__search_thoughts \\\n    mcp__open-brain__list_thoughts \\\n    mcp__open-brain__thought_stats \\\n    mcp__open-brain__capture_thought \\\n    mcp__supabase__execute_sql \\\n    'Bash(*)' \\\n    CronCreate CronDelete\"\n```\n\n### 6.4 Option C: Auto Permission Mode\n\nA middle ground. Claude can take actions automatically but still respects certain guardrails:\n\n```bash\nclaude --channels plugin:telegram@claude-plugins-official --permission-mode auto\n```\n\n(Swap `telegram` for `discord` if using Discord.)\n\n### 6.5 Option D: Skip Permissions (Testing Only)\n\nFor initial setup and testing on a machine you fully trust:\n\n```bash\nclaude --channels plugin:telegram@claude-plugins-official --dangerously-skip-permissions\n```\n\n> [!CAUTION]\n> This means Claude can run any tool, any bash command, write any file — without asking. Use this for initial testing, then switch to Option A for daily operation.\n\n### 6.6 Test Before You Walk Away\n\n1. Start Claude Code with your chosen permission strategy\n2. Run `/life-engine` manually\n3. Watch for any permission prompts — if you see one, add that tool to your allowlist\n4. Repeat until the skill runs clean with no prompts\n5. Only then start the loop and step away\n\n✅ **Checkpoint:** `/life-engine` completes a full cycle (calendar check → briefing → log) with zero permission prompts.\n\n---\n\n## Step 7: Start Simple — Your First Loop\n\n**Don't activate everything at once.** Start with just calendar + Telegram.\n\n### 7.1 Start Claude Code with Channels and Permissions\n\nIf you configured `settings.json` in Step 6 (recommended), just launch with the channel flag:\n\n```bash\n# Telegram\nclaude --channels plugin:telegram@claude-plugins-official\n\n# Discord\nclaude --channels plugin:discord@claude-plugins-official\n```\n\nOr append your preferred permission flag from Step 6 if you didn't use `settings.json`.\n\n### 7.2 Test the Skill Manually\n\nIn your session, run:\n\n```\n/life-engine\n```\n\nClaude should check the time, look at your calendar, and send you a Telegram message. If it's morning, you'll get a daily briefing. If there's a meeting coming up, you'll get a prep brief.\n\n### 7.3 Start the Loop\n\nOnce you've confirmed it works:\n\n```\n/loop 30m /life-engine\n```\n\nThat's it. Claude will now check in every 30 minutes and decide if you need anything. When you reply on Telegram or Discord, the channel pushes your message directly into the session — Claude reads and responds inline, no separate polling loop needed.\n\n> **Note:** Loop jobs and channels are session-only — they stop when Claude Code exits. For persistent operation, keep a Claude Code session running on a dedicated machine or persistent terminal, or restart when you begin your day.\n\n✅ **Checkpoint:** You're receiving proactive Telegram messages from Claude based on your calendar, and your Telegram replies reach Claude in real time.\n\n---\n\n## Step 8: Grow It Over Time\n\nThis is where Life Engine becomes unique to you. Here's the progression:\n\n### Week 1: Calendar + Telegram (Start Here)\n- Morning briefing with today's events\n- Pre-meeting prep from Open Brain\n- That's it. Keep it simple.\n\n### Week 2: Add Habits\nTell Claude:\n> \"Add a morning jog habit to my Life Engine. Remind me at 7am and ask me to confirm when I'm done.\"\n\nClaude will:\n1. Insert a record into `life_engine_habits`\n2. Start including it in morning briefings\n3. Log completions when you reply\n\n### Week 3: Add Check-ins\nTell Claude:\n> \"Add a midday mood check-in. Just ask me how I'm feeling and log it.\"\n\nClaude will:\n1. Start sending a midday prompt\n2. Log your responses to `life_engine_checkins`\n3. Include mood trends in evening summaries\n\n### Week 4: First Self-Improvement Cycle\nAfter 7 days of data, Claude reviews its own performance:\n- Which messages did you respond to?\n- Which ones did you ignore?\n- What did you ask for manually that could be automated?\n\nIt sends you a suggestion via your messaging channel. You approve or reject. The skill evolves.\n\n### Beyond: It's Yours\nOver weeks and months, your Life Engine accumulates:\n- A log of every briefing it sent\n- Your habit completion streaks\n- Your mood and energy patterns\n- A history of its own evolution\n\nNo two Life Engines look the same. Yours adapts to your schedule, your habits, your communication style, and your needs.\n\n---\n\n## Troubleshooting\n\n| Issue | Solution |\n|-------|----------|\n| **Life Engine stopped responding** | Most likely blocked on a permission prompt. Check the terminal — if you see a prompt waiting, approve it and configure permissions per Step 6 |\n| **Loop stops firing** | Loops are session-only. If Claude Code exits, restart with the full launch command and `/loop 30m /life-engine` |\n| **No Telegram messages received** | Verify you started with `--channels plugin:telegram@claude-plugins-official` and completed pairing. Run `/plugin list` to confirm the plugin is installed |\n| **Telegram replies not reaching Claude** | Channels only push while the session is open. Verify pairing completed (`/telegram:access pair`) and policy is set (`/telegram:access policy allowlist`) |\n| **`--channels` flag not recognized** | Update Claude Code to the latest version. The flag is in research preview and not shown in `--help` — but it works |\n| **Bun not found** | Install via `brew install oven-sh/bun/bun` or `curl -fsSL https://bun.sh/install \\| bash` |\n| **Plugin not loading** | Check `~/.claude/channels/telegram/.env` exists with your bot token. Try `/reload-plugins` in the session |\n| **Calendar not showing events** | Run `/mcp` and verify Google Calendar is connected |\n| **Open Brain returns nothing** | Test with: *\"Search my Open Brain for [topic]\"* — you may need more captured thoughts |\n| **Duplicate briefings** | The skill checks `life_engine_briefings` before sending. If duplicates occur, verify Supabase connection |\n| **Claude suggests too many changes** | The self-improvement protocol limits to 1 suggestion per 7 days. Adjust in the skill if needed |\n\n---\n\n## Going Further\n\n### Video Briefings with Remotion\nInstead of text, render a short video summary using [Remotion](https://www.remotion.dev/). Claude can generate a Remotion composition from the briefing data and send the rendered video via the Telegram channel's `reply` tool (which supports file attachments up to 50MB).\n\n### Multi-Person Households\nCombine with the [Family Calendar Extension](/ob1/extensions/family-calendar) to track multiple family members' schedules and send briefings relevant to the whole household.\n\n### Professional CRM Integration\nCombine with the [Professional CRM Extension](/ob1/extensions/professional-crm) to automatically pull contact history and opportunity status into pre-meeting briefings.\n\n### Voice Briefings\nUse ElevenLabs or another TTS API to convert briefings to audio. Send voice messages via Telegram instead of text — perfect for when you're driving.\n\n---\n\n## How It Works (Technical)\n\n### The Loop\n\nClaude Code's `/loop` command creates a cron job that fires a skill at a set interval. Each firing is a fresh invocation within the same session context, meaning Claude retains conversation history across firings.\n\n```\n/loop 30m /life-engine\n```\n\nThis creates a `*/30 * * * *` cron entry that triggers the `/life-engine` skill every 30 minutes. The loop handles the **proactive** side — Claude wakes up on a schedule and decides what you need.\n\n### The Channel\n\nThe messaging channel handles the **reactive** side — two-way communication. When Claude sends a briefing, it goes out through the channel using the `reply` tool. When you reply on Telegram or Discord, the message is pushed directly into the Claude Code session in real time as a `<channel>` event. No polling, no bridge server.\n\n```bash\nclaude --channels plugin:telegram@claude-plugins-official\n# or\nclaude --channels plugin:discord@claude-plugins-official\n```\n\nThe `--channels` flag enables the chosen plugin for the session. Events only arrive while the session is open. Both plugins expose the same three tools: `reply` (send text or files), `react` (add emoji reactions), and `edit_message` (update a previously sent message).\n\n### The Skill\n\nThe skill file (`.claude/skills/life-engine/SKILL.md`) is a prompt that Claude follows when the skill is invoked. It contains:\n- **Behavioral rules** — what to do at different times of day\n- **Tool instructions** — which MCP tools to use and how\n- **Output formatting** — how to structure Telegram messages\n- **Self-improvement protocol** — how and when to suggest changes\n\n### The MCP Layer\n\nClaude Code communicates with external services through MCP (Model Context Protocol) servers:\n- **Google Calendar MCP** — reads calendar events\n- **Open Brain MCP** — searches your knowledge base\n- **Messaging Channel** — sends and receives messages via Telegram or Discord plugin (`reply`, `react`, `edit_message`)\n- **Supabase MCP** — reads/writes Life Engine tables\n\nAll of these are configured in Claude Code's MCP settings and available to the skill automatically.\n\n### The Self-Improvement Loop\n\n```\nWeek N:\n  Claude runs Life Engine daily\n  Logs every briefing to life_engine_briefings\n  Tracks user responses\n\nWeek N+1:\n  Claude reviews past 7 days\n  Identifies high-value vs low-value behaviors\n  Proposes ONE change\n  User approves/rejects via Telegram\n  Change logged to life_engine_evolution\n  Skill behavior updates\n\nWeek N+2:\n  Repeat with updated behavior\n```\n\nOver time, this creates a feedback loop where the system continuously refines itself based on actual usage patterns.\n\n---\n\n## Expected Outcome\n\nAfter setup, you'll have:\n\n- ✅ A Claude Code session running `/loop 30m /life-engine`\n- ✅ Proactive morning briefings on your phone via Telegram\n- ✅ Automatic meeting prep with context from your Open Brain\n- ✅ Habit tracking with reminders and completion logging\n- ✅ Mood and health check-ins logged to your database\n- ✅ Evening day summaries with habit and mood trends\n- ✅ A self-improving system that suggests its own enhancements weekly\n\n**You started with a calendar check. You end up with an AI that knows your life.**\n\n---\n\n## Next Steps\n\n- Add more habits and track streaks over time\n- Connect additional Open Brain extensions for richer context\n- Experiment with different loop intervals (15m for busy days, 1h for relaxed days)\n- Build a [dashboard](/ob1/dashboards) to visualize your habit and mood data\n- Share your Life Engine configuration with the community\n\n---\n\n<details>\n<summary>📋 Full Credential Reference</summary>\n\n| Service | Value | Where It's Used |\n|---------|-------|----------------|\n| Supabase Project URL | `https://xxx.supabase.co` | Open Brain MCP, Life Engine tables |\n| Supabase Service Key | `eyJ...` | Database access |\n| OB1 MCP URL | `https://xxx.supabase.co/functions/v1/open-brain-mcp?key=xxx` | Knowledge search |\n| Telegram Bot Token | `123456:ABC...` | Telegram channel plugin |\n| Google Calendar | (OAuth via Claude Code) | Calendar events |\n\n</details>\n"
+    },
+    {
+      "slug": "life-engine-video",
+      "category": "recipes",
+      "site_path": "/ob1/recipes/life-engine-video",
+      "name": "Life Engine Video Briefings",
+      "description": "Add-on for Life Engine that renders short video briefings using Remotion and ElevenLabs TTS instead of text-only Telegram messages. Turns your daily briefing into a 30-60 second animated video with voiceover, delivered directly to your phone.",
+      "author": {
+        "name": "Jonathan Edwards",
+        "github": "jonathanedwards"
+      },
+      "version": "1.0.0",
+      "tags": [
+        "video",
+        "remotion",
+        "elevenlabs",
+        "tts",
+        "briefing",
+        "telegram",
+        "life-engine",
+        "add-on"
+      ],
+      "difficulty": "advanced",
+      "estimated_time": "60-90 minutes",
+      "created": "2026-03-18",
+      "updated": "2026-03-19",
+      "learning_order": null,
+      "compatibility": {
+        "open_brain": "required"
+      },
+      "requirements": {
+        "services": [
+          "supabase",
+          "elevenlabs",
+          "telegram"
+        ],
+        "tools": [
+          "claude-code",
+          "remotion",
+          "node",
+          "ffmpeg",
+          "bun",
+          "telegram-channel"
+        ]
+      },
+      "dependencies": {
+        "skills": [],
+        "primitives": []
+      },
+      "reverse_dependencies": {
+        "skills": [],
+        "primitives": []
+      },
+      "urls": {
+        "github_folder": "https://github.com/NateBJones-Projects/OB1/tree/main/recipes/life-engine-video",
+        "github_readme": "https://github.com/NateBJones-Projects/OB1/blob/main/recipes/life-engine-video/README.md"
+      },
+      "readme_markdown": "# 🎬 Life Engine — Video Briefings Add-On\n\n> Your daily briefing, but as a 30-second animated video on your phone.\n\nAn add-on for [Life Engine](/ob1/recipes/life-engine) that replaces (or supplements) text Telegram messages with short, animated video briefings — complete with AI voiceover, synced subtitles, and animated data cards. Built with [Remotion](https://www.remotion.dev/) and [ElevenLabs](https://elevenlabs.io/).\n\n> [!IMPORTANT]\n> **Built for [Claude Code](https://claude.ai/download), but not exclusive to it.** The Life Engine core requires Claude Code (it depends on `/loop` and skills), but this video add-on — the Remotion rendering, ElevenLabs TTS, and pipeline scripting — can be driven by any capable AI coding agent. ChatGPT handles Remotion well; other agents may work too. If you're adapting this to a different tool, the architecture and components in this guide give you everything you need.\n\n<!-- -->\n\n> [!NOTE]\n> **Expect iteration.** Your first rendered video will have timing issues, subtitle drift, or a voiceover script that sounds stilted. That's normal. Each render gives you feedback — adjust the VO script guidelines, tweak the subtitle chunking, tune the ElevenLabs voice settings. The structured data flowing from your Open Brain means the *content* improves automatically as your knowledge base grows. The *presentation* improves as you and your agent dial in the rendering pipeline together.\n\n---\n\n## What It Does\n\nInstead of receiving a text message like this:\n\n```\n☀️ Good morning!\n📅 3 events today:\n• 9:00 AM — Standup\n• 11:00 AM — Client call with Dave\n• 2:00 PM — Design review\n🏃 Habits: Morning jog — not yet today\n```\n\nYou receive a **30-second animated video** on Telegram with:\n\n- 🎙️ AI voiceover narrating your day (ElevenLabs TTS)\n- 📊 Animated cards sliding in for each event, task, and habit\n- 📝 Synced subtitles so you can watch without sound\n- 🎵 Optional ambient background music\n- 📱 Vertical format (9:16) optimized for phone viewing\n\nThe video is rendered on your machine by Remotion, then sent to your Telegram via the channel's `reply` tool.\n\n---\n\n## Prerequisites\n\n| Requirement | Status |\n|-------------|--------|\n| [Life Engine](/ob1/recipes/life-engine) set up and running | ☐ |\n| Node.js 18+ and pnpm installed | ☐ |\n| FFmpeg installed (`brew install ffmpeg`) | ☐ |\n| ElevenLabs API key ([elevenlabs.io](https://elevenlabs.io)) | ☐ |\n| ~2GB disk space for Remotion renders | ☐ |\n\n### Credential Tracker\n\n```\n# ElevenLabs\nELEVENLABS_API_KEY=\n\n# Telegram\n# (Reuse from Life Engine setup — the channel plugin's `reply` tool handles video delivery)\n\n# Voice Selection\nELEVENLABS_VOICE_ID=         # See Voice Options below\n```\n\n### Voice Options\n\nBrowse the [ElevenLabs Voice Library](https://elevenlabs.io/voice-library) to find a voice that fits your style. Here are two examples to give you an idea of what works well:\n\n| Voice | Style | Best For |\n|-------|-------|----------|\n| A bright, energetic voice | Playful, upbeat | Morning briefings |\n| A warm, smooth voice | Trustworthy, calm | Professional meeting prep |\n\nPick one to start. You can switch later or use different voices for different briefing types. Copy the voice ID from your ElevenLabs dashboard into the credential tracker above.\n\n---\n\n## Architecture\n\n```\nLife Engine Loop fires\n        │\n        ▼\n  Gather briefing data\n  (calendar, OB1, habits)\n        │\n        ▼\n  Generate VO script\n        │\n        ▼\n  ┌─────────────────────┐\n  │   ElevenLabs API    │\n  │   TTS + Timestamps  │◄── Voice + word-level timing\n  └──────────┬──────────┘\n             │\n             ▼\n  ┌─────────────────────┐\n  │  Write data.json    │◄── Events, tasks, habits, subtitles\n  └──────────┬──────────┘\n             │\n             ▼\n  ┌─────────────────────┐\n  │   Remotion Render   │◄── React components + animation\n  └──────────┬──────────┘\n             │\n             ▼\n  ┌─────────────────────┐\n  │  FFmpeg Normalize   │◄── -14 LUFS audio normalization\n  └──────────┬──────────┘\n             │\n             ▼\n  ┌─────────────────────┐\n  │  Telegram Channel   │◄── Send video via `reply` tool\n  │  reply(files: [...])│     (max 50MB per file)\n  └─────────────────────┘\n```\n\n**Render time:** ~60-90 seconds for a 30-second video on Apple Silicon. The full pipeline (TTS → render → normalize → send) takes about 2-3 minutes.\n\n---\n\n## Quick Setup with Claude Code\n\nThis guide contains everything Claude Code needs to scaffold the entire project for you — the data contract, every component, the pipeline scripts, and the Remotion config. Instead of manually creating 10+ files, point Claude Code at this README and let it do the work:\n\n**1. Install prerequisites:**\n\n```bash\nbrew install ffmpeg\n```\n\n**2. Tell Claude Code:**\n\n> Read the Life Engine Video Briefings README at `~/path-to-ob1/recipes/life-engine-video/README.md` and set up the full Remotion project in `~/life-engine-video`. Create all the components, scenes, shared modules, pipeline scripts, and config files described in the guide. Use the data contract as the TypeScript interface and include placeholder `briefing.json` data so I can preview immediately.\n\n**3. Verify it worked:**\n\n```bash\ncd ~/life-engine-video && pnpm exec remotion preview\n```\n\nYou should see the Briefing composition in Remotion Studio. From there, skip ahead to [Step 4: Connect to Life Engine](#step-4-connect-to-life-engine) to wire it into your loop.\n\nIf you prefer to build it manually step-by-step, continue below.\n\n---\n\n## Step 1: Set Up the Remotion Project\n\n### 1.1 Create the Project\n\n```bash\nmkdir ~/life-engine-video && cd ~/life-engine-video\npnpm create video@latest --template blank\n```\n\nOr if you prefer manual setup:\n\n```bash\nmkdir ~/life-engine-video && cd ~/life-engine-video\npnpm init\npnpm add remotion @remotion/cli @remotion/player react react-dom\npnpm add -D @types/react typescript\npnpm add lucide-react\n```\n\n### 1.2 Project Structure\n\n```\nlife-engine-video/\n├── src/\n│   ├── index.ts              # Remotion entry\n│   ├── Root.tsx               # Composition registry\n│   ├── BriefingVideo.tsx      # Main composition\n│   ├── scenes/\n│   │   ├── TitleScene.tsx     # \"Good Morning\" opener\n│   │   ├── CalendarScene.tsx  # Today's events\n│   │   ├── HabitsScene.tsx    # Habit reminders\n│   │   ├── PrepScene.tsx      # Meeting prep from OB1\n│   │   ├── SummaryScene.tsx   # Evening wrap-up\n│   │   └── ClosingScene.tsx   # Sign-off\n│   ├── shared/\n│   │   ├── SubtitleBar.tsx    # Synced subtitle overlay\n│   │   ├── ProgressBar.tsx    # Playback progress bar\n│   │   ├── TaskCard.tsx       # Animated event/task card\n│   │   ├── SectionHeader.tsx  # Section title with icon\n│   │   └── Background.tsx     # Animated gradient background\n│   └── data/\n│       └── briefing.json      # Generated per-render by Claude\n├── public/\n│   ├── voice.mp3              # Generated per-render by ElevenLabs\n│   └── music.mp3              # Optional ambient track\n├── scripts/\n│   ├── generate-briefing.sh   # Full pipeline script\n│   └── normalize-audio.sh     # FFmpeg LUFS normalization\n├── package.json\n└── tsconfig.json\n```\n\n✅ **Checkpoint:** `pnpm exec remotion preview` opens the Remotion studio.\n\n---\n\n## Step 2: Build the Video Components\n\n### 2.1 The Data Contract\n\nEvery render is driven by a single `briefing.json` file that Claude generates. This is the contract between Claude and Remotion:\n\n```typescript\n// src/types.ts\nexport interface BriefingData {\n  type: 'morning' | 'pre_meeting' | 'evening' | 'checkin';\n  date: string;           // \"Wednesday, March 18\"\n  greeting: string;       // \"Good morning!\" | \"Day wrap-up\"\n\n  // Calendar events\n  events: Array<{\n    time: string;         // \"9:00 AM\"\n    title: string;        // \"Standup\"\n    subtitle?: string;    // \"With engineering team\"\n    color: string;        // \"#3b82f6\"\n  }>;\n\n  // Habits\n  habits: Array<{\n    name: string;         // \"Morning jog\"\n    completed: boolean;\n    streak?: number;      // days\n  }>;\n\n  // Meeting prep (pre_meeting type only)\n  prep?: {\n    meetingTitle: string;\n    attendees: string[];\n    obContext: string[];   // relevant OB1 thoughts\n    talkingPoints: string[];\n  };\n\n  // Evening summary (evening type only)\n  summary?: {\n    meetingsAttended: number;\n    habitsCompleted: number;\n    habitsTotal: number;\n    mood?: string;\n    tomorrowFirst?: string;\n  };\n\n  // Voiceover\n  voiceover: {\n    script: string;             // full VO text\n    audioFile: string;          // path to generated MP3\n    subtitles: Array<{\n      text: string;             // 5-7 word phrase\n      start: number;            // seconds\n      end: number;              // seconds\n    }>;\n  };\n\n  // Styling\n  theme: {\n    background: string;         // \"#fafafa\" light | \"#0a0a0f\" dark\n    accent: string;             // primary accent color\n    mode: 'light' | 'dark';\n  };\n}\n```\n\n### 2.2 Shared Components\n\nThese components are reusable across all briefing types. They handle animation, layout, and visual consistency.\n\n<details>\n<summary>📄 src/shared/SubtitleBar.tsx</summary>\n\n```tsx\nimport React from \"react\";\nimport { useCurrentFrame, useVideoConfig } from \"remotion\";\n\ninterface SubtitleCue {\n  text: string;\n  start: number;\n  end: number;\n}\n\nexport const SubtitleBar: React.FC<{\n  subtitles: SubtitleCue[];\n  color?: string;\n  bottom?: number;\n  fontSize?: number;\n}> = ({ subtitles, color = \"rgba(99,102,241,0.88)\", bottom = 180, fontSize = 38 }) => {\n  const frame = useCurrentFrame();\n  const { fps } = useVideoConfig();\n  const timeSec = frame / fps;\n\n  let currentCue = subtitles.find(\n    (c) => timeSec >= c.start && timeSec <= c.end\n  );\n  let isActive = !!currentCue;\n\n  if (!currentCue) {\n    const past = subtitles.filter((c) => c.end <= timeSec);\n    currentCue = past.length > 0 ? past[past.length - 1] : undefined;\n  }\n\n  if (!currentCue) return null;\n\n  return (\n    <div style={{\n      position: \"absolute\", bottom, left: 0, right: 0, zIndex: 50,\n      background: color, padding: \"20px 40px\",\n      display: \"flex\", alignItems: \"center\", justifyContent: \"center\",\n    }}>\n      <div style={{\n        color: \"#fff\", fontSize, fontWeight: 600, textAlign: \"center\",\n        lineHeight: 1.35, opacity: isActive ? 1 : 0.5,\n        fontFamily: \"Inter, system-ui, sans-serif\",\n      }}>\n        {currentCue.text}\n      </div>\n    </div>\n  );\n};\n```\n\n</details>\n\n<details>\n<summary>📄 src/shared/ProgressBar.tsx</summary>\n\n```tsx\nimport React from \"react\";\nimport { useCurrentFrame, useVideoConfig } from \"remotion\";\n\nexport const ProgressBar: React.FC = () => {\n  const frame = useCurrentFrame();\n  const { durationInFrames } = useVideoConfig();\n  return (\n    <div style={{\n      position: \"absolute\", bottom: 0, left: 0, zIndex: 100,\n      width: `${(frame / durationInFrames) * 100}%`, height: 6,\n      background: \"linear-gradient(90deg, #60a5fa, #a78bfa, #f472b6)\",\n    }} />\n  );\n};\n```\n\n</details>\n\n<details>\n<summary>📄 src/shared/TaskCard.tsx</summary>\n\n```tsx\nimport React from \"react\";\nimport { useCurrentFrame, useVideoConfig, spring, interpolate } from \"remotion\";\n\nexport const TaskCard: React.FC<{\n  icon: React.ReactNode;\n  title: string;\n  subtitle?: string;\n  color: string;\n  delay: number;\n}> = ({ icon, title, subtitle, color, delay }) => {\n  const frame = useCurrentFrame();\n  const { fps } = useVideoConfig();\n  const s = spring({\n    frame: frame - delay, fps,\n    config: { stiffness: 200, damping: 20 },\n  });\n\n  return (\n    <div style={{\n      transform: `translateX(${interpolate(s, [0, 1], [80, 0])}px)`,\n      opacity: s, display: \"flex\", alignItems: \"center\", gap: 24,\n      padding: \"24px 32px\", marginBottom: 16, borderRadius: 20,\n      background: \"rgba(255,255,255,0.9)\",\n      boxShadow: `0 2px 16px rgba(0,0,0,0.06), inset 0 0 0 2px ${color}22`,\n      borderLeft: `5px solid ${color}`,\n    }}>\n      <div style={{ color, flexShrink: 0 }}>{icon}</div>\n      <div>\n        <div style={{\n          fontSize: 34, fontWeight: 600, color: \"rgba(0,0,0,0.85)\",\n          lineHeight: 1.3, fontFamily: \"Inter, system-ui, sans-serif\",\n        }}>{title}</div>\n        {subtitle && (\n          <div style={{\n            fontSize: 26, color: \"rgba(0,0,0,0.5)\", marginTop: 4,\n            fontFamily: \"Inter, system-ui, sans-serif\",\n          }}>{subtitle}</div>\n        )}\n      </div>\n    </div>\n  );\n};\n```\n\n</details>\n\n<details>\n<summary>📄 src/shared/SectionHeader.tsx</summary>\n\n```tsx\nimport React from \"react\";\nimport { useCurrentFrame, useVideoConfig, spring } from \"remotion\";\n\nexport const SectionHeader: React.FC<{\n  icon: React.ReactNode;\n  label: string;\n  count?: number;\n  color: string;\n  delay: number;\n}> = ({ icon, label, count, color, delay }) => {\n  const frame = useCurrentFrame();\n  const { fps } = useVideoConfig();\n  const s = spring({\n    frame: frame - delay, fps,\n    config: { stiffness: 250, damping: 22 },\n  });\n\n  return (\n    <div style={{\n      transform: `scale(${s})`, opacity: s,\n      display: \"flex\", alignItems: \"center\", gap: 18,\n      marginBottom: 24, marginTop: 12,\n    }}>\n      <div style={{ color }}>{icon}</div>\n      <div style={{\n        fontSize: 42, fontWeight: 700, color,\n        fontFamily: \"Inter, system-ui, sans-serif\",\n      }}>{label}</div>\n      {count !== undefined && (\n        <div style={{\n          background: color, color: \"#fff\", borderRadius: 30,\n          padding: \"4px 18px\", fontSize: 30, fontWeight: 700,\n          fontFamily: \"Inter, system-ui, sans-serif\",\n        }}>{count}</div>\n      )}\n    </div>\n  );\n};\n```\n\n</details>\n\n### 2.3 Scene Components\n\nEach briefing type is composed of scenes. Scenes are Remotion `<Sequence>` blocks with their own duration and animations. The composition assembles them based on the briefing data.\n\n> **Key pattern:** Scenes are data-driven. The same `CalendarScene` component renders 2 events or 6 events — the layout adapts. Scene durations are calculated from the voiceover timestamps, not hardcoded.\n\n<details>\n<summary>📄 src/scenes/TitleScene.tsx (example)</summary>\n\n```tsx\nimport React from \"react\";\nimport { AbsoluteFill, useCurrentFrame, useVideoConfig, spring } from \"remotion\";\nimport { Sun, Moon } from \"lucide-react\";\n\nexport const TitleScene: React.FC<{\n  greeting: string;\n  date: string;\n  type: 'morning' | 'evening' | 'pre_meeting' | 'checkin';\n}> = ({ greeting, date, type }) => {\n  const frame = useCurrentFrame();\n  const { fps } = useVideoConfig();\n  const s = spring({ frame, fps, config: { stiffness: 120, damping: 22 } });\n  const pulse = 1 + Math.sin(frame / 20) * 0.02;\n\n  const Icon = type === 'evening' ? Moon : Sun;\n  const iconColor = type === 'evening' ? '#a78bfa' : '#f59e0b';\n\n  return (\n    <AbsoluteFill style={{\n      justifyContent: \"center\", alignItems: \"center\",\n      flexDirection: \"column\", gap: 30,\n    }}>\n      <div style={{ transform: `scale(${s})`, opacity: s }}>\n        <Icon size={120} color={iconColor} strokeWidth={1.5} />\n      </div>\n      <div style={{\n        transform: `scale(${s * pulse})`, opacity: s,\n        fontSize: 80, fontWeight: 800, color: \"rgba(0,0,0,0.85)\",\n        fontFamily: \"Inter, system-ui, sans-serif\",\n      }}>{greeting}</div>\n      <div style={{\n        transform: `scale(${s})`, opacity: s,\n        fontSize: 56, fontWeight: 500, color: \"rgba(0,0,0,0.5)\",\n        fontFamily: \"Inter, system-ui, sans-serif\", marginTop: -10,\n      }}>{date}</div>\n    </AbsoluteFill>\n  );\n};\n```\n\n</details>\n\n### 2.4 Main Composition\n\nThe `BriefingVideo` composition reads `briefing.json`, calculates scene durations from voiceover timestamps, and assembles the appropriate scenes.\n\n```tsx\n// src/BriefingVideo.tsx (simplified structure)\nimport { AbsoluteFill, Sequence, Audio, staticFile } from \"remotion\";\nimport briefingData from \"./data/briefing.json\";\nimport { SubtitleBar } from \"./shared/SubtitleBar\";\nimport { ProgressBar } from \"./shared/ProgressBar\";\nimport { TitleScene } from \"./scenes/TitleScene\";\nimport { CalendarScene } from \"./scenes/CalendarScene\";\n// ... other scene imports\n\nconst FPS = 30;\n\nexport const BriefingVideo: React.FC = () => {\n  const data = briefingData as BriefingData;\n\n  // Calculate total duration from voiceover\n  const lastCue = data.voiceover.subtitles[data.voiceover.subtitles.length - 1];\n  const totalDuration = Math.ceil((lastCue.end + 1) * FPS);\n\n  // Scene durations derived from VO timing (not hardcoded)\n  // Claude calculates these when generating briefing.json\n\n  return (\n    <AbsoluteFill style={{\n      background: data.theme.background,\n      fontFamily: \"Inter, system-ui, sans-serif\",\n    }}>\n      {/* Scenes assembled based on briefing type */}\n      <Sequence from={0} durationInFrames={Math.round(2 * FPS)}>\n        <TitleScene\n          greeting={data.greeting}\n          date={data.date}\n          type={data.type}\n        />\n      </Sequence>\n\n      {data.events.length > 0 && (\n        <Sequence from={Math.round(2 * FPS)} durationInFrames={Math.round(data.events.length * 3 * FPS)}>\n          <CalendarScene events={data.events} />\n        </Sequence>\n      )}\n\n      {/* ... additional scenes based on data.type */}\n\n      <SubtitleBar subtitles={data.voiceover.subtitles} />\n      <ProgressBar />\n      <Audio src={staticFile(\"voice.mp3\")} />\n      {/* Optional music */}\n      <Audio src={staticFile(\"music.mp3\")} volume={0.12} />\n    </AbsoluteFill>\n  );\n};\n```\n\n### 2.5 Register the Composition\n\n```tsx\n// src/Root.tsx\nimport { Composition } from \"remotion\";\nimport { BriefingVideo } from \"./BriefingVideo\";\nimport briefingData from \"./data/briefing.json\";\n\nconst FPS = 30;\n\nexport const RemotionRoot: React.FC = () => {\n  // Duration from VO data\n  const lastCue = briefingData.voiceover?.subtitles?.slice(-1)[0];\n  const duration = lastCue ? Math.ceil((lastCue.end + 2) * FPS) : 30 * FPS;\n\n  return (\n    <Composition\n      id=\"Briefing\"\n      component={BriefingVideo}\n      durationInFrames={duration}\n      fps={FPS}\n      width={1080}\n      height={1920}\n    />\n  );\n};\n```\n\n✅ **Checkpoint:** Remotion studio shows the Briefing composition with placeholder data.\n\n---\n\n## Step 3: Set Up the Rendering Pipeline\n\n### 3.1 ElevenLabs TTS with Timestamps\n\nThe voiceover is generated using ElevenLabs' `/with-timestamps` endpoint, which returns both audio and character-level timing data. Claude uses this to build synced subtitles.\n\n**API call pattern:**\n\n```\nPOST https://api.elevenlabs.io/v1/text-to-speech/{voice_id}/with-timestamps\n\n{\n  \"text\": \"Good morning! You have 3 events today...\",\n  \"model_id\": \"eleven_multilingual_v2\",\n  \"voice_settings\": {\n    \"stability\": 0.55,\n    \"similarity_boost\": 0.75,\n    \"style\": 0.15,\n    \"speed\": 1.0,\n    \"use_speaker_boost\": true\n  }\n}\n```\n\n**Response includes:**\n- `audio_base64` — the full audio as base64 MP3\n- `alignment.characters` — every character with start/end times in seconds\n\n**Claude converts character timestamps to word-level subtitle cues** by grouping characters between spaces, then chunking into 5-7 word phrases for readable subtitles.\n\n### 3.2 Audio Normalization\n\nAfter rendering, normalize audio to broadcast standard:\n\n```bash\n#!/bin/bash\n# scripts/normalize-audio.sh\nINPUT=\"$1\"\nOUTPUT=\"${INPUT%.mp4}-normalized.mp4\"\nffmpeg -y -i \"$INPUT\" -af loudnorm=I=-14:TP=-1.5:LRA=11 \\\n  -c:v copy \"$OUTPUT\" 2>/dev/null\necho \"Normalized: $OUTPUT\"\n```\n\n### 3.3 Full Pipeline Script\n\nThis script orchestrates the entire flow — Claude calls this to generate and send a video briefing:\n\n```bash\n#!/bin/bash\n# scripts/generate-briefing.sh\n# Called by Claude with: bash scripts/generate-briefing.sh\n\nPROJECT_DIR=\"$HOME/life-engine-video\"\ncd \"$PROJECT_DIR\"\n\necho \"1/3 — Rendering video...\"\nPATH=\"/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin\" \\\n  pnpm exec remotion render src/index.ts Briefing \\\n  out/briefing.mp4 --codec h264 --crf 23 --scale 1\n\necho \"2/3 — Normalizing audio...\"\nbash scripts/normalize-audio.sh out/briefing.mp4\n\necho \"3/3 — Done! Video ready for delivery.\"\n# Delivery handled by Claude via the Telegram channel's `reply` tool:\n#   reply(chat_id=..., text=\"📹 Your briefing is ready\", files=[\"/path/to/out/briefing-normalized.mp4\"])\n# The `reply` tool supports file attachments (images, videos, documents) up to 50MB each.\n```\n\n✅ **Checkpoint:** Running the pipeline script manually produces a normalized video file. Claude then delivers it via `reply(files=[...])` in the next step.\n\n---\n\n## Step 4: Connect to Life Engine\n\n### 4.1 Update the Life Engine Skill\n\nAdd video briefing capability to your existing `/life-engine` skill by adding this section:\n\n```markdown\n## Video Briefing Mode (Optional)\n\nWhen generating a morning briefing or evening summary, you MAY render\na video briefing instead of (or in addition to) a text message.\n\n### When to use video:\n- Morning briefings (daily rundown)\n- Evening summaries (day wrap-up)\n- NOT for pre-meeting prep (too slow — use text for time-sensitive briefs)\n- NOT for check-in prompts (text is faster for quick interactions)\n\n### Video briefing flow:\n1. Gather all briefing data (calendar, habits, OB1 context)\n2. Write a natural voiceover script (30-45 seconds spoken)\n3. Call ElevenLabs /with-timestamps API to generate audio + timing\n4. Save audio to ~/life-engine-video/public/voice.mp3\n5. Convert character timestamps to 5-7 word subtitle cues\n6. Write briefing.json to ~/life-engine-video/src/data/\n7. Run: bash ~/life-engine-video/scripts/generate-briefing.sh\n8. Send via Telegram channel: `reply(chat_id=..., text=\"📹 Your briefing is ready\", files=[\"~/life-engine-video/out/briefing-normalized.mp4\"])`\n9. Log to life_engine_briefings with delivered_via = 'telegram_video'\n\n### Voiceover script guidelines:\n- Keep it under 45 seconds spoken (~100-120 words)\n- Conversational tone — like a friend giving you a heads up\n- Start with greeting, end with encouragement\n- Pre-normalize numbers: \"3\" → \"three\", phone numbers spelled out\n- No special characters or abbreviations the TTS might stumble on\n\n### Example VO script (morning):\n\"Good morning! It's Wednesday March eighteenth. You've got three things\non the calendar today. First up, a standup at nine. Then a client call\nwith Dave at eleven — I pulled some notes from your brain on Rooster\nCreative. And a design review at two. Don't forget your morning jog.\nHave a great day!\"\n```\n\n### 4.2 Skill Decision Logic\n\nThe updated Life Engine skill now has two delivery modes. Claude decides which to use:\n\n| Briefing Type | Delivery | Why |\n|--------------|----------|-----|\n| Morning briefing | **Video** | Not time-sensitive, worth the 2-min render |\n| Pre-meeting prep | **Text** | Time-sensitive, needs to arrive quickly |\n| Check-in prompt | **Text** | Interactive, expects a reply |\n| Evening summary | **Video** | Reflective, nice to watch at end of day |\n| Habit reminder | **Text** | Quick nudge, not worth a video |\n\n---\n\n## Step 5: Customize Your Style\n\n### 5.1 Theme Options\n\nThe briefing data includes a `theme` object. Switch between light and dark:\n\n| Theme | Background | Accent | Best For |\n|-------|-----------|--------|----------|\n| Light | `#fafafa` | `#6366f1` (indigo) | Morning briefings |\n| Dark | `#0a0a0f` | `#a78bfa` (purple) | Evening summaries |\n| Warm | `#fdf6e3` | `#f59e0b` (amber) | Casual check-ins |\n\n### 5.2 Voice Selection\n\nDifferent briefing types can use different voices:\n\n```json\n{\n  \"morning\": { \"voice_id\": \"YOUR_MORNING_VOICE_ID\", \"name\": \"Your morning voice\" },\n  \"evening\": { \"voice_id\": \"YOUR_EVENING_VOICE_ID\", \"name\": \"Your evening voice\" }\n}\n```\n\n### 5.3 Music\n\nAdd ambient background music at low volume (0.10-0.15). Generate short loops via:\n- ElevenLabs Music API\n- Suno\n- Any royalty-free ambient track\n\nPlace in `public/music.mp3`. The composition plays it at 12-15% volume under the voiceover.\n\n---\n\n## Troubleshooting\n\n| Issue | Solution |\n|-------|----------|\n| **Render crashes with SIGSEGV** | Use `--codec h264`, NOT h265/libx265 (crashes on Apple Silicon) |\n| **Render takes too long** | Keep videos under 45 seconds. Use `--scale 0.5` for testing |\n| **Subtitles out of sync** | Use `normalized_alignment` from ElevenLabs, not `alignment` |\n| **Telegram rejects video** | Max file size is 50MB per the `reply` tool. 30s H.264 at CRF 23 is typically 3-5MB |\n| **TTS sounds robotic** | Adjust stability (0.4-0.6) and style (0.1-0.3). Lower stability = more expressive |\n| **Missing fonts** | Install Inter font, or Remotion will fall back to system-ui |\n| **FFmpeg not found** | Set PATH explicitly: `PATH=\"/opt/homebrew/bin:$PATH\"` |\n\n---\n\n## Going Further\n\n### Dynamic Scene Assembly\n\nInstead of fixed scene types, let Claude decide which scenes to include based on the data. If there are no habits, skip the habits scene. If there's a lot of OB1 context for a meeting, add an extra context scene. The composition adapts to the data.\n\n### Weekly Recap Videos\n\nEvery Sunday, render a 60-second recap of the week: meetings attended, habits completed, mood trends, and highlights. Use chart/graph animations for habit streaks.\n\n### Voice Briefings (Audio Only)\n\nSkip the video render entirely and just send the TTS audio as a voice message via Telegram. Much faster (seconds instead of minutes), still personal. Good for quick habit reminders.\n\n### Screen Recording Integration\n\nFor meeting prep, capture a screenshot of the client's website or relevant dashboard and animate it into the prep briefing video. Use `@remotion/gif` to embed Chrome GIF captures.\n\n---\n\n## How the Pipeline Works (Technical)\n\n```\n┌──────────────────────────────────────────────────────────────┐\n│                    Claude Code Session                        │\n│                                                              │\n│  /life-engine fires                                          │\n│       │                                                      │\n│  1. Gather data (Calendar MCP + OB1 MCP + Supabase)         │\n│       │                                                      │\n│  2. Generate VO script (~100 words, conversational)          │\n│       │                                                      │\n│  3. POST to ElevenLabs /with-timestamps                     │\n│       │  → Returns: audio_base64 + character timestamps     │\n│       │                                                      │\n│  4. Decode audio → save to public/voice.mp3                 │\n│       │                                                      │\n│  5. Group characters into 5-7 word subtitle cues            │\n│       │                                                      │\n│  6. Write briefing.json with all data + subtitles           │\n│       │                                                      │\n│  7. Run: remotion render → out/briefing.mp4                 │\n│       │  (~60-90 sec render on Apple Silicon)                │\n│       │                                                      │\n│  8. Run: normalize-audio.sh → out/briefing-normalized.mp4   │\n│       │                                                      │\n│  9. Send via Telegram channel `reply` tool (files param)     │\n│       │                                                      │\n│  10. Log to life_engine_briefings (type: telegram_video)    │\n│       │                                                      │\n│  11. Cleanup temp files                                     │\n│                                                              │\n└──────────────────────────────────────────────────────────────┘\n```\n\n**Total pipeline time:** 2-3 minutes (TTS: ~5s, Render: ~90s, Normalize: ~10s, Upload: ~5s)\n\nThis is why video briefings are used for non-time-sensitive messages (morning, evening) and text is used for urgent ones (pre-meeting prep).\n\n---\n\n## Expected Outcome\n\nAfter setup, your Life Engine will:\n\n- ✅ Render a **30-second morning briefing video** with your day's events, habits, and voiceover\n- ✅ Render an **evening summary video** with your day's stats and tomorrow's preview\n- ✅ Send videos directly to your phone via Telegram\n- ✅ Fall back to text for time-sensitive briefings (meeting prep, check-ins)\n- ✅ Use synced subtitles so you can watch without sound\n- ✅ Customize voice, theme, and music to your preference\n\n**You started with a text message. Now you have a personal AI news anchor.**\n"
+    },
+    {
+      "slug": "live-retrieval",
+      "category": "recipes",
+      "site_path": "/ob1/recipes/live-retrieval",
+      "name": "Live Retrieval",
+      "description": "Automatically surfaces relevant Open Brain thoughts during active work. Searches when topic shifts are detected, shows brief context notes on hits, stays silent on misses. The read side of the flywheel.",
+      "author": {
+        "name": "Jared Irish",
+        "github": "jaredirish"
+      },
+      "version": "1.0.0",
+      "tags": [
+        "retrieval",
+        "context",
+        "search",
+        "live",
+        "read",
+        "flywheel",
+        "proactive"
+      ],
+      "difficulty": "beginner",
+      "estimated_time": "5 minutes",
+      "created": "2026-03-19",
+      "updated": "2026-03-19",
+      "learning_order": null,
+      "compatibility": {
+        "open_brain": "required"
+      },
+      "requirements": {
+        "services": [],
+        "tools": [
+          "Claude Code"
+        ]
+      },
+      "dependencies": {
+        "skills": [],
+        "primitives": []
+      },
+      "reverse_dependencies": {
+        "skills": [],
+        "primitives": []
+      },
+      "urls": {
+        "github_folder": "https://github.com/NateBJones-Projects/OB1/tree/main/recipes/live-retrieval",
+        "github_readme": "https://github.com/NateBJones-Projects/OB1/blob/main/recipes/live-retrieval/README.md"
+      },
+      "readme_markdown": "# Live Retrieval\n\n*The read side of the flywheel.*\n\nAutomatically surfaces relevant Open Brain thoughts during active work. Fires when topic shifts are detected (person names, project names, technologies). Silent on miss, brief on hit. No manual searching required.\n\n**This is the recipe nobody else has built.** Every OB1 recipe writes data in. This one reads it back during active creation.\n\n## What It Does\n\nYou're working on a project. You mention a person's name or switch topics. The skill silently searches Open Brain. If it finds related thoughts you captured last week, it surfaces them in a brief 2-3 line note. If it finds nothing, you never know it searched.\n\nThe result: knowledge you captured Tuesday shows up Thursday when you're working on the same topic, without you having to remember it exists.\n\n## Prerequisites\n\n- Working Open Brain setup ([guide](https://github.com/NateBJones-Projects/OB1/blob/main/docs/01-getting-started.md))\n- Claude Code installed and working\n- Open Brain MCP tools connected (`search_thoughts`, `list_thoughts`)\n\n### Credential Tracker\n\n```\nFrom your existing Open Brain setup:\n- Project URL: _______________\n- Open Brain MCP server connected: yes / no\n\nNo additional credentials needed for this recipe.\n```\n\n## Steps\n\n### 1. Create the skill directory\n\n```bash\nmkdir -p ~/.claude/skills/live-retrieval\n```\n\n### 2. Copy the skill file\n\n```bash\ncp live-retrieval.skill.md ~/.claude/skills/live-retrieval/SKILL.md\n```\n\n### 3. Verify Claude Code picks up the skill\n\nRestart Claude Code. The skill fires proactively (you don't invoke it). To test: mention a topic you've previously captured thoughts about and see if context surfaces.\n\n### 4. Work normally\n\nThe skill does its job in the background. You'll notice it when it surfaces something useful. You won't notice it when it doesn't.\n\n### 5. Review the retrieval log\n\nAfter a few sessions, check `.claude/live-retrieval-log.jsonl` in your project root to see hit/miss rates and tune sensitivity.\n\n## Expected Outcome\n\nWhen working correctly, you should see:\n\n- At session start, a brief note showing recent Open Brain activity (ACT NOW items, recent captures)\n- During work, occasional context notes when you mention a person or topic that has related thoughts\n- No noise: if nothing relevant is found, nothing appears\n- A growing retrieval log that helps tune the skill over time\n\nTarget: at least 1 useful surfacing per 5 sessions. If you're getting zero, your Open Brain may not have enough thoughts yet (keep using Auto-Capture and Panning for Gold to build density).\n\n## Troubleshooting\n\n**Issue:** The skill never surfaces anything.\n**Solution:** Check that your Open Brain has thoughts to find. Run `list_thoughts({ \"limit\": 5 })` manually. If you have fewer than 20 thoughts, the density is too low for useful retrieval. Use the other flywheel recipes (Auto-Capture, Panning for Gold) to build up content first.\n\n**Issue:** The skill surfaces too much irrelevant context.\n**Solution:** Check the retrieval log. If hit scores are consistently below 0.6, the skill is matching on noise. This usually means your queries are too broad. The skill should only search on specific entity names, not generic topics.\n\n**Issue:** `search_thoughts` MCP tool not available.\n**Solution:** The skill silently skips when the MCP connection is down. Verify your Open Brain MCP server is connected in Claude Code settings. The skill degrades gracefully: no MCP means no retrieval, but no errors either.\n\n---\n\n*Every recipe writes in. This one reads back. The flywheel needs both sides.*\n"
+    },
+    {
+      "slug": "local-ollama-embeddings",
+      "category": "recipes",
+      "site_path": "/ob1/recipes/local-ollama-embeddings",
+      "name": "Local Embeddings via Ollama",
+      "description": "Generate embeddings locally using Ollama and insert thoughts into Supabase — no cloud API key needed for the embedding step.",
+      "author": {
+        "name": "Sam Rogers",
+        "github": "snapsynapse"
+      },
+      "version": "1.0.0",
+      "tags": [
+        "ollama",
+        "embeddings",
+        "local",
+        "offline",
+        "privacy"
+      ],
+      "difficulty": "intermediate",
+      "estimated_time": "30 minutes",
+      "created": "2026-03-14",
+      "updated": "2026-04-05",
+      "learning_order": null,
+      "compatibility": {
+        "open_brain": "required"
+      },
+      "requirements": {
+        "services": [],
+        "tools": [
+          "Python 3.10+",
+          "Ollama"
+        ]
+      },
+      "dependencies": {
+        "skills": [],
+        "primitives": []
+      },
+      "reverse_dependencies": {
+        "skills": [],
+        "primitives": []
+      },
+      "urls": {
+        "github_folder": "https://github.com/NateBJones-Projects/OB1/tree/main/recipes/local-ollama-embeddings",
+        "github_readme": "https://github.com/NateBJones-Projects/OB1/blob/main/recipes/local-ollama-embeddings/README.md"
+      },
+      "readme_markdown": "# Local Embeddings via Ollama\n\n> Generate embeddings locally and insert thoughts into Open Brain — no cloud API key needed.\n\n## What It Does\n\nReplaces the OpenRouter embedding step with a local Ollama model. You feed it text (stdin, file, or argument), it generates embeddings on your machine, and inserts the thoughts into your Supabase `thoughts` table. Zero API cost, full privacy, works offline.\n\n## Prerequisites\n\n- Working Open Brain setup ([guide](https://github.com/NateBJones-Projects/OB1/blob/main/docs/01-getting-started.md))\n- [Ollama](https://ollama.com) installed and running\n- Python 3.10+\n\n## Credential Tracker\n\nCopy this block into a text editor and fill it in as you go.\n\n```text\nLOCAL OLLAMA EMBEDDINGS -- CREDENTIAL TRACKER\n----------------------------------------------\n\nFROM YOUR OPEN BRAIN SETUP\n  Project URL:           ____________\n  Service role key:      ____________\n\nGENERATED DURING SETUP\n  Ollama model pulled:   ____________  (default: nomic-embed-text)\n\n----------------------------------------------\n```\n\n## Steps\n\n### 1. Install Ollama\n\nDownload from [ollama.com](https://ollama.com) and start it:\n\n```bash\nollama serve\n```\n\n### 2. Pull an embedding model\n\nThe default model is **nomic-embed-text** — smallest pull, widest community support, and fast on any hardware:\n\n```bash\nollama pull nomic-embed-text\n```\n\n**Tested models:**\n\nAll three models below were tested end-to-end: local Ollama embedding, live Supabase insertion, and `match_thoughts` semantic search verification.\n\n| Model | Dimensions | Pull size | Best for |\n|-------|-----------|-----------|----------|\n| **nomic-embed-text** (default) | 768 | ~275 MB | Fastest setup, lowest resource use |\n| **mxbai-embed-large** | 1024 | ~670 MB | Best retrieval quality |\n| **rjmalagon/gte-qwen2-1.5b-instruct-embed-f16** | **1536** | ~3.2 GB | **Drop-in compatible** with default Open Brain schema (no ALTER needed) |\n\n**Quality comparison:**\n\nTested with 4 text pairs (similar, unrelated, paraphrase, topically related). Gap = similar score minus unrelated score. Higher gap = better at distinguishing relevant from irrelevant results.\n\n| Model | Dims | Speed | Gap | Notes |\n|-------|:---:|:---:|:---:|-------|\n| nomic-embed-text | 768 | 0.4s | 0.222 | Fastest, but weaker at filtering irrelevant results |\n| **mxbai-embed-large** | 1024 | 0.4s | **0.587** | Best discrimination between related and unrelated |\n| gte-qwen2 (1536) | 1536 | 1.9s | 0.492 | Strong discrimination, no schema change needed |\n\n### Schema compatibility\n\nThe default Open Brain schema uses `vector(1536)` (matching OpenAI's `text-embedding-3-small`). If you use `rjmalagon/gte-qwen2-1.5b-instruct-embed-f16`, **no schema change is needed** — embeddings are directly compatible with the default `thoughts` table.\n\nFor nomic-embed-text or mxbai-embed-large, adjust your Supabase schema to match the model's dimensions:\n\n```sql\n-- For nomic-embed-text (768-dim):\nALTER TABLE thoughts ALTER COLUMN embedding TYPE vector(768);\n\n-- For mxbai-embed-large (1024-dim):\nALTER TABLE thoughts ALTER COLUMN embedding TYPE vector(1024);\n```\n\nYou will also need to recreate the `match_thoughts` function with the matching dimension. See the [getting started guide](https://github.com/NateBJones-Projects/OB1/blob/main/docs/01-getting-started.md) for the function definition and replace `vector(1536)` with your model's dimension.\n\n> **Note:** `rjmalagon/gte-qwen2-1.5b-instruct-embed-f16` is a community-published model (a quantized version of Alibaba's GTE-Qwen2-1.5B-instruct). It is not published by an official organization on Ollama. If you prefer an officially published model, use nomic-embed-text or mxbai-embed-large and adjust your schema accordingly.\n>\n> **Important:** Do **not** mix embeddings from different models in the same similarity search. Embeddings from different models occupy different semantic spaces — cosine similarity between them is meaningless, even if the dimensions happen to match. If you switch models, re-embed your entire corpus.\n\n### 3. Clone and install\n\n```bash\ncd recipes/local-ollama-embeddings\npip install -r requirements.txt\n```\n\n### 4. Configure environment\n\n```bash\ncp .env.example .env\n# Edit .env with your Supabase credentials\nset -a\nsource .env\nset +a\n```\n\n### 5. Embed a thought\n\n**From a string argument:**\n\n```bash\npython embed-local.py \"The key insight from today's meeting was that we need to ship the MVP before expanding the feature set.\"\n```\n\n**From stdin (pipe from another tool):**\n\n```bash\necho \"My important thought\" | python embed-local.py\n```\n\n**From a text file (one thought per line):**\n\n```bash\npython embed-local.py --file my-thoughts.txt\n```\n\n**From a JSONL file (structured input):**\n\n```bash\npython embed-local.py --file thoughts.jsonl\n```\n\nJSONL format:\n\n```json\n{\"content\": \"The thought text\", \"source\": \"journal\", \"metadata\": {\"project\": \"acme\"}}\n{\"content\": \"Another thought\", \"source\": \"meeting-notes\"}\n```\n\n### 6. Dry run first\n\nAlways test before live insertion:\n\n```bash\npython embed-local.py --file my-thoughts.txt --dry-run --verbose\n```\n\nThis generates embeddings (confirming Ollama works) but skips the Supabase insert.\n\n## Expected Outcome\n\nAfter running against your Supabase instance, you should see:\n\n```\nOpen Brain — Local Ollama Embeddings\n  Mode:     LIVE\n  Model:    nomic-embed-text (768-dim)\n  Ollama:   http://localhost:11434\n  Source:   ollama-local\n  Thoughts: 3\n\n1/3: The key insight from today's meeting was that we need to ship the MVP...\n   -> Ingested\n2/3: Our north star metric is weekly active users, not signups.\n   -> Ingested\n3/3: Decision: use Postgres RLS instead of application-level auth checks.\n   -> Ingested\n\n--------------------------------------------------\nSummary:\n  Input:     3 thoughts\n  Embedded:  3\n  Ingested:  3\n  Errors:    0\n  API cost:  $0.00 (local)\n--------------------------------------------------\n```\n\nVerify in Supabase:\n\n```sql\nSELECT content, metadata->>'source' as source, metadata->>'embedding_model' as model\nFROM thoughts\nWHERE metadata->>'source' = 'ollama-local'\nORDER BY created_at DESC\nLIMIT 10;\n```\n\n## Using With Other Recipes\n\nThis recipe works as a drop-in embedding replacement for any capture flow. Pipe output from other tools:\n\n```bash\n# Pipe from a custom extraction script\npython my-extractor.py | python embed-local.py --source my-extractor\n\n# Embed from a file another recipe produced\npython embed-local.py --file extracted-thoughts.txt --source chatgpt-import\n```\n\n## Troubleshooting\n\n**Issue: \"Cannot reach Ollama at http://localhost:11434\"**\nSolution: Start Ollama with `ollama serve`. If you're running Ollama on a different host or port, use `--ollama-url` or set `OLLAMA_BASE_URL`.\n\n**Issue: \"Ollama embedding failed (404)\"**\nSolution: The model isn't pulled yet. Run `ollama pull nomic-embed-text` (or whichever model you're using).\n\n**Issue: Supabase returns a dimension mismatch error**\nSolution: Your embedding model's output dimension doesn't match your `thoughts` table. Alter your column to match (see the model table in Step 2). Back up first.\n\n**Issue: Embeddings are slow**\nSolution: First run for a model is slow (loading into memory). Subsequent calls are fast. If consistently slow, check that Ollama isn't competing for RAM with other processes. GPU acceleration (if available) speeds things up significantly.\n\n**Issue: \"requests\" import error**\nSolution: `pip install -r requirements.txt`\n"
+    },
+    {
+      "slug": "ob-graph",
+      "category": "recipes",
+      "site_path": "/ob1/recipes/ob-graph",
+      "name": "ob-graph",
+      "description": "A knowledge graph layer for Open Brain. Adds graph database functionality using PostgreSQL nodes + edges with recursive CTE traversal, shortest-path queries, and a full MCP server for building and exploring relationship networks across your thoughts and entities.",
+      "author": {
+        "name": "Nate Jones",
+        "github": "NateBJones-Projects"
+      },
+      "version": "1.0.0",
+      "tags": [
+        "graph",
+        "knowledge-graph",
+        "relationships",
+        "traversal",
+        "nodes",
+        "edges",
+        "supabase",
+        "mcp",
+        "postgresql"
+      ],
+      "difficulty": "intermediate",
+      "estimated_time": "30 minutes",
+      "created": "2026-04-05",
+      "updated": "2026-04-05",
+      "learning_order": null,
+      "compatibility": {
+        "open_brain": "required"
+      },
+      "requirements": {
+        "services": [
+          "Supabase"
+        ],
+        "tools": [
+          "Supabase CLI",
+          "Deno"
+        ]
+      },
+      "dependencies": {
+        "skills": [],
+        "primitives": []
+      },
+      "reverse_dependencies": {
+        "skills": [],
+        "primitives": []
+      },
+      "urls": {
+        "github_folder": "https://github.com/NateBJones-Projects/OB1/tree/main/recipes/ob-graph",
+        "github_readme": "https://github.com/NateBJones-Projects/OB1/blob/main/recipes/ob-graph/README.md"
+      },
+      "readme_markdown": "# OB-Graph: Knowledge Graph Layer for Open Brain\n\nA knowledge graph you can build and query through your AI — powered by PostgreSQL, deployed as a Supabase Edge Function, and accessed via MCP.\n\n## Why This Matters\n\nYour Open Brain stores thoughts, but thoughts don't exist in isolation. Projects depend on tools. People work at companies. Concepts connect to other concepts. Without explicit relationships, your AI has to re-derive connections every time you ask \"how is X related to Y?\" OB-Graph gives your thoughts a relationship layer — nodes for entities, edges for connections, and graph traversal to surface paths you didn't know existed.\n\n## What It Does\n\nAdds two tables (`graph_nodes`, `graph_edges`) and an MCP server with 10 tools for:\n\n- **Building** a knowledge graph — create nodes (people, projects, concepts, tools) and connect them with typed edges (works_on, depends_on, related_to)\n- **Querying** relationships — get direct neighbors, multi-hop traversal, and shortest-path between any two nodes\n- **Linking** to existing thoughts — nodes can optionally reference a thought via `thought_id`\n\nAll graph traversal runs in PostgreSQL using recursive CTEs — no external graph database needed.\n\n## Prerequisites\n\n- Working Open Brain setup ([Getting Started guide](https://github.com/NateBJones-Projects/OB1/blob/main/docs/01-getting-started.md))\n- Supabase project configured\n- Supabase CLI installed and linked to your project\n\n## Credential Tracker\n\n```text\nOB-GRAPH -- CREDENTIAL TRACKER\n--------------------------------------\n\nSUPABASE (from your Open Brain setup)\n  Project URL:           ____________\n  Secret key:            ____________\n  Project ref:           ____________\n\nGENERATED DURING SETUP\n  Default User ID:       ____________\n  MCP Access Key:        ____________\n  MCP Server URL:        ____________\n  MCP Connection URL:    ____________\n\n--------------------------------------\n```\n\n## Setup Instructions\n\n![Step 1](https://img.shields.io/badge/Step_1-Create_Database_Schema-2E86AB?style=for-the-badge)\n\n<details>\n<summary><strong>SQL: Create tables, indexes, RLS, and graph functions</strong> (click to expand)</summary>\n\nRun the contents of `schema.sql` in your Supabase SQL Editor (Dashboard → SQL Editor → New Query → paste → Run).\n\nThe schema creates:\n\n| Object | Purpose |\n|--------|---------|\n| `graph_nodes` | Entities in your knowledge graph |\n| `graph_edges` | Directed relationships between nodes |\n| `traverse_graph()` | Recursive CTE function for multi-hop traversal |\n| `find_shortest_path()` | BFS shortest path between two nodes |\n| RLS policies | User-scoped data isolation on both tables |\n| Indexes | Fast lookups by user, type, label, source/target |\n\n</details>\n\n> [!IMPORTANT]\n> The schema includes `GRANT` statements for `service_role`. These are required on newer Supabase projects — don't skip them.\n\nDone when: You can see `graph_nodes` and `graph_edges` in the Supabase Table Editor, and both functions appear under Database → Functions.\n\n---\n\n![Step 2](https://img.shields.io/badge/Step_2-Deploy_the_MCP_Server-2E86AB?style=for-the-badge)\n\nFollow the [Deploy an Edge Function](/ob1/primitives/deploy-edge-function) guide using these values:\n\n| Setting | Value |\n|---------|-------|\n| Function name | `ob-graph-mcp` |\n| Download path | `recipes/ob-graph` |\n\nBefore you deploy, generate an MCP access key and decide which Open Brain user this graph belongs to. Then set the function secrets from `.env.example`:\n\n```bash\nopenssl rand -hex 32\nsupabase secrets set \\\n  MCP_ACCESS_KEY=your-generated-key \\\n  DEFAULT_USER_ID=your-user-uuid\n```\n\n`SUPABASE_URL` and `SUPABASE_SERVICE_ROLE_KEY` are provided automatically by Supabase for Edge Functions. You only need to set `MCP_ACCESS_KEY` and `DEFAULT_USER_ID` manually.\n\nDone when: The `ob-graph-mcp` function is deployed successfully and its secrets include `MCP_ACCESS_KEY` and `DEFAULT_USER_ID`.\n\n---\n\n![Step 3](https://img.shields.io/badge/Step_3-Connect_to_Your_AI-2E86AB?style=for-the-badge)\n\nFollow the [Remote MCP Connection](/ob1/primitives/remote-mcp) guide to connect this recipe to Claude Desktop, ChatGPT, Claude Code, or any other MCP client.\n\n| Setting | Value |\n|---------|-------|\n| Connector name | `OB-Graph` |\n| URL | Your **MCP Connection URL** from the credential tracker |\n\nDone when: Your AI client can connect to the OB-Graph MCP server without authentication errors and the tools appear in its MCP tool list.\n\n---\n\n![Step 4](https://img.shields.io/badge/Step_4-Test_the_Graph-2E86AB?style=for-the-badge)\n\nTry these commands with your AI:\n\n**Build a small graph:**\n```\nCreate these graph nodes:\n- \"Supabase\" (type: tool)\n- \"Open Brain\" (type: project)\n- \"PostgreSQL\" (type: tool)\n\nThen connect them:\n- Open Brain --depends_on--> Supabase\n- Open Brain --depends_on--> PostgreSQL\n- Supabase --built_with--> PostgreSQL\n```\n\n**Query relationships:**\n```\nWhat are all the neighbors of \"Open Brain\" in my graph?\n```\n\n```\nTraverse my graph starting from \"Supabase\" up to 3 hops deep\n```\n\n```\nFind the shortest path between \"PostgreSQL\" and \"Open Brain\"\n```\n\nDone when: Your AI can create nodes, connect them with edges, and traverse the graph to answer relationship questions.\n\n## MCP Tools Reference\n\n| Tool | Description |\n|------|-------------|\n| `create_node` | Add an entity node (person, project, concept, tool, place) |\n| `create_edge` | Create a directed relationship between two nodes |\n| `search_nodes` | Find nodes by label or type |\n| `get_neighbors` | Get direct connections (incoming, outgoing, or both) |\n| `traverse_graph` | Multi-hop walk from a starting node (recursive CTE) |\n| `find_path` | Shortest path between two nodes (bidirectional BFS) |\n| `update_node` | Update label, type, or merge new properties |\n| `delete_node` | Remove a node and all its edges (CASCADE) |\n| `delete_edge` | Remove a specific relationship |\n| `list_edge_types` | List all relationship types in use with counts |\n\n> [!TIP]\n> As your graph grows, see the [MCP Tool Audit & Optimization Guide](https://github.com/NateBJones-Projects/OB1/blob/main/docs/05-tool-audit.md) for strategies on managing tool context.\n\n## How the Graph Traversal Works\n\nOB-Graph uses PostgreSQL recursive CTEs instead of a dedicated graph database. Here's the pattern:\n\n```sql\nWITH RECURSIVE graph_walk AS (\n    -- Base case: start node\n    SELECT id, label, 0 AS depth, ARRAY[id] AS path\n    FROM graph_nodes WHERE id = start_id\n\n    UNION ALL\n\n    -- Recursive case: follow edges, prevent cycles via path check\n    SELECT n.id, n.label, gw.depth + 1, gw.path || n.id\n    FROM graph_walk gw\n    JOIN graph_edges e ON e.source_node_id = gw.id\n    JOIN graph_nodes n ON n.id = e.target_node_id\n    WHERE gw.depth < max_depth\n      AND NOT n.id = ANY(gw.path)  -- cycle prevention\n)\nSELECT * FROM graph_walk;\n```\n\nThis approach works well for knowledge graphs with thousands of nodes. It stays within Supabase's free tier limits (no extra services or extensions required) and gives you traversal, pathfinding, and neighbor queries — the core operations you need for relationship exploration.\n\n> [!NOTE]\n> Recursive CTEs are bounded by `max_depth` and cycle prevention. For very large graphs (100k+ edges), consider adding a `weight` threshold filter to prune low-confidence edges during traversal.\n\n## Expected Outcome\n\nAfter setup, your AI can:\n\n1. Build a knowledge graph of entities and relationships as you talk about them\n2. Answer \"how is X related to Y?\" with concrete graph paths\n3. Explore multi-hop connections (\"what's 3 degrees from this project?\")\n4. List all relationship types to understand your graph's structure\n5. Link graph nodes back to existing thoughts for full context\n\n## Troubleshooting\n\n### \"relation 'graph_nodes' does not exist\"\n\nYou haven't run the SQL from Step 1 yet. Copy `schema.sql` into your Supabase SQL Editor and run it.\n\n### \"function traverse_graph does not exist\"\n\nThe SQL functions at the bottom of `schema.sql` didn't run. Make sure you execute the **entire** file, not just the `CREATE TABLE` statements. The functions (`traverse_graph`, `find_shortest_path`) are defined after the tables.\n\n> [!WARNING]\n> If you ran only part of the SQL, run the full file again — all statements use `IF NOT EXISTS` or `CREATE OR REPLACE`, so re-running is safe.\n\n### \"duplicate key value violates constraint unique_edge\"\n\nYou're trying to create an edge that already exists (same source, target, and relationship type). This is by design — the `unique_edge` constraint prevents duplicate relationships. If you want to update an existing edge's weight or properties, delete the old edge first and create a new one.\n"
+    },
+    {
+      "slug": "obsidian-vault-import",
+      "category": "recipes",
+      "site_path": "/ob1/recipes/obsidian-vault-import",
+      "name": "Obsidian Vault Import",
+      "description": "Parse your Obsidian vault and import notes into Open Brain as searchable, embedded thoughts with full metadata.",
+      "author": {
+        "name": "Sam Rogers",
+        "github": "snapsynapse"
+      },
+      "version": "1.0.0",
+      "tags": [
+        "obsidian",
+        "import",
+        "migration",
+        "vault",
+        "markdown",
+        "pkm"
+      ],
+      "difficulty": "intermediate",
+      "estimated_time": "20 minutes setup + ~16 min per 1000 thoughts",
+      "created": "2026-03-13",
+      "updated": "2026-03-23",
+      "learning_order": null,
+      "compatibility": {
+        "open_brain": "required"
+      },
+      "requirements": {
+        "services": [
+          "OpenRouter"
+        ],
+        "tools": [
+          "Python 3.10+"
+        ]
+      },
+      "dependencies": {
+        "skills": [],
+        "primitives": []
+      },
+      "reverse_dependencies": {
+        "skills": [],
+        "primitives": []
+      },
+      "urls": {
+        "github_folder": "https://github.com/NateBJones-Projects/OB1/tree/main/recipes/obsidian-vault-import",
+        "github_readme": "https://github.com/NateBJones-Projects/OB1/blob/main/recipes/obsidian-vault-import/README.md"
+      },
+      "readme_markdown": "# Obsidian Vault Import\n\n<div align=\"center\">\n\n![Community Contribution](https://img.shields.io/badge/OB1_COMMUNITY-Approved_Contribution-2ea44f?style=for-the-badge&logo=github)\n\n**Created by [@snapsynapse](https://github.com/snapsynapse)**\n\n*Reviewed and merged by the Open Brain maintainer team — thank you for building the future of AI memory!*\n\n</div>\n\n> Parse your Obsidian vault and import notes into Open Brain as searchable, embedded thoughts.\n\n## What It Does\n\nTakes any Obsidian vault directory, parses every markdown note (including frontmatter tags, dates, and wikilinks), chunks long notes into atomic thoughts, generates vector embeddings, and inserts everything into your Open Brain `thoughts` table. Your entire vault becomes semantically searchable through any MCP-connected AI.\n\n## Vault Compatibility\n\nThis recipe works with any Obsidian vault regardless of organizational method. It parses standard markdown, frontmatter, wikilinks, and tags — features common to all major patterns.\n\n| Pattern | Structure | Import notes |\n|---------|-----------|--------------|\n| **BASB / PARA** | Folders: Projects, Areas, Resources, Archives | Works out of the box. Use `--skip-folders` to exclude Archives if desired. |\n| **LYT / Ideaverse** | Maps of Content (MOCs) as hub notes, emergent linking | MOCs import as thoughts; wikilinks are captured in metadata. |\n| **LifeHQ** | Full life OS with dashboards, tasks, planning workflows | Use `--skip-folders Templates` to exclude Templater files. Tested on 500+ note vault. |\n| **FLAP** | Pipeline: Fleeting → Literature → Atomic → Permanent | Atomic notes import cleanly. Literature notes chunk well via heading splits. |\n| **Zettelkasten** | Atomic notes with dense linking, bottom-up structure | Ideal fit — small atomic notes map 1:1 to thoughts. |\n| **MOC-centric hubs** | Curated hub notes per topic, domain, or role | Hub notes import with all wikilinks preserved in metadata for graph traversal. |\n\nNo special configuration is needed for any of these — the script handles them all with the same parsing pipeline. Use `--dry-run` to preview your vault before importing.\n\n## Prerequisites\n\n- Working Open Brain setup ([guide](https://github.com/NateBJones-Projects/OB1/blob/main/docs/01-getting-started.md))\n- Python 3.10+\n- Your Supabase project URL and API key\n- OpenRouter API key (for embeddings and optional LLM chunking)\n- Recommended: add a `content_fingerprint` column and unique index for database-level dedup (see [Re-running and Deduplication](#re-running-and-deduplication))\n\n## Credential Tracker\n\nCopy this block into a text editor and fill it in as you go.\n\n```text\nOBSIDIAN VAULT IMPORT -- CREDENTIAL TRACKER\n--------------------------------------\n\nFROM YOUR OPEN BRAIN SETUP\n  Supabase Project URL:  ____________\n  Supabase API key:      ____________\n  OpenRouter API key:    ____________\n\nFILE LOCATION\n  Path to Obsidian vault:  ____________\n\n--------------------------------------\n```\n\n## Steps\n\n1. **Clone or copy this recipe folder** to your local machine.\n\n2. **Install Python dependencies:**\n\n   ```bash\n   cd recipes/obsidian-vault-import\n   pip install -r requirements.txt\n   ```\n\n3. **Create your `.env` file** from the example:\n\n   ```bash\n   cp .env.example .env\n   ```\n\n   Edit `.env` and fill in your Supabase URL, API key, and OpenRouter API key. Find your Supabase credentials in the dashboard under Settings → API.\n\n4. **Run a dry run first** to see what would be imported:\n\n   ```bash\n   python import-obsidian.py /path/to/your/vault --dry-run --verbose\n   ```\n\n   This scans your vault, shows how many notes pass filters, how many thoughts would be generated, and flags any notes containing potential secrets — without inserting anything.\n\n5. **Start with a small batch** to verify everything works:\n\n   ```bash\n   python import-obsidian.py /path/to/your/vault --limit 20 --verbose\n   ```\n\n   The script runs a preflight check before any import — it verifies your Supabase connection and OpenRouter API key before spending time on chunking or embeddings.\n\n6. **Run the full import** once you're satisfied:\n\n   ```bash\n   python import-obsidian.py /path/to/your/vault --verbose\n   ```\n\n7. **Verify in Supabase.** Open your Supabase dashboard → Table Editor → `thoughts`. You should see rows with:\n   - `content` — your note text with an `[Obsidian: Title | Folder]` prefix\n   - `embedding` — a 1536-dimensional vector\n   - `metadata` — JSON with source, title, folder, tags, date, and wikilinks\n\n## Options\n\n| Flag | Description |\n|------|-------------|\n| `--dry-run` | Preview without inserting (shows what would be imported) |\n| `--limit N` | Process only the first N notes |\n| `--min-words N` | Skip notes with fewer than N words (default: 50) |\n| `--skip-folders X` | Comma-separated additional folder names to skip |\n| `--after DATE` | Only import notes modified after this date (YYYY-MM-DD) |\n| `--no-llm` | Disable LLM chunking — heading splits only, zero API cost beyond embeddings |\n| `--no-embed` | Skip embedding generation (insert thoughts without vectors) |\n| `--no-secret-scan` | Disable secret detection (not recommended) |\n| `--verbose` | Show detailed progress for each note |\n| `--report` | Generate an `import-report.md` summary file |\n\n## What Gets Filtered\n\nThe script automatically skips notes that wouldn't make useful thoughts. Run with `--dry-run --verbose` to preview exactly what gets included and excluded.\n\n**Always-skipped folders** (Obsidian internals, not your content):\n- `.obsidian/` — plugin configs, themes, workspace state\n- `.trash/` — Obsidian's soft-delete folder\n- `.git/`, `node_modules/` — version control and dependencies\n- Any folder starting with `.` (hidden directories)\n\n**Template files** — notes inside any folder with \"templates\" in its name (case-insensitive). These contain Templater syntax (`<% %>`) and placeholder variables, not real content. Applies to `Templates/`, `8_Reference/Templates/`, etc.\n\n**Short notes** — notes with fewer than 50 words (default). These are typically stubs, empty MOCs, or link-only index files. Adjust with `--min-words`:\n- `--min-words 20` to include shorter notes\n- `--min-words 100` to be more selective\n\n**Already-imported notes** — the sync log tracks content hashes so re-runs skip unchanged notes automatically.\n\n**Date-filtered notes** — when using `--after YYYY-MM-DD`, notes not modified after that date are skipped.\n\n**Additional folder exclusions** — use `--skip-folders` for vault-specific directories you don't want imported:\n\n```bash\n# Skip framework reference materials, archive, and attachments\npython import-obsidian.py /path/to/vault --skip-folders \"Archive,Files,patterns\"\n```\n\n## Secret Detection\n\nThe script scans each thought for potential secrets before embedding or inserting. Thoughts containing API keys, tokens, passwords, or connection strings are skipped and logged — they never reach your database.\n\nDetected patterns include:\n- API keys (OpenAI, OpenRouter, AWS, GitHub, Supabase)\n- JWT tokens\n- Private key blocks\n- Connection strings with embedded credentials\n- Generic secret assignments (`password=`, `token=`, `api_key=`, etc.)\n\nThe dry run (`--dry-run`) also runs the scanner, so you can review what would be flagged before a live import. If the scanner flags a false positive, use `--no-secret-scan` to disable it.\n\n## How Chunking Works\n\nThe script uses a hybrid chunking strategy to turn notes into atomic thoughts:\n\n1. **Short notes** (under 500 words) become a single thought.\n2. **Notes with headings** are split at `## ` boundaries — each section becomes one thought.\n3. **Long sections** (over 1000 words) are sent to an LLM (gpt-4o-mini via OpenRouter) which distills them into 1-3 standalone thoughts.\n\nUse `--no-llm` to skip step 3 if you want to avoid LLM costs. Heading-based splitting still works.\n\n## Cost Estimate\n\nCosts depend on vault size and whether LLM chunking is enabled. Embeddings use `text-embedding-3-small` and LLM chunking uses `gpt-4o-mini`, both via OpenRouter.\n\n| Vault size | Embeddings only (`--no-llm`) | With LLM chunking |\n|------------|------------------------------|---------------------|\n| 100 notes  | ~$0.02                       | ~$0.15              |\n| 500 notes  | ~$0.10                       | ~$0.75              |\n| 1000+ notes | ~$0.20                      | ~$1.50              |\n\nUse `--dry-run` to see how many thoughts your vault would generate before committing to a full run. Use `--no-embed` to skip embeddings entirely (zero API cost) if you plan to generate them separately.\n\n**Time estimate:** Roughly 1 second per thought or 16 minutes per 1,000 thoughts. A 700-note vault producing ~2,700 thoughts takes about 45 minutes. The bottleneck is embedding generation — each thought requires a round-trip API call.\n\n## Rate Limiting\n\nThe script self-throttles to respect upstream API limits:\n- **150ms delay** between embedding API calls to avoid flooding OpenRouter\n- **1-second pause** every 50 inserts to give Supabase breathing room\n- **Exponential backoff** on 429/5xx errors (2s → 4s → 8s, up to 3 retries)\n\nFor large vaults (1000+ notes), use `--limit` to import in batches if you encounter rate limit errors. The sync log ensures you can resume where you left off.\n\nSee also: [Graceful Boundaries](https://github.com/snapsynapse/graceful-boundaries) — a spec for how services communicate operational limits to humans and agents.\n\n## Re-running and Deduplication\n\nThe script prevents duplicates at two levels:\n\n**Local sync log** (`obsidian-sync-log.json`) — tracks content hashes of imported notes. On re-runs, unchanged notes are skipped entirely (saving embedding API calls). Modified notes are re-imported, and new notes are added.\n\n**Database-level fingerprinting** — each thought includes a `content_fingerprint` (SHA-256 of normalized content). If your `thoughts` table has a unique index on `content_fingerprint`, the insert automatically skips duplicates even if the sync log is deleted or a different machine imports overlapping content. To add the index:\n\n```sql\nCREATE UNIQUE INDEX IF NOT EXISTS thoughts_content_fingerprint_idx\n  ON thoughts (content_fingerprint);\n```\n\nWithout the index, the fingerprint is stored but dedup relies on the sync log only.\n\nTo do a clean re-import, delete `obsidian-sync-log.json` and remove the imported thoughts from your `thoughts` table (filter by `metadata->>'source' = 'obsidian'`).\n\n## Expected Outcome\n\nAfter a successful import, searching your Open Brain for topics from your vault returns relevant results. The metadata on each thought includes:\n\n```json\n{\n  \"source\": \"obsidian\",\n  \"title\": \"Note Title\",\n  \"folder\": \"Projects/My Project\",\n  \"tags\": [\"project\", \"active\"],\n  \"date\": \"2026-01-15\",\n  \"wikilinks\": [\"Related Note\", \"Another Note\"]\n}\n```\n\nYou can filter by source to find only Obsidian-imported thoughts: search with `{\"source\": \"obsidian\"}` as a metadata filter.\n\n## Troubleshooting\n\n**Issue: `python-frontmatter` not found**\nSolution: Make sure you ran `pip install -r requirements.txt`. If using a virtual environment, activate it first.\n\n**Issue: Import is slow on large vaults (1000+ notes)**\nSolution: Embedding generation is the bottleneck — each note requires an API call. Use `--limit` to import in batches, or `--no-llm` to skip LLM chunking and reduce API calls. The script rate-limits itself to avoid hitting OpenRouter quotas.\n\n**Issue: Some notes are skipped unexpectedly**\nSolution: Run with `--verbose` to see which notes are filtered and why. Common reasons: notes under 50 words (adjust with `--min-words`), notes in a `Templates/` folder, or notes already in the sync log. Check `--dry-run` output first.\n\n**Issue: Encoding errors on some notes**\nSolution: The parser handles encoding errors gracefully — problematic files are skipped with a warning. If you see many parse errors, your vault may contain non-UTF-8 files. The script will continue processing the rest.\n\n**Issue: Duplicate thoughts after re-running**\nSolution: The sync log prevents duplicates on re-runs. For stronger protection, add the `content_fingerprint` unique index (see \"Re-running and Deduplication\" above) — this catches duplicates even if the sync log is deleted or another machine imports the same content. To clean up existing duplicates, filter by `metadata->>'source' = 'obsidian'` in the Supabase Table Editor.\n\n**Issue: Import aborts after \"10 consecutive insert failures\"**\nSolution: The script stops early if 10 inserts fail in a row to avoid wasting embedding credits. Check your Supabase connection, verify the `thoughts` table exists, and confirm your API key is correct. The preflight check catches most of these, but a connection drop mid-import can also trigger this.\n\n**Issue: Notes flagged as containing secrets (false positive)**\nSolution: Review the flagged content. If it's a false positive (e.g., a note discussing API key formats without containing real keys), re-run with `--no-secret-scan`. The scanner is intentionally conservative — it's better to flag and skip than to store a real secret in your database.\n"
+    },
+    {
+      "slug": "panning-for-gold",
+      "category": "recipes",
+      "site_path": "/ob1/recipes/panning-for-gold",
+      "name": "Panning for Gold",
+      "description": "Mine raw brain dumps, voice transcripts, and stream-of-consciousness notes for actionable ideas. Three-phase process: extract every thread, evaluate the best ones, synthesize into Open Brain thoughts.",
+      "author": {
+        "name": "Jared Irish",
+        "github": "jaredirish"
+      },
+      "version": "2.0.0",
+      "tags": [
+        "brain-dump",
+        "transcript",
+        "extraction",
+        "evaluation",
+        "voice",
+        "processing",
+        "skill"
+      ],
+      "difficulty": "intermediate",
+      "estimated_time": "20 minutes",
+      "created": "2026-03-13",
+      "updated": "2026-03-19",
+      "learning_order": null,
+      "compatibility": {
+        "open_brain": "required"
+      },
+      "requirements": {
+        "services": [
+          "OpenRouter"
+        ],
+        "tools": [
+          "Claude Code or similar AI coding tool"
+        ]
+      },
+      "dependencies": {
+        "skills": [],
+        "primitives": []
+      },
+      "reverse_dependencies": {
+        "skills": [],
+        "primitives": []
+      },
+      "urls": {
+        "github_folder": "https://github.com/NateBJones-Projects/OB1/tree/main/recipes/panning-for-gold",
+        "github_readme": "https://github.com/NateBJones-Projects/OB1/blob/main/recipes/panning-for-gold/README.md"
+      },
+      "readme_markdown": "# Panning for Gold\n\n<div align=\"center\">\n\n![Community Contribution](https://img.shields.io/badge/OB1_COMMUNITY-Approved_Contribution-2ea44f?style=for-the-badge&logo=github)\n\n**Created by [@jaredirish](https://github.com/jaredirish)**\n\n*Reviewed and merged by the Open Brain maintainer team — thank you for building the future of AI memory!*\n\n</div>\n\n*Brain dump processor for Open Brain*\n\nTurn raw brain dumps, voice transcripts, and stream-of-consciousness notes into structured, evaluated thought inventories that get captured into Open Brain automatically. Every line gets examined. The gold is in the tangents.\n\n## What It Does\n\nTakes any unstructured text (voice transcripts, ChatGPT exports, freeform notes, multi-topic brain dumps) and runs a three-phase process: **Extract** every idea thread without filtering, **Evaluate** the highest-signal ones with deep brainstorming, and **Synthesize** into a permanent gold-found file with results captured as Open Brain thoughts. Nothing gets dismissed as noise on the first pass.\n\n## When to Use It\n\n- **After a meeting or brainstorm call.** Export your Fathom/Otter/Fireflies transcript, point Panning for Gold at it, and get a clean inventory of every topic — including the half-sentence at minute 38 that's actually a warm intro worth more than the whole agenda.\n- **Weekly brain dump ritual.** Every Friday, write for 10 minutes with no structure, then run Panning for Gold on it. You'll be surprised what surfaces when every line gets examined without skimming.\n- **Processing AI conversation exports.** Exported a long ChatGPT or Claude session where you explored 8 different ideas? Point this at it instead of re-reading. Pairs well with the [ChatGPT Import recipe](/ob1/recipes/chatgpt-conversation-import).\n- **Post-conference notes.** You scribbled 4 pages at a conference. Run Panning for Gold to get a structured inventory and walk away with concrete next actions instead of a notebook you'll never reopen.\n- **End-of-day processing.** Had one of those days where 15 things are bouncing around? Brain dump it all, run the recipe, and let it sort the signal from the noise. The PARK and KILL verdicts are just as valuable as ACT NOW.\n\n## Prerequisites\n\n- Working Open Brain setup ([guide](https://github.com/NateBJones-Projects/OB1/blob/main/docs/01-getting-started.md))\n- Claude Code (or another AI coding tool that supports skills/system prompts)\n- Open Brain MCP tools connected to your AI coding tool (`capture_thought`, `search_thoughts`)\n\n### Credential Tracker\n\n```\nFrom your existing Open Brain setup:\n- Project URL: _______________\n- OpenRouter API key: _______________\n- Open Brain MCP server connected: yes / no\n\nNo additional credentials needed for this recipe.\n```\n\n## Steps\n\n### 1. Create the skill directory\n\n```bash\nmkdir -p ~/.claude/skills/panning-for-gold\n```\n\n### 2. Copy the skill file\n\nCopy `panning-for-gold.skill.md` from this recipe into the directory you just created:\n\n```bash\ncp panning-for-gold.skill.md ~/.claude/skills/panning-for-gold/SKILL.md\n```\n\nIf you downloaded this recipe from GitHub, adjust the source path accordingly.\n\n### 3. Verify Claude Code picks up the skill\n\nRestart Claude Code (close and reopen, or start a new session). Claude Code automatically loads skills from `~/.claude/skills/` on startup. To verify, ask Claude Code: \"What skills do you have loaded?\" or simply say \"process this\" and confirm it references the Panning for Gold methodology.\n\n### 4. Prepare your brain dump\n\nSave your raw input to a file. Examples:\n\n```bash\n# Voice transcript from Fathom, Otter, etc.\ncp ~/Downloads/meeting-notes.md ~/project/docs/brainstorming/YYYY-MM-DD-meeting.md\n\n# ChatGPT export\ncp ~/Downloads/chatgpt-export.md ~/project/docs/brainstorming/YYYY-MM-DD-ideas.md\n\n# Or just paste text into a new file\ncat > ~/project/docs/brainstorming/YYYY-MM-DD-brain-dump.md << 'EOF'\n(paste your brain dump here)\nEOF\n```\n\n### 5. Run the processor\n\nIn Claude Code, point the skill at your file:\n\n```\nProcess this brain dump: docs/brainstorming/YYYY-MM-DD-brain-dump.md\n```\n\nRun this from within your project directory, or provide an absolute file path.\n\nOr simply paste raw text and say \"process this\" or \"pan for gold.\"\n\nThe processor will:\n\n1. **Phase 1 (Extract):** Read every line, extract all idea threads regardless of category, save an inventory file, and present it to you for confirmation.\n2. **Phase 2 (Evaluate):** After you confirm the inventory, evaluate the top 3-5 threads with deep brainstorming (Build vs Buy analysis, feasibility, connections to your existing work).\n3. **Phase 3 (Synthesize):** Write a permanent gold-found file with verdicts (ACT NOW / RESEARCH MORE / PARK / KILL) and capture key insights to Open Brain via `capture_thought`.\n\n### 6. Review the outputs\n\nAfter processing, you will have:\n\n- **Inventory file:** `docs/brainstorming/YYYY-MM-DD-{source}-inventory.md` listing every extracted thread\n- **Gold-found file:** `docs/brainstorming/YYYY-MM-DD-{source}-gold-found.md` with evaluated threads, verdicts, and next actions\n- **Open Brain thoughts:** ACT NOW items and key insights captured as searchable thoughts\n\n### 7. (Optional) Adapt for your tool\n\nIf you are not using Claude Code, the skill file works as a prompt template. Copy the content of `panning-for-gold.skill.md` into your AI tool's system prompt or custom instructions. The core methodology works with any LLM that can read files and write output.\n\n## Expected Outcome\n\nWhen working correctly, you should see:\n\n- A numbered inventory of **every** idea thread found in your input, grouped by category (technical, personal, creative, financial, relational, etc.), with exact quotes from the source\n- A triage step where you confirm the inventory before evaluation begins\n- Deep evaluations for the top threads, each with a clear verdict and next actions\n- A gold-found markdown file saved to your project's docs directory\n- Key findings captured in Open Brain, searchable across future sessions with `search_thoughts`\n\nA typical 30-minute voice transcript yields 10-20 threads, with 3-5 getting full evaluations. Processing takes 2-5 minutes depending on length.\n\n## Why a Skill File?\n\nYou could ask Claude \"process this brain dump and save the good stuff\" without the skill file, and sometimes it'd be great. But it'd also skim, miss threads, bias toward technical topics, or dump everything without evaluating what's worth keeping.\n\nPanning for Gold makes the process repeatable. It enforces a \"read every line\" discipline (skimming is the #1 failure mode), forces a human checkpoint between extraction and evaluation so you confirm nothing was missed, categorizes across six domains (not just tech — personal, wellness, financial, relational, and creative threads get equal weight), and saves files to disk as it goes so you don't lose work if a session crashes. The Red Flags diagnostic tables even help you spot when the process is going sideways.\n\nThink of it less as \"new capability\" and more as a senior analyst's methodology, encoded as a system prompt. The 5-minute setup buys you consistency every time you use it.\n\n## Troubleshooting\n\n**Issue:** The processor skips personal or non-technical threads.\n**Solution:** This is the most common failure mode. The skill explicitly instructs against tech bias. If threads are being filtered, check that the skill file is loaded correctly and that the \"Red Flags: You're Rushing\" section is intact. Personal, wellness, and relational threads often contain the highest-signal ideas.\n\n**Issue:** Evaluation agents lose their work (output missing after processing).\n**Solution:** The skill requires all evaluators to write to permanent files as part of their task. If you see missing evaluations, the synthesis phase will still work from the inventory and inline analysis. Check that your AI tool has write permissions to the output directory.\n\n**Issue:** Open Brain capture fails during Phase 3.\n**Solution:** Verify your Open Brain MCP connection is active by running `search_thoughts` with a test query. If the MCP server is disconnected, the gold-found file still contains all results locally. You can manually capture key items later with `capture_thought`.\n\n**Issue:** Processing a very long transcript (60+ minutes) uses excessive tokens.\n**Solution:** The skill uses a \"summaries first\" strategy. If your transcript tool (Fathom, Otter, Fireflies) generates a summary alongside the full transcript, place both files in the same directory. The processor reads the summary first and only dips into the transcript for exact quotes and verification of completeness.\n\n---\n\n*The gold is always in the tangents.*\n"
+    },
+    {
+      "slug": "perplexity-conversation-import",
+      "category": "recipes",
+      "site_path": "/ob1/recipes/perplexity-conversation-import",
+      "name": "Perplexity Conversation Import",
+      "description": "Import your Perplexity conversations and memories from a data export (.xlsx) into Open Brain as searchable thoughts with embeddings and metadata.",
+      "author": {
+        "name": "Antonio De Marinis",
+        "github": "demarant"
+      },
+      "version": "1.0.0",
+      "tags": [
+        "perplexity",
+        "import",
+        "conversations",
+        "memory",
+        "migration",
+        "summarization"
+      ],
+      "difficulty": "beginner",
+      "estimated_time": "20 minutes",
+      "created": "2026-03-22",
+      "updated": "2026-03-22",
+      "learning_order": null,
+      "compatibility": {
+        "open_brain": "required"
+      },
+      "requirements": {
+        "services": [
+          "OpenRouter"
+        ],
+        "tools": [
+          "Python 3.10+"
+        ]
+      },
+      "dependencies": {
+        "skills": [],
+        "primitives": []
+      },
+      "reverse_dependencies": {
+        "skills": [],
+        "primitives": []
+      },
+      "urls": {
+        "github_folder": "https://github.com/NateBJones-Projects/OB1/tree/main/recipes/perplexity-conversation-import",
+        "github_readme": "https://github.com/NateBJones-Projects/OB1/blob/main/recipes/perplexity-conversation-import/README.md"
+      },
+      "readme_markdown": "# Perplexity Conversation Import\n\n<div align=\"center\">\n\n![Community Contribution](https://img.shields.io/badge/OB1_COMMUNITY-Approved_Contribution-2ea44f?style=for-the-badge&logo=github)\n\n**Created by [@demarant](https://github.com/demarant)**\n\n*Reviewed and merged by the Open Brain maintainer team — thank you for building the future of AI memory!*\n\n</div>\n\nImport your Perplexity AI search history and memory entries into Open Brain as searchable thoughts.\n\n## What It Does\n\nTakes a Perplexity data export (.xlsx), processes two data streams:\n\n- **Conversations** — Each search query + answer is summarized by an LLM into 1-3 standalone thoughts, then loaded into your `thoughts` table with embeddings and metadata.\n- **Memory** — Perplexity's curated memory entries are ingested directly (already concise summaries). JSON profile rows are flattened into per-section thoughts (demographics, interests, technology, etc.).\n\nDeduplication via a sync log ensures safe re-runs without duplicates.\n\n## Prerequisites\n\n- Working Open Brain setup ([getting started guide](https://github.com/NateBJones-Projects/OB1/blob/main/docs/01-getting-started.md))\n- Perplexity data export (`.xlsx` file)\n- Python 3.10+\n- OpenRouter API key (for embeddings + conversation summarization)\n\n## Step-by-Step\n\n### 1. Request Your Perplexity Data Export\n\nPerplexity does not currently offer a self-service data export via the UI. You must request your data directly from their privacy team:\n\n1. **Submit a data request** at [perplexity.typeform.com/datarequest](https://perplexity.typeform.com/datarequest) (recommended — fastest)\n2. **Or email** [privacy@perplexity.ai](mailto:privacy@perplexity.ai) with a subject like \"GDPR Data Export Request\"\n\nYou'll receive your data via email (typically within a few days). The export is an `.xlsx` file. Save it somewhere accessible.\n\n> [!TIP]\n> Under GDPR (Article 15/20) you have the right to request a copy of your personal data (including inferred memories about you). Mention this if you want to speed things up.\n\n### 2. Clone This Recipe\n\nCopy the `perplexity-conversation-import` folder to your working directory.\n\n### 3. Install Dependencies\n\n```bash\npip install -r requirements.txt\n```\n\n### 4. Set Environment Variables\n\nGet your Supabase Secret Key from the dashboard: **Settings → API → Secret key** (click reveal). It starts with `sb_secret_`. This is the key formerly known as \"service_role key.\"\n\n```bash\nexport SUPABASE_URL=\"https://your-project.supabase.co\"\nexport SUPABASE_SERVICE_ROLE_KEY=\"sb_secret_...\"  # Your Secret Key\nexport OPENROUTER_API_KEY=\"sk-or-v1-your-key\"\n```\n\nOr copy `.env.example` to `.env` and fill in the values, then:\n\n```bash\nsource .env\n```\n\n### 5. Dry Run\n\nPreview what will be imported without touching your database:\n\n```bash\npython import-perplexity.py path/to/export.xlsx --dry-run --limit 5\n```\n\nYou should see each conversation and memory entry listed with extracted thoughts.\n\n### 6. Run the Full Import\n\n```bash\npython import-perplexity.py path/to/export.xlsx\n```\n\nOr import only conversations or only memory:\n\n```bash\npython import-perplexity.py path/to/export.xlsx --type conversations\npython import-perplexity.py path/to/export.xlsx --type memory\n```\n\n### 7. Verify in Supabase\n\nCheck your Supabase dashboard → Table Editor → `thoughts` table. You should see new rows with:\n- `content` starting with `[Perplexity:` or `[Perplexity Memory:`\n- `created_at` matching the original Perplexity date (not today's date)\n- `metadata.source` set to `perplexity` or `perplexity_memory`\n- `embedding` vectors populated\n\n### 8. Test Search\n\nIn any MCP-connected AI, search for something from your Perplexity history:\n\n```\nSearch my brain for \"Malmö pubs\"\n```\n\n## Expected Outcome\n\nStats table at the end of the run:\n\n```\nSummary:\n  Conversations:\n    Found:              150\n    Processed:          142\n    Thoughts:           280\n    Ingested:           278\n    Errors:             2\n\n  Memory:\n    Found:              45\n    Processed:          43\n    Thoughts:           55\n    Ingested:           55\n    Errors:             0\n\n  Est. API cost:          $0.0045\n```\n\n## How It Works\n\n### Three-Stage Pipeline\n\n**Stage 1: Parse & Filter**\n- Reads the `.xlsx` file using openpyxl (no CSV conversion needed)\n- Skips conversations with no answer text\n- Skips memory entries marked as deleted or forgotten\n- Deduplicates against `perplexity-sync-log.json` (safe to re-run)\n- Optional date range filtering (`--after`, `--before`)\n\n**Stage 2: Summarize (conversations only)**\n- Sends each query + answer to an LLM (gpt-4o-mini via OpenRouter by default)\n- Prompt is tuned for Perplexity's Q&A format — focuses on decisions, lessons, and lasting context\n- Extracts 1-3 standalone thoughts per conversation\n- Memory entries skip this stage — they're already concise summaries from Perplexity\n\n**Stage 3: Ingest**\n- Generates a 1536-dim embedding per thought (text-embedding-3-small via OpenRouter)\n- Inserts into the `thoughts` table via Supabase REST API\n- Attaches metadata: source, title/date/UUID (conversations), memory key/confidence (memory)\n- Preserves original timestamps — the `created_at` column is set to the Perplexity export's `CREATED` or `FIRST_CREATED_AT`, not \"now\"\n\n### Timestamp Preservation\n\nImported thoughts retain their original dates from Perplexity, not the import date. This means a search from December 2023 will appear in your timeline as December 2023, not today.\n\n| Source | Column used | Perplexity export column |\n|--------|------------|------------------------|\n| Conversations | `created_at` | `CREATED` |\n| Memory | `created_at` | `FIRST_CREATED_AT` |\n\nThe `updated_at` column defaults to `now()` on insert (overwritten by Supabase trigger on any subsequent update), but `created_at` reflects the original date.\n\n### JSON Profile Rows\n\nSome memory exports contain a special row where `MEMORY_KEY` is empty and `MEMORY_VALUE` holds a JSON object with the user's persona (demographics, interests, technology preferences, etc.).\n\nThese are automatically detected and flattened into separate thoughts:\n\n| Profile Section | Thought Prefix |\n|----------------|---------------|\n| Summary | `[Perplexity Memory: Profile — Summary]` |\n| Demographics | `[Perplexity Memory: Profile — Demographics]` |\n| Interests | `[Perplexity Memory: Profile — Interests]` |\n| Technology | `[Perplexity Memory: Profile — Technology]` |\n| Knowledge | `[Perplexity Memory: Profile — Knowledge]` |\n| Lifestyle | `[Perplexity Memory: Profile — Lifestyle]` |\n| Work and Education | `[Perplexity Memory: Profile — Work And Education]` |\n| Personal Traits | `[Perplexity Memory: Profile — Personal Traits]` |\n\n### Deduplication\n\n- **Conversations**: SHA256 hash of the UUID\n- **Memory**: SHA256 hash of `MEMORY_KEY | FIRST_CREATED_AT`\n- **JSON profiles**: SHA256 hash of the first 200 chars of `MEMORY_VALUE`\n- Stored in `perplexity-sync-log.json` (gitignored)\n\n## Options Reference\n\n| Flag | Default | Description |\n|------|---------|-------------|\n| `--dry-run` | `false` | Preview mode — parse, filter, summarize, but don't ingest |\n| `--after YYYY-MM-DD` | — | Only import conversations created after this date |\n| `--before YYYY-MM-DD` | — | Only import conversations created before this date |\n| `--limit N` | `0` (unlimited) | Max items to process per type |\n| `--type` | `both` | `conversations`, `memory`, or `both` |\n| `--model` | `openrouter` | LLM backend: `openrouter` or `ollama` |\n| `--ollama-model` | `qwen3` | Ollama model name (when using `--model ollama`) |\n| `--verbose` | `false` | Show full thought content during processing |\n| `--report FILE` | — | Write a markdown report of everything imported |\n\n## Local LLM Option\n\nUse Ollama for free, private summarization (embeddings still require OpenRouter):\n\n```bash\npython import-perplexity.py export.xlsx --model ollama --ollama-model qwen3\n```\n\n## Cost Estimates\n\n| Component | Cost per item | Notes |\n|-----------|--------------|-------|\n| Summarization | ~$0.0003 | gpt-4o-mini via OpenRouter, conversations only |\n| Embeddings | ~$0.000002 | text-embedding-3-small, all thoughts |\n\nFor a typical export with 100 conversations and 50 memory entries, total cost is under $0.04.\n\n## Troubleshooting\n\n**\"No module named 'openpyxl'\"**\n\n```bash\npip install openpyxl>=3.1\n```\n\n**\"No 'Conversations' sheet found\"**\nYour export may use different sheet names. Open the file in a spreadsheet app and check the sheet tabs. The script looks for exact names \"Conversations\" and \"Memory\".\n\n**\"OPENROUTER_API_KEY environment variable required\"**\n\n```bash\nexport OPENROUTER_API_KEY=\"sk-or-v1-your-key\"\n```\n\nOr use `--model ollama` for local summarization (embeddings still need OpenRouter).\n\n**Summarization returns empty thoughts**\nSome Q&A pairs are too simple (e.g., \"what time is it?\"). This is expected — the LLM is designed to be selective. Try `--verbose` to see what's being skipped.\n\n**\"Failed to generate embedding\"**\nCheck your OpenRouter API key has credits and access to `text-embedding-3-small`. Test with:\n\n```bash\ncurl https://openrouter.ai/api/v1/embeddings \\\n  -H \"Authorization: Bearer $OPENROUTER_API_KEY\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"model\":\"openai/text-embedding-3-small\",\"input\":\"test\"}'\n```\n\n**Re-running imports**\nThe sync log (`perplexity-sync-log.json`) prevents duplicates. Delete it to re-import everything, or edit it to remove specific entries.\n\n**Large exports**\nIf you have hundreds of conversations, the run may take a while due to rate limiting (0.2s between ingests). This is intentional — Supabase REST has rate limits. Grab a coffee.\n"
+    },
+    {
+      "slug": "repo-learning-coach",
+      "category": "recipes",
+      "site_path": "/ob1/recipes/repo-learning-coach",
+      "name": "Repo Learning Coach",
+      "description": "Run a local learning app backed by Supabase tables inside your Open Brain project, with file-based curriculum content and durable captures into thoughts.",
+      "author": {
+        "name": "Jonathan Edwards"
+      },
+      "version": "1.0.0",
+      "tags": [
+        "learning",
+        "onboarding",
+        "curriculum",
+        "repo",
+        "supabase",
+        "thoughts"
+      ],
+      "difficulty": "intermediate",
+      "estimated_time": "45 minutes",
+      "created": "2026-04-12",
+      "updated": "2026-04-12",
+      "learning_order": null,
+      "compatibility": {
+        "open_brain": "required"
+      },
+      "requirements": {
+        "services": [
+          "OpenRouter"
+        ],
+        "tools": [
+          "Node.js 18+"
+        ]
+      },
+      "dependencies": {
+        "skills": [],
+        "primitives": []
+      },
+      "reverse_dependencies": {
+        "skills": [],
+        "primitives": []
+      },
+      "urls": {
+        "github_folder": "https://github.com/NateBJones-Projects/OB1/tree/main/recipes/repo-learning-coach",
+        "github_readme": "https://github.com/NateBJones-Projects/OB1/blob/main/recipes/repo-learning-coach/README.md"
+      },
+      "readme_markdown": "# Repo Learning Coach\n\n> Turn repo research into a local lesson app backed by Supabase learning tables, with durable takeaways captured into Open Brain.\n\n## What It Does\n\nRepo Learning Coach gives you a local React + Express learning workspace for understanding a codebase. Research docs and lesson files live in markdown, structured learning state lives in dedicated Supabase tables, and the best takeaways flow back into `thoughts` so they can resurface in future sessions.\n\nUnlike an OB1 extension, this stays a local app in v1. It uses your existing Open Brain project as the backend, but it does not create a new MCP server.\n\n## Prerequisites\n\n- Working Open Brain setup ([guide](https://github.com/NateBJones-Projects/OB1/blob/main/docs/01-getting-started.md))\n- Node.js 18+ and `npm`\n- Supabase project URL and service role key from your existing Open Brain setup\n- OpenRouter API key for related-thought retrieval and durable capture into `thoughts`\n\n## Credential Tracker\n\nCopy this block into a text editor and fill it in as you go.\n\n```text\nREPO LEARNING COACH -- CREDENTIAL TRACKER\n-----------------------------------------\n\nFROM YOUR OPEN BRAIN SETUP\n  Supabase Project URL:        ____________\n  Supabase Service Role Key:   ____________\n  OpenRouter API Key:          ____________\n\nLOCAL APP\n  Recipe folder path:          ____________\n  Local app URL:               ____________\n\n-----------------------------------------\n```\n\n![Step 1](https://img.shields.io/badge/Step_1-Create_the_Learning_Tables-1E88E5?style=for-the-badge)\n\nOpen your Supabase SQL Editor and run the contents of [schema.sql](https://github.com/NateBJones-Projects/OB1/blob/main/recipes/repo-learning-coach/schema.sql).\n\n<details>\n<summary>📋 <strong>SQL: Repo Learning Coach tables</strong> (copy from <code>schema.sql</code>)</summary>\n\nThis recipe keeps its structured state in these tables:\n\n- `repo_learning_projects`\n- `repo_learning_research_documents`\n- `repo_learning_tracks`\n- `repo_learning_lessons`\n- `repo_learning_quizzes`\n- `repo_learning_quiz_questions`\n- `repo_learning_lesson_progress`\n- `repo_learning_quiz_attempts`\n- `repo_learning_quiz_responses`\n- `repo_learning_lesson_comments`\n\nThe SQL also creates the `updated_at` trigger helper and grants `service_role` access for every table.\n\n</details>\n\n> [!IMPORTANT]\n> This recipe does **not** modify the core `thoughts` table. The only Open Brain integration is through the existing `upsert_thought` and `match_thoughts` path your OB1 setup already provides.\n\n✅ **Done when:** The new `repo_learning_*` tables appear in Supabase Table Editor and the query finishes without errors.\n\n---\n\n![Step 2](https://img.shields.io/badge/Step_2-Configure_the_Local_App-1E88E5?style=for-the-badge)\n\n**1. Move into the recipe folder:**\n\n```bash\ncd recipes/repo-learning-coach\n```\n\n**2. Copy the environment file:**\n\n```bash\ncp .env.example .env\n```\n\n**3. Fill in the variables:**\n\n```text\nSUPABASE_URL=https://your-project-ref.supabase.co\nSUPABASE_SERVICE_ROLE_KEY=your-service-role-key\nOPENROUTER_API_KEY=your-openrouter-key\nOPENROUTER_EMBEDDING_MODEL=openai/text-embedding-3-small\nPORT=8787\n```\n\n**4. Install dependencies:**\n\n```bash\nnpm install\n```\n\n✅ **Done when:** `node_modules/` exists and your `.env` file contains real values.\n\n---\n\n![Step 3](https://img.shields.io/badge/Step_3-Sync_the_Source_Content-1E88E5?style=for-the-badge)\n\nThe recipe treats markdown as the source of truth.\n\n**1. Run the importer:**\n\n```bash\nnpm run sync\n```\n\n**2. Inspect the content files if you want to understand the contract:**\n\n- Project config: [repo-learning.config.ts](https://github.com/NateBJones-Projects/OB1/blob/main/recipes/repo-learning-coach/repo-learning.config.ts)\n- Research docs: [research/](https://github.com/NateBJones-Projects/OB1/blob/main/recipes/repo-learning-coach/research)\n- Lessons: [curriculum/lessons/](https://github.com/NateBJones-Projects/OB1/blob/main/recipes/repo-learning-coach/curriculum/lessons)\n\n> [!NOTE]\n> Re-running `npm run sync` updates content in place for surviving lesson and research slugs. If you delete or rename source content, the importer prunes the stale database rows so markdown remains the source of truth.\n\n✅ **Done when:** The sync command reports lesson and research counts, and you can see rows in the new `repo_learning_*` tables.\n\n---\n\n![Step 4](https://img.shields.io/badge/Step_4-Run_the_App-1E88E5?style=for-the-badge)\n\n**1. Start the local app:**\n\n```bash\nnpm run dev\n```\n\n**2. Open the browser UI:**\n\n```text\nhttp://localhost:5173\n```\n\nYou should see:\n\n- a lesson path in the sidebar\n- a research library\n- lesson progress controls\n- quizzes and note capture\n- an Open Brain capture panel\n- related thoughts when the bridge is configured successfully\n\n✅ **Done when:** You can open a lesson, save progress, submit a quiz, and save a note without errors.\n\n---\n\n![Step 5](https://img.shields.io/badge/Step_5-Adapt_It_to_Your_Repo-1E88E5?style=for-the-badge)\n\nTo retarget this recipe to a new repo, change content first, not app code.\n\n**1. Update the project identity in [repo-learning.config.ts](https://github.com/NateBJones-Projects/OB1/blob/main/recipes/repo-learning-coach/repo-learning.config.ts).**\n\n**2. Replace the sample research docs in [research/](https://github.com/NateBJones-Projects/OB1/blob/main/recipes/repo-learning-coach/research).**\n\nEach research file uses frontmatter:\n\n```yaml\n---\nslug: architecture-overview\ntitle: Architecture Overview\nsummary: What matters most about the system design.\ncategory: architecture\nsourceUrl: https://example.com/optional-source\n---\n```\n\n**3. Replace the lesson files in [curriculum/lessons/](https://github.com/NateBJones-Projects/OB1/blob/main/recipes/repo-learning-coach/curriculum/lessons).**\n\nEach lesson file uses frontmatter for the lesson metadata and quiz, followed by markdown for the actual lesson body:\n\n```yaml\n---\nslug: orient-the-system\ntitle: Orient the System\nstage: Foundations\ndifficulty: Intro\norder: 1\nestimatedMinutes: 20\nsummary: What this lesson is trying to teach.\ngoals:\n  - First goal\n  - Second goal\nrelatedResearch:\n  - architecture-overview\nquiz:\n  title: Check the basics\n  passingScore: 70\n  questions:\n    - prompt: A real question\n      options:\n        - Option A\n        - Option B\n      correctOption: Option A\n      explanation: Why that answer is right.\n---\n```\n\n**4. Re-run the importer:**\n\n```bash\nnpm run sync\n```\n\n✅ **Done when:** Your own repo title, research docs, and lessons show up in the UI.\n\n---\n\n![Step 6](https://img.shields.io/badge/Step_6-Use_the_Open_Brain_Bridge-1E88E5?style=for-the-badge)\n\nOpen a lesson and use the **Open Brain capture** panel to save one of three artifact types:\n\n- `Takeaway` — a durable lesson insight\n- `Confusion note` — something worth resurfacing later\n- `Lesson summary` — a reusable summary for future work\n\nThe lesson view also shows **Related thoughts** pulled from your existing `thoughts` table when OpenRouter retrieval is configured.\n\n> [!TIP]\n> Keep this bridge narrow. Capture durable artifacts, not every note or every quiz result.\n\n✅ **Done when:** Clicking **Send to Open Brain** returns a success message and a later search can find that saved artifact.\n\n## Expected Outcome\n\nWhen working correctly, you should have:\n\n- a local lesson app running against your existing OB1 Supabase project\n- research and lesson content sourced from plain markdown files\n- persistent progress, notes, and quiz history in dedicated `repo_learning_*` tables\n- explicit capture of durable learning artifacts back into `thoughts`\n- lesson views that can surface related prior thoughts from Open Brain\n\n## Future Extraction Path\n\nThis v1 intentionally keeps the UI local. If you want to turn it into a hosted OB1 dashboard later, the clean extraction path is:\n\n1. keep the content contract and Supabase tables the same\n2. move the React app into `dashboards/`\n3. keep the capture/retrieval bridge behind the existing server-layer interface\n\nThat way the frontend can move without redesigning the learning schema.\n\n## Troubleshooting\n\n**Issue: `npm run sync` fails with a missing table error**  \nSolution: Run the full contents of [schema.sql](https://github.com/NateBJones-Projects/OB1/blob/main/recipes/repo-learning-coach/schema.sql) in Supabase first. The app assumes the `repo_learning_*` tables already exist.\n\n**Issue: The app loads, but “Related thoughts” stays empty**  \nSolution: Check `OPENROUTER_API_KEY` in `.env`. The bridge needs embeddings to query `match_thoughts`. Also make sure your Open Brain already has useful content in `thoughts`.\n\n**Issue: “Send to Open Brain” fails**  \nSolution: Confirm your OB1 project includes the usual `upsert_thought` flow from the core setup and that your service role key is correct. This recipe writes through that existing path; it does not define its own capture RPC.\n\n**Issue: Re-syncing creates duplicate lessons**  \nSolution: Keep lesson `slug` values stable. The importer uses slugs as the durable source-of-truth key for content updates.\n"
+    },
+    {
+      "slug": "research-to-decision-workflow",
+      "category": "recipes",
+      "site_path": "/ob1/recipes/research-to-decision-workflow",
+      "name": "Research-to-Decision Workflow",
+      "description": "Workflow recipe for composing canonical OB1 skills into operator and investor decision pipelines, from competitive work and model review through synthesis, meeting outputs, and memo drafting.",
+      "author": {
+        "name": "Nate B. Jones",
+        "github": "NateBJones"
+      },
+      "version": "1.0.0",
+      "tags": [
+        "workflow",
+        "decision-support",
+        "diligence",
+        "memo",
+        "skill-composition"
+      ],
+      "difficulty": "intermediate",
+      "estimated_time": "20 minutes",
+      "created": "2026-03-31",
+      "updated": "2026-03-31",
+      "learning_order": null,
+      "compatibility": {
+        "open_brain": "required"
+      },
+      "requirements": {
+        "services": [],
+        "tools": [
+          "Claude Code or similar AI coding tool with reusable skills/system prompts"
+        ]
+      },
+      "dependencies": {
+        "skills": [
+          "competitive-analysis",
+          "financial-model-review",
+          "deal-memo-drafting",
+          "research-synthesis",
+          "meeting-synthesis"
+        ],
+        "primitives": []
+      },
+      "reverse_dependencies": {
+        "skills": [],
+        "primitives": []
+      },
+      "urls": {
+        "github_folder": "https://github.com/NateBJones-Projects/OB1/tree/main/recipes/research-to-decision-workflow",
+        "github_readme": "https://github.com/NateBJones-Projects/OB1/blob/main/recipes/research-to-decision-workflow/README.md"
+      },
+      "readme_markdown": "# Research-to-Decision Workflow\n\n> Composition recipe for chaining canonical OB1 skills into operator and investor decision workflows.\n\n## What It Does\n\nThis recipe shows how to use five reusable skill packs together without duplicating their prompt logic. The skills handle the canonical behavior; this recipe defines the install order, workspace structure, handoffs, skip rules, and two recommended paths from raw inputs to a reusable decision artifact.\n\nThe canonical reusable skills live here:\n\n- [Competitive Analysis](/ob1/skills/competitive-analysis)\n- [Financial Model Review](/ob1/skills/financial-model-review)\n- [Deal Memo Drafting](/ob1/skills/deal-memo-drafting)\n- [Research Synthesis](/ob1/skills/research-synthesis)\n- [Meeting Synthesis](/ob1/skills/meeting-synthesis)\n\n## Prerequisites\n\n- Working Open Brain setup ([guide](https://github.com/NateBJones-Projects/OB1/blob/main/docs/01-getting-started.md))\n- Claude Code or another AI coding tool that supports reusable skills/system prompts\n- The canonical [Competitive Analysis skill](/ob1/skills/competitive-analysis)\n- The canonical [Financial Model Review skill](/ob1/skills/financial-model-review)\n- The canonical [Deal Memo Drafting skill](/ob1/skills/deal-memo-drafting)\n- The canonical [Research Synthesis skill](/ob1/skills/research-synthesis)\n- The canonical [Meeting Synthesis skill](/ob1/skills/meeting-synthesis)\n- Optional but useful: Open Brain search and capture tools so the workflow can pull prior context and store the highest-value outputs\n\n## Credential Tracker\n\n```text\nRESEARCH-TO-DECISION WORKFLOW -- CREDENTIAL TRACKER\n---------------------------------------------------\n\nFROM YOUR OPEN BRAIN SETUP\n  Project URL:           ____________\n  Secret key:            ____________\n  OpenRouter API key:    ____________\n  Search tool available: yes / no\n  Capture tool available: yes / no\n\nGENERATED DURING SETUP\n  Workspace path:        ____________\n  Default output folder: ____________\n\n---------------------------------------------------\n```\n\n## Steps\n\n### 1. Install the canonical skill dependencies\n\nInstall all five skill packs from `skills/` first. This recipe depends on them and does not duplicate their prompt behavior.\n\n### 2. Create a working folder for the workflow\n\nCreate a single folder where the workflow can store sources and outputs:\n\n```bash\nmkdir -p docs/research-to-decision/sources\nmkdir -p docs/research-to-decision/meetings\nmkdir -p docs/research-to-decision/models\n```\n\nThen copy the helper template into your workspace or use it as a guide:\n\n- [`workflow-template.md`](https://github.com/NateBJones-Projects/OB1/blob/main/recipes/research-to-decision-workflow/workflow-template.md)\n\n### 3. Start with the decision brief\n\nBefore using any skill, define:\n\n- the decision you are trying to support\n- the primary audience\n- whether you are running the operator path or investor path\n- where the source materials live\n\nThe helper template includes a short starter brief for this.\n\n### 4. Choose the path\n\n#### Operator path\n\nUse this when the end goal is a strategic brief, GTM recommendation, partnership view, or internal decision support:\n\n```text\ncompetitive-analysis\n    ->\nresearch-synthesis\n    ->\nmeeting-synthesis\n```\n\nUse this path when:\n\n- you are comparing the market or a competitor set\n- you have supporting source material that needs to be synthesized\n- you want clean meeting outputs feeding a decision discussion\n\n#### Investor path\n\nUse this when the end goal is a memo, IC-style recommendation, or diligence package:\n\n```text\ncompetitive-analysis\n    ->\nfinancial-model-review\n    ->\nresearch-synthesis\n    ->\nmeeting-synthesis\n    ->\ndeal-memo-drafting\n```\n\nUse this path when:\n\n- the economics matter to the decision\n- you have an existing model or forecast that needs review\n- meeting notes or calls should shape the recommendation\n- the final deliverable is a memo, not just a synthesis\n\n### 5. Respect the handoffs\n\nEach step should produce a clean artifact for the next step instead of forcing the next skill to reconstruct context. The helper template defines a default structure, but the minimum handoffs are:\n\n- `competitive-analysis` -> market and competitor brief\n- `financial-model-review` -> model review memo with red flags and scenario notes\n- `research-synthesis` -> source-backed synthesis with contradictions and confidence markers\n- `meeting-synthesis` -> decision log, action list, open questions, and follow-up notes\n- `deal-memo-drafting` -> final recommendation memo\n\n### 6. Skip steps when the workflow is lighter\n\nYou do not need every step every time.\n\n- Skip `financial-model-review` if there is no meaningful model artifact.\n- Skip `meeting-synthesis` if there is no call, interview, or internal review feeding the decision.\n- Skip `deal-memo-drafting` if the final deliverable is a strategy brief rather than a memo.\n\n### 7. Capture only the durable outputs\n\nRecommended Open Brain capture points:\n\n- after a strong competitive brief is finished\n- after research synthesis identifies durable findings\n- after meeting synthesis produces real decisions\n- after the final memo or recommendation is complete\n\nDo not capture raw packet noise just because it passed through the workflow.\n\n## Expected Outcome\n\nWhen working correctly, this recipe should give you:\n\n- a clean install and usage order for the five canonical skills\n- a workspace layout that keeps intermediate outputs reusable\n- one of two decision paths that are easy to follow and easy to skip around within\n- a final operator brief or investor memo built from explicit handoffs instead of loose chat context\n\n## Troubleshooting\n\n**Issue: The recipe feels like it is repeating the skill instructions**\nSolution: Keep the boundary clean. The skills are the source of truth for behavior. The recipe should only explain sequencing, handoffs, and workflow usage.\n\n**Issue: The memo step feels weak even after running the workflow**\nSolution: Check the handoffs. `deal-memo-drafting` needs actual research, model, and meeting outputs. If earlier artifacts are thin, the memo will be thin.\n\n**Issue: The workflow feels too heavy for a small decision**\nSolution: Use the skip rules. This recipe is modular on purpose. Run only the steps that materially improve the decision.\n"
+    },
+    {
+      "slug": "schema-aware-routing",
+      "category": "recipes",
+      "site_path": "/ob1/recipes/schema-aware-routing",
+      "name": "schema-aware-routing",
+      "description": "A pattern for using LLM-extracted metadata to route unstructured text into the correct database tables. Demonstrates multi-table writes to thoughts, people, interactions, and action_items based on structured fields extracted by an LLM from raw input.",
+      "author": {
+        "name": "Clay Dunker",
+        "github": "claydunker-yalc"
+      },
+      "version": "1.0.0",
+      "tags": [
+        "ingestion",
+        "routing",
+        "schema",
+        "slack",
+        "supabase",
+        "llm",
+        "metadata-extraction",
+        "people-graph",
+        "action-items"
+      ],
+      "difficulty": "intermediate",
+      "estimated_time": "45 minutes",
+      "created": "2026-03-19",
+      "updated": "2026-03-19",
+      "learning_order": null,
+      "compatibility": {
+        "open_brain": "required"
+      },
+      "requirements": {
+        "services": [
+          "OpenAI-compatible API (LLM + embeddings)"
+        ],
+        "tools": [
+          "Node.js 18+ or Deno"
+        ]
+      },
+      "dependencies": {
+        "skills": [],
+        "primitives": []
+      },
+      "reverse_dependencies": {
+        "skills": [],
+        "primitives": []
+      },
+      "urls": {
+        "github_folder": "https://github.com/NateBJones-Projects/OB1/tree/main/recipes/schema-aware-routing",
+        "github_readme": "https://github.com/NateBJones-Projects/OB1/blob/main/recipes/schema-aware-routing/README.md"
+      },
+      "readme_markdown": "# Schema-Aware Routing Pattern\n\n<div align=\"center\">\n\n![Community Contribution](https://img.shields.io/badge/OB1_COMMUNITY-Approved_Contribution-2ea44f?style=for-the-badge&logo=github)\n\n**Created by [@claydunker-yalc](https://github.com/claydunker-yalc)**\n\n*Reviewed and merged by the Open Brain maintainer team — thank you for building the future of AI memory!*\n\n</div>\n\nA pattern for using LLM-extracted metadata to route unstructured text into the correct database tables automatically. One input message becomes writes to four different tables — `thoughts`, `people`, `interactions`, and `action_items` — based entirely on what the LLM finds in the text.\n\n> [!NOTE]\n> I'm an elementary school teacher, not a developer. I built this entire system with Claude Code. If I can get it running, you can too. The instructions below are written for people like me.\n\n## Prerequisites\n\nBefore you start, make sure you have:\n\n- A **Supabase** project with the database tables created (SQL provided below)\n- An **OpenAI-compatible API key** for LLM calls and embeddings (OpenAI, OpenRouter, Anthropic, etc.)\n- **Node.js 18+** or **Deno** installed on your machine\n- The `@supabase/supabase-js` package installed (`npm install @supabase/supabase-js`)\n\n## How It Works\n\nThe routing pattern follows three stages:\n\n```\nRaw text\n  │\n  ▼\n┌──────────────────────────┐\n│  LLM Metadata Extraction │  ← Extracts people, action items, topics, type, domain\n└──────────┬───────────────┘\n           │\n           ▼\n┌──────────────────────────┐\n│  Schema-Aware Router     │  ← Reads metadata fields, decides which tables to write\n└──────────┬───────────────┘\n           │\n           ├──→ thoughts table      (ALWAYS — the raw capture is never lost)\n           ├──→ people table        (IF people are mentioned — find, fuzzy-match, or create)\n           ├──→ interactions table  (FOR EACH resolved person — links person ↔ thought)\n           └──→ action_items table  (ONLY IF speaker uses first-person intent)\n```\n\n### The Key Routing Decisions\n\n**Decision 1 — Thoughts (always written):**\nEvery input always creates a `thoughts` row. This is your safety net — raw data is never lost regardless of what else happens.\n\n**Decision 2 — People (find, fuzzy-match, or create):**\nWhen the LLM extracts a `people` array, each person goes through a three-pass resolution:\n\n1. **Exact match** — checks name and aliases (case-insensitive). If found, backfills any missing metadata (role, relationship_type) on the existing record.\n2. **Fuzzy match** — uses first-name similarity. \"Mike\" matches \"Mike Smith\", \"Rob\" matches \"Robert\". Same last name alone does NOT match (so \"Kristin Dunker\" won't match \"Rosie Dunker\"). Fuzzy matches get flagged for human confirmation.\n3. **First-name collision** — catches \"Sarah J.\" vs existing \"Sarah Johnson\". Also flagged for confirmation.\n4. **No match** — creates a new person record.\n\n**Decision 3 — Interactions (one per resolved person):**\nFor every person that gets resolved (found or created) with a valid ID, an `interactions` record is written. This links the person to the original thought and carries the same embedding vector for semantic search.\n\n**Decision 4 — Action items (first-person intent only):**\nThe LLM is prompted to ONLY extract action items when the speaker commits to doing something themselves: \"I need to\", \"I should\", \"remind me to\". If someone ELSE wants something (\"she asked me to\", \"he needs\"), that's an observation — not an action item. This prevents your task list from filling up with other people's requests.\n\n> [!IMPORTANT]\n> The LLM prompt is the single source of truth for routing. If you change the extraction prompt, you change what gets routed where. Treat it like a schema definition.\n\n## Setup Instructions\n\n![Step 1](https://img.shields.io/badge/Step_1-Create_Your_Database_Tables-2E86AB?style=for-the-badge)\n\n<details>\n<summary>📋 <strong>SQL: Create all five tables and grant permissions</strong> (click to expand)</summary>\n\n```sql\n-- Enable the vector extension for embeddings\ncreate extension if not exists vector;\n\n-- 1. Thoughts table — the raw capture\ncreate table thoughts (\n  id uuid primary key default gen_random_uuid(),\n  content text not null,\n  embedding vector(1536),\n  domain text default 'personal',\n  status text default 'active',\n  source text default 'api',\n  metadata jsonb default '{}',\n  created_at timestamptz default now(),\n  updated_at timestamptz default now()\n);\n\n-- 2. People table — your contact graph\ncreate table people (\n  id uuid primary key default gen_random_uuid(),\n  name text not null,\n  aliases text[] default '{}',\n  relationship_type text,\n  role text,\n  status text default 'active',\n  created_at timestamptz default now(),\n  updated_at timestamptz default now()\n);\n\n-- 3. Interactions table — links people to thoughts\ncreate table interactions (\n  id uuid primary key default gen_random_uuid(),\n  person_id uuid references people(id),\n  note text,\n  source text default 'api',\n  embedding vector(1536),\n  created_at timestamptz default now()\n);\n\n-- 4. Action items table — first-person commitments only\ncreate table action_items (\n  id uuid primary key default gen_random_uuid(),\n  title text not null,\n  domain text default 'personal',\n  source text default 'api',\n  status text default 'open',\n  linked_person_id uuid references people(id),\n  created_at timestamptz default now(),\n  updated_at timestamptz default now()\n);\n\n-- 5. Pending confirmations table — for fuzzy match resolution\ncreate table pending_confirmations (\n  id uuid primary key default gen_random_uuid(),\n  type text not null,\n  payload jsonb not null,\n  slack_ts text,\n  status text default 'pending',\n  created_at timestamptz default now()\n);\n\n-- Grant permissions to service_role (required on newer Supabase projects)\ngrant select, insert, update, delete on table public.thoughts to service_role;\ngrant select, insert, update, delete on table public.people to service_role;\ngrant select, insert, update, delete on table public.interactions to service_role;\ngrant select, insert, update, delete on table public.action_items to service_role;\ngrant select, insert, update, delete on table public.pending_confirmations to service_role;\n```\n\n</details>\n\nRun this SQL in your Supabase SQL Editor (Dashboard → SQL Editor → New Query → paste → Run).\n\n✅ **Done when:** You can see all five tables in the Supabase Table Editor.\n\n---\n\n![Step 2](https://img.shields.io/badge/Step_2-Wire_Up_Your_LLM_and_Embedding_Calls-2E86AB?style=for-the-badge)\n\nOpen `index.ts` and find the two placeholder functions:\n\n**1. Replace `extractMetadata()`:**\nSwap out the `throw` with your LLM API call. The system prompt (`EXTRACTION_SYSTEM_PROMPT`) is already defined for you. Send it as the system message and the input text as the user message. Request JSON response format.\n\n**2. Replace `getEmbedding()`:**\nSwap out the `throw` with your embedding API call. We used `text-embedding-3-small` from OpenAI (1536 dimensions). If you use a different model, update the `vector(1536)` in the SQL above to match your model's dimensions.\n\n> [!TIP]\n> You can use OpenRouter as a proxy to access multiple LLM providers with one API key. That's what I use — it lets me swap models without changing code.\n\n✅ **Done when:** Both functions make real API calls and return data instead of throwing errors.\n\n---\n\n![Step 3](https://img.shields.io/badge/Step_3-Initialize_Your_Supabase_Client-2E86AB?style=for-the-badge)\n\n```typescript\nimport { createClient } from \"@supabase/supabase-js\";\n\nconst supabase = createClient(\n  \"https://YOUR_PROJECT.supabase.co\",\n  \"YOUR_SERVICE_ROLE_KEY\"\n);\n```\n\n> [!CAUTION]\n> Use the **service role key**, not the anon key. The anon key has Row Level Security restrictions that will block server-side inserts. Never expose the service role key in client-side code.\n\n✅ **Done when:** You can run `supabase.from(\"thoughts\").select(\"id\").limit(1)` without errors.\n\n---\n\n![Step 4](https://img.shields.io/badge/Step_4-Call_the_Router-2E86AB?style=for-the-badge)\n\n```typescript\nimport { processThought } from \"./index\";\n\nconst result = await processThought(\n  supabase,\n  \"I need to call Sarah tomorrow about the school fundraiser\"\n);\n\nconsole.log(result);\n// {\n//   thoughtId: \"uuid-here\",\n//   writes: [\n//     { table: \"thoughts\", success: true },\n//     { table: \"people\", success: true, details: \"Created: Sarah\" },\n//     { table: \"interactions\", success: true, details: \"For: Sarah\" },\n//     { table: \"action_items\", success: true, details: \"call Sarah tomorrow about the school f...\" }\n//   ],\n//   people: [\n//     { name: \"Sarah\", id: \"uuid-here\", action: \"created\" }\n//   ]\n// }\n```\n\n✅ **Done when:** You see rows appear in all four tables in the Supabase Table Editor after running the script.\n\n---\n\n![Step 5](https://img.shields.io/badge/Step_5-Verify_the_Routing_Logic-2E86AB?style=for-the-badge)\n\nTest these three inputs to confirm each routing path works:\n\n| Input | Expected Tables Written |\n|---|---|\n| `\"I need to call Sarah tomorrow\"` | thoughts + people + interactions + action_items |\n| `\"My daughter Poppy has swimming tonight\"` | thoughts + people + interactions (no action items — it's an observation) |\n| `\"Really interesting article about AI in education\"` | thoughts only (no people, no action items) |\n\n✅ **Done when:** Each test input writes to exactly the tables listed above — no more, no less.\n\n## Expected Outcome\n\nAfter following all five steps, you'll have a working schema-aware router that:\n\n- Captures every input to the `thoughts` table (nothing is ever lost)\n- Automatically builds a contact graph in the `people` table as you mention names\n- Links every person mention to an `interactions` record with a semantic embedding\n- Only creates action items for things YOU commit to doing (not other people's requests)\n- Flags ambiguous name matches for human review instead of guessing\n\nYour Supabase dashboard should show data flowing into all four tables, with proper foreign key relationships between `people`, `interactions`, and `action_items`.\n\n## Troubleshooting\n\n### \"Error: relation 'thoughts' does not exist\"\n\nYou haven't run the SQL from Step 1 yet, or you ran it in the wrong Supabase project. Double-check that you're looking at the correct project in your Supabase dashboard, then re-run the SQL in the SQL Editor.\n\n> [!WARNING]\n> If you have multiple Supabase projects, make sure your `SUPABASE_URL` matches the project where you created the tables. This is the #1 mistake I made — spent an hour debugging before I realized I was pointed at my dev project instead of production.\n\n### \"LLM returns empty people array even though I mentioned someone by name\"\n\nThe extraction prompt expects clear, explicit name mentions. Pronouns like \"he\" or \"she\" won't resolve to a person. Try rephrasing: instead of \"She wants me to call her\", say \"Sarah wants me to call her\". The LLM is instructed to only extract what's explicitly there.\n\nIf you're consistently getting bad extractions, try upgrading your LLM model. `gpt-4o-mini` works well for this. Smaller or older models may struggle with the structured JSON output.\n\n### \"Action items are being created for things other people asked me to do\"\n\nThe extraction prompt has very specific rules about first-person intent. Check that you haven't modified the `EXTRACTION_SYSTEM_PROMPT`. The key line is:\n\n> \"If someone ELSE wants something ('she wants', 'he asked', 'they need') that is NOT an action item\"\n\nIf you've customized the prompt, make sure this rule survived your edits.\n\n### \"Fuzzy matching is creating duplicate people\"\n\nThe `namesAreSimilar()` function intentionally has conservative matching — it only looks at first names. If \"Mike\" and \"Michael Smith\" aren't matching, it's because the first name \"Mike\" doesn't contain \"Michael\" (it goes the other direction). You may want to adjust the fuzzy logic for your specific use case, but be careful: too aggressive and you'll merge different people; too conservative and you'll create duplicates.\n\n> [!TIP]\n> Check the `pending_confirmations` table in Supabase. If fuzzy matches are being flagged there but never resolved, that's your queue of ambiguous matches waiting for human review. Build a simple UI or bot command to process them.\n\n### \"Embeddings dimension mismatch\"\n\nIf you switched from `text-embedding-3-small` (1536 dimensions) to a different model, you need to update the `vector(1536)` in the SQL schema to match. For example, `text-embedding-3-large` uses 3072 dimensions. Drop and recreate the tables with the correct dimension, or alter the columns:\n\n<details>\n<summary>📋 <strong>SQL: Change embedding dimensions</strong> (click to expand)</summary>\n\n```sql\nalter table thoughts alter column embedding type vector(YOUR_DIMENSION);\nalter table interactions alter column embedding type vector(YOUR_DIMENSION);\n```\n\n</details>\n\n## Credits\n\nBuilt by Clay Dunker ([@claydunker-yalc](https://github.com/claydunker-yalc)) — an elementary school teacher who builds with Claude Code. This pattern emerged from building a personal knowledge management system (Open Brain / OB1) that captures thoughts from Slack and routes them into a structured database.\n\nIf you want to learn more about the project, check out the main [OB1 repository](https://github.com/NateBJones-Projects/OB1).\n"
+    },
+    {
+      "slug": "source-filtering",
+      "category": "recipes",
+      "site_path": "/ob1/recipes/source-filtering",
+      "name": "Source Filtering",
+      "description": "Filter thoughts by source (mcp, gmail, chatgpt, obsidian) and backfill missing metadata for early imports.",
+      "author": {
+        "name": "Matt Hallett",
+        "github": "matthallett1"
+      },
+      "version": "1.0.0",
+      "tags": [
+        "source",
+        "filtering",
+        "metadata",
+        "backfill",
+        "search"
+      ],
+      "difficulty": "beginner",
+      "estimated_time": "15 minutes",
+      "created": "2026-03-13",
+      "updated": "2026-03-13",
+      "learning_order": null,
+      "compatibility": {
+        "open_brain": "required"
+      },
+      "requirements": {
+        "services": [
+          "OpenRouter"
+        ],
+        "tools": [
+          "Deno 1.40+"
+        ]
+      },
+      "dependencies": {
+        "skills": [],
+        "primitives": []
+      },
+      "reverse_dependencies": {
+        "skills": [],
+        "primitives": []
+      },
+      "urls": {
+        "github_folder": "https://github.com/NateBJones-Projects/OB1/tree/main/recipes/source-filtering",
+        "github_readme": "https://github.com/NateBJones-Projects/OB1/blob/main/recipes/source-filtering/README.md"
+      },
+      "readme_markdown": "# Source Filtering\n\n> Filter and search thoughts by source, backfill metadata for early imports.\n\n## What It Does\n\nSource filtering lets you scope `search_thoughts`, `list_thoughts`, and `thought_stats` to a single source type (e.g., `mcp`, `gmail`, `chatgpt`, `obsidian`). The backfill script adds structured metadata (type, topics, people, sentiment) to thoughts that were imported without LLM extraction — like bulk email imports that went straight into Supabase.\n\n## Prerequisites\n\n- Working Open Brain setup ([guide](https://github.com/NateBJones-Projects/OB1/blob/main/docs/01-getting-started.md))\n- Deno 1.40+ (for backfill script only)\n- Supabase project URL and service role key\n- OpenRouter API key (for backfill script only)\n\n## Credential Tracker\n\nCopy this block into a text editor and fill it in as you go.\n\n```text\nSOURCE FILTERING -- CREDENTIAL TRACKER\n--------------------------------------\n\nFROM YOUR OPEN BRAIN SETUP\n  Supabase Project URL:        ____________\n  Supabase Service Role Key:   ____________\n\nFOR BACKFILL ONLY\n  OpenRouter API Key:          ____________\n\n--------------------------------------\n```\n\n## Steps\n\n1. Check your sources\n2. Use source filtering\n3. Check if you need backfill\n4. Set up environment variables for backfill\n5. Run the backfill\n6. Verify\n\n### Step 1: Check your sources\n\nRun this query in the Supabase SQL Editor to see what sources exist in your brain:\n\n```sql\nSELECT metadata->>'source' AS source, COUNT(*) AS count\nFROM thoughts\nGROUP BY metadata->>'source'\nORDER BY count DESC;\n```\n\nYou'll see something like:\n\n| source   | count |\n|----------|-------|\n| gmail    | 1200  |\n| mcp      | 180   |\n| chatgpt  | 50    |\n| *null*   | 15    |\n\n### Step 2: Use source filtering\n\nSource filtering works with three MCP tools. Pass the `source` parameter to scope results:\n\n**search_thoughts** — semantic search within a single source:\n\n```\n\"Search my gmail thoughts for conversations about the product roadmap\"\n→ search_thoughts({ query: \"product roadmap\", source: \"gmail\" })\n```\n\n**list_thoughts** — recent thoughts from a specific source:\n\n```\n\"Show me my last 10 ChatGPT thoughts\"\n→ list_thoughts({ limit: 10, source: \"chatgpt\" })\n```\n\n**thought_stats** — stats scoped to a source:\n\n```\n\"How many gmail thoughts do I have?\"\n→ thought_stats({ source: \"gmail\" })\n```\n\nWithout the `source` parameter, all three tools return results across all sources (existing behavior).\n\n### Step 3: Check if you need backfill\n\nIf you imported thoughts without going through `capture_thought` (e.g., bulk email import via direct Supabase insert), those thoughts may be missing LLM-extracted metadata like `type`, `topics`, and `people`. Check:\n\n```sql\nSELECT COUNT(*) AS missing_metadata\nFROM thoughts\nWHERE metadata->>'type' IS NULL;\n```\n\nIf this returns 0, you're done — skip to Step 6. If it returns a number, continue to Step 4.\n\n### Step 4: Set up environment variables for backfill\n\n```bash\nexport SUPABASE_URL=\"https://your-project.supabase.co\"\nexport SUPABASE_SERVICE_ROLE_KEY=\"your-service-role-key\"\nexport OPENROUTER_API_KEY=\"your-openrouter-key\"\n```\n\n### Step 5: Run the backfill\n\nStart with a dry run to see what would be updated:\n\n```bash\ndeno run --allow-net --allow-env backfill-metadata.ts --dry-run --limit=10\n```\n\nThen run a small live batch:\n\n```bash\ndeno run --allow-net --allow-env backfill-metadata.ts --limit=10\n```\n\nIf that looks good, run the full backfill:\n\n```bash\ndeno run --allow-net --allow-env backfill-metadata.ts --limit=1000\n```\n\nYou can also scope the backfill to a specific source:\n\n```bash\ndeno run --allow-net --allow-env backfill-metadata.ts --source=gmail --limit=500\n```\n\n### Step 6: Verify\n\nRun `thought_stats` (or `thought_stats({ source: \"gmail\" })`) — the output should now include a \"By source:\" breakdown and \"By type:\" categories for backfilled thoughts.\n\nYou can also verify in SQL:\n\n```sql\nSELECT metadata->>'type' AS type, COUNT(*)\nFROM thoughts\nWHERE metadata->>'type' IS NOT NULL\nGROUP BY metadata->>'type'\nORDER BY count DESC;\n```\n\n## Expected Outcome\n\n- `thought_stats` shows a \"By source:\" section with counts per source\n- `search_thoughts` with `source: \"gmail\"` returns only Gmail-sourced thoughts\n- `search_thoughts` without `source` returns thoughts from all sources\n- Backfilled thoughts now have `type`, `topics`, `people`, `sentiment`, and `action_items` in their metadata\n\n## Troubleshooting\n\n**Thoughts have `null` source**\nSome early thoughts were captured before source tracking was added. You can backfill the source field manually:\n\n```sql\nUPDATE thoughts SET metadata = metadata || '{\"source\": \"mcp\"}'::jsonb\nWHERE metadata->>'source' IS NULL;\n```\n\n**Backfill says \"Found 0 thought(s) missing metadata\"**\nAll your thoughts already have LLM-extracted metadata. This happens if everything was imported through `capture_thought`, which extracts metadata automatically.\n\n**Rate limiting from OpenRouter**\nThe script batches requests (default 10 concurrent) with a 500ms pause between batches. If you hit rate limits, reduce the batch size:\n\n```bash\ndeno run --allow-net --allow-env backfill-metadata.ts --batch-size=3\n```\n\n**Source strings are case-sensitive**\n`source: \"Gmail\"` won't match `source: \"gmail\"`. Sources are stored lowercase. If you have mixed-case sources from a custom import, normalize them:\n\n```sql\nUPDATE thoughts SET metadata = jsonb_set(metadata, '{source}', to_jsonb(LOWER(metadata->>'source')))\nWHERE metadata->>'source' IS DISTINCT FROM LOWER(metadata->>'source');\n```\n"
+    },
+    {
+      "slug": "vercel-neon-telegram",
+      "category": "recipes",
+      "site_path": "/ob1/recipes/vercel-neon-telegram",
+      "name": "Vercel + Neon + Telegram",
+      "description": "Alternative Open Brain architecture using Vercel serverless functions, Neon Postgres with pgvector, and Telegram for mobile capture. Replaces the default Cloudflare + Supabase + Slack stack while keeping the same thoughts table schema and MCP interface.",
+      "author": {
+        "name": "Geoff Price",
+        "github": "geoff-price"
+      },
+      "version": "1.0.0",
+      "tags": [
+        "vercel",
+        "neon",
+        "telegram",
+        "alternative-architecture",
+        "mcp",
+        "next-js",
+        "pgvector"
+      ],
+      "difficulty": "intermediate",
+      "estimated_time": "1 hour",
+      "created": "2026-03-14",
+      "updated": "2026-03-14",
+      "learning_order": null,
+      "compatibility": {
+        "open_brain": "required"
+      },
+      "requirements": {
+        "services": [
+          "Neon Postgres",
+          "Vercel",
+          "OpenAI API",
+          "Telegram"
+        ],
+        "tools": [
+          "Node.js 18+"
+        ]
+      },
+      "dependencies": {
+        "skills": [],
+        "primitives": []
+      },
+      "reverse_dependencies": {
+        "skills": [],
+        "primitives": []
+      },
+      "urls": {
+        "github_folder": "https://github.com/NateBJones-Projects/OB1/tree/main/recipes/vercel-neon-telegram",
+        "github_readme": "https://github.com/NateBJones-Projects/OB1/blob/main/recipes/vercel-neon-telegram/README.md"
+      },
+      "readme_markdown": "# Vercel + Neon + Telegram\n\nAn alternative Open Brain architecture that replaces Cloudflare Workers with **Vercel serverless functions**, Supabase with **Neon Postgres** (pgvector), and Slack with **Telegram** for mobile capture. Uses the **Vercel AI SDK** with OpenAI directly — no OpenRouter required.\n\n## What It Does\n\nDeploys a complete Open Brain on the Vercel + Neon stack with four capture channels:\n\n- **MCP server** — ChatGPT, Claude Desktop, Claude Code, Cursor, and any MCP-compatible client can read and write thoughts\n- **Telegram bot** — capture thoughts from your phone, search with `/search <query>`\n- **HTTP API** — direct REST endpoint for scripts, shortcuts, and automation\n- **CLI function** — one-liner bash function for terminal capture\n\nAll thoughts are embedded with `text-embedding-3-small`, classified by `gpt-4o-mini`, stored in Neon with pgvector, and searchable via cosine similarity.\n\n## Prerequisites\n\n- A working Open Brain setup (completed the [Getting Started guide](https://github.com/NateBJones-Projects/OB1/blob/main/docs/01-getting-started.md))\n- A [Neon](https://neon.tech) account (free tier)\n- A [Vercel](https://vercel.com) account (free tier)\n- An [OpenAI](https://platform.openai.com) API key\n- A [Telegram](https://telegram.org) account (for mobile capture — optional)\n- Node.js 18+\n\n## Architecture\n\n```\nTelegram (phone)  ──→  Vercel Function  ──→  Neon Postgres (pgvector)\nCLI (terminal)    ──→  /api/capture     ──→    thoughts table\nMCP clients       ──→  /api/mcp         ──→    match_thoughts()\n                           ↓\n                     Vercel AI SDK  ──→  OpenAI API\n                     (embed + extract)   (text-embedding-3-small + gpt-4o-mini)\n```\n\n**3 services total.** Monthly cost: ~$0.10–0.30 (API calls only, infrastructure on free tiers).\n\n## Step-by-Step Instructions\n\n### 1. Clone and install\n\n```bash\ngit clone https://github.com/YOUR_USERNAME/open-brain-vercel-neon.git\ncd open-brain-vercel-neon\nnpm install\n```\n\nOr copy the source files from this recipe into a new directory and run `npm install`.\n\n### 2. Create a Neon project\n\n1. Go to [console.neon.tech](https://console.neon.tech)\n2. Create a new project (name it anything — e.g., \"open-brain\")\n3. Copy the connection string\n\n### 3. Generate an access key\n\n```bash\nnpm run generate-key\n```\n\nSave the output — you'll need it for the `.env.local` file and for connecting clients.\n\n### 4. Configure environment variables\n\nCreate `.env.local` from the template:\n\n```bash\ncp .env.example .env.local\n```\n\nFill in:\n\n| Variable | Where to get it |\n|----------|----------------|\n| `DATABASE_URL` | Neon dashboard → Connection string |\n| `OPENAI_API_KEY` | [platform.openai.com/api-keys](https://platform.openai.com/api-keys) |\n| `BRAIN_ACCESS_KEY` | Output from step 3 |\n| `TELEGRAM_BOT_TOKEN` | @BotFather on Telegram (optional) |\n| `TELEGRAM_WEBHOOK_SECRET` | Any alphanumeric string you choose (optional) |\n| `APP_URL` | Your Vercel deployment URL (set after step 6) |\n\n### 5. Run database migrations\n\n```bash\nnpm run migrate\n```\n\nThis creates the `thoughts` table with pgvector indexes and the `match_thoughts()` function.\n\n### 6. Deploy to Vercel\n\n```bash\nnpx vercel --prod\n```\n\nIf this is your first deploy, Vercel will prompt you to link the project. Set the framework to **Next.js**.\n\nAfter deployment, note your production URL (e.g., `https://your-project.vercel.app`).\n\n**Add environment variables to Vercel:**\n\n```bash\nnpx vercel env add DATABASE_URL\nnpx vercel env add OPENAI_API_KEY\nnpx vercel env add BRAIN_ACCESS_KEY\n```\n\nOr add them via the Vercel dashboard → Settings → Environment Variables. Then redeploy:\n\n```bash\nnpx vercel --prod\n```\n\n### 7. Verify the deployment\n\n```bash\n# Health check\ncurl https://your-project.vercel.app/api/health\n\n# Capture a test thought\ncurl -X POST https://your-project.vercel.app/api/capture \\\n  -H \"Content-Type: application/json\" \\\n  -H \"x-brain-key: YOUR_ACCESS_KEY\" \\\n  -d '{\"content\": \"Testing Open Brain on Vercel + Neon\"}'\n```\n\nYou should see a JSON response with `id` and `metadata` (type, topics, people, action items).\n\n### 8. Connect MCP clients\n\n**ChatGPT** (Settings → Apps & Connectors → Add MCP):\n\n```\nhttps://your-project.vercel.app/api/mcp?key=YOUR_ACCESS_KEY\n```\n\nSet auth to \"None\" (key is in the URL). Note: enabling Developer Mode in ChatGPT disables its built-in Memory — Open Brain replaces it.\n\n**Claude Desktop** (Settings > Connectors > Add custom connector):\n\n1. Open Claude Desktop\n2. Go to **Settings** > **Connectors**\n3. Click **Add custom connector**\n4. Name: `Open Brain`\n5. Remote MCP server URL: `https://your-project.vercel.app/api/mcp?key=YOUR_ACCESS_KEY`\n6. Click **Add**\n\nThe connector will appear as \"Open Brain\" in your MCP tools list. Enable it per conversation via the \"+\" button > Connectors.\n\n**Claude Code:**\n\n```bash\nclaude mcp add --transport http open-brain \\\n  https://your-project.vercel.app/api/mcp \\\n  --header \"x-brain-key: YOUR_ACCESS_KEY\"\n```\n\n### 9. Set up Telegram (optional)\n\n1. Message [@BotFather](https://t.me/BotFather) on Telegram → `/newbot`\n2. Add `TELEGRAM_BOT_TOKEN` and `TELEGRAM_WEBHOOK_SECRET` to Vercel env vars\n3. Set `APP_URL` in your `.env.local` to your Vercel deployment URL\n4. Redeploy: `npx vercel --prod`\n5. Register the webhook:\n\n```bash\nnpm run set-telegram-webhook\n```\n\n6. Send a message to your bot — it should reply with a classification\n\n### 10. Add CLI capture (optional)\n\nAdd to your `~/.bashrc` or `~/.zshrc`:\n\n```bash\nbrain() {\n  curl -s -X POST \"https://your-project.vercel.app/api/capture\" \\\n    -H \"Content-Type: application/json\" \\\n    -H \"x-brain-key: YOUR_ACCESS_KEY\" \\\n    -d \"{\\\"content\\\": \\\"$*\\\", \\\"source\\\": \\\"cli\\\"}\"\n}\n```\n\nThen capture from anywhere:\n\n```bash\nbrain \"Book the Lake Tahoe cabin before June — ask Sarah about group size\"\n```\n\n## Expected Outcome\n\nAfter completing these steps, you should be able to:\n\n1. **Capture** a thought from any channel (MCP, Telegram, CLI, HTTP)\n2. **Search** by meaning — \"upcoming deadlines\" finds thoughts about due dates, even if the word \"deadline\" isn't used\n3. **List** thoughts filtered by type (task, idea, observation, etc.) or topic\n4. **Cross-client memory** — capture from Telegram on your phone, retrieve from ChatGPT on your laptop\n\nEach captured thought is automatically:\n- Embedded as a 1536-dimension vector (`text-embedding-3-small`)\n- Classified by type (observation, task, idea, reference, person_note, decision, meeting_note)\n- Tagged with topics (1–3), people mentioned, action items, and dates\n\n## How It Differs from the Default Stack\n\n| Component | Default (OB1) | This recipe |\n|-----------|---------------|-------------|\n| Runtime | Cloudflare Workers | Vercel Serverless (Next.js App Router) |\n| Database | Supabase (pgvector) | Neon Postgres (pgvector) |\n| AI Provider | OpenAI via OpenRouter | OpenAI direct (Vercel AI SDK) |\n| Mobile capture | Slack | Telegram (grammY) |\n| MCP transport | SSE | Streamable HTTP (2025-03-26 spec) |\n| Auth | Supabase auth + API keys | Static access key (timing-safe) |\n\nThe `thoughts` table schema and `match_thoughts()` function are identical to OB1's — data is portable between stacks.\n\n## File Structure\n\n```\nvercel-neon-telegram/\n├── README.md\n├── metadata.json\n├── package.json\n├── tsconfig.json\n├── next.config.mjs\n├── vercel.json\n├── .env.example\n├── sql/\n│   ├── 001-create-thoughts.sql\n│   └── 002-match-thoughts.sql\n├── scripts/\n│   ├── generate-key.ts\n│   ├── migrate.ts\n│   └── set-telegram-webhook.ts\n└── src/\n    ├── lib/\n    │   ├── types.ts          # Zod metadata schema\n    │   ├── ai.ts             # Vercel AI SDK (embed + extract)\n    │   ├── db.ts             # Neon tagged-template queries\n    │   ├── auth.ts           # Timing-safe key validation\n    │   ├── capture.ts        # Core pipeline (parallel embed + extract + store)\n    │   ├── rate-limit.ts     # In-memory rate limiter (30 req/min)\n    │   └── __tests__/        # Unit tests (vitest)\n    │       ├── auth.test.ts\n    │       ├── rate-limit.test.ts\n    │       └── types.test.ts\n    └── app/api/\n        ├── mcp/route.ts      # MCP server (3 tools)\n        ├── capture/route.ts  # Direct HTTP capture\n        ├── telegram/route.ts # Telegram webhook (grammY)\n        └── health/route.ts   # Health check\n```\n\n## Running Tests\n\n```bash\nnpm test\n```\n\nUnit tests cover auth (key extraction from 3 sources, timing-safe validation), rate limiting (sliding window, expiration), and metadata schemas (Zod validation, defaults, constraints). No external services required.\n\n## Security\n\n- **Auth:** timing-safe key comparison on all write/read endpoints\n- **Rate limiting:** 30 captures per minute (prevents runaway AI agent loops)\n- **Input cap:** 10KB max per thought (prevents OpenAI cost abuse)\n- **Telegram:** webhook secret required — rejects requests when not configured\n- **Health endpoint:** intentionally public (no secrets exposed)\n\n## Troubleshooting\n\n### \"DATABASE_URL is required\" when running migrate\n\nYour `.env.local` file is missing or the variable isn't set. Make sure you copied `.env.example` to `.env.local` and filled in the Neon connection string. The migrate script reads from `.env.local` — run it with:\n\n```bash\nsource .env.local && npm run migrate\n```\n\n### Vercel build fails with \"No Output Directory named public\"\n\nThe Vercel project isn't configured as a Next.js project. Add to `vercel.json`:\n\n```json\n{ \"framework\": \"nextjs\" }\n```\n\nOr set the framework in the Vercel dashboard → Settings → General → Framework Preset → Next.js.\n\n### \"cannot insert multiple commands into a prepared statement\" during migration\n\nThe Neon HTTP driver can't execute multiple SQL statements in a single call. The included `migrate.ts` script handles this automatically by splitting statements. If you're running SQL manually, execute each statement separately.\n\n### MCP connection fails in Claude Desktop\n\nMake sure you're using the custom connectors UI, not a JSON config file:\n\n1. Open **Settings** > **Connectors** > **Add custom connector**\n2. Paste the full URL including the key: `https://your-project.vercel.app/api/mcp?key=YOUR_KEY`\n3. If the connector shows \"disconnected,\" verify your Vercel deployment is running (`curl https://your-project.vercel.app/api/health`)\n\nIf your Claude Desktop doesn't have the Connectors option, update to the latest version.\n\n### Telegram webhook returns 503\n\n`TELEGRAM_WEBHOOK_SECRET` is not set in your Vercel environment variables. Add it in the Vercel dashboard, redeploy, then re-run `npm run set-telegram-webhook`. The secret must contain only letters, numbers, underscores, and hyphens.\n\n### ChatGPT doesn't pick up MCP tools automatically\n\nChatGPT is less intuitive at discovering MCP tools than Claude. Be explicit: \"Use the capture_thought tool to save...\" or \"Use search_thoughts to find...\" until it learns the pattern.\n"
+    },
+    {
+      "slug": "work-operating-model-activation",
+      "category": "recipes",
+      "site_path": "/ob1/recipes/work-operating-model-activation",
+      "name": "Work Operating Model Activation",
+      "description": "Conversation-first workflow for eliciting a user's operating rhythms, recurring decisions, dependencies, institutional knowledge, and friction into structured Open Brain data plus agent-ready exports.",
+      "author": {
+        "name": "Jonathan Edwards",
+        "github": "jonathanedwards"
+      },
+      "version": "1.0.0",
+      "tags": [
+        "workflow",
+        "operating-model",
+        "interview",
+        "agent-config",
+        "mcp",
+        "activation"
+      ],
+      "difficulty": "intermediate",
+      "estimated_time": "45 minutes",
+      "created": "2026-04-14",
+      "updated": "2026-04-14",
+      "learning_order": null,
+      "compatibility": {
+        "open_brain": "required"
+      },
+      "requirements": {
+        "services": [
+          "Supabase"
+        ],
+        "tools": [
+          "Supabase CLI",
+          "AI client with MCP support and reusable skills/prompts"
+        ]
+      },
+      "dependencies": {
+        "skills": [
+          "work-operating-model"
+        ],
+        "primitives": []
+      },
+      "reverse_dependencies": {
+        "skills": [],
+        "primitives": []
+      },
+      "urls": {
+        "github_folder": "https://github.com/NateBJones-Projects/OB1/tree/main/recipes/work-operating-model-activation",
+        "github_readme": "https://github.com/NateBJones-Projects/OB1/blob/main/recipes/work-operating-model-activation/README.md"
+      },
+      "readme_markdown": "# Work Operating Model Activation\n\n> A conversation-first workflow that interviews you about how your work actually runs, stores the answers as structured Open Brain data, and generates agent-ready operating files.\n> [!NOTE]\n> If you are coming from the Bring Your Own Context post or want the article-friendly entrypoint, start with [Bring Your Own Context](/ob1/recipes/bring-your-own-context). This recipe is the structured profiling engine that BYOC uses under the hood.\n\n## What It Does\n\nThis recipe adds a dedicated MCP server plus schema for a 45-minute elicitation workflow. The interview runs in five fixed layers:\n\n1. operating rhythms\n2. recurring decisions\n3. dependencies\n4. institutional knowledge\n5. friction\n\nEach approved layer is saved into structured tables, summarized into one durable Open Brain thought through your existing core connector, and made available for later querying and export generation.\n\nThis recipe depends on the canonical [Work Operating Model skill](/ob1/skills/work-operating-model), which owns the interview behavior. The recipe owns the data model, remote MCP server, and export snapshots. The higher-level [Bring Your Own Context](/ob1/recipes/bring-your-own-context) recipe packages this workflow together with context extraction prompts and the portable bundle contract.\n\n## Prerequisites\n\n- Working Open Brain setup ([guide](https://github.com/NateBJones-Projects/OB1/blob/main/docs/01-getting-started.md))\n- Existing core Open Brain connector with `search_thoughts` and `capture_thought`\n- AI client that supports reusable skills or prompt packs\n- Supabase CLI installed and linked to your project\n- Canonical [Work Operating Model skill](/ob1/skills/work-operating-model)\n\n## Credential Tracker\n\n```text\nWORK OPERATING MODEL ACTIVATION -- CREDENTIAL TRACKER\n----------------------------------------------------\n\nFROM YOUR OPEN BRAIN SETUP\n  Project URL:           ____________\n  Secret key:            ____________\n  Project ref:           ____________\n  MCP Access Key:        ____________\n  Core Open Brain tools available:  yes / no\n\nGENERATED DURING SETUP\n  Default User ID:       ____________\n  Function URL:          ____________\n  MCP Connection URL:    ____________\n  Current profile version: ____________\n\n----------------------------------------------------\n```\n\n## Steps\n\n### 1. Install the skill dependency\n\nFollow the installation steps in the [Work Operating Model skill](/ob1/skills/work-operating-model). The skill handles the interview, confirmation gates, contradiction pass, and summary-thought capture.\n\n### 2. Run the schema\n\nOpen your Supabase SQL Editor and run [`schema.sql`](https://github.com/NateBJones-Projects/OB1/blob/main/recipes/work-operating-model-activation/schema.sql):\n\n```text\nhttps://supabase.com/dashboard/project/YOUR_PROJECT_ID/sql/new\n```\n\nThis creates:\n\n- `operating_model_profiles`\n- `operating_model_sessions`\n- `operating_model_layer_checkpoints`\n- `operating_model_entries`\n- `operating_model_exports`\n\nIt also adds the helper RPC functions `operating_model_start_session()` and `operating_model_save_layer()` for atomic session and layer persistence.\n\n### 3. Generate your default user ID\n\nThis recipe is single-user on purpose. Generate one UUID and reuse it for future sessions:\n\n```bash\nuuidgen | tr '[:upper:]' '[:lower:]'\n```\n\nSave it to your credential tracker, then set it in Supabase:\n\n```bash\nsupabase secrets set DEFAULT_USER_ID=your-generated-uuid\n```\n\n### 4. Deploy the MCP server\n\nFollow the [Deploy an Edge Function](/ob1/primitives/deploy-edge-function) guide using these values:\n\n| Setting | Value |\n|---------|-------|\n| Function name | `work-operating-model-mcp` |\n| Download path | `recipes/work-operating-model-activation` |\n\nThis function uses:\n\n- `SUPABASE_URL`\n- `SUPABASE_SERVICE_ROLE_KEY`\n- `MCP_ACCESS_KEY`\n- `DEFAULT_USER_ID`\n\n### 5. Connect it to your AI client\n\nUse the [Remote MCP Connection](/ob1/primitives/remote-mcp) pattern.\n\n| Setting | Value |\n|---------|-------|\n| Connector name | `Work Operating Model` |\n| URL | Your function URL with the same MCP key pattern you use for your other OB1 servers |\n\nKeep your core Open Brain connector enabled too. This recipe stores structured data in its own tables, but the skill still uses the base `search_thoughts` and `capture_thought` tools for hints and summary memory writes.\n\n### 6. Start the interview\n\nWith both connectors enabled and the skill installed, prompt your AI client:\n\n```text\nUse the Work Operating Model workflow to interview me and build my operating model.\n```\n\nThe skill should:\n\n1. call `start_operating_model_session`\n2. run the five layers in order\n3. show a checkpoint summary after each layer\n4. wait for your confirmation before saving\n5. save the layer with `save_operating_model_layer`\n6. capture one summary thought through your core Open Brain connector\n7. run a contradiction pass\n8. call `generate_operating_model_exports`\n\n### 7. Review the exports\n\nAt the end of a successful run, the MCP server stores and returns:\n\n- `operating-model.json`\n- `USER.md`\n- `SOUL.md`\n- `HEARTBEAT.md`\n- `schedule-recommendations.json`\n\nThese are stored in `operating_model_exports`, so they still exist even if your client cannot write files locally.\n\n## Available MCP Tools\n\n1. `start_operating_model_session`\n   Create or resume the active interview run. Returns profile status, session status, completed layers, pending layer, session checkpoints, and latest approved checkpoints.\n\n2. `save_operating_model_layer`\n   Atomically upserts the approved layer checkpoint plus canonical entries for that layer, then advances the session to the next layer or review state.\n\n3. `query_operating_model`\n   Reads the latest operating model or a filtered slice by `layer`, `keyword`, `cadence`, `stakeholder`, `unresolved_only`, or `friction_priority`.\n\n4. `generate_operating_model_exports`\n   Renders and stores the final JSON/markdown artifacts after all five layers are approved.\n\n## Expected Outcome\n\nWhen this recipe is working correctly:\n\n- a first session creates version `1` of a structured operating model\n- pausing after layer 2 and restarting later resumes at the correct pending layer\n- each approved layer writes one checkpoint plus canonical entries into the recipe tables\n- the skill captures six summary thoughts in your core Open Brain:\n  - one per layer\n  - one final synthesis\n- `query_operating_model` can find things like `Monday planning block`, `finance email dependency`, or `handoff friction`\n- `generate_operating_model_exports` returns all five artifact blobs even if no local files are written\n\n## Troubleshooting\n\n**Issue: `start_operating_model_session` says no environment variable is configured**\nSolution: Verify `DEFAULT_USER_ID` was set with `supabase secrets set DEFAULT_USER_ID=...` and redeploy the function if needed.\n\n**Issue: The skill can see the recipe connector but not `search_thoughts` or `capture_thought`**\nSolution: This recipe does not replace the core Open Brain server. Re-enable your base connector alongside this one.\n\n**Issue: Export generation fails with missing layers**\nSolution: At least one approved checkpoint must exist for each of the five layers. Resume the session and finish the missing layer summaries before exporting.\n\n**Issue: Querying by friction priority returns nothing**\nSolution: `friction_priority` reads from `details.priority`, so the saved friction entries need `low`, `medium`, or `high` in that field.\n\n## Next Steps\n\n- Feed `USER.md`, `SOUL.md`, and `HEARTBEAT.md` into any agent platform that uses operating files.\n- Re-run the workflow quarterly or after a major role change to create a new version.\n- Use the [MCP Tool Audit & Optimization Guide](https://github.com/NateBJones-Projects/OB1/blob/main/docs/05-tool-audit.md) once you add this server so your capture/query/admin tool surface stays manageable.\n"
+    },
+    {
+      "slug": "x-twitter-import",
+      "category": "recipes",
+      "site_path": "/ob1/recipes/x-twitter-import",
+      "name": "X/Twitter Import",
+      "description": "Import X (Twitter) data exports — tweets, DMs, and Grok chats — into Open Brain as searchable thoughts.",
+      "author": {
+        "name": "Alan Shurafa",
+        "github": "alanshurafa"
+      },
+      "version": "1.0.0",
+      "tags": [
+        "import",
+        "twitter",
+        "x",
+        "tweets",
+        "social-media"
+      ],
+      "difficulty": "intermediate",
+      "estimated_time": "20 minutes",
+      "created": "2026-03-15",
+      "updated": "2026-03-15",
+      "learning_order": null,
+      "compatibility": {
+        "open_brain": "required"
+      },
+      "requirements": {
+        "services": [
+          "OpenRouter API",
+          "Supabase"
+        ],
+        "tools": [
+          "Node.js 18+"
+        ]
+      },
+      "dependencies": {
+        "skills": [],
+        "primitives": []
+      },
+      "reverse_dependencies": {
+        "skills": [],
+        "primitives": []
+      },
+      "urls": {
+        "github_folder": "https://github.com/NateBJones-Projects/OB1/tree/main/recipes/x-twitter-import",
+        "github_readme": "https://github.com/NateBJones-Projects/OB1/blob/main/recipes/x-twitter-import/README.md"
+      },
+      "readme_markdown": "# X/Twitter Import\n\n<div align=\"center\">\n\n![Community Contribution](https://img.shields.io/badge/OB1_COMMUNITY-Approved_Contribution-2ea44f?style=for-the-badge&logo=github)\n\n**Created by [@alanshurafa](https://github.com/alanshurafa)**\n\n*Reviewed and merged by the Open Brain maintainer team — thank you for building the future of AI memory!*\n\n</div>\n\n> Import your X (Twitter) data export — tweets, DMs, and Grok chats — into Open Brain.\n\n## What It Does\n\nParses X (formerly Twitter) data exports and imports three types of content as searchable thoughts:\n- **Tweets** — your original tweets (retweets filtered out), batched by date\n- **DMs** — direct message conversations (minimum 3 messages)\n- **Grok chats** — conversations with X's Grok AI assistant\n\n## Prerequisites\n\n- Working Open Brain setup ([guide](https://github.com/NateBJones-Projects/OB1/blob/main/docs/01-getting-started.md))\n- **X/Twitter data export** — request from X Settings → Your Account → Download an archive\n- **Node.js 18+** installed\n- **OpenRouter API key** for embedding generation\n\n## Credential Tracker\n\n```text\nX/TWITTER IMPORT -- CREDENTIAL TRACKER\n--------------------------------------\n\nFROM YOUR OPEN BRAIN SETUP\n  Supabase URL:          ____________\n  Service Role Key:      ____________\n\nFROM OPENROUTER\n  API Key:               ____________\n\n--------------------------------------\n```\n\n## Steps\n\n1. **Request your X data export:**\n   - Go to X Settings → Your Account → Download an archive of your data\n   - Wait for the email notification (can take 24-48 hours)\n   - Download and extract the archive\n   - You should see a `data/` folder containing `tweets.js`, `direct-messages.js`, etc.\n\n2. **Copy this recipe folder** and install dependencies:\n\n   ```bash\n   cd x-twitter-import\n   npm install\n   ```\n\n3. **Create `.env`** with your credentials (see `.env.example`):\n\n   ```env\n   SUPABASE_URL=https://your-project.supabase.co\n   SUPABASE_SERVICE_ROLE_KEY=your-service-role-key\n   OPENROUTER_API_KEY=sk-or-v1-your-key\n   ```\n\n4. **Preview what will be imported** (dry run):\n\n   ```bash\n   node import-x-twitter.mjs /path/to/twitter-export --dry-run\n   ```\n\n5. **Import specific types only** (optional):\n\n   ```bash\n   node import-x-twitter.mjs /path/to/twitter-export --types tweets\n   node import-x-twitter.mjs /path/to/twitter-export --types dms,grok\n   ```\n\n6. **Run the full import:**\n\n   ```bash\n   node import-x-twitter.mjs /path/to/twitter-export\n   ```\n\n## Expected Outcome\n\nAfter running the import:\n- Tweets are grouped into batches of 20, each becoming one thought\n- DM conversations become individual thoughts\n- Grok chats are grouped by chat ID\n- All tagged with `source_type: x_twitter_import`\n- Retweets are automatically excluded\n- Short DM conversations (<3 messages) are filtered out\n\n**Scale reference:** Tested with 1,000+ tweets and DMs imported successfully.\n\n## Troubleshooting\n\n**Issue: \"file not found\" for tweets.js**\nX data exports use different filenames across versions. The script tries both `tweets.js` and `tweet.js`. Check your `data/` folder for the actual filename.\n\n**Issue: Twitter JS file won't parse**\nTwitter wraps JSON in a `window.YTD.tweets.part0 = [...]` prefix. The script strips this automatically. If parsing fails, the file may be corrupted — re-download from X.\n\n**Issue: All tweets showing as \"skipped\"**\nTweets under 30 characters and retweets (starting with \"RT @\") are filtered out. If all your tweets are short, lower the threshold in the `processTweets()` function.\n"
+    },
+    {
+      "slug": "workflow-status",
+      "category": "schemas",
+      "site_path": "/ob1/schemas/workflow-status",
+      "name": "Workflow Status Tracking",
+      "description": "Adds status and status_updated_at columns to the thoughts table, enabling kanban-style workflow management for tasks and ideas.",
+      "author": {
+        "name": "Ivan",
+        "github": "csakzozo"
+      },
+      "version": "1.0.0",
+      "tags": [
+        "workflow",
+        "kanban",
+        "status",
+        "tasks"
+      ],
+      "difficulty": "beginner",
+      "estimated_time": "5 minutes",
+      "created": "2026-03-31",
+      "updated": "2026-03-31",
+      "learning_order": null,
+      "compatibility": {
+        "open_brain": "required"
+      },
+      "requirements": {
+        "services": [],
+        "tools": []
+      },
+      "dependencies": {
+        "skills": [],
+        "primitives": []
+      },
+      "reverse_dependencies": {
+        "skills": [],
+        "primitives": []
+      },
+      "urls": {
+        "github_folder": "https://github.com/NateBJones-Projects/OB1/tree/main/schemas/workflow-status",
+        "github_readme": "https://github.com/NateBJones-Projects/OB1/blob/main/schemas/workflow-status/README.md"
+      },
+      "readme_markdown": "# Workflow Status Tracking\n\n> Adds `status` and `status_updated_at` columns to the `thoughts` table for kanban-style workflow management of tasks and ideas.\n\n## What It Does\n\nExtends the `thoughts` table with two columns that track workflow state. This enables the [Workflow board](/ob1/dashboards/open-brain-dashboard-next#workflow-board) in the Next.js dashboard and the `progress_task` MCP tool for AI-assisted task management.\n\n**Valid statuses:** `new`, `planning`, `active`, `review`, `done`, `archived`\n\nOnly `task` and `idea` thought types use the status field. All other types have `status = NULL`.\n\n## Prerequisites\n\n- Working Open Brain setup ([guide](https://github.com/NateBJones-Projects/OB1/blob/main/docs/01-getting-started.md))\n- Access to the Supabase SQL Editor or CLI\n\n## Credential Tracker\n\n```text\nWORKFLOW STATUS -- CREDENTIAL TRACKER\n--------------------------------------\n\nSUPABASE (from your Open Brain setup)\n  Project URL:           ____________\n  Secret key:            ____________\n\n--------------------------------------\n```\n\n## Steps\n\n![Step 1](https://img.shields.io/badge/Step_1-Run_Migration-1E88E5?style=for-the-badge)\n\n1. Open your **Supabase SQL Editor** (Dashboard > SQL Editor)\n2. Paste and run the migration:\n\n<details>\n<summary>SQL: Add status columns and backfill existing tasks/ideas</summary>\n\n```sql\n-- Add status column (nullable — only task/idea types use it)\nALTER TABLE thoughts ADD COLUMN IF NOT EXISTS status TEXT DEFAULT NULL;\n\n-- Add timestamp for tracking when status last changed\nALTER TABLE thoughts ADD COLUMN IF NOT EXISTS status_updated_at TIMESTAMPTZ DEFAULT now();\n\n-- Index for fast status filtering (partial — only rows with a status)\nCREATE INDEX IF NOT EXISTS idx_thoughts_status ON thoughts (status) WHERE status IS NOT NULL;\n\n-- Backfill: set existing task and idea thoughts to 'new' status\nUPDATE thoughts\nSET status = 'new', status_updated_at = now()\nWHERE type IN ('task', 'idea') AND status IS NULL;\n```\n\n</details>\n\nOr via the Supabase CLI:\n\n```bash\nsupabase db push\n```\n\n(if you have the migration file in `supabase/migrations/`)\n\n![Step 2](https://img.shields.io/badge/Step_2-Verify-1E88E5?style=for-the-badge)\n\n3. Verify the columns exist:\n\n```sql\nSELECT column_name, data_type, is_nullable\nFROM information_schema.columns\nWHERE table_name = 'thoughts' AND column_name IN ('status', 'status_updated_at');\n```\n\n4. Verify the backfill worked:\n\n```sql\nSELECT status, count(*) FROM thoughts\nWHERE type IN ('task', 'idea')\nGROUP BY status;\n```\n\n## Expected Outcome\n\nAfter running the migration:\n\n- The `thoughts` table has two new columns: `status` (TEXT, nullable) and `status_updated_at` (TIMESTAMPTZ)\n- All existing `task` and `idea` thoughts have `status = 'new'`\n- A partial index `idx_thoughts_status` exists for fast status queries\n- Other thought types (`observation`, `reference`, etc.) have `status = NULL` and are unaffected\n\n> [!TIP]\n> The migration is idempotent — safe to run multiple times. `IF NOT EXISTS` prevents duplicate columns or indexes.\n\n## MCP Integration\n\nOnce the schema is applied, update your `open-brain-mcp` Edge Function to include the `progress_task` tool. This allows AI assistants to manage task status conversationally:\n\n| Tool | Parameters | Description |\n|------|-----------|-------------|\n| `progress_task` | `thought_id` (required), `status`, `importance` | Update workflow status or priority of a task/idea |\n\nExample prompts after setup:\n- \"Move thought 42 to active\"\n- \"Set the priority on the API redesign to high\"\n- \"Mark the karaoke task as done\"\n\n## Troubleshooting\n\n**Issue: \"column already exists\" error**\nSolution: This is expected if you run the migration twice. The `IF NOT EXISTS` clause handles this — the error is informational only.\n\n**Issue: Existing tasks don't appear on the Workflow board**\nSolution: Run the backfill query manually: `UPDATE thoughts SET status = 'new' WHERE type IN ('task', 'idea') AND status IS NULL;`\n\n**Issue: Non-task thoughts showing status values**\nSolution: The status column should only be set for `task` and `idea` types. Run: `UPDATE thoughts SET status = NULL WHERE type NOT IN ('task', 'idea');`\n"
+    },
+    {
+      "slug": "open-brain-dashboard",
+      "category": "dashboards",
+      "site_path": "/ob1/dashboards/open-brain-dashboard",
+      "name": "Open Brain Dashboard",
+      "description": "A production-ready SvelteKit dashboard for searching, filtering, and capturing Open Brain thoughts.",
+      "author": {
+        "name": "Mads Bergdal (aka Headcrest)",
+        "github": "headcrest"
+      },
+      "version": "1.0.0",
+      "tags": [
+        "dashboard",
+        "open-brain",
+        "OB1",
+        "sveltekit",
+        "search",
+        "thought-capture",
+        "mcp"
+      ],
+      "difficulty": "intermediate",
+      "estimated_time": "1 hour",
+      "created": "2026-03-16",
+      "updated": "2026-03-16",
+      "learning_order": null,
+      "compatibility": {
+        "open_brain": "required"
+      },
+      "requirements": {
+        "services": [],
+        "tools": [
+          "Node.js 18+"
+        ]
+      },
+      "dependencies": {
+        "skills": [],
+        "primitives": []
+      },
+      "reverse_dependencies": {
+        "skills": [],
+        "primitives": []
+      },
+      "urls": {
+        "github_folder": "https://github.com/NateBJones-Projects/OB1/tree/main/dashboards/open-brain-dashboard",
+        "github_readme": "https://github.com/NateBJones-Projects/OB1/blob/main/dashboards/open-brain-dashboard/README.md"
+      },
+      "readme_markdown": "# Open Brain Dashboard\n\n<div align=\"center\">\n\n![Community Contribution](https://img.shields.io/badge/OB1_COMMUNITY-Approved_Contribution-2ea44f?style=for-the-badge&logo=github)\n\n**Created by [@headcrest](https://github.com/headcrest) | Auth fixes by [@matthallett1](https://github.com/matthallett1)**\n\n*Reviewed and merged by the Open Brain maintainer team — thank you for building the future of AI memory!*\n\n</div>\n\n> Search, filter, and capture your thoughts from a production-ready SvelteKit UI.\n\n## What it does\n\nThis dashboard connects directly to your Open Brain MCP endpoint and gives you an interface to:\n\n- capture new thoughts from a web form,\n- search and filter existing thoughts by type, topic, and people,\n- inspect stats, action items, and recent capture activity in a clean, focused layout.\n\n## Prerequisites\n\n- Working Open Brain setup ([guide](https://github.com/NateBJones-Projects/OB1/blob/main/docs/01-getting-started.md))\n- Supabase project URL + anon key for your Open Brain project\n- MCP function URL + access key for your Open Brain MCP function\n- Node.js 18+\n- A Supabase-authenticated user in your project (this dashboard uses email/password sign-in)\n\n## Credential Tracker\n\nCopy this block into a text editor and fill it as you go.\n\n```text\nOPEN BRAIN DASHBOARD -- CREDENTIAL TRACKER\n------------------------------------------\n\nFROM OPEN BRAIN\n  Supabase URL:              ____________\n  Supabase anon key:         ____________\n  MCP Function URL:          ____________\n  MCP Access Key:            ____________\n\nHOSTING\n  Deploy URL:                ____________\n\n------------------------------------------\n```\n\n## Quick Start\n\n1. Install dependencies:\n\n   ```bash\n   cd dashboards/open-brain-dashboard\n   npm install\n   ```\n\n2. Create `.env.local` in the dashboard folder (or symlink from the repo root):\n\n   ```bash\n   cp .env.example .env.local\n   ```\n\n3. Fill in your 4 values. You can find them at:\n\n   | Variable | Where to get it |\n   |----------|----------------|\n   | `PUBLIC_SUPABASE_URL` | Supabase Dashboard → Settings → API → Project URL |\n   | `PUBLIC_SUPABASE_ANON_KEY` | Supabase Dashboard → Settings → API → `anon` `public` key |\n   | `MCP_URL` | Your deployed Edge Function URL (e.g. `https://<ref>.supabase.co/functions/v1/open-brain-mcp`) |\n   | `MCP_KEY` | The `MCP_ACCESS_KEY` you set during Open Brain setup. Also visible in Claude Desktop → Settings → Connectors → your connector URL after `?key=` |\n\n4. Create a sign-in user (if you don't have one). In Supabase Dashboard → Authentication → Add user → create with email + password + Auto Confirm.\n\n   > **Note:** If your existing user was created via OAuth, you won't have a password. Click \"Send password recovery\" from the user detail panel, or create a second user with email/password (e.g. `you+dashboard@gmail.com`).\n\n5. Start the app:\n\n   ```bash\n   npm run dev\n   ```\n\n6. Open `http://localhost:5173` and sign in.\n\n## Deploy to Production\n\n- **Vercel:** Import this folder, set the same 4 environment variables.\n- **Netlify:** Deploy as a SvelteKit site, set the same 4 environment variables.\n\n## Expected outcome\n\nAfter setup, you should be able to:\n\n- see your total captured-thoughts count in the header,\n- search thoughts and get results sorted by recency,\n- filter by type (Observation/Task/Idea/Reference/Person Note), topic, and people,\n- open a thought for full text review,\n- capture a new thought and immediately persist it through MCP.\n\nIf a value is missing in env, the app will show startup errors about missing `PUBLIC_SUPABASE_URL` / `PUBLIC_SUPABASE_ANON_KEY` or missing MCP credentials.\n\n## Troubleshooting\n\n**Issue: `Missing PUBLIC_SUPABASE_URL or PUBLIC_SUPABASE_ANON_KEY`**\nSolution: Ensure `.env.local` exists, both variables are set, and SvelteKit has been restarted after editing env.\n\n**Issue: App keeps redirecting to sign-in**\nSolution: Confirm you have a valid Supabase user in the project and correct credentials; the app intentionally requires auth via `/signin`.\n\n**Issue: MCP calls fail with `Unauthorized` or 401**\nSolution: Verify `MCP_URL` points to the Supabase Edge Function for this project, and `MCP_KEY` matches the function key expected by `open-brain-mcp`.\n\n**Issue: Search returns \"No thoughts found\" but stats show thoughts exist**\nSolution: Search uses semantic (vector) similarity, not keyword matching. Three things to check:\n\n1. **OpenRouter API key** — `search_thoughts` calls OpenRouter to generate a query embedding. If `OPENROUTER_API_KEY` is missing or invalid in your Supabase secrets, search silently returns nothing. Verify with: `supabase secrets list | grep OPENROUTER`\n2. **Embeddings exist** — Thoughts captured before embeddings were configured won't be searchable. Check in SQL Editor: `SELECT count(*) FROM thoughts WHERE embedding IS NULL`\n3. **Similarity threshold** — Short queries against long content may score below the default 0.5 threshold. Try a more specific search phrase, or pass a lower `threshold` value.\n\n**Issue: \"Database error querying schema\" on sign-in**\nSolution: Your user was likely created via OAuth and has no password set. Either send a password recovery email from the Supabase Dashboard user detail panel, or create a new email/password user.\n"
+    },
+    {
+      "slug": "open-brain-dashboard-next",
+      "category": "dashboards",
+      "site_path": "/ob1/dashboards/open-brain-dashboard-next",
+      "name": "Open Brain Dashboard",
+      "description": "Full-featured web dashboard for browsing, searching, capturing, and managing thoughts with session auth, smart ingest, reflections, and quality auditing.",
+      "author": {
+        "name": "Alan Shurafa",
+        "github": "alanshurafa"
+      },
+      "version": "1.1.0",
+      "tags": [
+        "dashboard",
+        "web-ui",
+        "nextjs",
+        "search",
+        "capture",
+        "ingest",
+        "browse",
+        "audit",
+        "kanban",
+        "workflow",
+        "drag-and-drop"
+      ],
+      "difficulty": "intermediate",
+      "estimated_time": "30 minutes",
+      "created": "2026-03-23",
+      "updated": "2026-03-31",
+      "learning_order": null,
+      "compatibility": {
+        "open_brain": "required"
+      },
+      "requirements": {
+        "services": [],
+        "tools": [
+          "Node.js 18+"
+        ]
+      },
+      "dependencies": {
+        "skills": [],
+        "primitives": []
+      },
+      "reverse_dependencies": {
+        "skills": [],
+        "primitives": []
+      },
+      "urls": {
+        "github_folder": "https://github.com/NateBJones-Projects/OB1/tree/main/dashboards/open-brain-dashboard-next",
+        "github_readme": "https://github.com/NateBJones-Projects/OB1/blob/main/dashboards/open-brain-dashboard-next/README.md"
+      },
+      "readme_markdown": "# Open Brain Dashboard (Next.js)\n\n<div align=\"center\">\n\n![Community Contribution](https://img.shields.io/badge/OB1_COMMUNITY-Approved_Contribution-2ea44f?style=for-the-badge&logo=github)\n\n**Created by [@alanshurafa](https://github.com/alanshurafa)**\n\n*Reviewed and merged by the Open Brain maintainer team — thank you for building the future of AI memory!*\n\n</div>\n\nA full-featured web dashboard for your Open Brain second brain. Browse, search, capture, and manage thoughts through a modern dark-themed UI. Built with Next.js, React, TypeScript, and Tailwind CSS. Deploy to Vercel or any Node.js host.\n\n## What It Does\n\nProvides 9 pages for managing your thoughts:\n\n| Page | Description |\n|------|-------------|\n| **Dashboard** | Stats overview (total thoughts, type distribution, top topics), recent activity, quick capture, workflow summary widget |\n| **Workflow** | Kanban board for tasks and ideas with drag-and-drop status management (New → Planning → Active → Review → Done → Archived) |\n| **Browse** | Paginated thought table with filters for type, source, and importance |\n| **Detail** | Full thought view with inline editing, delete, linked reflections, and related connections |\n| **Search** | Semantic (vector similarity) and full-text search with match scores and pagination |\n| **Add to Brain** | Smart ingest with auto-routing — short text goes to single capture, long text to extraction with dry-run preview |\n| **Audit** | Quality review for low-score thoughts with bulk delete |\n| **Duplicates** | Semantic similarity detection with keep/delete/keep-both resolution |\n| **Login** | API key authentication via encrypted session cookie |\n\n## Prerequisites\n\n- A working Open Brain setup with the **REST API gateway** (`open-brain-rest`) deployed\n- **Node.js 18+** installed\n- A **Vercel account** (free tier works) or any Node.js hosting\n\n### Credential Tracker\n\n| Credential | Where to get it | Where it goes |\n|------------|----------------|---------------|\n| `NEXT_PUBLIC_API_URL` | Your Supabase project URL + `/functions/v1/open-brain-rest` | `.env` or hosting env vars |\n| `SESSION_SECRET` | Generate: `openssl rand -hex 32` | `.env` or hosting env vars |\n| `RESTRICTED_PASSPHRASE_HASH` | Optional. Generate: `echo -n \"passphrase\" \\| shasum -a 256` | `.env` or hosting env vars |\n\n## Steps\n\n### Step 1: Clone the dashboard\n\n```bash\n# From the OB1 repo\ncd dashboards/open-brain-dashboard\n```\n\nOr copy the folder to your own project directory.\n\n### Step 2: Install dependencies\n\n```bash\nnpm install\n```\n\n### Step 3: Configure environment\n\n```bash\ncp .env.example .env\n```\n\nEdit `.env` and set your values:\n\n```\nNEXT_PUBLIC_API_URL=https://YOUR-PROJECT-REF.supabase.co/functions/v1/open-brain-rest\nSESSION_SECRET=your-32-char-secret-here\n```\n\n### Step 4: Run locally\n\n```bash\nnpm run dev\n```\n\nOpen [http://localhost:3000](http://localhost:3000). You should see the login page.\n\nEnter your Open Brain API key (the `MCP_ACCESS_KEY` from your Supabase Edge Function secrets). After login, the dashboard loads with your stats and recent thoughts.\n\n### Step 5: Deploy to Vercel (optional)\n\n```bash\nnpx vercel --prod\n```\n\nOr connect the folder to Vercel via the dashboard. Set the environment variables (`NEXT_PUBLIC_API_URL`, `SESSION_SECRET`) in your Vercel project settings.\n\n> [!TIP]\n> The free Vercel tier is sufficient. The dashboard makes server-side API calls to your Open Brain REST endpoint — there's no heavy compute.\n\n## Expected Outcome\n\nWhen working correctly:\n\n- **Login page** accepts your Open Brain API key and redirects to the dashboard\n- **Dashboard** shows thought count, type distribution chart, top topics, and recent thoughts\n- **Browse** displays a paginated table of all thoughts with working type/source/importance filters\n- **Search** returns results with similarity scores (semantic mode) or rank scores (full-text mode)\n- **Add to Brain** auto-routes short text (< 500 chars, single paragraph) to single capture, and long/structured text to extraction with dry-run preview\n- **Detail page** shows full thought content with metadata, inline edit for content/type/importance, and linked reflections\n\n## Workflow Board\n\nThe Workflow page adds a visual kanban board for managing `task` and `idea` thoughts through status stages.\n\n### Features\n\n- **Drag-and-drop** between status columns using @dnd-kit (touch-friendly with 200ms hold delay)\n- **Collapsible columns** — click the arrow to collapse any column to a slim vertical bar (persisted in localStorage)\n- **Auto-adjusting widths** — expanded columns share available space equally, no horizontal scrollbar\n- **Inline editing** — tap a card to open the edit modal (status, priority, type, content)\n- **Priority dots** — click to change priority (Critical/High/Medium/Low mapped from importance 0-100)\n- **Dashboard widget** — summary of active workflow items on the main dashboard\n- **Mobile-first** — responsive layout, pinch-to-zoom enabled, full-screen edit modal on small screens\n\n### Status Flow\n\n```\nNew → Planning → Active → Review → Done → (Archived)\n```\n\nCards auto-archive from Done after 30 days. Archived cards are hidden by default (toggle with \"Show archived\").\n\n### Database Requirements\n\nThe Workflow board requires two additional columns on the `thoughts` table. See the [workflow-status schema](/ob1/schemas/workflow-status) for the migration SQL.\n\n### MCP Integration\n\nThe `progress_task` tool in the Open Brain MCP server allows AI assistants to update task status and priority conversationally:\n\n```\n\"Move the API redesign task to active\"\n\"Set priority on thought 42 to high\"\n```\n\nWhen a new task or idea is captured, the MCP server auto-assigns `status: \"new\"`.\n\n## REST API Endpoints Required\n\nThe dashboard calls these endpoints on your Open Brain REST API:\n\n| Endpoint | Method | Used By |\n|----------|--------|---------|\n| `/health` | GET | Login validation |\n| `/thoughts` | GET | Browse page (paginated, filtered) |\n| `/thought/:id` | GET | Detail page |\n| `/thought/:id` | PUT | Inline edit (content, type, importance) |\n| `/thought/:id` | DELETE | Delete button |\n| `/search` | POST | Search page (semantic + full-text) |\n| `/stats` | GET | Dashboard stats widget |\n| `/capture` | POST | Quick capture (single thought) |\n| `/thought/:id/reflection` | GET | Detail page (linked reflections) |\n| `/ingest` | POST | Smart ingest (extraction) |\n| `/ingestion-jobs` | GET | Ingest page (job history) |\n| `/duplicates` | GET | Duplicates page |\n| `/thoughts?type=task` | GET | Workflow board (filtered by type) |\n| `/thought/:id` | PUT | Workflow board (status/priority updates) |\n\n> [!NOTE]\n> If your Open Brain instance doesn't have all these endpoints (e.g., no smart-ingest or duplicates), those pages will show errors but the core pages (dashboard, browse, search, detail) will still work.\n\n## Optional: Restricted Content\n\nIf you've applied the [sensitivity-tiers](https://github.com/NateBJones-Projects/OB1/pull/110) primitive and want to control access to sensitive thoughts:\n\n1. Set `RESTRICTED_PASSPHRASE_HASH` in your environment\n2. A lock/unlock toggle appears in the sidebar\n3. When locked (default), restricted thoughts are filtered from all views\n4. Enter your passphrase to temporarily unlock restricted content for the session\n\nIf `RESTRICTED_PASSPHRASE_HASH` is not set, the toggle is hidden — no action needed.\n\n## Authentication\n\nThe dashboard uses **iron-session** for encrypted HTTP-only session cookies:\n\n1. User enters their Open Brain API key once at login\n2. Key is validated against the `/health` endpoint\n3. Key is stored in an encrypted session cookie (not in client-side JS or localStorage)\n4. All server-side API calls use the key from the session\n5. Sessions expire after 24 hours\n\nNo API key is stored in environment variables or exposed to the browser.\n\n## Tech Stack\n\n- **Next.js 16** (App Router)\n- **React 19** with TypeScript\n- **Tailwind CSS 4** (dark theme)\n- **iron-session 8** (encrypted cookies)\n- **@dnd-kit** (drag-and-drop for workflow board)\n- Zero external runtime dependencies beyond these\n\n## Troubleshooting\n\n1. **\"Could not reach API\" on login** — Verify `NEXT_PUBLIC_API_URL` is correct and your REST API gateway (`open-brain-rest`) is deployed. Test with: `curl https://YOUR-REF.supabase.co/functions/v1/open-brain-rest/health -H \"x-brain-key: YOUR_KEY\"`.\n\n2. **\"SESSION_SECRET env var is required\"** — The app requires a 32+ character secret for cookie encryption. Generate one with `openssl rand -hex 32`.\n\n3. **Build fails with SWC error** — This happens when `node_modules` was installed on a different platform (e.g., Windows modules on Linux). Delete `node_modules` and `package-lock.json`, then run `npm install` on your target platform.\n\n4. **Search returns no results** — Ensure your thoughts have embeddings. Semantic search requires the `embedding` column to be populated. Run an embedding backfill if needed.\n\n5. **Ingest page shows \"extracting\" forever** — Check that the `smart-ingest` Edge Function is deployed. The ingest feature depends on a separate Edge Function for document extraction.\n"
+    },
+    {
+      "slug": "discord-capture",
+      "category": "integrations",
+      "site_path": "/ob1/integrations/discord-capture",
+      "name": "Discord Capture",
+      "description": "Discord bot that captures messages from designated channels into Open Brain, mirroring the Slack capture pattern.",
+      "author": {
+        "name": "OB1 Team"
+      },
+      "version": "1.0.0",
+      "tags": [
+        "discord",
+        "capture",
+        "bot",
+        "messaging"
+      ],
+      "difficulty": "intermediate",
+      "estimated_time": "30 minutes",
+      "created": "2026-03-11",
+      "updated": "2026-03-11",
+      "learning_order": null,
+      "compatibility": {
+        "open_brain": "required"
+      },
+      "requirements": {
+        "services": [
+          "Discord API",
+          "OpenRouter"
+        ],
+        "tools": [
+          "Supabase CLI"
+        ]
+      },
+      "dependencies": {
+        "skills": [],
+        "primitives": []
+      },
+      "reverse_dependencies": {
+        "skills": [],
+        "primitives": []
+      },
+      "urls": {
+        "github_folder": "https://github.com/NateBJones-Projects/OB1/tree/main/integrations/discord-capture",
+        "github_readme": "https://github.com/NateBJones-Projects/OB1/blob/main/integrations/discord-capture/README.md"
+      },
+      "readme_markdown": "# Discord Capture\n\n> Capture messages from Discord channels into Open Brain — the same pattern as Slack capture, but for Discord.\n\n## What It Does\n\nA Discord bot that monitors designated channels and captures messages into Open Brain as thoughts. Messages are embedded and stored with Discord-specific metadata (server, channel, author, timestamp). Works just like the built-in Slack capture but for Discord communities.\n\n## Prerequisites\n\n- Working Open Brain setup ([guide](https://github.com/NateBJones-Projects/OB1/blob/main/docs/01-getting-started.md))\n- A Discord account with permission to add bots to your server\n- Discord Developer Portal access (free)\n- Supabase CLI available ([Homebrew/Scoop/standalone binary or `npx supabase`](https://supabase.com/docs/guides/local-development/cli/getting-started); `npm i -g supabase` is not supported)\n- OpenRouter API key (for generating embeddings)\n\n## Credential Tracker\n\nCopy this block into a text editor and fill it in as you go.\n\n```text\nDISCORD CAPTURE -- CREDENTIAL TRACKER\n--------------------------------------\n\nFROM YOUR OPEN BRAIN SETUP\n  OpenRouter API key:    ____________\n\nDISCORD INFO\n  Server name:           ____________\n\nGENERATED DURING SETUP\n  Discord Bot Token:     ____________\n  Channel IDs to monitor:\n    - ____________\n    - ____________\n    - ____________\n\n--------------------------------------\n```\n\n## Steps\n\n<!-- TODO: Fill in step-by-step instructions -->\n\n1. Create a Discord application in the Developer Portal\n2. Create a bot and copy the bot token\n3. Invite the bot to your server with message read permissions\n4. Clone this folder to your Supabase project's `supabase/functions/` directory\n5. Configure environment variables (bot token, channel IDs to monitor, Supabase keys, OpenRouter key)\n6. Deploy the edge function: `supabase functions deploy discord-capture`\n7. Send a test message in a monitored channel\n8. Verify the thought was captured in your Supabase database\n\n## Expected Outcome\n\nWhen you send a message in a monitored Discord channel, it appears as a new thought in your `thoughts` table within a few seconds. The `metadata` jsonb field includes:\n- `source`: `\"discord\"`\n- `server`: Discord server name\n- `channel`: channel name\n- `author`: message author's Discord username\n- `timestamp`: original message timestamp\n\nYou can search for anything you've captured from Discord using your Open Brain MCP server's `search_thoughts` tool.\n\n## Troubleshooting\n\n**Issue: Bot is online but not capturing messages**\nSolution: Check that the bot has \"Message Content Intent\" enabled in the Developer Portal (Bot → Privileged Gateway Intents). Also verify the channel IDs in your config match the channels you're posting in.\n\n**Issue: Bot captures messages but they don't appear in Supabase**\nSolution: Check your edge function logs (`supabase functions logs discord-capture`). Most likely a missing or incorrect `SUPABASE_SERVICE_ROLE_KEY`.\n\n**Issue: Duplicate thoughts from edited messages**\nSolution: By default, message edits create a new thought. To update the existing thought instead, set `UPDATE_ON_EDIT=true` in your environment variables.\n"
+    },
+    {
+      "slug": "kubernetes-deployment",
+      "category": "integrations",
+      "site_path": "/ob1/integrations/kubernetes-deployment",
+      "name": "Kubernetes Self-Hosted Deployment",
+      "description": "Deploy Open Brain on Kubernetes with self-hosted PostgreSQL + pgvector, replacing Supabase with fully self-managed infrastructure.",
+      "author": {
+        "name": "Marvin",
+        "github": "velo"
+      },
+      "version": "1.0.0",
+      "tags": [
+        "kubernetes",
+        "k8s",
+        "self-hosted",
+        "postgresql",
+        "pgvector",
+        "deployment",
+        "infrastructure"
+      ],
+      "difficulty": "advanced",
+      "estimated_time": "60 minutes",
+      "created": "2026-03-22",
+      "updated": "2026-03-22",
+      "learning_order": null,
+      "compatibility": {
+        "open_brain": "required"
+      },
+      "requirements": {
+        "services": [
+          "Kubernetes",
+          "PostgreSQL",
+          "pgvector"
+        ],
+        "tools": [
+          "kubectl",
+          "Docker"
+        ]
+      },
+      "dependencies": {
+        "skills": [],
+        "primitives": []
+      },
+      "reverse_dependencies": {
+        "skills": [],
+        "primitives": []
+      },
+      "urls": {
+        "github_folder": "https://github.com/NateBJones-Projects/OB1/tree/main/integrations/kubernetes-deployment",
+        "github_readme": "https://github.com/NateBJones-Projects/OB1/blob/main/integrations/kubernetes-deployment/README.md"
+      },
+      "readme_markdown": "# Kubernetes Self-Hosted Deployment\n\n<div align=\"center\">\n\n![Community Contribution](https://img.shields.io/badge/OB1_COMMUNITY-Approved_Contribution-2ea44f?style=for-the-badge&logo=github)\n\n**Created by [@velo](https://github.com/velo)**\n\n*Reviewed and merged by the Open Brain maintainer team — thank you for building the future of AI memory!*\n\n</div>\n\n> Deploy Open Brain on Kubernetes with self-hosted PostgreSQL + pgvector, replacing Supabase with fully self-managed infrastructure.\n\n## What It Does\n\nThis integration provides Kubernetes manifests and a modified MCP server that connects directly to PostgreSQL instead of Supabase. Your thoughts database, embeddings, and MCP endpoint all run on your own cluster. The MCP HTTP endpoint is served via Kubernetes Ingress, making it a remote endpoint accessible by URL from any MCP client.\n\n## Prerequisites\n\n- Working Kubernetes cluster (tested on K3s v1.31, works with any K8s distribution)\n- `kubectl` configured for your cluster\n- Docker installed (for building the MCP server image)\n- An embedding/chat API provider (OpenRouter, OpenAI, or a local model with OpenAI-compatible API)\n- An ingress controller (Traefik, nginx-ingress, etc.) if you want external access\n\n## Credential Tracker\n\nCopy this block into a text editor and fill it in as you go.\n\n```text\nKUBERNETES DEPLOYMENT -- CREDENTIAL TRACKER\n--------------------------------------------\n\nPOSTGRESQL\n  Password:              ____________\n\nMCP SERVER\n  Access key:            ____________\n\nEMBEDDING/CHAT API\n  API base URL:          ____________\n  API key:               ____________\n  Embedding model:       ____________\n  Chat model:            ____________\n\n--------------------------------------------\n```\n\n## Steps\n\n### 1. Build the MCP Server Docker Image\n\nFrom this directory, build and import the image:\n\n```bash\ndocker build -t openbrain-mcp-server:latest .\n\n# For K3s:\ndocker save openbrain-mcp-server:latest | sudo k3s ctr images import -\n\n# For minikube:\nminikube image load openbrain-mcp-server:latest\n\n# For other clusters, push to your registry:\ndocker tag openbrain-mcp-server:latest your-registry/openbrain-mcp-server:latest\ndocker push your-registry/openbrain-mcp-server:latest\n```\n\n### 2. Configure Secrets\n\n```bash\ncp k8s/secrets.yml.example k8s/secrets.yml\n```\n\nEdit `k8s/secrets.yml` with your actual credentials. **Never commit this file.**\n\n### 3. Deploy to Kubernetes\n\n```bash\nkubectl apply -f k8s/secrets.yml\nkubectl apply -f k8s/openbrain.yml\n```\n\n### 4. Verify Deployment\n\n```bash\n# Check pod status\nkubectl get pods -n openbrain\n\n# Check database is initialized\nkubectl exec -n openbrain openbrain-0 -c db -- \\\n  psql -U postgres -d openbrain -c '\\dt'\n\n# Test MCP endpoint (via port-forward)\nkubectl port-forward -n openbrain svc/openbrain 8000:8000 &\ncurl -X POST http://localhost:8000 \\\n  -H \"x-brain-key: YOUR_ACCESS_KEY\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"jsonrpc\":\"2.0\",\"method\":\"tools/list\",\"id\":1}'\n```\n\n### 5. Connect Your MCP Client\n\nFor Claude Desktop or any MCP-compatible client, configure the remote MCP endpoint:\n\n```json\n{\n  \"mcpServers\": {\n    \"openbrain\": {\n      \"url\": \"http://openbrain.openbrain.svc.cluster.local:8000\",\n      \"transport\": \"http\",\n      \"headers\": {\n        \"x-brain-key\": \"YOUR_ACCESS_KEY\"\n      }\n    }\n  }\n}\n```\n\nIf you've configured an Ingress, use your external URL instead:\n\n```json\n{\n  \"mcpServers\": {\n    \"openbrain\": {\n      \"url\": \"https://brain.yourdomain.com\",\n      \"transport\": \"http\",\n      \"headers\": {\n        \"x-brain-key\": \"YOUR_ACCESS_KEY\"\n      }\n    }\n  }\n}\n```\n\n## Using a Local LLM Instead of OpenRouter\n\nTo use a local model (e.g., Ollama, BitNet, llama.cpp) for embeddings and chat, update the environment variables in `k8s/openbrain.yml`:\n\n```yaml\n- name: EMBEDDING_API_BASE\n  value: \"http://your-local-model:8080/v1\"\n- name: EMBEDDING_API_KEY\n  value: \"not-needed\"\n- name: EMBEDDING_MODEL\n  value: \"your-model-name\"\n- name: CHAT_API_BASE\n  value: \"http://your-local-model:8080/v1\"\n- name: CHAT_API_KEY\n  value: \"not-needed\"\n- name: CHAT_MODEL\n  value: \"your-model-name\"\n```\n\nIf your embedding model produces a different vector dimension than 1536, update the `vector(1536)` in the init SQL to match.\n\n## Expected Outcome\n\nAfter deployment you should see:\n\n- `openbrain-0` pod running with 2 containers (db + mcp-server)\n- PostgreSQL with `thoughts` table and `match_thoughts` function\n- MCP endpoint responding to `tools/list` with 4 tools: `search_thoughts`, `list_thoughts`, `thought_stats`, `capture_thought`\n- Thoughts captured via any MCP client are stored in your self-hosted database\n\n## Troubleshooting\n\n**Pod stuck in CrashLoopBackOff (mcp-server)**\n- Check logs: `kubectl logs -n openbrain openbrain-0 -c mcp-server`\n- Most common cause: invalid API key or unreachable embedding API base URL\n- For local models, ensure the model service is running and accessible from the cluster\n\n**Database not initialized / tables missing**\n- The init SQL runs only on first startup. If the data volume already exists with an old database, the init script is skipped.\n- To re-initialize: delete the data volume directory and restart the pod\n- `kubectl delete pod openbrain-0 -n openbrain` (StatefulSet will recreate it)\n\n**Embedding dimension mismatch**\n- If you see errors about vector dimensions, your embedding model produces vectors of a different size than expected\n- Check your model's output dimension and update `vector(1536)` in the init SQL ConfigMap\n- Drop and recreate the `thoughts` table if changing dimensions on an existing database\n\n**Connection refused to database**\n- Containers in the same pod communicate via `127.0.0.1` — this is normal Kubernetes multi-container pod behavior\n- Check that the `db` container is ready: `kubectl logs -n openbrain openbrain-0 -c db`\n"
+    },
+    {
+      "slug": "slack-capture",
+      "category": "integrations",
+      "site_path": "/ob1/integrations/slack-capture",
+      "name": "Slack Capture",
+      "description": "Add Slack as a quick-capture interface for your Open Brain. Type thoughts in a channel, automatically embedded and stored.",
+      "author": {
+        "name": "Nate B. Jones",
+        "github": "NateBJones"
+      },
+      "version": "1.0.0",
+      "tags": [
+        "slack",
+        "capture",
+        "integration",
+        "messaging"
+      ],
+      "difficulty": "beginner",
+      "estimated_time": "15 minutes",
+      "created": "2026-03-12",
+      "updated": "2026-03-12",
+      "learning_order": null,
+      "compatibility": {
+        "open_brain": "required"
+      },
+      "requirements": {
+        "services": [
+          "Slack"
+        ],
+        "tools": [
+          "Supabase CLI"
+        ]
+      },
+      "dependencies": {
+        "skills": [],
+        "primitives": []
+      },
+      "reverse_dependencies": {
+        "skills": [],
+        "primitives": []
+      },
+      "urls": {
+        "github_folder": "https://github.com/NateBJones-Projects/OB1/tree/main/integrations/slack-capture",
+        "github_readme": "https://github.com/NateBJones-Projects/OB1/blob/main/integrations/slack-capture/README.md"
+      },
+      "readme_markdown": "# Slack Capture Integration\n\n## What It Does\n\nAdds Slack as a quick-capture interface for your Open Brain. Type a thought in a Slack channel, it gets automatically embedded, classified, and stored — with a threaded confirmation reply showing how your message was categorized.\n\n## Prerequisites\n\n- A working Open Brain setup (follow the [Getting Started guide](https://github.com/NateBJones-Projects/OB1/blob/main/docs/01-getting-started.md) through Step 4 — you need the Supabase database, OpenRouter API key, and Supabase CLI installed)\n- A Slack workspace (free tier works)\n\n## Cost\n\nSlack is free. The Edge Function uses the same OpenRouter credits from your main Open Brain setup — embeddings cost ~$0.02 per million tokens, metadata extraction ~$0.15 per million input tokens. For 20 thoughts/day, expect roughly $0.10–0.30/month in API costs.\n\n---\n\n## Credential Tracker\n\nCopy this block into a text editor and fill it in as you go.\n\n```text\nSLACK CAPTURE -- CREDENTIAL TRACKER\n--------------------------------------\n\nFROM YOUR OPEN BRAIN SETUP\n  OpenRouter API key:    ____________\n\nSLACK WORKSPACE INFO\n  Workspace name/URL:    ____________\n\nGENERATED DURING SETUP\n  Channel name:          ____________\n  Channel ID (Step 1):   C____________\n  Bot OAuth Token:       xoxb-____________\n  Edge Function URL:     https://____________.supabase.co/functions/v1/ingest-thought\n\n--------------------------------------\n```\n\n---\n\n## Step 1: Create Your Slack Capture Channel\n\n1. If you don't have a Slack workspace, create one at slack.com (free tier works)\n2. Click the **+** next to Channels → **Create new channel**\n3. Name it \"capture\" (or brain, inbox, whatever feels natural)\n4. Make it **Private** (recommended — this is personal)\n5. Get the Channel ID: right-click channel → View channel details → scroll to bottom (starts with C)\n6. Save the Channel ID — you'll need it in Step 3\n\n---\n\n## Step 2: Create the Slack App\n\nThis is the bridge between Slack and your database.\n\n### Create the App\n\n1. Go to api.slack.com/apps → **Create New App** → **From scratch**\n2. App Name: \"Open Brain\", select your workspace\n3. Click **Create App**\n\n### Set Permissions\n\n1. Left sidebar → **OAuth & Permissions**\n2. Scroll to **Scopes → Bot Token Scopes**\n3. Add: `channels:history`, `groups:history`, `chat:write`\n4. Scroll up → **Install to Workspace** → Allow\n5. Copy the **Bot User OAuth Token** (starts with `xoxb-`) — save it for Step 3\n\n### Add App to Channel\n\nIn Slack, open your capture channel and type: `/invite @Open Brain`\n\n> Don't set up Event Subscriptions yet — you need the Edge Function URL first (Step 3).\n\n---\n\n## Step 3: Deploy the Edge Function\n\nThis is the brains of the operation. One function receives messages from Slack, generates an embedding, extracts metadata, stores everything in Supabase, and replies with a confirmation.\n\n> **New to the terminal?** The \"terminal\" is the text-based command line on your computer. On Mac, open the app called **Terminal** (search for it in Spotlight). On Windows, open **PowerShell**. Everything below gets typed there, not in your browser.\n\n### Verify Supabase CLI\n\nMake sure you completed Step 7 of the main guide (Supabase CLI installation). Verify it's working:\n\n```bash\nsupabase --version\n```\n\nIf that command fails, go back to the [Getting Started guide](https://github.com/NateBJones-Projects/OB1/blob/main/docs/01-getting-started.md) Step 7 and install the CLI first.\n\n### Log In and Link (if not already done)\n\n```bash\nsupabase login\nsupabase link --project-ref YOUR_PROJECT_REF\n```\n\nReplace `YOUR_PROJECT_REF` with the project ref from your Supabase dashboard URL: `supabase.com/dashboard/project/THIS_PART`.\n\n### Create the Function\n\n```bash\nsupabase functions new ingest-thought\n```\n\nOpen `supabase/functions/ingest-thought/index.ts` and replace its entire contents with:\n\n```typescript\nimport { createClient } from \"https://esm.sh/@supabase/supabase-js@2\";\n\nconst SUPABASE_URL = Deno.env.get(\"SUPABASE_URL\")!;\nconst SUPABASE_SERVICE_ROLE_KEY = Deno.env.get(\"SUPABASE_SERVICE_ROLE_KEY\")!;\nconst OPENROUTER_API_KEY = Deno.env.get(\"OPENROUTER_API_KEY\")!;\nconst SLACK_BOT_TOKEN = Deno.env.get(\"SLACK_BOT_TOKEN\")!;\nconst SLACK_CAPTURE_CHANNEL = Deno.env.get(\"SLACK_CAPTURE_CHANNEL\")!;\n\nconst OPENROUTER_BASE = \"https://openrouter.ai/api/v1\";\nconst supabase = createClient(SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY);\n\nasync function getEmbedding(text: string): Promise<number[]> {\n  const r = await fetch(`${OPENROUTER_BASE}/embeddings`, {\n    method: \"POST\",\n    headers: { \"Authorization\": `Bearer ${OPENROUTER_API_KEY}`, \"Content-Type\": \"application/json\" },\n    body: JSON.stringify({ model: \"openai/text-embedding-3-small\", input: text }),\n  });\n  const d = await r.json();\n  return d.data[0].embedding;\n}\n\nasync function extractMetadata(text: string): Promise<Record<string, unknown>> {\n  const r = await fetch(`${OPENROUTER_BASE}/chat/completions`, {\n    method: \"POST\",\n    headers: { \"Authorization\": `Bearer ${OPENROUTER_API_KEY}`, \"Content-Type\": \"application/json\" },\n    body: JSON.stringify({\n      model: \"openai/gpt-4o-mini\",\n      response_format: { type: \"json_object\" },\n      messages: [\n        { role: \"system\", content: `Extract metadata from the user's captured thought. Return JSON with:\n- \"people\": array of people mentioned (empty if none)\n- \"action_items\": array of implied to-dos (empty if none)\n- \"dates_mentioned\": array of dates YYYY-MM-DD (empty if none)\n- \"topics\": array of 1-3 short topic tags (always at least one)\n- \"type\": one of \"observation\", \"task\", \"idea\", \"reference\", \"person_note\"\nOnly extract what's explicitly there.` },\n        { role: \"user\", content: text },\n      ],\n    }),\n  });\n  const d = await r.json();\n  try { return JSON.parse(d.choices[0].message.content); }\n  catch { return { topics: [\"uncategorized\"], type: \"observation\" }; }\n}\n\nasync function replyInSlack(channel: string, threadTs: string, text: string): Promise<void> {\n  await fetch(\"https://slack.com/api/chat.postMessage\", {\n    method: \"POST\",\n    headers: { \"Authorization\": `Bearer ${SLACK_BOT_TOKEN}`, \"Content-Type\": \"application/json\" },\n    body: JSON.stringify({ channel, thread_ts: threadTs, text }),\n  });\n}\n\nDeno.serve(async (req: Request): Promise<Response> => {\n  try {\n    const body = await req.json();\n    if (body.type === \"url_verification\") {\n      return new Response(JSON.stringify({ challenge: body.challenge }), {\n        headers: { \"Content-Type\": \"application/json\" },\n      });\n    }\n    const event = body.event;\n    if (!event || event.type !== \"message\" || event.subtype || event.bot_id\n        || event.channel !== SLACK_CAPTURE_CHANNEL) {\n      return new Response(\"ok\", { status: 200 });\n    }\n    const messageText: string = event.text;\n    const channel: string = event.channel;\n    const messageTs: string = event.ts;\n    if (!messageText || messageText.trim() === \"\") return new Response(\"ok\", { status: 200 });\n\n    // Deduplicate: Slack retries webhooks if response takes >3s, so check if we already captured this message\n    const { data: existing } = await supabase\n      .from(\"thoughts\")\n      .select(\"id\")\n      .contains(\"metadata\", { slack_ts: messageTs })\n      .limit(1);\n    if (existing && existing.length > 0) return new Response(\"ok\", { status: 200 });\n\n    const [embedding, metadata] = await Promise.all([\n      getEmbedding(messageText),\n      extractMetadata(messageText),\n    ]);\n\n    const { error } = await supabase.from(\"thoughts\").insert({\n      content: messageText,\n      embedding,\n      metadata: { ...metadata, source: \"slack\", slack_ts: messageTs },\n    });\n\n    if (error) {\n      console.error(\"Supabase insert error:\", error);\n      await replyInSlack(channel, messageTs, `Failed to capture: ${error.message}`);\n      return new Response(\"error\", { status: 500 });\n    }\n\n    const meta = metadata as Record<string, unknown>;\n    let confirmation = `Captured as *${meta.type || \"thought\"}*`;\n    if (Array.isArray(meta.topics) && meta.topics.length > 0)\n      confirmation += ` - ${meta.topics.join(\", \")}`;\n    if (Array.isArray(meta.people) && meta.people.length > 0)\n      confirmation += `\\nPeople: ${meta.people.join(\", \")}`;\n    if (Array.isArray(meta.action_items) && meta.action_items.length > 0)\n      confirmation += `\\nAction items: ${meta.action_items.join(\"; \")}`;\n\n    await replyInSlack(channel, messageTs, confirmation);\n    return new Response(\"ok\", { status: 200 });\n  } catch (err) {\n    console.error(\"Function error:\", err);\n    return new Response(\"error\", { status: 500 });\n  }\n});\n```\n\n### Set Your Secrets\n\n```bash\nsupabase secrets set OPENROUTER_API_KEY=your-openrouter-key-here\nsupabase secrets set SLACK_BOT_TOKEN=xoxb-your-slack-bot-token-here\nsupabase secrets set SLACK_CAPTURE_CHANNEL=C0your-channel-id-here\n```\n\nReplace the values with:\n- Your OpenRouter API key from the main guide (Step 4)\n- Your Slack Bot OAuth Token from Step 2 above\n- Your Slack Channel ID from Step 1 above\n\n> SUPABASE_URL and SUPABASE_SERVICE_ROLE_KEY are automatically available inside Edge Functions — you don't need to set them.\n\n<!-- -->\n\n> **If you ever rotate your OpenRouter key:** you must re-run `supabase secrets set OPENROUTER_API_KEY=...` with the new key. This Edge Function reads the key from Supabase secrets at runtime — updating it on openrouter.ai alone won't propagate here. See the [FAQ on key rotation](https://github.com/NateBJones-Projects/OB1/blob/main/docs/03-faq.md#api-key-rotation) for the full checklist.\n\n### Deploy\n\n```bash\nsupabase functions deploy ingest-thought --no-verify-jwt\n```\n\n> Copy the Edge Function URL immediately after deployment! It looks like: `https://YOUR_PROJECT_REF.supabase.co/functions/v1/ingest-thought`\n\nSave this URL — you'll need it in Step 4.\n\n---\n\n## Step 4: Connect Slack to the Edge Function\n\n1. Go to api.slack.com/apps → select your Open Brain app\n2. Left sidebar → **Event Subscriptions** → toggle **Enable Events ON**\n3. Paste your Edge Function URL in the **Request URL** field\n4. Wait for the green checkmark — Verified\n5. Under **Subscribe to bot events**, add both: `message.channels` and `message.groups`\n6. Click **Save Changes** (reinstall if prompted)\n\n> **You need both events.** Slack treats public and private channels as separate entity types. Public channels fire `message.channels`, private channels fire `message.groups`. If you only add one, messages in the other channel type will silently fail — no error, just nothing happens. Add both so you're covered regardless of how your capture channel is configured.\n\n---\n\n## Step 5: Test It\n\nGo to your capture channel in Slack and type:\n\n```text\nSarah mentioned she's thinking about leaving her job to start a consulting business\n```\n\nWait 5–10 seconds. You should see a threaded reply:\n\n```text\nCaptured as person_note — career, consulting\nPeople: Sarah\nAction items: Check in with Sarah about consulting plans\n```\n\nThen open Supabase dashboard → Table Editor → thoughts. You should see one row with your message, an embedding, and metadata.\n\n---\n\n## Expected Outcome\n\nEvery message you post in your Slack capture channel automatically gets:\n- Embedded with a 1536-dimensional vector for semantic search\n- Classified by type (observation, task, idea, reference, person_note)\n- Tagged with topics, people, action items, and dates (where applicable)\n- Stored in your Supabase `thoughts` table\n- Confirmed with a threaded reply showing the extracted metadata\n\nYou can now search for these thoughts using any MCP-connected AI (Claude Desktop, ChatGPT, Claude Code, etc.) via the Open Brain MCP server from the main guide.\n\n---\n\n## Troubleshooting\n\n### Slack says \"Request URL not verified\"\n\nYour Edge Function isn't deployed or isn't reachable. Run the deploy command again and check the output for errors.\n\n```bash\nsupabase functions deploy ingest-thought --no-verify-jwt\n```\n\n### Messages aren't triggering the function\n\nCheck Event Subscriptions — make sure both `message.channels` and `message.groups` are listed (public channels use the first, private channels use the second — you need both). Verify the app is invited to the channel. Confirm the channel ID in your secrets matches the actual channel.\n\n### Slack creates duplicate database entries\n\nSlack retries webhook delivery if it doesn't get a response within 3 seconds. The Edge Function includes built-in deduplication — it checks for existing rows with the same `slack_ts` before processing. If you're still seeing duplicates, make sure you're on the latest version of the code (see Step 3) and have redeployed.\n\n### Function runs but nothing in the database\n\nCheck Edge Function logs: Supabase dashboard → Edge Functions → ingest-thought → Logs. Most likely the OpenRouter key is wrong or has no credits.\n\n```bash\nsupabase secrets list\n```\n\n### No confirmation reply in Slack\n\nThe bot token might be wrong, or `chat:write` scope wasn't added. Go to your Slack app → OAuth & Permissions and verify. If you added the scope after installing, you need to reinstall the app.\n\n### Metadata extraction seems off\n\nThat's normal — the LLM is making its best guess with limited context. The metadata is a convenience layer on top of semantic search, not the primary retrieval mechanism. The embedding handles fuzzy matching regardless.\n\n---\n\n## What You Just Built\n\nYou now have a Slack channel that acts as a direct write path into your Open Brain. Type anything — meeting notes, random ideas, observations, reminders — and it's automatically embedded, classified, and searchable from any AI tool connected to your MCP server.\n\nThis is one of many possible capture interfaces. Your Open Brain MCP server also includes a `capture_thought` tool, which means any MCP-connected AI (Claude Desktop, ChatGPT, Claude Code, Cursor) can write directly to your brain without switching apps. Slack is just the dedicated inbox.\n\n---\n\n*Built by Nate B. Jones — part of the [Open Brain project](https://github.com/NateBJones-Projects/OB1)*\n"
+    },
+    {
+      "slug": "auto-capture",
+      "category": "skills",
+      "site_path": "/ob1/skills/auto-capture",
+      "name": "Auto-Capture",
+      "description": "Reusable skill pack that captures ACT NOW items and a session summary to Open Brain when a session ends.",
+      "author": {
+        "name": "Jared Irish",
+        "github": "jaredirish"
+      },
+      "version": "1.0.0",
+      "tags": [
+        "skill",
+        "capture",
+        "session-close",
+        "workflow",
+        "open-brain"
+      ],
+      "difficulty": "beginner",
+      "estimated_time": "5 minutes",
+      "created": "2026-03-31",
+      "updated": "2026-03-31",
+      "learning_order": null,
+      "compatibility": {
+        "open_brain": "required"
+      },
+      "requirements": {
+        "services": [],
+        "tools": [
+          "AI client with reusable skills, rules, or custom instructions"
+        ]
+      },
+      "dependencies": {
+        "skills": [],
+        "primitives": []
+      },
+      "reverse_dependencies": {
+        "skills": [
+          {
+            "category": "recipes",
+            "slug": "auto-capture",
+            "name": "Auto-Capture Protocol"
+          }
+        ],
+        "primitives": []
+      },
+      "urls": {
+        "github_folder": "https://github.com/NateBJones-Projects/OB1/tree/main/skills/auto-capture",
+        "github_readme": "https://github.com/NateBJones-Projects/OB1/blob/main/skills/auto-capture/README.md"
+      },
+      "readme_markdown": "# Auto-Capture\n\n> Behavioral skill that captures ACT NOW items and a session summary to Open Brain when a session ends.\n\n## What It Does\n\nThis skill teaches your AI client to treat session close as a capture moment. When a work session, brainstorm, or Panning for Gold run is wrapping up, it stores the highest-value outputs in Open Brain instead of relying on you to remember later.\n\nIf you want the OB1 workflow, composition guidance, and examples for using this skill with Panning for Gold, see the [Auto-Capture recipe](/ob1/recipes/auto-capture).\n\n## Supported Clients\n\n- Claude Code\n- Codex\n- Cursor\n- Other AI clients that support reusable prompt packs, rules, or custom instructions\n\n## Prerequisites\n\n- Working Open Brain setup with a capture tool available ([guide](https://github.com/NateBJones-Projects/OB1/blob/main/docs/01-getting-started.md))\n- AI client that supports reusable skills, rules, or custom instructions\n- Recommended: an Open Brain search tool is also available so the skill can avoid obvious duplicates\n\n## Installation\n\n1. Copy [`SKILL.md`](https://github.com/NateBJones-Projects/OB1/blob/main/skills/auto-capture/SKILL.md) into the right reusable-instructions location for your AI client.\n2. Restart or reload the client so it picks up the skill.\n3. Verify by ending a short session with one clear next action and confirming the client captures both the action and a session summary to Open Brain.\n\nFor Claude Code, a common install path is:\n\n```bash\nmkdir -p ~/.claude/skills/auto-capture\ncp skills/auto-capture/SKILL.md ~/.claude/skills/auto-capture/SKILL.md\n```\n\n## Trigger Conditions\n\n- End-of-session phrases like \"wrap up\", \"park this\", \"goodnight\", or \"let's stop here\"\n- Finishing a brainstorm with ACT NOW items\n- Finishing a Panning for Gold run or similar evaluation workflow\n- Any session where decisions or next actions would be costly to lose\n\n## Expected Outcome\n\nWhen installed and invoked correctly, the skill:\n\n- captures each ACT NOW item as its own Open Brain thought\n- captures one session summary\n- includes concrete next actions and enough context to make the captures useful later\n- avoids capturing raw transcript noise or parked/killed items\n\n## Troubleshooting\n\n**Issue: The client ends the session without saving anything**\nSolution: Confirm the skill is loaded and that your client exposes an Open Brain capture tool in the current environment. Test the tool manually first if needed.\n\n**Issue: Captures appear, but they are too vague**\nSolution: Tighten the prompt behavior by preserving the skill's requirement for strong summaries, concrete next actions, and provenance. The skill works best when captures are self-contained.\n\n**Issue: The skill references the wrong tool name**\nSolution: Tool prefixes vary by client and connector. Adapt the skill to the names exposed in your environment. Many setups expose `capture_thought` and `search_thoughts`, but namespaced variants are common.\n\n## Notes for Other Clients\n\nThis skill is written as a plain-text prompt pack so it can travel. In Claude Code it fits naturally in `~/.claude/skills/`. In Codex or Cursor, adapt it into the equivalent reusable instruction or project rule system without changing the core behavior: capture only the high-value outputs at session close.\n"
+    },
+    {
+      "slug": "autodream-brain-sync",
+      "category": "skills",
+      "site_path": "/ob1/skills/autodream-brain-sync",
+      "name": "Autodream Brain Sync",
+      "description": "Syncs Claude Code's local memory saves to Open Brain so memories are accessible from all AI clients and devices.",
+      "author": {
+        "name": "rumbitopi",
+        "github": "rumbitopi"
+      },
+      "version": "1.0.0",
+      "tags": [
+        "memory",
+        "autodream",
+        "sync",
+        "multi-client"
+      ],
+      "difficulty": "beginner",
+      "estimated_time": "5 minutes",
+      "created": "2026-03-31",
+      "updated": "2026-03-31",
+      "learning_order": null,
+      "compatibility": {
+        "open_brain": "required"
+      },
+      "requirements": {
+        "services": [],
+        "tools": [
+          "mcp__open-brain__capture_thought"
+        ]
+      },
+      "dependencies": {
+        "skills": [],
+        "primitives": []
+      },
+      "reverse_dependencies": {
+        "skills": [],
+        "primitives": []
+      },
+      "urls": {
+        "github_folder": "https://github.com/NateBJones-Projects/OB1/tree/main/skills/autodream-brain-sync",
+        "github_readme": "https://github.com/NateBJones-Projects/OB1/blob/main/skills/autodream-brain-sync/README.md"
+      },
+      "readme_markdown": "# Autodream Brain Sync\n\n> Syncs Claude Code's local memory saves to Open Brain so memories are accessible from all AI clients and devices.\n\n## What It Does\n\nWhenever Claude Code saves a memory (via dreaming, autodream, or explicit requests), this skill also captures it to Open Brain via `mcp__open-brain__capture_thought`. This ensures memories aren't siloed in one machine's local files — they're available from ChatGPT, Claude Desktop, Codex, and any other MCP-connected client.\n\n## Supported Clients\n\n- Claude Code\n\n## Prerequisites\n\n- Working Open Brain setup with `capture_thought` tool available ([guide](https://github.com/NateBJones-Projects/OB1/blob/main/docs/01-getting-started.md))\n- Claude Code with auto-memory enabled\n\n## Installation\n\n1. Copy `SKILL.md` into your project's `.claude/` directory, or add its contents to your `CLAUDE.md` under a skills section\n2. Restart Claude Code so it picks up the new instructions\n3. Verify by saving a memory (\"remember that I prefer TypeScript over JavaScript\") and checking that both a local memory file and an Open Brain capture are created\n\n## Trigger Conditions\n\n- Any memory file write to `.claude/projects/*/memory/`\n- User says \"remember this\", \"save to memory\", \"dream\", \"autodream\"\n- End-of-session auto-dreaming\n- Explicit `/memory` command usage\n\n## Expected Outcome\n\nEach memory save produces three things:\n1. A local `.md` file in the memory directory (standard Claude Code behavior)\n2. An updated `MEMORY.md` index (standard Claude Code behavior)\n3. A corresponding Open Brain thought capture (added by this skill)\n\nThe Open Brain capture is prefixed with the memory type (e.g., `[feedback]`, `[user]`, `[project]`) for context when retrieved from other clients.\n\n## Troubleshooting\n\n**Issue: Open Brain capture fails but local memory saves fine**\nSolution: Check that your MCP server is running (`supabase functions list` should show `open-brain-mcp` as ACTIVE). The skill is designed to not block local saves if the capture fails.\n\n**Issue: Duplicate thoughts in Open Brain**\nSolution: Open Brain uses embedding-based dedup. If you update an existing memory, the new capture may coexist with the old one. This is expected — semantic search will surface the most relevant version.\n\n**Issue: Memories not appearing in ChatGPT/Claude Desktop**\nSolution: Other clients need to explicitly search Open Brain — memories aren't pushed to them automatically. Ask \"search my brain for [topic]\" to retrieve synced memories.\n\n## Notes for Other Clients\n\nThis skill is specific to Claude Code's auto-memory system. Other clients (ChatGPT, Claude Desktop, Codex) capture directly to Open Brain without needing a sync step — they don't have local memory files. The skill ensures Claude Code's local memories don't become an isolated silo.\n"
+    },
+    {
+      "slug": "claudeception",
+      "category": "skills",
+      "site_path": "/ob1/skills/claudeception",
+      "name": "Aiception (formerly Claudeception)",
+      "description": "Standalone skill pack that extracts reusable knowledge from work sessions, turns it into new skills, and captures those lessons back into Open Brain.",
+      "author": {
+        "name": "Jared Irish",
+        "github": "jaredirish"
+      },
+      "version": "2.0.0",
+      "tags": [
+        "skill",
+        "learning",
+        "meta",
+        "knowledge",
+        "workflow"
+      ],
+      "difficulty": "intermediate",
+      "estimated_time": "5 minutes",
+      "created": "2026-03-27",
+      "updated": "2026-03-27",
+      "learning_order": null,
+      "compatibility": {
+        "open_brain": "optional"
+      },
+      "requirements": {
+        "services": [],
+        "tools": [
+          "Claude Code or similar AI client with reusable skills/prompts"
+        ]
+      },
+      "dependencies": {
+        "skills": [],
+        "primitives": []
+      },
+      "reverse_dependencies": {
+        "skills": [],
+        "primitives": []
+      },
+      "urls": {
+        "github_folder": "https://github.com/NateBJones-Projects/OB1/tree/main/skills/claudeception",
+        "github_readme": "https://github.com/NateBJones-Projects/OB1/blob/main/skills/claudeception/README.md"
+      },
+      "readme_markdown": "# Aiception (Formerly Claudeception)\n\n<div align=\"center\">\n\n![Community Contribution](https://img.shields.io/badge/OB1_COMMUNITY-Approved_Contribution-2ea44f?style=for-the-badge&logo=github)\n\n**Created by [@jaredirish](https://github.com/jaredirish)**\n\n</div>\n\n*Standalone skill pack for extracting reusable lessons from work sessions and turning them into new skills.*\n\nThe repo keeps the historical `claudeception` folder name for continuity, but the installable\nskill should now be named `aiception`. Anthropic reserves skill names containing `claude`\nor `anthropic` in skill frontmatter, so `aiception` is the compatible replacement name.\n\n## What It Does\n\nAiception watches for hard-won knowledge during real work: debugging breakthroughs, misleading errors, undocumented behavior, and repeatable workflow shortcuts. When the knowledge is specific, verified, and reusable, it helps turn that discovery into a new skill and records it back into Open Brain.\n\n## Supported Clients\n\n- Claude Code\n- Codex\n- Cursor\n- Any AI client that supports reusable rules, skills, or custom instructions\n\n## Prerequisites\n\n- Working Open Brain setup if you want duplicate checking and capture via `search_thoughts` and `capture_thought` ([guide](https://github.com/NateBJones-Projects/OB1/blob/main/docs/01-getting-started.md))\n- An AI client that can load a reusable skill or prompt file\n- A place to save newly created skill files\n\n## Installation\n\n1. Copy [`SKILL.md`](https://github.com/NateBJones-Projects/OB1/blob/main/skills/claudeception/SKILL.md) into your client's skill/rules directory.\n2. For Claude Code, place it at `~/.claude/skills/aiception/SKILL.md`.\n3. Restart or reload your AI client so the skill becomes available.\n4. If your client does not support native skill files, adapt the contents into that client's reusable project rules or system prompt.\n\n## Trigger Conditions\n\n- The user says \"save this as a skill,\" \"extract a skill from this,\" or \"what did we learn?\"\n- A task required non-obvious debugging, a workaround, or a misleading-error investigation\n- You want a session-end retrospective that preserves lessons instead of losing them\n\n## Expected Outcome\n\nWhen the skill is working correctly, it should:\n\n- Identify which discoveries are worth preserving\n- Check Open Brain and local skill directories for duplicates\n- Draft a structured new skill with exact trigger conditions\n- Capture the new skill back into Open Brain so future sessions can find it\n\n## Full Recipe\n\nIf you want the broader walkthrough and examples, use the companion recipe: [../../recipes/claudeception/](/ob1/recipes/claudeception).\n\n## Troubleshooting\n\n**Issue:** The skill creates too many low-value skills.  \nSolution: Tighten the quality gate. The knowledge needs to be reusable, non-trivial, specific, and verified before it graduates into a skill.\n\n**Issue:** Later sessions do not rediscover the saved skill.  \nSolution: Make the description field more concrete. Exact trigger phrases, error messages, and symptoms surface better than vague summaries.\n\n**Issue:** Your client does not support native skill files.  \nSolution: Use the contents of [`SKILL.md`](https://github.com/NateBJones-Projects/OB1/blob/main/skills/claudeception/SKILL.md) as reusable project rules or a system prompt. The operating model still works outside native skill systems.\n"
+    },
+    {
+      "slug": "competitive-analysis",
+      "category": "skills",
+      "site_path": "/ob1/skills/competitive-analysis",
+      "name": "Competitive Analysis",
+      "description": "Standalone skill pack for competitor profiling, pricing comparisons, market mapping, SWOT generation, and strategic recommendations.",
+      "author": {
+        "name": "Nate B. Jones",
+        "github": "NateBJones"
+      },
+      "version": "1.0.0",
+      "tags": [
+        "competitive-analysis",
+        "strategy",
+        "positioning",
+        "pricing",
+        "market-research"
+      ],
+      "difficulty": "intermediate",
+      "estimated_time": "10 minutes",
+      "created": "2026-03-31",
+      "updated": "2026-03-31",
+      "learning_order": null,
+      "compatibility": {
+        "open_brain": "optional"
+      },
+      "requirements": {
+        "services": [],
+        "tools": [
+          "Claude Code or similar AI coding tool with reusable skills/system prompts"
+        ]
+      },
+      "dependencies": {
+        "skills": [],
+        "primitives": []
+      },
+      "reverse_dependencies": {
+        "skills": [
+          {
+            "category": "recipes",
+            "slug": "research-to-decision-workflow",
+            "name": "Research-to-Decision Workflow"
+          }
+        ],
+        "primitives": []
+      },
+      "urls": {
+        "github_folder": "https://github.com/NateBJones-Projects/OB1/tree/main/skills/competitive-analysis",
+        "github_readme": "https://github.com/NateBJones-Projects/OB1/blob/main/skills/competitive-analysis/README.md"
+      },
+      "readme_markdown": "# Competitive Analysis\n\n> Standalone skill pack for competitor profiling, pricing comparison, market mapping, and strategic recommendations.\n\n## What It Does\n\nThis skill turns a loose \"analyze the competition\" request into a structured competitive brief. It helps an AI client identify the relevant competitor set, compare positioning and packaging, call out real threats and openings, and end with recommended moves instead of a generic market summary.\n\nIf you want the multi-step OB1 workflow that combines this with synthesis, meeting notes, and memo drafting, use the [Research-to-Decision Workflow recipe](/ob1/recipes/research-to-decision-workflow).\n\n## Supported Clients\n\n- Claude Code\n- Codex\n- Cursor\n- Other AI clients that support reusable prompt packs, rules, or custom instructions\n\n## Prerequisites\n\n- Working Open Brain setup if you want the skill to use memory search or capture ([guide](https://github.com/NateBJones-Projects/OB1/blob/main/docs/01-getting-started.md))\n- AI client that supports reusable skills, rules, or custom instructions\n- Public source access for competitor websites, pricing pages, docs, and announcements\n\n## Installation\n\n1. Copy [`SKILL.md`](https://github.com/NateBJones-Projects/OB1/blob/main/skills/competitive-analysis/SKILL.md) into the reusable-instructions location for your AI client.\n2. Restart or reload the client so it picks up the skill.\n3. Test it with a prompt like: `Analyze our top 3 competitors and tell me where our pricing looks weak.`\n\nFor Claude Code, a common install path is:\n\n```bash\nmkdir -p ~/.claude/skills/competitive-analysis\ncp skills/competitive-analysis/SKILL.md ~/.claude/skills/competitive-analysis/SKILL.md\n```\n\n## Trigger Conditions\n\n- \"Analyze our competitors\"\n- \"Benchmark our pricing\"\n- \"Map the market\"\n- \"Who are we up against?\"\n- \"Build a SWOT\"\n- \"Show me how we stack up against X, Y, and Z\"\n\n## Expected Outcome\n\nWhen installed and invoked correctly, the skill should produce:\n\n- a clearly scoped competitor set\n- a comparison table across the dimensions that matter for the decision\n- a positioning or market-map view\n- explicit risks, opportunities, and recommended moves\n- optional Open Brain capture of the final brief or highest-value takeaways\n\n## Troubleshooting\n\n**Issue: The output reads like a generic market summary**\nSolution: Make sure the prompt includes the decision the work should support. This skill is strongest when it knows whether the goal is pricing, positioning, roadmap, or diligence.\n\n**Issue: The skill invents pricing or feature parity**\nSolution: Keep the evidence rules intact. Pricing and packaging should only be compared when there is public support for the claim. Unknowns should stay unknown.\n\n**Issue: The competitor set is too broad to be useful**\nSolution: Tighten the ICP or segment focus. \"Accounting software\" is too broad; \"crypto accounting software for SMBs\" is usable.\n\n## Notes for Other Clients\n\nThis skill is portable because the core behavior is procedural, not tool-specific. Adapt the Open Brain tool names to whatever your client exposes, but preserve the same flow: frame the decision, compare the right dimensions, label inference, and finish with real strategic implications.\n"
+    },
+    {
+      "slug": "deal-memo-drafting",
+      "category": "skills",
+      "site_path": "/ob1/skills/deal-memo-drafting",
+      "name": "Deal Memo Drafting",
+      "description": "Standalone skill pack for drafting structured deal, IC, partnership, or acquisition memos from existing diligence materials.",
+      "author": {
+        "name": "Nate B. Jones",
+        "github": "NateBJones"
+      },
+      "version": "1.0.0",
+      "tags": [
+        "deal-memo",
+        "investment-memo",
+        "diligence",
+        "ic-memo",
+        "decision-doc"
+      ],
+      "difficulty": "intermediate",
+      "estimated_time": "10 minutes",
+      "created": "2026-03-31",
+      "updated": "2026-03-31",
+      "learning_order": null,
+      "compatibility": {
+        "open_brain": "optional"
+      },
+      "requirements": {
+        "services": [],
+        "tools": [
+          "Claude Code or similar AI coding tool with reusable skills/system prompts"
+        ]
+      },
+      "dependencies": {
+        "skills": [],
+        "primitives": []
+      },
+      "reverse_dependencies": {
+        "skills": [
+          {
+            "category": "recipes",
+            "slug": "research-to-decision-workflow",
+            "name": "Research-to-Decision Workflow"
+          }
+        ],
+        "primitives": []
+      },
+      "urls": {
+        "github_folder": "https://github.com/NateBJones-Projects/OB1/tree/main/skills/deal-memo-drafting",
+        "github_readme": "https://github.com/NateBJones-Projects/OB1/blob/main/skills/deal-memo-drafting/README.md"
+      },
+      "readme_markdown": "# Deal Memo Drafting\n\n> Standalone skill pack for turning existing diligence materials into a structured deal, IC, partnership, or acquisition memo.\n\n## What It Does\n\nThis skill helps an AI client draft a real decision memo from work that already exists. It takes market findings, model review output, meeting synthesis, and supporting documents, then shapes them into a recommendation-ready memo while keeping evidence gaps and confidence levels explicit.\n\nFor the OB1 composition workflow that feeds this skill from earlier analysis steps, use the [Research-to-Decision Workflow recipe](/ob1/recipes/research-to-decision-workflow).\n\n## Supported Clients\n\n- Claude Code\n- Codex\n- Cursor\n- Other AI clients that support reusable prompt packs, rules, or custom instructions\n\n## Prerequisites\n\n- Working Open Brain setup if you want the skill to use memory search or capture ([guide](https://github.com/NateBJones-Projects/OB1/blob/main/docs/01-getting-started.md))\n- AI client that supports reusable skills, rules, or custom instructions\n- A real diligence packet, not just a company name and a blank page\n\n## Installation\n\n1. Copy [`SKILL.md`](https://github.com/NateBJones-Projects/OB1/blob/main/skills/deal-memo-drafting/SKILL.md) into the reusable-instructions location for your AI client.\n2. Restart or reload the client so it picks up the skill.\n3. Test it with a prompt like: `Draft an IC memo from this research summary, model review, and meeting notes.`\n\nFor Claude Code, a common install path is:\n\n```bash\nmkdir -p ~/.claude/skills/deal-memo-drafting\ncp skills/deal-memo-drafting/SKILL.md ~/.claude/skills/deal-memo-drafting/SKILL.md\n```\n\n## Trigger Conditions\n\n- \"Draft a deal memo\"\n- \"Write the IC memo\"\n- \"Turn this diligence packet into a memo\"\n- \"Draft the partnership recommendation\"\n- \"Write the acquisition brief\"\n\n## Expected Outcome\n\nWhen installed and invoked correctly, the skill should produce:\n\n- a structured memo with thesis, market, business, economics, risks, and recommendation\n- explicit open questions instead of hidden assumptions\n- confidence signaling that matches the evidence quality\n- optional Open Brain capture of the final memo summary or recommendation\n\n## Troubleshooting\n\n**Issue: The memo sounds polished but thin**\nSolution: Provide the actual underlying diligence materials. This skill is strongest when it has research, model review, and meeting outputs to work from.\n\n**Issue: The draft hides uncertainty**\nSolution: Preserve the rule that evidence gaps stay visible. The memo should never become more certain than the diligence allows.\n\n**Issue: The skill gets used too early**\nSolution: If the source set is still messy or contradictory, run `research-synthesis` first. If the economics are still unreviewed, run `financial-model-review` first.\n\n## Notes for Other Clients\n\nKeep the core behavior intact even if your client uses different tool names. The skill should draft from diligence, separate fact from inference, and finish with a recommendation that reflects the evidence instead of smoothing over it.\n"
+    },
+    {
+      "slug": "financial-model-review",
+      "category": "skills",
+      "site_path": "/ob1/skills/financial-model-review",
+      "name": "Financial Model Review",
+      "description": "Standalone skill pack for reviewing an existing financial model, forecast, or scenario set for assumption quality, structural risk, and decision usefulness.",
+      "author": {
+        "name": "Nate B. Jones",
+        "github": "NateBJones"
+      },
+      "version": "1.0.0",
+      "tags": [
+        "financial-model",
+        "forecast-review",
+        "diligence",
+        "assumptions",
+        "finance"
+      ],
+      "difficulty": "intermediate",
+      "estimated_time": "10 minutes",
+      "created": "2026-03-31",
+      "updated": "2026-03-31",
+      "learning_order": null,
+      "compatibility": {
+        "open_brain": "optional"
+      },
+      "requirements": {
+        "services": [],
+        "tools": [
+          "Claude Code or similar AI coding tool with reusable skills/system prompts"
+        ]
+      },
+      "dependencies": {
+        "skills": [],
+        "primitives": []
+      },
+      "reverse_dependencies": {
+        "skills": [
+          {
+            "category": "recipes",
+            "slug": "research-to-decision-workflow",
+            "name": "Research-to-Decision Workflow"
+          }
+        ],
+        "primitives": []
+      },
+      "urls": {
+        "github_folder": "https://github.com/NateBJones-Projects/OB1/tree/main/skills/financial-model-review",
+        "github_readme": "https://github.com/NateBJones-Projects/OB1/blob/main/skills/financial-model-review/README.md"
+      },
+      "readme_markdown": "# Financial Model Review\n\n> Standalone skill pack for reviewing an existing financial model, forecast, or scenario set before using it in a decision.\n\n## What It Does\n\nThis skill helps an AI client review a model like an investor or serious operator would. It checks whether assumptions are supported, whether the structure can be trusted, whether downside cases exist, and whether the model is actually decision-ready instead of merely well-formatted.\n\nFor the full OB1 workflow that chains this into research synthesis, meeting notes, and memo drafting, use the [Research-to-Decision Workflow recipe](/ob1/recipes/research-to-decision-workflow).\n\n## Supported Clients\n\n- Claude Code\n- Codex\n- Cursor\n- Other AI clients that support reusable prompt packs, rules, or custom instructions\n\n## Prerequisites\n\n- Working Open Brain setup if you want the skill to use memory search or capture ([guide](https://github.com/NateBJones-Projects/OB1/blob/main/docs/01-getting-started.md))\n- AI client that supports reusable skills, rules, or custom instructions\n- A model artifact, spreadsheet export, or pasted assumption set\n\n## Installation\n\n1. Copy [`SKILL.md`](https://github.com/NateBJones-Projects/OB1/blob/main/skills/financial-model-review/SKILL.md) into the reusable-instructions location for your AI client.\n2. Restart or reload the client so it picks up the skill.\n3. Test it with a prompt like: `Review this forecast and tell me which assumptions are fragile.`\n\nFor Claude Code, a common install path is:\n\n```bash\nmkdir -p ~/.claude/skills/financial-model-review\ncp skills/financial-model-review/SKILL.md ~/.claude/skills/financial-model-review/SKILL.md\n```\n\n## Trigger Conditions\n\n- \"Review this model\"\n- \"Audit these assumptions\"\n- \"Tell me what breaks in this forecast\"\n- \"Stress test this revenue plan\"\n- \"Is this model decision-ready?\"\n\n## Expected Outcome\n\nWhen installed and invoked correctly, the skill should produce:\n\n- a review memo with an overall verdict\n- clear red flags and assumption stress points\n- structural and scenario gaps\n- guidance on what the model is good enough for right now\n- optional Open Brain capture of the final review or highest-signal findings\n\n## Troubleshooting\n\n**Issue: The output critiques the business but not the model**\nSolution: Include the model artifact or a clear export of assumptions and outputs. This skill needs something concrete to review.\n\n**Issue: The review sounds overly certain**\nSolution: Preserve the skill's rule that hidden formulas and invisible mechanics should stay labeled as unknown. The review should be honest about what it can and cannot verify.\n\n**Issue: The model gets treated like a build request**\nSolution: Keep the boundary intact. This skill reviews existing work. If the user wants a fresh model, that should be a separate workflow.\n\n## Notes for Other Clients\n\nAdapt the Open Brain tool names to your environment, but keep the same review posture: frame the decision, inspect assumptions and structure, pressure-test scenarios, and finish with a usable verdict rather than a vague spreadsheet commentary.\n"
+    },
+    {
+      "slug": "heavy-file-ingestion",
+      "category": "skills",
+      "site_path": "/ob1/skills/heavy-file-ingestion",
+      "name": "Heavy File Ingestion",
+      "description": "Converts heavyweight files such as PDFs, slide decks, spreadsheets, and documents into markdown, CSV, and lightweight indexes before an agent spends model tokens on them.",
+      "author": {
+        "name": "Nate B. Jones",
+        "github": "NateBJones"
+      },
+      "version": "1.0.0",
+      "tags": [
+        "skill",
+        "file-conversion",
+        "markdown",
+        "pdf",
+        "spreadsheet",
+        "token-efficiency"
+      ],
+      "difficulty": "intermediate",
+      "estimated_time": "10 minutes",
+      "created": "2026-03-31",
+      "updated": "2026-03-31",
+      "learning_order": null,
+      "compatibility": {
+        "open_brain": "optional"
+      },
+      "requirements": {
+        "services": [],
+        "tools": [
+          "Python 3.10+",
+          "uv or pip",
+          "AI client with reusable skills/prompts"
+        ]
+      },
+      "dependencies": {
+        "skills": [],
+        "primitives": []
+      },
+      "reverse_dependencies": {
+        "skills": [],
+        "primitives": []
+      },
+      "urls": {
+        "github_folder": "https://github.com/NateBJones-Projects/OB1/tree/main/skills/heavy-file-ingestion",
+        "github_readme": "https://github.com/NateBJones-Projects/OB1/blob/main/skills/heavy-file-ingestion/README.md"
+      },
+      "readme_markdown": "# Heavy File Ingestion\n\n> Convert heavyweight files into agent-friendly markdown, CSV, and a lightweight index before analysis.\n\n## What It Does\n\nHeavy File Ingestion stops agents from wasting expensive context on raw PDFs, slide decks, spreadsheets, and other bulky files. It routes each file through a deterministic conversion step first, writes a reusable artifact to disk, and creates a small index so the main agent can decide whether it even needs deeper analysis.\n\n## Supported Clients\n\n- Claude Code\n- Codex\n- Claude Desktop\n- Cursor\n- Any AI client that supports reusable skills, rules, or custom instructions and can run local scripts\n\n## Prerequisites\n\n- Python 3.10+\n- `uv` or `pip` for optional converter dependencies\n- AI client that can load a reusable skill file and run local commands\n- Working Open Brain setup if you want to pair this with Open Brain capture or retrieval flows ([guide](https://github.com/NateBJones-Projects/OB1/blob/main/docs/01-getting-started.md))\n\n## Installation\n\n1. Copy the entire [`heavy-file-ingestion`](/ob1/skills/heavy-file-ingestion) folder into a place your AI client can access, not just `SKILL.md`. The skill expects the bundled `scripts/` and `references/` folders to stay next to it.\n1. For Claude Code, place the folder at `~/.claude/skills/heavy-file-ingestion/`.\n1. For Codex or Cursor, keep the folder in your workspace or copy the contents into that client's skills or rules location.\n1. Restart or reload the client so it picks up [`SKILL.md`](https://github.com/NateBJones-Projects/OB1/blob/main/skills/heavy-file-ingestion/SKILL.md).\n1. When you want the deterministic converters available, run the skill script with either:\n\n```bash\nuv run \\\n  --with pdfplumber \\\n  --with python-docx \\\n  --with python-pptx \\\n  --with openpyxl \\\n  python skills/heavy-file-ingestion/scripts/convert_heavy_file.py /absolute/path/to/file.pdf\n```\n\n1. If you already have `markitdown` installed and want to prefer it for rich document conversion, add `--prefer markitdown`.\n\n## Downloadable Variants\n\nIf you want packaged client-specific downloads instead of the raw source folder, use:\n\n- Claude Code: [../../resources/heavy-file-ingestion-claude-code.zip](https://raw.githubusercontent.com/NateBJones-Projects/OB1/main/resources/heavy-file-ingestion-claude-code.zip)\n- Codex: [../../resources/heavy-file-ingestion-codex.zip](https://raw.githubusercontent.com/NateBJones-Projects/OB1/main/resources/heavy-file-ingestion-codex.zip)\n- Claude Desktop: [../../resources/heavy-file-ingestion-claude-desktop.skill](https://github.com/NateBJones-Projects/OB1/blob/main/resources/heavy-file-ingestion-claude-desktop.skill)\n\nThe Claude Code and Codex downloads include the bundled `scripts/` and `references/` directories. The Claude Desktop `.skill` is intentionally lighter because Claude Desktop is better treated as a policy layer than a local conversion runtime.\n\n## Trigger Conditions\n\n- The user asks the agent to \"read,\" \"analyze,\" \"summarize,\" or \"extract from\" a PDF, DOCX, PPTX, XLSX, CSV, TSV, or other large file\n- The file is big enough or structured enough that raw ingestion would burn unnecessary tokens\n- The user wants a reusable markdown version, a CSV normalization step, or a quick structural index before analysis\n- The agent needs to know whether the file can be handled deterministically or should escalate to a cheap model fallback\n\n## Expected Outcome\n\nWhen the skill is working correctly, it should:\n\n- Detect that the file should be converted before the main model reads it\n- Write an extracted artifact to disk instead of pushing raw content into context\n- Create an `index.md` and `index.json` summary with counts, structure hints, preview lines, and quality flags\n- Recommend the cheapest safe next step: use the deterministic artifact, escalate to a small model, or retry with a stronger converter\n\n## Open Source Stack\n\nThis skill was shaped around a small set of open-source projects with permissive licensing:\n\n- [Microsoft MarkItDown](https://github.com/microsoft/markitdown) for broad document-to-markdown conversion\n- [Docling](https://github.com/docling-project/docling) as the heavy-duty fallback for ugly or scanned documents\n- [xlsx2csv](https://github.com/dilshod/xlsx2csv) as the reference pattern for spreadsheet normalization\n- [pdfplumber](https://github.com/jsvine/pdfplumber) as the reference pattern for cheap PDF indexing and page-level extraction\n\nMore detail lives in [`references/open-source-stack.md`](https://github.com/NateBJones-Projects/OB1/blob/main/skills/heavy-file-ingestion/references/open-source-stack.md).\n\n## Troubleshooting\n\n**Issue:** The extracted PDF markdown is sparse or missing whole pages.  \nSolution: Check the generated `index.md`. If it flags `scanned_pdf_suspected` or `low_text_density`, rerun with a stronger converter or use a cheap model only on the extracted artifact, not on the original PDF.\n\n**Issue:** The script says a dependency is missing.  \nSolution: Use the `uv run --with ...` command from this README or install the named package with `pip`.\n\n**Issue:** The client can load the skill text but cannot run scripts.  \nSolution: Use the skill as policy guidance only and run the bundled script manually from Terminal. The skill is still useful because it tells the main agent when not to read a raw heavyweight file.\n\n## Notes for Other Clients\n\nIf your client only supports a single prompt file, paste the contents of [`SKILL.md`](https://github.com/NateBJones-Projects/OB1/blob/main/skills/heavy-file-ingestion/SKILL.md) into that client and keep the script path nearby. The reusable behavior is the policy: convert first, inspect the index second, and only spend model tokens on the compressed artifact.\n"
+    },
+    {
+      "slug": "meeting-synthesis",
+      "category": "skills",
+      "site_path": "/ob1/skills/meeting-synthesis",
+      "name": "Meeting Synthesis",
+      "description": "Standalone skill pack for turning meeting transcripts or notes into decisions, action items, unresolved questions, risks, and follow-up artifacts.",
+      "author": {
+        "name": "Nate B. Jones",
+        "github": "NateBJones"
+      },
+      "version": "1.0.0",
+      "tags": [
+        "meeting",
+        "meeting-notes",
+        "transcript",
+        "actions",
+        "synthesis"
+      ],
+      "difficulty": "intermediate",
+      "estimated_time": "10 minutes",
+      "created": "2026-03-31",
+      "updated": "2026-03-31",
+      "learning_order": null,
+      "compatibility": {
+        "open_brain": "optional"
+      },
+      "requirements": {
+        "services": [],
+        "tools": [
+          "Claude Code or similar AI coding tool with reusable skills/system prompts"
+        ]
+      },
+      "dependencies": {
+        "skills": [],
+        "primitives": []
+      },
+      "reverse_dependencies": {
+        "skills": [
+          {
+            "category": "recipes",
+            "slug": "research-to-decision-workflow",
+            "name": "Research-to-Decision Workflow"
+          }
+        ],
+        "primitives": []
+      },
+      "urls": {
+        "github_folder": "https://github.com/NateBJones-Projects/OB1/tree/main/skills/meeting-synthesis",
+        "github_readme": "https://github.com/NateBJones-Projects/OB1/blob/main/skills/meeting-synthesis/README.md"
+      },
+      "readme_markdown": "# Meeting Synthesis\n\n> Standalone skill pack for turning meeting transcripts or notes into decisions, action items, risks, unresolved questions, and follow-up artifacts.\n\n## What It Does\n\nThis skill helps an AI client convert raw meeting material into a durable working document. It separates decisions from discussion, action items from loose ideas, and unresolved questions from false certainty, then produces a clean artifact you can use in follow-up or downstream decision work.\n\nFor the OB1 workflow that chains meeting synthesis into research and memo drafting, use the [Research-to-Decision Workflow recipe](/ob1/recipes/research-to-decision-workflow).\n\n## Supported Clients\n\n- Claude Code\n- Codex\n- Cursor\n- Other AI clients that support reusable prompt packs, rules, or custom instructions\n\n## Prerequisites\n\n- Working Open Brain setup if you want the skill to use memory search or capture ([guide](https://github.com/NateBJones-Projects/OB1/blob/main/docs/01-getting-started.md))\n- AI client that supports reusable skills, rules, or custom instructions\n- Notes, transcript, or a trustworthy meeting summary\n\n## Installation\n\n1. Copy [`SKILL.md`](https://github.com/NateBJones-Projects/OB1/blob/main/skills/meeting-synthesis/SKILL.md) into the reusable-instructions location for your AI client.\n2. Restart or reload the client so it picks up the skill.\n3. Test it with a prompt like: `Summarize this diligence call and list decisions, action items, and open questions.`\n\nFor Claude Code, a common install path is:\n\n```bash\nmkdir -p ~/.claude/skills/meeting-synthesis\ncp skills/meeting-synthesis/SKILL.md ~/.claude/skills/meeting-synthesis/SKILL.md\n```\n\n## Trigger Conditions\n\n- \"Summarize this meeting\"\n- \"What did we decide?\"\n- \"Extract action items\"\n- \"Draft the follow-up\"\n- \"Turn this transcript into a clean brief\"\n\n## Expected Outcome\n\nWhen installed and invoked correctly, the skill should produce:\n\n- a concise summary of why the meeting mattered\n- clear decisions and action items\n- unresolved questions and active risks\n- a clean follow-up artifact when requested\n- optional Open Brain capture of key decisions or the final synthesis\n\n## Troubleshooting\n\n**Issue: The output turns discussion into decisions**\nSolution: Preserve the separation between \"decided\", \"assigned\", and \"discussed\". This skill should not invent closure.\n\n**Issue: The notes lose ownership**\nSolution: Include attendee context when possible. Even rough role labels improve action attribution and follow-up quality.\n\n**Issue: The summary is too generic**\nSolution: Include the meeting purpose and what the output should support. A partner call, diligence call, and internal standup should not be synthesized the same way.\n\n## Notes for Other Clients\n\nAdapt the Open Brain tool names to your environment, but keep the same discipline: treat the meeting artifact as the source of truth, preserve uncertainty honestly, and produce outputs that are reusable in future work rather than just readable today.\n"
+    },
+    {
+      "slug": "n-agentic-harnesses",
+      "category": "skills",
+      "site_path": "/ob1/skills/n-agentic-harnesses",
+      "name": "N Agentic Harnesses",
+      "description": "Reusable skill pack for designing, auditing, and improving the harness layer around agentic products, including tool-use architecture, permissions, workflow state, memory, evaluation, and operator visibility.",
+      "author": {
+        "name": "Jonathan Edwards",
+        "github": "jonathanedwards"
+      },
+      "version": "1.0.0",
+      "tags": [
+        "agentic-harness",
+        "agents",
+        "workflow",
+        "architecture",
+        "evaluation",
+        "memory"
+      ],
+      "difficulty": "advanced",
+      "estimated_time": "10 minutes",
+      "created": "2026-04-02",
+      "updated": "2026-04-02",
+      "learning_order": null,
+      "compatibility": {
+        "open_brain": "optional"
+      },
+      "requirements": {
+        "services": [],
+        "tools": [
+          "AI client with reusable skills/prompts",
+          "Ability to install the bundled references directory"
+        ]
+      },
+      "dependencies": {
+        "skills": [],
+        "primitives": []
+      },
+      "reverse_dependencies": {
+        "skills": [],
+        "primitives": []
+      },
+      "urls": {
+        "github_folder": "https://github.com/NateBJones-Projects/OB1/tree/main/skills/n-agentic-harnesses",
+        "github_readme": "https://github.com/NateBJones-Projects/OB1/blob/main/skills/n-agentic-harnesses/README.md"
+      },
+      "readme_markdown": "# N Agentic Harnesses\n\n> Reusable skill pack for designing, auditing, and improving the harness layer around agentic products.\n\n## What It Does\n\nN Agentic Harnesses helps an AI client reason about the parts of an agentic system that usually get hand-waved: tool boundaries, permission policy, approval flow, workflow state, durability, context assembly, memory, evals, and operator visibility.\n\nIt is a routing skill, not a framework. It helps the client choose the right harness shape, inspect the right subsystem, and return a buildable plan or a findings-first review instead of vague \"agent architecture\" advice.\n\n## Supported Clients\n\n- Codex\n- Claude Code\n- Claude Desktop or other Anthropic-style skill systems\n- Cursor or similar AI clients that can keep a skill file next to bundled references\n\n## Prerequisites\n\n- Working Open Brain setup if you want to capture resulting architecture notes or evaluation findings into memory ([guide](https://github.com/NateBJones-Projects/OB1/blob/main/docs/01-getting-started.md))\n- AI client that supports reusable skill files, project rules, or custom instructions\n- Ability to keep the bundled `references/` directory next to the installed skill file\n\n## Installation\n\n1. Copy the entire [`n-agentic-harnesses`](/ob1/skills/n-agentic-harnesses) folder into a location your AI client can access. Keep `references/`, `variants/`, and `agents/` next to the active `SKILL.md`.\n2. For the default portable install, use the root [`SKILL.md`](https://github.com/NateBJones-Projects/OB1/blob/main/skills/n-agentic-harnesses/SKILL.md).\n3. If you want the Codex-tuned variant, replace the contents of the root `SKILL.md` with [`variants/codex/SKILL.md`](https://github.com/NateBJones-Projects/OB1/blob/main/skills/n-agentic-harnesses/variants/codex/SKILL.md) and keep the rest of the folder unchanged.\n4. If you want the Anthropic-oriented variant, do the same with [`variants/anthropic/SKILL.md`](https://github.com/NateBJones-Projects/OB1/blob/main/skills/n-agentic-harnesses/variants/anthropic/SKILL.md).\n5. Reload the client and test it with a prompt like: `Design the harness for a solo-dev coding agent and tell me what primitives I should build first.`\n\nFor Claude Code, a common install path is:\n\n```bash\nmkdir -p ~/.claude/skills/n-agentic-harnesses\ncp -R skills/n-agentic-harnesses/* ~/.claude/skills/n-agentic-harnesses/\n```\n\n## Trigger Conditions\n\n- \"Design an agentic harness for this product\"\n- \"Audit my agent architecture\"\n- \"Help me structure tool permissions and approvals\"\n- \"Should this be single-agent or multi-agent?\"\n- \"How should I handle workflow state, retries, and resumability?\"\n- \"How do I know if this harness is actually good?\"\n- Any request where the real issue is stale context, brittle sessions, missing approval controls, weak evals, or poor operator visibility\n\n## Expected Outcome\n\nWhen installed and invoked correctly, the skill should produce:\n\n- a clear harness mode: design, evaluation, or both\n- the recommended product shape and subsystem boundaries\n- a lean MVP boundary instead of scalability theater\n- a phased implementation plan or findings-first audit\n- explicit acceptance checks, regression checks, or evaluation criteria\n\n## Troubleshooting\n\n**Issue: The output sounds abstract and never gets buildable**\nSolution: Make sure the request includes the product shape, the actions the agent takes, and the main constraint. This skill is strongest when it can turn real constraints into subsystem choices.\n\n**Issue: The client gives a generic \"use multi-agent\" answer**\nSolution: Keep the single-agent default posture intact. This skill is designed to push back on unnecessary orchestration unless the request includes a real coordination constraint.\n\n**Issue: The skill cannot find its reference files**\nSolution: Install the whole folder, not just one prompt file. The root `SKILL.md` and the client variants expect the bundled [`references/`](https://github.com/NateBJones-Projects/OB1/blob/main/skills/n-agentic-harnesses/references) directory to remain adjacent.\n\n## Notes for Other Clients\n\nThe root [`SKILL.md`](https://github.com/NateBJones-Projects/OB1/blob/main/skills/n-agentic-harnesses/SKILL.md) is the canonical portable version for OB1. The two client variants are adaptation layers:\n\n- [`variants/codex/SKILL.md`](https://github.com/NateBJones-Projects/OB1/blob/main/skills/n-agentic-harnesses/variants/codex/SKILL.md) adds Codex-friendly discovery metadata and routing signals\n- [`variants/anthropic/SKILL.md`](https://github.com/NateBJones-Projects/OB1/blob/main/skills/n-agentic-harnesses/variants/anthropic/SKILL.md) stays closer to the Anthropic-style prompt shape\n\nThe shared architectural guidance lives once in [`references/`](https://github.com/NateBJones-Projects/OB1/blob/main/skills/n-agentic-harnesses/references). Keep that directory with the skill no matter which variant you activate.\n"
+    },
+    {
+      "slug": "panning-for-gold",
+      "category": "skills",
+      "site_path": "/ob1/skills/panning-for-gold",
+      "name": "Panning for Gold",
+      "description": "Standalone skill pack that turns transcripts, brain dumps, and raw multi-topic captures into evaluated idea inventories and Open Brain-ready outputs.",
+      "author": {
+        "name": "Jared Irish",
+        "github": "jaredirish"
+      },
+      "version": "2.0.0",
+      "tags": [
+        "skill",
+        "brain-dump",
+        "transcript",
+        "evaluation",
+        "workflow"
+      ],
+      "difficulty": "intermediate",
+      "estimated_time": "5 minutes",
+      "created": "2026-03-27",
+      "updated": "2026-03-27",
+      "learning_order": null,
+      "compatibility": {
+        "open_brain": "optional"
+      },
+      "requirements": {
+        "services": [],
+        "tools": [
+          "Claude Code or similar AI client with reusable skills/prompts"
+        ]
+      },
+      "dependencies": {
+        "skills": [],
+        "primitives": []
+      },
+      "reverse_dependencies": {
+        "skills": [],
+        "primitives": []
+      },
+      "urls": {
+        "github_folder": "https://github.com/NateBJones-Projects/OB1/tree/main/skills/panning-for-gold",
+        "github_readme": "https://github.com/NateBJones-Projects/OB1/blob/main/skills/panning-for-gold/README.md"
+      },
+      "readme_markdown": "# Panning for Gold\n\n<div align=\"center\">\n\n![Community Contribution](https://img.shields.io/badge/OB1_COMMUNITY-Approved_Contribution-2ea44f?style=for-the-badge&logo=github)\n\n**Created by [@jaredirish](https://github.com/jaredirish)**\n\n</div>\n\n*Standalone skill pack for processing transcripts, brain dumps, and raw multi-topic captures.*\n\n## What It Does\n\nPanning for Gold turns messy source material into an evaluated inventory of ideas. It extracts every thread first, evaluates the highest-signal ones second, and writes permanent outputs so nothing gets lost between agent runs or session compaction.\n\n## Supported Clients\n\n- Claude Code\n- Codex\n- Cursor\n- Any AI client that supports reusable rules, skills, or custom instructions\n\n## Prerequisites\n\n- Working Open Brain setup if you want the skill to use `search_thoughts` and `capture_thought` ([guide](https://github.com/NateBJones-Projects/OB1/blob/main/docs/01-getting-started.md))\n- An AI client that can load a reusable skill or prompt file\n- A project workspace where the skill can save inventory and synthesis files\n\n## Installation\n\n1. Copy [`SKILL.md`](https://github.com/NateBJones-Projects/OB1/blob/main/skills/panning-for-gold/SKILL.md) into your client's skill/rules directory.\n2. For Claude Code, place it at `~/.claude/skills/panning-for-gold/SKILL.md`.\n3. Restart or reload your AI client so it picks up the skill.\n4. If your client does not support native skill files, paste the contents into that client's reusable system prompt or project rules.\n\n## Trigger Conditions\n\n- The user says \"process this,\" \"pan for gold,\" \"brain dump,\" or \"what did I say?\"\n- The input is a transcript, export, or multi-topic markdown file\n- The task is to extract signal from raw, messy, or stream-of-consciousness input\n\n## Expected Outcome\n\nWhen the skill is working correctly, it should:\n\n- Save the raw input to disk before analysis\n- Produce a numbered thread inventory file\n- Evaluate the strongest threads with clear verdicts\n- Write a final gold-found synthesis file\n- Optionally capture the strongest outcomes back into Open Brain\n\n## Full Recipe\n\nIf you want the full walkthrough, setup framing, and usage examples, use the companion recipe: [../../recipes/panning-for-gold/](/ob1/recipes/panning-for-gold).\n\n## Troubleshooting\n\n**Issue:** The skill skips non-technical or personal threads.  \nSolution: Keep the \"no category filtering\" and \"read every line\" instructions intact. Tech bias is the main failure mode this skill is designed to prevent.\n\n**Issue:** Evaluations disappear after parallel agent work.  \nSolution: Make sure the skill is being used in a workspace where it can write permanent files. The process assumes evaluators save to disk, not just chat output.\n\n**Issue:** The client does not support native skill files.  \nSolution: Use the contents of [`SKILL.md`](https://github.com/NateBJones-Projects/OB1/blob/main/skills/panning-for-gold/SKILL.md) as a reusable project prompt or system rule. The behavior is portable even if the file format is not.\n"
+    },
+    {
+      "slug": "research-synthesis",
+      "category": "skills",
+      "site_path": "/ob1/skills/research-synthesis",
+      "name": "Research Synthesis",
+      "description": "Standalone skill pack for turning a source set into a decision-grade synthesis with findings, contradictions, confidence markers, and next questions.",
+      "author": {
+        "name": "Nate B. Jones",
+        "github": "NateBJones"
+      },
+      "version": "1.0.0",
+      "tags": [
+        "research",
+        "synthesis",
+        "diligence",
+        "evidence",
+        "decision-support"
+      ],
+      "difficulty": "intermediate",
+      "estimated_time": "10 minutes",
+      "created": "2026-03-31",
+      "updated": "2026-03-31",
+      "learning_order": null,
+      "compatibility": {
+        "open_brain": "optional"
+      },
+      "requirements": {
+        "services": [],
+        "tools": [
+          "Claude Code or similar AI coding tool with reusable skills/system prompts"
+        ]
+      },
+      "dependencies": {
+        "skills": [],
+        "primitives": []
+      },
+      "reverse_dependencies": {
+        "skills": [
+          {
+            "category": "recipes",
+            "slug": "research-to-decision-workflow",
+            "name": "Research-to-Decision Workflow"
+          }
+        ],
+        "primitives": []
+      },
+      "urls": {
+        "github_folder": "https://github.com/NateBJones-Projects/OB1/tree/main/skills/research-synthesis",
+        "github_readme": "https://github.com/NateBJones-Projects/OB1/blob/main/skills/research-synthesis/README.md"
+      },
+      "readme_markdown": "# Research Synthesis\n\n> Standalone skill pack for turning a source set into a decision-grade brief with findings, contradictions, confidence, and next questions.\n\n## What It Does\n\nThis skill helps an AI client synthesize research instead of merely summarize it. It organizes a source set into clear findings, preserves meaningful disagreement, marks confidence honestly, and ends with what the evidence supports now versus what still needs work.\n\nFor the OB1 workflow that chains this into competitive work, meeting outputs, and memo drafting, use the [Research-to-Decision Workflow recipe](/ob1/recipes/research-to-decision-workflow).\n\n## Supported Clients\n\n- Claude Code\n- Codex\n- Cursor\n- Other AI clients that support reusable prompt packs, rules, or custom instructions\n\n## Prerequisites\n\n- Working Open Brain setup if you want the skill to use memory search or capture ([guide](https://github.com/NateBJones-Projects/OB1/blob/main/docs/01-getting-started.md))\n- AI client that supports reusable skills, rules, or custom instructions\n- A real source set with a defined research question\n\n## Installation\n\n1. Copy [`SKILL.md`](https://github.com/NateBJones-Projects/OB1/blob/main/skills/research-synthesis/SKILL.md) into the reusable-instructions location for your AI client.\n2. Restart or reload the client so it picks up the skill.\n3. Test it with a prompt like: `Synthesize these ten sources into a brief and show where they disagree.`\n\nFor Claude Code, a common install path is:\n\n```bash\nmkdir -p ~/.claude/skills/research-synthesis\ncp skills/research-synthesis/SKILL.md ~/.claude/skills/research-synthesis/SKILL.md\n```\n\n## Trigger Conditions\n\n- \"Synthesize these sources\"\n- \"Turn this research into a brief\"\n- \"What are the key findings?\"\n- \"Where do these sources disagree?\"\n- \"What can we actually conclude from this packet?\"\n\n## Expected Outcome\n\nWhen installed and invoked correctly, the skill should produce:\n\n- a clean synthesis tied to a defined question\n- explicit contradictions instead of fake consensus\n- honest confidence signaling\n- gaps and next questions that matter to the decision\n- optional Open Brain capture of the final synthesis or most important findings\n\n## Troubleshooting\n\n**Issue: The output is just a summary of each source**\nSolution: Make sure the prompt includes a real synthesis question or decision context. This skill is built to answer a question, not restate documents in sequence.\n\n**Issue: Contradictions disappear in the final brief**\nSolution: Preserve the contradiction rules. If two sources diverge materially, the synthesis should either resolve the difference with stronger evidence or keep the disagreement visible.\n\n**Issue: Confidence sounds inflated**\nSolution: Keep the evidence hierarchy and thin-source rule intact. The brief should never sound more certain than the source set deserves.\n\n## Notes for Other Clients\n\nAdapt the Open Brain tool names as needed, but preserve the core behavior: frame the question, inventory the evidence, surface contradictions, mark confidence honestly, and finish with decision-relevant conclusions and gaps.\n"
+    },
+    {
+      "slug": "weekly-signal-diff",
+      "category": "skills",
+      "site_path": "/ob1/skills/weekly-signal-diff",
+      "name": "Weekly Signal Diff",
+      "description": "Standalone skill pack for turning a week's worth of market or AI news into a personalized structural diff using Open Brain memory, a suggested starter universe, and optional live web search.",
+      "author": {
+        "name": "Jonathan Edwards",
+        "github": "justfinethanku"
+      },
+      "version": "1.0.0",
+      "tags": [
+        "weekly-review",
+        "signal-diff",
+        "market-intelligence",
+        "news",
+        "openrouter",
+        "research"
+      ],
+      "difficulty": "intermediate",
+      "estimated_time": "15 minutes",
+      "created": "2026-04-13",
+      "updated": "2026-04-13",
+      "learning_order": null,
+      "compatibility": {
+        "open_brain": "required"
+      },
+      "requirements": {
+        "services": [
+          "Optional: OpenRouter (Perplexity Sonar family) for live search"
+        ],
+        "tools": [
+          "Claude Code or similar AI coding tool with reusable skills/system prompts"
+        ]
+      },
+      "dependencies": {
+        "skills": [],
+        "primitives": []
+      },
+      "reverse_dependencies": {
+        "skills": [],
+        "primitives": []
+      },
+      "urls": {
+        "github_folder": "https://github.com/NateBJones-Projects/OB1/tree/main/skills/weekly-signal-diff",
+        "github_readme": "https://github.com/NateBJones-Projects/OB1/blob/main/skills/weekly-signal-diff/README.md"
+      },
+      "readme_markdown": "# Weekly Signal Diff\n\n> Standalone skill pack for turning a week's worth of market noise into a\n> personalized structural diff.\n\n## What It Does\n\nThis skill runs a weekly scan across a suggested universe of categories and\ncompanies, then reweights the analysis using what Open Brain already knows\nabout the user. It produces a `diff, not digest`: what changed, why it\nmatters, and what to watch next.\n\nThe default starter universe is AI-first because that is where the original\nuse case came from, but the logic is universal. You can swap the categories and\ncompanies for any fast-moving market and keep the same structural-diff process.\n\n## Supported Clients\n\n- Claude Code\n- Codex\n- Cursor\n- Other AI clients that support reusable prompt packs, rules, or custom\n  instructions\n\n## Prerequisites\n\n- Working Open Brain setup if you want memory search and capture\n  ([guide](https://github.com/NateBJones-Projects/OB1/blob/main/docs/01-getting-started.md))\n- AI client that supports reusable skills, rules, or custom instructions\n- One of:\n  - live web access in the client\n  - a user-provided weekly source set\n- Optional upgrade for automated live-search runs: OpenRouter access to the\n  Perplexity Sonar family\n  ([OpenRouter model page](https://openrouter.ai/perplexity/sonar/api))\n\n## Installation\n\n1. Copy [`SKILL.md`](https://github.com/NateBJones-Projects/OB1/blob/main/skills/weekly-signal-diff/SKILL.md) into your client's reusable-instructions\n   location.\n2. Keep the [`references/`](https://github.com/NateBJones-Projects/OB1/blob/main/skills/weekly-signal-diff/references) folder alongside it if you want the\n   starter universe and live-search notes available to the client.\n3. Restart or reload the client so it picks up the skill.\n4. Test it with a prompt like:\n   `Run my weekly signal diff on AI infrastructure and tell me what changed this week that matters for a solo builder.`\n5. Optional: wire it into your weekly automation. If OpenRouter is available,\n   use the Perplexity Sonar family for the retrieval pass and keep the final\n   digest structure consistent every week.\n\nIf you want an agent to do the installation for you, copy and paste this:\n\n```text\nInstall the Weekly Signal Diff skill for me from this repository.\n\nSource files:\n- skills/weekly-signal-diff/SKILL.md\n- skills/weekly-signal-diff/references/starter-universe.md\n- skills/weekly-signal-diff/references/live-search-upgrade.md\n\nWhat I want you to do:\n1. Detect which AI client or agent environment we are in.\n2. Create the correct reusable-skill folder for that client.\n3. Copy the skill file and the full references folder into that location.\n4. Preserve the folder name as `weekly-signal-diff`.\n5. Tell me exactly where you installed it.\n6. Give me the shortest possible reload step if this client needs one.\n7. Give me one test prompt I can run immediately.\n\nIf the client has no native skill folder, put the contents somewhere easy to\nreuse and tell me exactly how to paste or load it into that client's reusable\ninstructions feature.\n```\n\nFor Claude Code, a common install path is:\n\n```bash\nmkdir -p ~/.claude/skills/weekly-signal-diff/references\ncp skills/weekly-signal-diff/SKILL.md ~/.claude/skills/weekly-signal-diff/SKILL.md\ncp -R skills/weekly-signal-diff/references ~/.claude/skills/weekly-signal-diff/references\n```\n\nIf your client does not support native skill folders, paste the contents of\n[`SKILL.md`](https://github.com/NateBJones-Projects/OB1/blob/main/skills/weekly-signal-diff/SKILL.md) into that client's reusable prompt or project-rules\nfeature and keep the reference files nearby.\n\n## Trigger Conditions\n\n- \"Run my weekly signal diff\"\n- \"What changed this week that matters to me?\"\n- \"Track AI this week\"\n- \"Turn this week's news into structural shifts\"\n- \"Give me the signal, not the headlines\"\n- Weekly automated digests or review rituals\n\n## Expected Outcome\n\nWhen installed and invoked correctly, the skill should produce:\n\n- a coverage note explaining what was scanned\n- 3-7 structural shifts instead of a long news list\n- user-specific implications pulled from Open Brain memory\n- a watchlist for next week\n- optional capture of the weekly digest back into Open Brain\n\n## Troubleshooting\n\n**Issue: The output reads like a news summary**\nSolution: Keep the structural questions intact. The skill should filter for\nconstraint shifts, leverage shifts, broken assumptions, and exposed\ndependencies.\n\n**Issue: The final diff feels generic**\nSolution: Check that the client actually searched Open Brain first. This skill\ngets sharper when it can pull active projects, recurring interests, and prior\ndigests before ranking the week's news.\n\n**Issue: The scan fixates on the default 30-company list**\nSolution: Treat the starter universe as a bootstrap layer. Replace or re-rank\nthe suggested companies and categories using the user's actual focus areas.\n\n**Issue: The live-search results are shallow or stale**\nSolution: If OpenRouter is available, upgrade the retrieval pass to a\nPerplexity Sonar search model and constrain domains or freshness when needed.\nSee [references/live-search-upgrade.md](https://github.com/NateBJones-Projects/OB1/blob/main/skills/weekly-signal-diff/references/live-search-upgrade.md).\n\n## Notes for Other Clients\n\nThis skill is portable because the logic is procedural. Any client that can\nload reusable instructions and access either Open Brain or a weekly source set\ncan run it. If the client has no live search, feed it a source packet and ask\nfor the same structural-diff output.\n"
+    },
+    {
+      "slug": "work-operating-model",
+      "category": "skills",
+      "site_path": "/ob1/skills/work-operating-model",
+      "name": "Work Operating Model",
+      "description": "Standalone skill pack for interviewing a user about how their work actually runs, saving the approved model into structured Open Brain tables, and generating agent-ready exports.",
+      "author": {
+        "name": "Jonathan Edwards",
+        "github": "jonathanedwards"
+      },
+      "version": "1.0.0",
+      "tags": [
+        "skill",
+        "operating-model",
+        "interview",
+        "workflow",
+        "agent-config"
+      ],
+      "difficulty": "intermediate",
+      "estimated_time": "10 minutes",
+      "created": "2026-04-14",
+      "updated": "2026-04-14",
+      "learning_order": null,
+      "compatibility": {
+        "open_brain": "required"
+      },
+      "requirements": {
+        "services": [],
+        "tools": [
+          "AI client with reusable skills/prompts and MCP support"
+        ]
+      },
+      "dependencies": {
+        "skills": [],
+        "primitives": []
+      },
+      "reverse_dependencies": {
+        "skills": [
+          {
+            "category": "recipes",
+            "slug": "bring-your-own-context",
+            "name": "Bring Your Own Context"
+          },
+          {
+            "category": "recipes",
+            "slug": "work-operating-model-activation",
+            "name": "Work Operating Model Activation"
+          }
+        ],
+        "primitives": []
+      },
+      "urls": {
+        "github_folder": "https://github.com/NateBJones-Projects/OB1/tree/main/skills/work-operating-model",
+        "github_readme": "https://github.com/NateBJones-Projects/OB1/blob/main/skills/work-operating-model/README.md"
+      },
+      "readme_markdown": "# Work Operating Model\n\n> Reusable interviewer skill that turns a user's tacit work patterns into structured Open Brain records and agent-ready exports.\n\n## What It Does\n\nThis skill runs a strict, five-layer elicitation interview:\n\n1. operating rhythms\n2. recurring decisions\n3. dependencies\n4. institutional knowledge\n5. friction\n\nIt resumes or starts a session, interviews through concrete recent examples, confirms each checkpoint before saving, writes one summary thought per approved layer through the base Open Brain connector, runs a final contradiction pass, and generates export artifacts.\n\nIf you want the schema, MCP server, and setup instructions, use the paired [Work Operating Model Activation recipe](/ob1/recipes/work-operating-model-activation).\n\n## Supported Clients\n\n- Claude Code\n- Codex\n- Cursor\n- Any client that supports reusable prompt packs plus MCP tools\n\n## Prerequisites\n\n- Working Open Brain setup with `search_thoughts` and `capture_thought` available ([guide](https://github.com/NateBJones-Projects/OB1/blob/main/docs/01-getting-started.md))\n- The [Work Operating Model Activation recipe](/ob1/recipes/work-operating-model-activation) installed and connected\n- AI client that supports reusable skills or equivalent system instructions\n\n## Installation\n\n1. Copy [`SKILL.md`](https://github.com/NateBJones-Projects/OB1/blob/main/skills/work-operating-model/SKILL.md) into your client's reusable-instructions location.\n2. Reload or restart the client.\n3. Verify the client can see:\n   - your core Open Brain search/capture tools\n   - `start_operating_model_session`\n   - `save_operating_model_layer`\n   - `query_operating_model`\n   - `generate_operating_model_exports`\n\nFor Claude Code, a common install path is:\n\n```bash\nmkdir -p ~/.claude/skills/work-operating-model\ncp skills/work-operating-model/SKILL.md ~/.claude/skills/work-operating-model/SKILL.md\n```\n\n## Trigger Conditions\n\n- “Help me document how I actually work”\n- “Interview me for my operating model”\n- “Build my USER.md / SOUL.md / HEARTBEAT.md from a conversation”\n- “I want to figure out what I actually do all day”\n- Starting the paired recipe in a client that supports skills\n\n## Expected Outcome\n\nWhen the skill is loaded and the paired recipe is connected, the client should:\n\n- create or resume a session\n- interview in the fixed five-layer order\n- show a checkpoint summary before every save\n- only persist confirmed or explicitly synthesized patterns\n- capture one summary thought per layer plus one final synthesis thought\n- return `operating-model.json`, `USER.md`, `SOUL.md`, `HEARTBEAT.md`, and `schedule-recommendations.json`\n\n## Troubleshooting\n\n**Issue: The skill starts asking broad abstract questions**\nSolution: Restore the “recent concrete examples first” rule from the skill. The workflow should anchor on last week or last month before synthesizing patterns.\n\n**Issue: The skill saves unconfirmed hints from search**\nSolution: It should not. Search results are hints only. They must be confirmed or reframed by the user before persistence.\n\n**Issue: The skill cannot find the paired MCP tools**\nSolution: Confirm the recipe connector is enabled. The skill needs both the recipe server and the base Open Brain connector.\n\n## Notes for Other Clients\n\nTool names may be namespaced in some clients. Keep the behavior the same even if the visible tool IDs differ:\n\n- identify the base search/capture tools that write to core Open Brain\n- identify the four recipe tools that manage the operating model\n- use those actual names in your environment rather than hard-coding a prefix\n"
+    },
+    {
+      "slug": "deploy-edge-function",
+      "category": "primitives",
+      "site_path": "/ob1/primitives/deploy-edge-function",
+      "name": "Deploy an Edge Function",
+      "description": "How to deploy any Open Brain extension as a Supabase Edge Function — create, configure, and deploy in 5 steps.",
+      "author": {
+        "name": "Nate B. Jones",
+        "github": "NateBJones"
+      },
+      "version": "1.0.0",
+      "tags": [
+        "deployment",
+        "edge-function",
+        "supabase",
+        "mcp",
+        "deno"
+      ],
+      "difficulty": "beginner",
+      "estimated_time": "10 minutes",
+      "created": "2026-03-13",
+      "updated": "2026-03-13",
+      "learning_order": null,
+      "compatibility": {
+        "open_brain": "required"
+      },
+      "requirements": {
+        "services": [
+          "Supabase CLI"
+        ],
+        "tools": []
+      },
+      "dependencies": {
+        "skills": [],
+        "primitives": []
+      },
+      "reverse_dependencies": {
+        "skills": [],
+        "primitives": [
+          {
+            "category": "extensions",
+            "slug": "family-calendar",
+            "name": "Kid Logistics / Family Calendar"
+          },
+          {
+            "category": "extensions",
+            "slug": "home-maintenance",
+            "name": "Home Maintenance Tracker"
+          },
+          {
+            "category": "extensions",
+            "slug": "household-knowledge",
+            "name": "Household Knowledge Base"
+          },
+          {
+            "category": "extensions",
+            "slug": "job-hunt",
+            "name": "Job Hunt Pipeline"
+          },
+          {
+            "category": "extensions",
+            "slug": "meal-planning",
+            "name": "Meal Planning"
+          },
+          {
+            "category": "extensions",
+            "slug": "professional-crm",
+            "name": "Professional CRM"
+          },
+          {
+            "category": "recipes",
+            "slug": "bring-your-own-context",
+            "name": "Bring Your Own Context"
+          }
+        ]
+      },
+      "urls": {
+        "github_folder": "https://github.com/NateBJones-Projects/OB1/tree/main/primitives/deploy-edge-function",
+        "github_readme": "https://github.com/NateBJones-Projects/OB1/blob/main/primitives/deploy-edge-function/README.md"
+      },
+      "readme_markdown": "# Deploy an Edge Function\n\nA guide to deploying any Open Brain extension as a Supabase Edge Function. This is the same pattern used by the core Open Brain MCP server — one deployment, accessible from any AI client.\n\n## Prerequisites\n\n- Completed the [Getting Started Guide](https://github.com/NateBJones-Projects/OB1/blob/main/docs/01-getting-started.md) — you should already have:\n  - Supabase CLI installed\n  - A project folder with `supabase init` and `supabase link` already done\n  - Your credential tracker with Supabase project ref and secrets\n\n## Before You Start\n\nNavigate to your Open Brain project folder — the one you created during the Getting Started guide.\n\n🟩 **Mac/Linux:**\n\n```bash\ncd /paste/your/path/here\n```\n\n🟦 **Windows (PowerShell):**\n\n```powershell\ncd \"C:\\paste\\your\\path\\here\"\n```\n\n> Not sure where it is? It's the folder you created in Step 6 of the Getting Started guide — the one with the `supabase/` directory inside it.\n\n## What You Need From the Extension\n\nEvery extension README includes a deployment table like this:\n\n| Setting | Value |\n|---------|-------|\n| Function name | `extension-name-mcp` |\n| Download path | `extensions/extension-name` |\n\nYou'll use these values in the steps below. Replace `FUNCTION_NAME` and `DOWNLOAD_PATH` with the values from the extension you're deploying.\n\n---\n\n## Step 1: Create the Function Folder\n\n```bash\nsupabase functions new FUNCTION_NAME\n```\n\nExample: `supabase functions new household-knowledge-mcp`\n\n## Step 2: Download the Server Files\n\n🟩 **Mac/Linux:**\n\n```bash\ncurl -o supabase/functions/FUNCTION_NAME/index.ts https://raw.githubusercontent.com/NateBJones-Projects/OB1/main/DOWNLOAD_PATH/index.ts\n```\n\n```bash\ncurl -o supabase/functions/FUNCTION_NAME/deno.json https://raw.githubusercontent.com/NateBJones-Projects/OB1/main/DOWNLOAD_PATH/deno.json\n```\n\n🟦 **Windows (PowerShell):**\n\n```powershell\nInvoke-WebRequest -Uri https://raw.githubusercontent.com/NateBJones-Projects/OB1/main/DOWNLOAD_PATH/index.ts -OutFile supabase\\functions\\FUNCTION_NAME\\index.ts\n```\n\n```powershell\nInvoke-WebRequest -Uri https://raw.githubusercontent.com/NateBJones-Projects/OB1/main/DOWNLOAD_PATH/deno.json -OutFile supabase\\functions\\FUNCTION_NAME\\deno.json\n```\n\n> Replace `FUNCTION_NAME` and `DOWNLOAD_PATH` with the values from the extension's deployment table.\n\n## Step 3: Generate an Access Key\n\n> **Already have an access key from a previous extension?** You can reuse it — skip to Step 4 and use the same key. Or generate a new one if you prefer each extension to have its own key.\n\n🟩 **Mac/Linux:**\n\n```bash\nopenssl rand -hex 32\n```\n\n🟦 **Windows (PowerShell):**\n\n```powershell\n-join ((1..32) | ForEach-Object { '{0:x2}' -f (Get-Random -Maximum 256) })\n```\n\nCopy the output (64 characters). Save it in your credential tracker.\n\nSet it as a Supabase secret:\n\n```bash\nsupabase secrets set MCP_ACCESS_KEY=your-generated-key-here\n```\n\n> If you already set `MCP_ACCESS_KEY` for a previous extension or during the Getting Started guide, setting it again will overwrite it. All functions share the same secrets, so every deployed function will use the new key. If you want separate keys per extension, use a different secret name (e.g., `HOUSEHOLD_MCP_KEY`) and update the extension's `index.ts` to read from that name instead.\n\n## Step 4: Deploy\n\n```bash\nsupabase functions deploy FUNCTION_NAME --no-verify-jwt\n```\n\nYour MCP server is now live at:\n\n```text\nhttps://YOUR_PROJECT_REF.supabase.co/functions/v1/FUNCTION_NAME\n```\n\nBuild your **MCP Connection URL** by adding your access key:\n\n```text\nhttps://YOUR_PROJECT_REF.supabase.co/functions/v1/FUNCTION_NAME?key=your-access-key\n```\n\nSave this in your credential tracker, then follow the [Remote MCP Connection](/ob1/primitives/remote-mcp) guide to connect it to your AI client.\n\n---\n\n## Updating a Deployed Function\n\nWhen the extension code is updated in the repo, pull the latest version and redeploy:\n\n🟩 **Mac/Linux:**\n\n```bash\ncurl -o supabase/functions/FUNCTION_NAME/index.ts https://raw.githubusercontent.com/NateBJones-Projects/OB1/main/DOWNLOAD_PATH/index.ts\n```\n\n🟦 **Windows (PowerShell):**\n\n```powershell\nInvoke-WebRequest -Uri https://raw.githubusercontent.com/NateBJones-Projects/OB1/main/DOWNLOAD_PATH/index.ts -OutFile supabase\\functions\\FUNCTION_NAME\\index.ts\n```\n\nThen deploy:\n\n```bash\nsupabase functions deploy FUNCTION_NAME --no-verify-jwt\n```\n\nThe URL and access key stay the same — no need to reconfigure your AI clients.\n\n---\n\n## Troubleshooting\n\n**\"Function not found\" during deploy**\n- Verify you ran `supabase functions new FUNCTION_NAME` first\n- Make sure you're in your Open Brain project folder (the one with the `supabase/` directory)\n\n**Import errors or \"not in import map\"**\n- Verify `deno.json` was downloaded into the function directory, not the project root\n- Run `ls supabase/functions/FUNCTION_NAME/` — you should see both `index.ts` and `deno.json`\n\n**Deploy succeeds but function returns errors**\n- Check Edge Function logs: Supabase Dashboard → Edge Functions → your function → Logs\n- Verify secrets are set: `supabase secrets list` should show `MCP_ACCESS_KEY`\n- `SUPABASE_URL` and `SUPABASE_SERVICE_ROLE_KEY` are auto-injected — if they're missing, your Supabase project may need to be restarted\n\n**\"Invalid JWT\" or authentication errors**\n- Make sure you deployed with `--no-verify-jwt` flag\n\n## Extensions That Use This\n\n- [Household Knowledge Base](/ob1/extensions/household-knowledge) (Extension 1)\n- [Home Maintenance Tracker](/ob1/extensions/home-maintenance) (Extension 2)\n- [Family Calendar](/ob1/extensions/family-calendar) (Extension 3)\n- [Meal Planning](/ob1/extensions/meal-planning) (Extension 4)\n- [Professional CRM](/ob1/extensions/professional-crm) (Extension 5)\n- [Job Hunt Pipeline](/ob1/extensions/job-hunt) (Extension 6)\n"
+    },
+    {
+      "slug": "remote-mcp",
+      "category": "primitives",
+      "site_path": "/ob1/primitives/remote-mcp",
+      "name": "Remote MCP Connection",
+      "description": "How to connect any remote MCP server (Supabase Edge Function) to Claude Desktop, ChatGPT, Claude Code, Cursor, and other AI clients.",
+      "author": {
+        "name": "Nate B. Jones",
+        "github": "NateBJones"
+      },
+      "version": "1.0.0",
+      "tags": [
+        "mcp",
+        "remote",
+        "connection",
+        "claude",
+        "chatgpt",
+        "cursor"
+      ],
+      "difficulty": "beginner",
+      "estimated_time": "5 minutes",
+      "created": "2026-03-13",
+      "updated": "2026-03-13",
+      "learning_order": null,
+      "compatibility": {
+        "open_brain": "required"
+      },
+      "requirements": {
+        "services": [],
+        "tools": []
+      },
+      "dependencies": {
+        "skills": [],
+        "primitives": []
+      },
+      "reverse_dependencies": {
+        "skills": [],
+        "primitives": [
+          {
+            "category": "extensions",
+            "slug": "family-calendar",
+            "name": "Kid Logistics / Family Calendar"
+          },
+          {
+            "category": "extensions",
+            "slug": "home-maintenance",
+            "name": "Home Maintenance Tracker"
+          },
+          {
+            "category": "extensions",
+            "slug": "household-knowledge",
+            "name": "Household Knowledge Base"
+          },
+          {
+            "category": "extensions",
+            "slug": "job-hunt",
+            "name": "Job Hunt Pipeline"
+          },
+          {
+            "category": "extensions",
+            "slug": "meal-planning",
+            "name": "Meal Planning"
+          },
+          {
+            "category": "extensions",
+            "slug": "professional-crm",
+            "name": "Professional CRM"
+          },
+          {
+            "category": "recipes",
+            "slug": "bring-your-own-context",
+            "name": "Bring Your Own Context"
+          }
+        ]
+      },
+      "urls": {
+        "github_folder": "https://github.com/NateBJones-Projects/OB1/tree/main/primitives/remote-mcp",
+        "github_readme": "https://github.com/NateBJones-Projects/OB1/blob/main/primitives/remote-mcp/README.md"
+      },
+      "readme_markdown": "# Remote MCP Connection\n\nA guide to connecting your Open Brain extensions to any AI client. Deploy once as a Supabase Edge Function, connect from anywhere.\n\n**Jump to your client:**\n[Claude Desktop](#claude-desktop) | [ChatGPT](#chatgpt) | [Claude Code](#claude-code) | [Cursor](#cursor) | [Other Clients](#other-clients-windsurf-vs-code-zed) | [Troubleshooting](#troubleshooting)\n\n## Prerequisites\n\n- Your **MCP Connection URL** (from the extension's credential tracker — looks like `https://YOUR_REF.supabase.co/functions/v1/extension-mcp?key=your-access-key`)\n- The AI client you want to connect\n\n## Step-by-step Instructions\n\n## Claude Desktop\n\n1. Open Claude Desktop → **Settings** → **Connectors**\n2. Click **Add custom connector**\n3. Name: the extension name (e.g., `Household Knowledge`, `Family Calendar`)\n4. Remote MCP server URL: paste your **MCP Connection URL**\n5. Click **Add**\n\nStart a new conversation and enable the connector via the \"+\" button at the bottom of the chat → Connectors.\n\n> You can add multiple extensions as separate connectors and toggle them per conversation.\n\n## ChatGPT\n\nRequires a paid ChatGPT plan (Plus, Pro, Business, Enterprise, or Edu). Works on the web at chatgpt.com — not available on mobile.\n\n**Enable Developer Mode (one-time setup):**\n\n1. Go to chatgpt.com → click your profile icon → **Settings**\n2. Navigate to **Apps & Connectors** → **Advanced settings**\n3. Toggle **Developer mode** ON\n\n> Enabling Developer Mode disables ChatGPT's built-in Memory feature. Your Open Brain replaces that functionality — and it works across every AI, not just ChatGPT.\n\n**Add the connector:**\n\n1. In Settings → **Apps & Connectors**, click **Create**\n2. Name: the extension name\n3. Description: brief description of what it does (for your reference only)\n4. MCP endpoint URL: paste your **MCP Connection URL**\n5. Authentication: select **No Authentication** (your access key is embedded in the URL)\n6. Click **Create**\n\n**Using it:** Start a new conversation and make sure the connector is enabled in the tools/apps panel. ChatGPT sometimes needs explicit tool references: \"Use the search_household_items tool to find my paint colors.\"\n\n## Claude Code\n\n```bash\nclaude mcp add --transport http extension-name \\\n  https://YOUR_PROJECT_REF.supabase.co/functions/v1/extension-mcp \\\n  --header \"x-access-key: your-access-key\"\n```\n\nReplace `extension-name` with a short name (e.g., `household-knowledge`, `family-calendar`), the URL with your MCP Server URL (without the `?key=` part), and `your-access-key` with your MCP Access Key.\n\n## Cursor\n\nCursor supports remote MCP servers natively. Add this to your `~/.cursor/mcp.json`:\n\n```json\n{\n  \"mcpServers\": {\n    \"extension-name\": {\n      \"url\": \"https://YOUR_PROJECT_REF.supabase.co/functions/v1/extension-mcp?key=your-access-key\"\n    }\n  }\n}\n```\n\nRestart Cursor and the extension's tools should appear in Settings → Features → MCP.\n\n> Do **not** use `mcp-remote` for Cursor. Newer versions of `mcp-remote` attempt OAuth client registration, which fails against Open Brain's simple key-based auth. Cursor's native `url` field works directly.\n\n## Other Clients (Windsurf, VS Code, Zed)\n\nEvery MCP client handles remote servers slightly differently. Your extension accepts the access key two ways — pick whichever your client supports:\n\n**Option A: URL with key (easiest).** If your client has a field for a remote MCP server URL, paste the full MCP Connection URL including `?key=your-access-key`. This works for any client that supports remote MCP without requiring headers.\n\n**Option B: mcp-remote bridge (if your client only supports stdio).** Use `mcp-remote` to bridge to the remote server. This requires Node.js installed. Pass the access key via the URL query parameter (not a header) to avoid OAuth discovery issues with newer versions of `mcp-remote`:\n\n```json\n{\n  \"mcpServers\": {\n    \"extension-name\": {\n      \"command\": \"npx\",\n      \"args\": [\n        \"-y\",\n        \"mcp-remote\",\n        \"https://YOUR_PROJECT_REF.supabase.co/functions/v1/extension-mcp?key=your-access-key\"\n      ]\n    }\n  }\n}\n```\n\n> Older examples pass the access key via `--header`. This breaks with `mcp-remote@latest` because it now attempts OAuth client registration before sending custom headers. Pass the key via the `?key=` query parameter instead.\n\n## Troubleshooting\n\n**Claude Desktop tools don't appear**\n- Make sure the connector is enabled for your conversation — click \"+\" → Connectors and check the toggle\n- Verify the MCP Connection URL is correct (it should end with `?key=your-access-key`)\n- Try removing and re-adding the connector in Settings → Connectors\n\n**ChatGPT doesn't use the tools**\n- Confirm Developer Mode is enabled (Settings → Apps & Connectors → Advanced settings)\n- Check that the connector is active for your current conversation in the tools/apps panel\n- Be explicit: \"Use the [tool_name] tool to [do thing].\" ChatGPT often needs direct tool references the first few times.\n\n**Getting 401 errors**\n- The access key doesn't match what's stored in Supabase secrets\n- Double-check that the `?key=` value in your URL matches your MCP Access Key exactly\n- If using the header approach (Claude Code), the core Open Brain server uses `x-brain-key` while extension servers use `x-access-key`\n- Prefer the `?key=` query parameter approach to avoid header name confusion\n\n**Tools work but responses are slow**\n- First request on a cold Edge Function takes a few seconds to warm up\n- Subsequent calls are faster\n- Check your Supabase project region — pick the one closest to you\n\n## Expected Outcome\n\nAfter following the steps for your client, your Open Brain extension should appear as a connected MCP server and its tools should be available inside that AI client without needing a local MCP bridge.\n\n## Extensions That Use This\n\n- [Household Knowledge Base](/ob1/extensions/household-knowledge) (Extension 1)\n- [Home Maintenance Tracker](/ob1/extensions/home-maintenance) (Extension 2)\n- [Family Calendar](/ob1/extensions/family-calendar) (Extension 3)\n- [Meal Planning](/ob1/extensions/meal-planning) (Extension 4)\n- [Professional CRM](/ob1/extensions/professional-crm) (Extension 5)\n- [Job Hunt Pipeline](/ob1/extensions/job-hunt) (Extension 6)\n\nEvery extension that deploys a remote MCP server uses this connection pattern.\n"
+    },
+    {
+      "slug": "rls",
+      "category": "primitives",
+      "site_path": "/ob1/primitives/rls",
+      "name": "Row Level Security (RLS)",
+      "description": "Reusable guide to PostgreSQL Row Level Security — the foundation for multi-user and shared-access extensions.",
+      "author": {
+        "name": "Nate B. Jones",
+        "github": "NateBJones"
+      },
+      "version": "1.0.0",
+      "tags": [
+        "security",
+        "postgresql",
+        "multi-user",
+        "rls"
+      ],
+      "difficulty": "intermediate",
+      "estimated_time": "20 minutes",
+      "created": null,
+      "updated": null,
+      "learning_order": null,
+      "compatibility": {
+        "open_brain": "required"
+      },
+      "requirements": {
+        "services": [],
+        "tools": []
+      },
+      "dependencies": {
+        "skills": [],
+        "primitives": []
+      },
+      "reverse_dependencies": {
+        "skills": [],
+        "primitives": [
+          {
+            "category": "extensions",
+            "slug": "job-hunt",
+            "name": "Job Hunt Pipeline"
+          },
+          {
+            "category": "extensions",
+            "slug": "meal-planning",
+            "name": "Meal Planning"
+          },
+          {
+            "category": "extensions",
+            "slug": "professional-crm",
+            "name": "Professional CRM"
+          }
+        ]
+      },
+      "urls": {
+        "github_folder": "https://github.com/NateBJones-Projects/OB1/tree/main/primitives/rls",
+        "github_readme": "https://github.com/NateBJones-Projects/OB1/blob/main/primitives/rls/README.md"
+      },
+      "readme_markdown": "# Row Level Security (RLS)\n\nRow Level Security (RLS) is PostgreSQL's built-in mechanism for controlling which rows in a table are visible or modifiable by different users. Instead of managing access control in your application code, you define policies directly on the database — so security is enforced at the data layer regardless of how you connect (MCP, REST API, direct SQL).\n\n## Why RLS Matters for Open Brain Extensions\n\nWhen you build an Open Brain extension that stores personal data (recipes, contacts, job applications), you need a way to ensure:\n\n- Each user only sees their own data\n- Household members can share access to certain tables (meal plans, shopping lists)\n- Service workers (like MCP servers) can operate with appropriate permissions\n- You don't accidentally leak data between users\n\nRLS is the foundation that makes multi-user and shared-access extensions possible.\n\n## Prerequisites\n\n- A Supabase project with at least one table created\n- Basic understanding of SQL and PostgreSQL\n- Familiarity with Supabase authentication (users have UUIDs via `auth.uid()`)\n\n## How PostgreSQL Policies Work in Supabase\n\nSupabase uses PostgreSQL's RLS system with a few key conventions:\n\n1. **Authentication context**: Supabase automatically sets the database user based on the JWT token passed in requests. You can access the current user's ID with `auth.uid()`.\n\n2. **Policies are additive**: If multiple policies apply to a query, a row is returned if ANY policy allows it (they're OR'd together).\n\n3. **Service role bypasses RLS**: The `service_role` key bypasses RLS entirely — useful for admin operations, but be careful not to use it when you want RLS enforced.\n\n4. **Four policy types**:\n   - `SELECT` — who can read rows\n   - `INSERT` — who can create rows\n   - `UPDATE` — who can modify rows\n   - `DELETE` — who can remove rows\n\n## Common RLS Patterns\n\n### Pattern 1: User-Scoped (Each User Sees Only Their Own Data)\n\nThis is the most common pattern for personal data like notes, tasks, or journal entries.\n\n**Step 1**: Enable RLS on the table:\n\n```sql\nALTER TABLE personal_notes ENABLE ROW LEVEL SECURITY;\n```\n\n**Step 2**: Create policies for each operation:\n\n```sql\n-- Users can view only their own notes\nCREATE POLICY \"Users can view their own notes\"\n  ON personal_notes\n  FOR SELECT\n  USING (auth.uid() = user_id);\n\n-- Users can insert notes with their own user_id\nCREATE POLICY \"Users can insert their own notes\"\n  ON personal_notes\n  FOR INSERT\n  WITH CHECK (auth.uid() = user_id);\n\n-- Users can update only their own notes\nCREATE POLICY \"Users can update their own notes\"\n  ON personal_notes\n  FOR UPDATE\n  USING (auth.uid() = user_id)\n  WITH CHECK (auth.uid() = user_id);\n\n-- Users can delete only their own notes\nCREATE POLICY \"Users can delete their own notes\"\n  ON personal_notes\n  FOR DELETE\n  USING (auth.uid() = user_id);\n```\n\n**Expected Outcome**: Each authenticated user sees only rows where `user_id` matches their Supabase auth UUID. Other users' data is completely invisible.\n\n### Pattern 2: Team/Household-Scoped (Family Members Share Access)\n\nFor extensions like meal planning or shared shopping lists, you want a \"household\" concept where multiple users can access the same data.\n\n**Prerequisites**: You need a `households` table and a `household_members` junction table:\n\n```sql\nCREATE TABLE households (\n  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),\n  name TEXT NOT NULL,\n  created_at TIMESTAMPTZ DEFAULT NOW()\n);\n\nCREATE TABLE household_members (\n  household_id UUID REFERENCES households(id) ON DELETE CASCADE,\n  user_id UUID REFERENCES auth.users(id) ON DELETE CASCADE,\n  role TEXT DEFAULT 'member',\n  PRIMARY KEY (household_id, user_id)\n);\n\nCREATE TABLE shared_shopping_lists (\n  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),\n  household_id UUID REFERENCES households(id) ON DELETE CASCADE,\n  item_name TEXT NOT NULL,\n  quantity INTEGER,\n  created_by UUID REFERENCES auth.users(id),\n  created_at TIMESTAMPTZ DEFAULT NOW()\n);\n```\n\n**Step 1**: Enable RLS:\n\n```sql\nALTER TABLE shared_shopping_lists ENABLE ROW LEVEL SECURITY;\nALTER TABLE household_members ENABLE ROW LEVEL SECURITY;\nALTER TABLE households ENABLE ROW LEVEL SECURITY;\n```\n\n**Step 2**: Create household access policies:\n\n```sql\n-- Users can view shopping lists for households they belong to\nCREATE POLICY \"Household members can view shared shopping lists\"\n  ON shared_shopping_lists\n  FOR SELECT\n  USING (\n    household_id IN (\n      SELECT household_id\n      FROM household_members\n      WHERE user_id = auth.uid()\n    )\n  );\n\n-- Users can insert items for their households\nCREATE POLICY \"Household members can add items\"\n  ON shared_shopping_lists\n  FOR INSERT\n  WITH CHECK (\n    household_id IN (\n      SELECT household_id\n      FROM household_members\n      WHERE user_id = auth.uid()\n    )\n  );\n\n-- Users can update items in their households\nCREATE POLICY \"Household members can update items\"\n  ON shared_shopping_lists\n  FOR UPDATE\n  USING (\n    household_id IN (\n      SELECT household_id\n      FROM household_members\n      WHERE user_id = auth.uid()\n    )\n  );\n\n-- Users can delete items from their households\nCREATE POLICY \"Household members can delete items\"\n  ON shared_shopping_lists\n  FOR DELETE\n  USING (\n    household_id IN (\n      SELECT household_id\n      FROM household_members\n      WHERE user_id = auth.uid()\n    )\n  );\n\n-- Household members can see their household membership\nCREATE POLICY \"Users can view their household memberships\"\n  ON household_members\n  FOR SELECT\n  USING (user_id = auth.uid());\n\n-- Users can view households they belong to\nCREATE POLICY \"Members can view their households\"\n  ON households\n  FOR SELECT\n  USING (\n    id IN (\n      SELECT household_id\n      FROM household_members\n      WHERE user_id = auth.uid()\n    )\n  );\n```\n\n**Expected Outcome**: Multiple users who are members of the same household can all see and modify the same shopping list items. Users who aren't in the household see nothing.\n\n### Pattern 3: Public + Private (Some Rows Visible to All, Some Restricted)\n\nFor content that has both public and private items (blog posts, recipes, portfolio items).\n\n**Prerequisites**: Your table needs a visibility column:\n\n```sql\nCREATE TABLE recipes (\n  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),\n  user_id UUID REFERENCES auth.users(id) ON DELETE CASCADE,\n  title TEXT NOT NULL,\n  ingredients TEXT[],\n  instructions TEXT,\n  visibility TEXT DEFAULT 'private' CHECK (visibility IN ('public', 'private')),\n  created_at TIMESTAMPTZ DEFAULT NOW()\n);\n```\n\n**Step 1**: Enable RLS:\n\n```sql\nALTER TABLE recipes ENABLE ROW LEVEL SECURITY;\n```\n\n**Step 2**: Create mixed-visibility policies:\n\n```sql\n-- Anyone can view public recipes; authenticated users can view their own\nCREATE POLICY \"Public recipes are visible to all\"\n  ON recipes\n  FOR SELECT\n  USING (\n    visibility = 'public'\n    OR auth.uid() = user_id\n  );\n\n-- Only authenticated users can insert recipes\nCREATE POLICY \"Authenticated users can create recipes\"\n  ON recipes\n  FOR INSERT\n  WITH CHECK (auth.uid() = user_id);\n\n-- Users can only update their own recipes\nCREATE POLICY \"Users can update their own recipes\"\n  ON recipes\n  FOR UPDATE\n  USING (auth.uid() = user_id)\n  WITH CHECK (auth.uid() = user_id);\n\n-- Users can only delete their own recipes\nCREATE POLICY \"Users can delete their own recipes\"\n  ON recipes\n  FOR DELETE\n  USING (auth.uid() = user_id);\n```\n\n**Expected Outcome**: Public recipes are visible to everyone (even unauthenticated users). Private recipes are only visible to their creator. Only the creator can modify or delete their own recipes.\n\n## Step-by-Step Guide for Enabling RLS on a Table\n\n1. **Navigate to the Supabase SQL Editor**:\n   - Go to your project dashboard\n   - Click \"SQL Editor\" in the left sidebar\n   - Click \"New query\"\n\n2. **Enable RLS on your table**:\n\n   ```sql\n   ALTER TABLE your_table_name ENABLE ROW LEVEL SECURITY;\n   ```\n\n3. **Create a SELECT policy** (decide who can read):\n\n   ```sql\n   CREATE POLICY \"Users can view their own rows\"\n     ON your_table_name\n     FOR SELECT\n     USING (auth.uid() = user_id);\n   ```\n\n4. **Create INSERT/UPDATE/DELETE policies** as needed:\n\n   ```sql\n   CREATE POLICY \"Users can insert their own rows\"\n     ON your_table_name\n     FOR INSERT\n     WITH CHECK (auth.uid() = user_id);\n   ```\n\n5. **Test with the Supabase client**:\n   - Use the `supabase-js` client with a user JWT (not the service role)\n   - Query the table and verify you only see appropriate rows\n   - Try inserting data and confirm the policy allows/blocks as expected\n\n6. **Verify RLS is active**:\n\n   ```sql\n   SELECT schemaname, tablename, rowsecurity\n   FROM pg_tables\n   WHERE tablename = 'your_table_name';\n   ```\n\n   The `rowsecurity` column should be `true`.\n\n## Troubleshooting\n\n### Issue 1: I enabled RLS but now I can't see any data\n\n**Cause**: RLS is enabled but you haven't created any policies, or your policies don't match your query context.\n\n**Solution**:\n- Check if policies exist:\n\n  ```sql\n  SELECT * FROM pg_policies WHERE tablename = 'your_table_name';\n  ```\n\n- If no policies exist, create at least a SELECT policy\n- Verify `auth.uid()` returns a value (run `SELECT auth.uid();` in SQL editor while authenticated)\n- Make sure you're using the `anon` or `authenticated` role, not the `service_role` key\n\n### Issue 2: My service role key bypasses RLS\n\n**Cause**: This is intentional behavior. The `service_role` key has superuser privileges and ignores all RLS policies.\n\n**Solution**:\n- Use the `anon` key for unauthenticated operations\n- Use the `authenticated` role (via user JWT tokens) for authenticated operations\n- Only use `service_role` for admin tasks where you explicitly want to bypass RLS\n- If your MCP server is using `service_role`, consider switching to user-scoped JWTs or use a dedicated service account with limited privileges\n\n### Issue 3: Policies aren't working with my MCP server\n\n**Cause**: MCP servers often use the `service_role` key, which bypasses RLS. Alternatively, the authentication context isn't being passed correctly.\n\n**Solution**:\n- Verify which key your MCP server is using (check the server config)\n- If using `service_role`: Either accept that RLS is bypassed, or refactor to use user tokens\n- If using `anon`/user tokens: Ensure the JWT is being passed in the `Authorization` header\n- Test policies directly in the SQL editor with `SELECT auth.uid();` to confirm authentication context\n- Consider implementing user-scoped RLS even with `service_role` by adding a `user_id` parameter to your queries and filtering explicitly\n\n## Extensions That Use This\n\n- [Meal Planning](/ob1/extensions/meal-planning) — All tables (recipes, meal_plans, shopping_lists) use RLS to enable shared household access\n- [Professional CRM](/ob1/extensions/professional-crm) — RLS protects contacts, interactions, and opportunities\n- [Job Hunt Pipeline](/ob1/extensions/job-hunt) — RLS secures the entire 5-table job search schema\n\n## Further Reading\n\n- [Supabase Row Level Security Guide](https://supabase.com/docs/guides/auth/row-level-security)\n- [PostgreSQL Policy Documentation](https://www.postgresql.org/docs/current/sql-createpolicy.html)\n- [Supabase Auth Helpers](https://supabase.com/docs/guides/auth/auth-helpers) — for implementing user authentication in your application\n- [Understanding PostgreSQL RLS Performance](https://supabase.com/blog/postgres-rls-performance) — optimization tips for complex policies\n"
+    },
+    {
+      "slug": "shared-mcp",
+      "category": "primitives",
+      "site_path": "/ob1/primitives/shared-mcp",
+      "name": "Shared MCP Server",
+      "description": "Guide to building scoped MCP servers that give other people limited access to specific parts of your Open Brain.",
+      "author": {
+        "name": "Nate B. Jones",
+        "github": "NateBJones"
+      },
+      "version": "1.0.0",
+      "tags": [
+        "mcp",
+        "sharing",
+        "multi-user",
+        "collaboration"
+      ],
+      "difficulty": "intermediate",
+      "estimated_time": "30 minutes",
+      "created": null,
+      "updated": null,
+      "learning_order": null,
+      "compatibility": {
+        "open_brain": "required"
+      },
+      "requirements": {
+        "services": [],
+        "tools": [
+          "Node.js 18+"
+        ]
+      },
+      "dependencies": {
+        "skills": [],
+        "primitives": []
+      },
+      "reverse_dependencies": {
+        "skills": [],
+        "primitives": [
+          {
+            "category": "extensions",
+            "slug": "meal-planning",
+            "name": "Meal Planning"
+          }
+        ]
+      },
+      "urls": {
+        "github_folder": "https://github.com/NateBJones-Projects/OB1/tree/main/primitives/shared-mcp",
+        "github_readme": "https://github.com/NateBJones-Projects/OB1/blob/main/primitives/shared-mcp/README.md"
+      },
+      "readme_markdown": "# Shared MCP Server\n\nA guide to building scoped MCP servers that give other people limited access to specific parts of your Open Brain.\n\n## When You Need This\n\nYou've built your Open Brain—a personal knowledge system with thoughts, contacts, goals, and work data. But now you want to share *part* of it with someone else:\n\n- Your spouse needs access to meal plans and shopping lists\n- A collaborator needs to see project tasks but not your personal notes\n- A family member needs to update shared calendars without seeing your work\n- A team member needs read-only access to specific documentation\n\nYou don't want to give them your entire MCP server with full database access. You need a **shared MCP server**—a separate server with scoped credentials, limited table access, and controlled permissions.\n\n## The Security Model\n\nA shared MCP server provides isolation through three layers:\n\n### 1. Scoped Credentials\n\nCreate a separate database user/role with limited permissions:\n- Different API key or database password\n- Can only access specific tables\n- Can be revoked without affecting your main server\n\n### 2. Limited Table Access\n\nExplicitly define which tables are available:\n- Use Row-Level Security (RLS) policies\n- Grant table-level permissions to the scoped role\n- Hide sensitive tables entirely from the shared role\n\n### 3. Read-Only vs Read-Write\n\nControl operations per table:\n- Some tables are read-only (view recipes, view meal plans)\n- Some tables allow updates (shopping list items)\n- Some tables allow inserts (adding new items)\n- Sensitive operations (delete) can be blocked entirely\n\n## Prerequisites\n\nBefore building a shared MCP server:\n\n- Working Open Brain installation with your primary MCP server\n- Supabase project (or PostgreSQL database with RLS support)\n- Node.js 18+ installed\n- Understanding of database roles and permissions\n- The other person's Claude Desktop config access (or ability to share config)\n\n## Build Guide\n\n### Step 1: Decide What to Share\n\nCreate a mapping of tables and operations:\n\n```\nTable: meal_plans\n  - Operations: SELECT\n  - Why: Spouse can view planned meals\n\nTable: recipes\n  - Operations: SELECT\n  - Why: Spouse can view recipe details\n\nTable: shopping_list_items\n  - Operations: SELECT, INSERT, UPDATE\n  - Why: Spouse can view, add, and check off items\n\nTable: thoughts (NOT SHARED)\nTable: contacts (NOT SHARED)\nTable: work_projects (NOT SHARED)\n```\n\nBe explicit. Default to not sharing unless there's a clear reason.\n\n### Step 2: Create a Scoped Database Role\n\nIn Supabase SQL Editor (or via psql):\n\n```sql\n-- Create a new database role for shared access\nCREATE ROLE household_member LOGIN PASSWORD 'secure_password_here';\n\n-- Grant connection to the database\nGRANT CONNECT ON DATABASE postgres TO household_member;\n\n-- Grant usage on the schema\nGRANT USAGE ON SCHEMA public TO household_member;\n\n-- Grant specific table permissions\nGRANT SELECT ON public.meal_plans TO household_member;\nGRANT SELECT ON public.recipes TO household_member;\nGRANT SELECT, INSERT, UPDATE ON public.shopping_list_items TO household_member;\n\n-- Set up Row-Level Security (optional, for finer control)\nALTER TABLE shopping_list_items ENABLE ROW LEVEL SECURITY;\n\nCREATE POLICY \"Household members see shared lists\"\n  ON shopping_list_items\n  FOR SELECT\n  TO household_member\n  USING (household_id = current_setting('app.current_household')::uuid);\n\nCREATE POLICY \"Household members update shared lists\"\n  ON shopping_list_items\n  FOR UPDATE\n  TO household_member\n  USING (household_id = current_setting('app.current_household')::uuid);\n```\n\n**For Supabase specifically**: Create a service role key with restricted permissions through the Supabase dashboard, or use connection pooling with different credentials.\n\n### Step 3: Build a Separate MCP Server\n\nCreate a new Edge Function for the shared server. This is a Supabase Edge Function using Hono and the MCP SDK — the same pattern as the core Open Brain and all extensions.\n\n```typescript\n// shared-server index.ts (Supabase Edge Function)\nimport { Hono } from \"hono\";\nimport { McpServer } from \"@modelcontextprotocol/sdk/server/mcp.js\";\nimport { StreamableHTTPTransport } from \"@hono/mcp\";\nimport { z } from \"zod\";\nimport { createClient } from \"@supabase/supabase-js\";\n\nconst app = new Hono();\n\napp.post(\"/mcp\", async (c) => {\n  // Authenticate with a SEPARATE access key for the shared server\n  const key = c.req.query(\"key\") || c.req.header(\"x-access-key\");\n  const expected = Deno.env.get(\"MCP_HOUSEHOLD_ACCESS_KEY\");\n  if (!key || key !== expected) {\n    return c.json({ error: \"Unauthorized\" }, 401);\n  }\n\n  // Use SCOPED credentials — not the service role key\n  const supabase = createClient(\n    Deno.env.get(\"SUPABASE_URL\")!,\n    Deno.env.get(\"SUPABASE_HOUSEHOLD_KEY\")!, // Limited key\n  );\n\n  const server = new McpServer(\n    { name: \"household-shared-server\", version: \"1.0.0\" },\n  );\n\n  // Only expose tools for shared tables\n  server.tool(\n    \"view_meal_plans\",\n    \"View upcoming meal plans\",\n    { days: z.number().optional().describe(\"Number of days to view\") },\n    async ({ days }) => {\n      const { data, error } = await supabase\n        .from(\"meal_plans\")\n        .select(\"*\")\n        .gte(\"date\", new Date().toISOString().split(\"T\")[0])\n        .order(\"date\", { ascending: true })\n        .limit(days || 7);\n\n      if (error) throw error;\n      return { content: [{ type: \"text\", text: JSON.stringify(data, null, 2) }] };\n    }\n  );\n\n  server.tool(\n    \"view_shopping_list\",\n    \"View current shopping list\",\n    {},\n    async () => {\n      const { data, error } = await supabase\n        .from(\"shopping_list_items\")\n        .select(\"*\")\n        .eq(\"purchased\", false)\n        .order(\"created_at\", { ascending: false });\n\n      if (error) throw error;\n      return { content: [{ type: \"text\", text: JSON.stringify(data, null, 2) }] };\n    }\n  );\n\n  server.tool(\n    \"add_shopping_item\",\n    \"Add item to shopping list\",\n    {\n      item: z.string().describe(\"Item name\"),\n      quantity: z.string().optional().describe(\"Quantity\"),\n    },\n    async ({ item, quantity }) => {\n      const { data, error } = await supabase\n        .from(\"shopping_list_items\")\n        .insert({ item, quantity: quantity || \"1\", purchased: false })\n        .select();\n\n      if (error) throw error;\n      return { content: [{ type: \"text\", text: `Added: ${JSON.stringify(data, null, 2)}` }] };\n    }\n  );\n\n  server.tool(\n    \"update_shopping_item\",\n    \"Mark shopping item as purchased\",\n    {\n      id: z.string().describe(\"Item ID\"),\n      purchased: z.boolean().describe(\"Purchased status\"),\n    },\n    async ({ id, purchased }) => {\n      const { data, error } = await supabase\n        .from(\"shopping_list_items\")\n        .update({ purchased })\n        .eq(\"id\", id)\n        .select();\n\n      if (error) throw error;\n      return { content: [{ type: \"text\", text: `Updated: ${JSON.stringify(data, null, 2)}` }] };\n    }\n  );\n\n  const transport = new StreamableHTTPTransport();\n  await server.connect(transport);\n  return transport.handleRequest(c);\n});\n\napp.get(\"/\", (c) => c.json({ status: \"ok\", service: \"Household Shared\", version: \"1.0.0\" }));\n\nDeno.serve(app.fetch);\n```\n\n### Step 4: Configure Separate Secrets\n\nSet the shared server's secrets in Supabase (separate from your main server's secrets):\n\n```bash\n# Generate a separate access key for the shared server\nopenssl rand -hex 32\n\n# Set secrets\nsupabase secrets set MCP_HOUSEHOLD_ACCESS_KEY=your-generated-shared-key\nsupabase secrets set SUPABASE_HOUSEHOLD_KEY=your-limited-supabase-key  # LIMITED KEY\n\n# Optional: Household ID for RLS\nSHARED_HOUSEHOLD_ID=uuid-here\n```\n\nAdd to `package.json`:\n\n```json\n{\n  \"name\": \"household-shared-server\",\n  \"version\": \"1.0.0\",\n  \"type\": \"module\",\n  \"scripts\": {\n    \"build\": \"tsc\",\n    \"start\": \"node --env-file=.env.shared dist/shared-server.js\"\n  },\n  \"dependencies\": {\n    \"@modelcontextprotocol/sdk\": \"^0.5.0\",\n    \"@supabase/supabase-js\": \"^2.39.0\"\n  },\n  \"devDependencies\": {\n    \"@types/node\": \"^20.0.0\",\n    \"typescript\": \"^5.3.0\"\n  }\n}\n```\n\n### Step 5: Deploy as a Separate Edge Function\n\nDeploy the shared server as its own Supabase Edge Function:\n\n```bash\nsupabase functions new household-shared-mcp\n```\n\nCopy the shared server code into `supabase/functions/household-shared-mcp/index.ts`, generate a separate access key, and deploy:\n\n```bash\n# Generate a separate access key for the shared server\nopenssl rand -hex 32\n\n# Set the shared server's secrets\nsupabase secrets set MCP_HOUSEHOLD_ACCESS_KEY=generated-key-here\nsupabase secrets set SUPABASE_HOUSEHOLD_KEY=household-scoped-api-key\n\n# Deploy\nsupabase functions deploy household-shared-mcp --no-verify-jwt\n```\n\nThe other person connects via Claude Desktop:\n\n1. Open Claude Desktop → **Settings** → **Connectors**\n2. Click **Add custom connector**\n3. Name: `Household Shared`\n4. Remote MCP server URL: `https://YOUR_PROJECT_REF.supabase.co/functions/v1/household-shared-mcp?key=shared-access-key`\n5. Click **Add**\n\n**Key points:**\n- They connect via URL — no Node.js, no config files, no terminal needed on their end\n- They do NOT need access to your main MCP server or credentials\n- You can revoke access by changing the shared access key in Supabase secrets\n\n### Step 6: Test the Access Boundaries\n\nVerify the security model works:\n\n```typescript\n// Test script: test-boundaries.ts\nimport { createClient } from \"@supabase/supabase-js\";\n\nconst sharedClient = createClient(\n  process.env.SHARED_SUPABASE_URL!,\n  process.env.SHARED_SUPABASE_KEY!\n);\n\nasync function testBoundaries() {\n  console.log(\"Testing allowed access...\");\n\n  // Should succeed: reading meal plans\n  const { data: meals, error: mealsError } = await sharedClient\n    .from(\"meal_plans\")\n    .select(\"*\");\n  console.log(\"meal_plans:\", mealsError ? \"BLOCKED\" : \"ALLOWED\");\n\n  // Should succeed: reading shopping list\n  const { data: shopping, error: shoppingError } = await sharedClient\n    .from(\"shopping_list_items\")\n    .select(\"*\");\n  console.log(\"shopping_list_items (SELECT):\", shoppingError ? \"BLOCKED\" : \"ALLOWED\");\n\n  // Should fail: reading thoughts\n  const { data: thoughts, error: thoughtsError } = await sharedClient\n    .from(\"thoughts\")\n    .select(\"*\");\n  console.log(\"thoughts:\", thoughtsError ? \"BLOCKED ✓\" : \"ALLOWED (BAD)\");\n\n  // Should fail: deleting from shopping list\n  const { error: deleteError } = await sharedClient\n    .from(\"shopping_list_items\")\n    .delete()\n    .eq(\"id\", \"test-id\");\n  console.log(\"shopping_list_items (DELETE):\", deleteError ? \"BLOCKED ✓\" : \"ALLOWED (BAD)\");\n}\n\ntestBoundaries();\n```\n\nExpected output:\n\n```\nmeal_plans: ALLOWED\nshopping_list_items (SELECT): ALLOWED\nthoughts: BLOCKED ✓\nshopping_list_items (DELETE): BLOCKED ✓\n```\n\n## Concrete Example: Spouse Access to Meal Planning\n\n**Scenario**: You and your spouse share meal planning and grocery shopping. Your spouse wants to:\n- See what's planned for dinner this week\n- Add items to the shopping list\n- Check off items when shopping\n- View recipes for planned meals\n\nBut should NOT be able to:\n- Read your personal thoughts or journal entries\n- Access your work projects\n- See your personal contacts\n- Modify anything outside meal planning\n\n**Implementation**:\n\n1. **Tables shared**: `meal_plans`, `recipes`, `shopping_list_items`\n2. **Operations**:\n   - `meal_plans`: SELECT only\n   - `recipes`: SELECT only\n   - `shopping_list_items`: SELECT, INSERT, UPDATE (no DELETE)\n3. **Credentials**: Separate Supabase service role key with table-level grants\n4. **Deployment**: Compiled MCP server on spouse's laptop, configured in their Claude Desktop\n\n**User experience for your spouse**:\n\n```\nSpouse: \"What's for dinner this week?\"\nClaude: [calls view_meal_plans tool] \"Here's the meal plan:\n- Monday: Chicken tacos\n- Tuesday: Pasta primavera\n- Wednesday: Leftover night\n...\"\n\nSpouse: \"Add milk and eggs to the shopping list\"\nClaude: [calls add_shopping_item twice] \"Added milk and eggs to the list.\"\n\nSpouse: \"Show me the recipe for chicken tacos\"\nClaude: [calls view_recipe tool] \"Here's the recipe: ...\"\n```\n\nBehind the scenes, Claude uses the shared MCP server—never touching your personal data.\n\n## Expected Outcome\n\nAfter following this guide, you will have:\n\n1. A scoped database role with limited table access\n2. A separate MCP server implementation with restricted tools\n3. Independent deployment on another person's machine\n4. Verified security boundaries preventing unauthorized access\n5. A working shared-access pattern you can replicate for other use cases\n\nThe other person can now use Claude to interact with shared data, while your personal Open Brain remains completely private.\n\n## Troubleshooting\n\n### Issue 1: \"Permission denied for table X\"\n\n**Symptom**: The shared server throws permission errors when trying to access a table.\n\n**Cause**: The scoped database role doesn't have the necessary grants.\n\n**Solution**:\n\n```sql\n-- Check current permissions\nSELECT grantee, privilege_type, table_name\nFROM information_schema.role_table_grants\nWHERE grantee = 'household_member';\n\n-- Grant missing permissions\nGRANT SELECT ON public.meal_plans TO household_member;\nGRANT SELECT, INSERT, UPDATE ON public.shopping_list_items TO household_member;\n```\n\n### Issue 2: Shared server can access tables it shouldn't\n\n**Symptom**: The scoped role can read tables that should be private (e.g., `thoughts`, `contacts`).\n\n**Cause**: The Supabase service role key has admin privileges, or the database role has excessive grants.\n\n**Solution**:\n\n```sql\n-- Revoke all permissions first\nREVOKE ALL PRIVILEGES ON ALL TABLES IN SCHEMA public FROM household_member;\n\n-- Grant only what's needed\nGRANT SELECT ON public.meal_plans TO household_member;\nGRANT SELECT ON public.recipes TO household_member;\nGRANT SELECT, INSERT, UPDATE ON public.shopping_list_items TO household_member;\n\n-- Verify no extra grants exist\nSELECT grantee, privilege_type, table_name\nFROM information_schema.role_table_grants\nWHERE grantee = 'household_member';\n```\n\nFor Supabase: Create a custom JWT with limited claims, or use connection pooling with role-based credentials.\n\n### Issue 3: Changes not syncing between users\n\n**Symptom**: You add a meal plan, but your spouse doesn't see it when they query.\n\n**Cause**: Different database connections, caching, or RLS policies blocking visibility.\n\n**Solution**:\n1. Check both users are connecting to the same database:\n\n   ```bash\n   # Your .env\n   echo $SUPABASE_URL\n\n   # Their .env.shared\n   echo $SHARED_SUPABASE_URL\n   ```\n\n2. Verify RLS policies allow visibility:\n\n   ```sql\n   -- Check RLS is enabled\n   SELECT tablename, rowsecurity\n   FROM pg_tables\n   WHERE schemaname = 'public';\n\n   -- If RLS is enabled, check policies\n   SELECT schemaname, tablename, policyname, permissive, roles, cmd, qual\n   FROM pg_policies\n   WHERE tablename = 'meal_plans';\n   ```\n\n3. Disable RLS if not needed:\n\n   ```sql\n   ALTER TABLE meal_plans DISABLE ROW LEVEL SECURITY;\n   ```\n\n### Issue 4: MCP server won't start on spouse's machine\n\n**Symptom**: Claude Desktop shows \"MCP server failed to start\" or tools don't appear.\n\n**Cause**: Missing Node.js, incorrect paths, or environment variable issues.\n\n**Solution**:\n1. Verify Node.js version:\n\n   ```bash\n   node --version  # Should be 18+\n   ```\n\n2. Test the server manually:\n\n   ```bash\n   node --env-file=/path/to/.env.shared /path/to/dist/shared-server.js\n   ```\n\n3. Check Claude Desktop logs:\n\n   ```bash\n   # macOS\n   tail -f ~/Library/Logs/Claude/mcp*.log\n   ```\n\n4. Verify the connector URL is correct:\n\n   - Check that the `?key=` value matches the `MCP_HOUSEHOLD_ACCESS_KEY` secret exactly\n   - Try removing and re-adding the connector in Settings → Connectors\n   - Verify the Edge Function is deployed: `supabase functions list`\n\n## Extensions That Use This\n\n- [Meal Planning](/ob1/extensions/meal-planning) — Includes a dedicated shared-server.ts for household grocery list and meal plan access\n\n## Next Steps\n\n- **Audit regularly**: Review what's shared and revoke access when no longer needed\n- **Monitor usage**: Set up logging to see what queries the shared server receives\n- **Iterate on permissions**: Start with read-only, add write permissions as trust builds\n- **Document for users**: Create a simple guide for the other person explaining what they can ask Claude to do\n- **Consider other use cases**: Team collaboration, family calendars, shared project tracking\n\nYou now have a reusable pattern for sharing parts of your Open Brain without compromising privacy.\n"
+    },
+    {
+      "slug": "troubleshooting",
+      "category": "primitives",
+      "site_path": "/ob1/primitives/troubleshooting",
+      "name": "Common Troubleshooting",
+      "description": "Solutions for connection, deployment, database, and performance issues across all Open Brain extensions.",
+      "author": {
+        "name": "Nate B. Jones",
+        "github": "NateBJones"
+      },
+      "version": "1.0.0",
+      "tags": [
+        "troubleshooting",
+        "debugging",
+        "errors",
+        "help"
+      ],
+      "difficulty": "beginner",
+      "estimated_time": "5 minutes",
+      "created": "2026-03-13",
+      "updated": "2026-03-13",
+      "learning_order": null,
+      "compatibility": {
+        "open_brain": "required"
+      },
+      "requirements": {
+        "services": [],
+        "tools": []
+      },
+      "dependencies": {
+        "skills": [],
+        "primitives": []
+      },
+      "reverse_dependencies": {
+        "skills": [],
+        "primitives": []
+      },
+      "urls": {
+        "github_folder": "https://github.com/NateBJones-Projects/OB1/tree/main/primitives/troubleshooting",
+        "github_readme": "https://github.com/NateBJones-Projects/OB1/blob/main/primitives/troubleshooting/README.md"
+      },
+      "readme_markdown": "# Common Troubleshooting\n\nSolutions for issues that come up across any Open Brain extension. If your problem is specific to one extension (e.g., a particular table or tool), check that extension's README instead.\n\n## Connection Issues\n\n**\"Cannot connect to Supabase\"**\n- Verify your Supabase project is active (check the dashboard — paused projects need to be restored)\n- If using Edge Functions, `SUPABASE_URL` and `SUPABASE_SERVICE_ROLE_KEY` are auto-injected — no manual setup needed\n- Check your Supabase project region matches your expectations\n- Ensure Row Level Security (RLS) policies are configured correctly (service role bypasses RLS, but policies must exist for RLS-enabled tables)\n\n**\"Getting 401 Unauthorized\"**\n- The access key doesn't match what's stored in Supabase secrets\n- Double-check that the `?key=` value in your Connection URL matches your MCP Access Key exactly\n- If using header-based auth (Claude Code), the core Open Brain server expects `x-brain-key` while extension servers expect `x-access-key` — prefer using the `?key=` query parameter to avoid confusion\n- Do not use `mcp-remote` with `--header` for Cursor — use Cursor's native `url` field instead (see [Remote MCP Connection](/ob1/primitives/remote-mcp))\n- Verify the secret is set: `supabase secrets list` should show `MCP_ACCESS_KEY`\n- Try regenerating the key: `openssl rand -hex 32`, then `supabase secrets set MCP_ACCESS_KEY=new-key` and update your Connection URL\n\n**\"Tools don't appear in Claude Desktop\"**\n- Verify the connector is enabled for your conversation — click the \"+\" button at the bottom of the chat → Connectors → check the toggle\n- Check that the MCP Connection URL is correct and includes `?key=your-access-key`\n- Try removing and re-adding the connector in Settings → Connectors\n- Start a new conversation after adding the connector\n- Restart Claude Desktop after making changes\n\n**\"ChatGPT doesn't use the tools\"**\n- Confirm Developer Mode is enabled (Settings → Apps & Connectors → Advanced settings)\n- Check that the connector is active for your current conversation in the tools/apps panel\n- Be explicit: \"Use the [tool_name] tool to [do thing].\" ChatGPT often needs direct tool references the first few times before it picks up the habit.\n\n## Deployment Issues\n\n**Edge Function won't deploy**\n- Verify the Supabase CLI is installed and linked: `supabase --version`\n- Check that you're linked to the right project: `supabase link --project-ref YOUR_PROJECT_REF`\n- Verify the function directory exists: `ls supabase/functions/your-function-name/`\n- Make sure `deno.json` is in the function directory (not the project root)\n- Run `supabase functions deploy your-function --no-verify-jwt` (the `--no-verify-jwt` flag is required for MCP)\n\n**\"Invalid JWT\" or JWT verification errors**\n- Make sure you deployed with `--no-verify-jwt` flag: `supabase functions deploy your-function --no-verify-jwt`\n- The MCP server handles its own authentication via the access key — JWT verification should be disabled\n\n**Deploy succeeds but function returns errors**\n- Check Edge Function logs: Supabase Dashboard → Edge Functions → your function → Logs\n- Look for import errors (usually means `deno.json` is missing or has wrong paths)\n- Verify secrets are set: `supabase secrets list`\n- Check function logs from terminal: `supabase functions logs your-function-name`\n\n## Database Issues\n\n**\"relation 'table_name' does not exist\"**\n- The extension's `schema.sql` wasn't run successfully\n- Go to your Supabase SQL Editor and re-run the SQL\n- Check for errors in the SQL output — common issues include missing the pgvector extension or running statements out of order\n\n**\"permission denied\" or RLS errors**\n- The service role key bypasses Row Level Security, so this usually means a configuration issue\n- Verify the `SUPABASE_SERVICE_ROLE_KEY` is correct (not the publishable/anon key)\n- For extensions using RLS (Extensions 4-6), verify the RLS policies were created by the schema.sql\n- Check that `user_id` values are valid UUIDs\n- Ensure all RLS-enabled tables have policies created correctly\n\n**\"Foreign key violation\" errors**\n- Parent records must exist before creating child records (e.g., create a company before adding a job posting)\n- Verify the referenced ID exists and belongs to the same `user_id`\n- Check that you're using the correct UUID — copy-paste rather than typing\n- Ensure foreign key constraints are not blocking inserts\n\n## Performance Issues\n\n**Tools work but responses are slow**\n- First request on a cold Edge Function takes a few seconds to warm up — this is normal\n- Subsequent calls within the same session are faster\n- Check your Supabase project region — pick the one closest to you\n- If consistently slow, check the Edge Function logs for query performance issues\n\n**Search returns no results**\n- Make sure you've added data first (the extension starts empty)\n- Try broader search terms — most search tools use ILIKE which requires partial matches\n- Check date ranges and filters — a common issue is filtering by a date range that doesn't include your data\n- For semantic search, try asking the AI to \"search with threshold 0.3\" for a wider net\n\n## Data Issues\n\n**\"Date parsing errors\"**\n- Ensure dates are in ISO 8601 format: `YYYY-MM-DD` or `YYYY-MM-DDTHH:MM:SSZ`\n- The MCP server expects date strings, which PostgreSQL will parse\n- For \"N days from now\" calculations, let the tool compute the date\n\n**\"Auto-calculated fields not updating\"**\n- Verify that the database trigger exists (check the schema.sql was run completely)\n- Check that the tool completed successfully (look at Edge Function logs)\n- For date calculations, ensure the frequency/interval field has a value set\n- For one-time tasks (null frequency), auto-calculated fields may remain null by design\n\n## Getting More Help\n\n- **Supabase AI assistant**: Look for the chat icon in the bottom-right corner of your Supabase dashboard. It has access to all Supabase documentation and can help with database, Edge Function, and SQL issues.\n- **OB1 Discord**: Join the [Open Brain Discord](https://discord.gg/Cgh9WJEkeG) — there's a `#help` channel for troubleshooting.\n\n## Extensions That Use This\n\nAll extensions reference this guide for common issues:\n\n- [Household Knowledge Base](/ob1/extensions/household-knowledge) (Extension 1)\n- [Home Maintenance Tracker](/ob1/extensions/home-maintenance) (Extension 2)\n- [Family Calendar](/ob1/extensions/family-calendar) (Extension 3)\n- [Meal Planning](/ob1/extensions/meal-planning) (Extension 4)\n- [Professional CRM](/ob1/extensions/professional-crm) (Extension 5)\n- [Job Hunt Pipeline](/ob1/extensions/job-hunt) (Extension 6)\n"
+    },
+    {
+      "slug": "family-calendar",
+      "category": "extensions",
+      "site_path": "/ob1/extensions/family-calendar",
+      "name": "Kid Logistics / Family Calendar",
+      "description": "Multi-person family scheduling — activities, important dates, and conflict detection across the whole household.",
+      "author": {
+        "name": "Nate B. Jones",
+        "github": "NateBJones"
+      },
+      "version": "1.0.0",
+      "tags": [
+        "family",
+        "calendar",
+        "scheduling",
+        "kids",
+        "logistics"
+      ],
+      "difficulty": "intermediate",
+      "estimated_time": "45 minutes",
+      "created": "2026-03-12",
+      "updated": "2026-03-12",
+      "learning_order": 3,
+      "compatibility": {
+        "open_brain": "required"
+      },
+      "requirements": {
+        "services": [],
+        "tools": [
+          "Supabase CLI"
+        ]
+      },
+      "dependencies": {
+        "skills": [],
+        "primitives": [
+          "deploy-edge-function",
+          "remote-mcp"
+        ]
+      },
+      "reverse_dependencies": {
+        "skills": [],
+        "primitives": []
+      },
+      "urls": {
+        "github_folder": "https://github.com/NateBJones-Projects/OB1/tree/main/extensions/family-calendar",
+        "github_readme": "https://github.com/NateBJones-Projects/OB1/blob/main/extensions/family-calendar/README.md"
+      },
+      "readme_markdown": "# Extension 3: Family Calendar\n\n## Why This Matters\n\nTwo kids, two parents, overlapping schedules. Soccer practice conflicts with the dentist appointment. Nobody bought the birthday present. The haircut hasn't been scheduled in months. The chaos isn't from lack of caring — it's from lack of a system that can reason across everyone's schedule at once. Your agent can cross-reference both parents' schedules against all kids' events and surface what's falling through the cracks.\n\n## Learning Path: Extension 3 of 6\n\n| Extension | Name | Status |\n|-----------|------|--------|\n| 1 | Household Knowledge Base | Complete |\n| 2 | Home Maintenance Tracker | Complete |\n| **3** | **Family Calendar** | **<-- You are here** |\n| 4 | Meal Planning | Not started |\n| 5 | Professional CRM | Not started |\n| 6 | Job Hunt Pipeline | Not started |\n\n## What You'll Learn\n\n- Multi-entity data models (family members → activities relationship)\n- Time-based queries and date handling\n- Recurring events (weekly activities with day_of_week)\n- Nullable foreign keys (activities can belong to one person or the whole family)\n- Querying across date ranges\n\n> **Note:** This extension doesn't use Row Level Security. RLS is introduced in Extension 4 (Meal Planning), where shared household access makes it necessary. Extensions 1-3 are single-user systems.\n\n## What It Does\n\nA multi-person family scheduling system. Track activities, important dates, and family members so your agent can spot conflicts, surface upcoming events, and make sure nothing gets forgotten.\n\n**Tables:**\n- `family_members` — People in your household\n- `activities` — Scheduled events and recurring activities (soccer every Tuesday, one-time dentist appointment)\n- `important_dates` — Birthdays, anniversaries, deadlines with optional yearly recurrence\n\n**MCP Tools:**\n- `add_family_member` — Add a person to your household roster\n- `add_activity` — Schedule a one-time or recurring activity\n- `get_week_schedule` — See everyone's schedule for a given week\n- `search_activities` — Find activities by title, type, or family member\n- `add_important_date` — Track birthdays, anniversaries, deadlines\n- `get_upcoming_dates` — Surface dates in the next N days\n\n## Prerequisites\n\n- Working Open Brain setup\n- Extensions 1-2 recommended but not required\n- Supabase CLI installed and linked to your project\n\n## Credential Tracker\n\nYou'll reference these values during setup. Copy this block into a text editor and fill it in as you go.\n\n> **Already have your Supabase credentials from the [Setup Guide](https://github.com/NateBJones-Projects/OB1/blob/main/docs/01-getting-started.md)?** You just need the same Project URL and Secret key.\n\n```text\nFAMILY CALENDAR -- CREDENTIAL TRACKER\n--------------------------------------\n\nSUPABASE (from your Open Brain setup)\n  Project URL:           ____________\n  Secret key:            ____________\n  Project ref:           ____________\n\nGENERATED DURING SETUP\n  Default User ID:       ____________\n  MCP Access Key:        ____________  (same key for all extensions)\n  MCP Server URL:        ____________\n  MCP Connection URL:    ____________\n\n--------------------------------------\n```\n\n## Steps\n\n### 1. Create the Database Schema\n\nRun the SQL in `schema.sql` against your Supabase database:\n\n```bash\n# Option A: Using Supabase SQL Editor (recommended)\n# 1. Open https://supabase.com/dashboard/project/YOUR_PROJECT_ID/sql/new\n# 2. Paste the contents of schema.sql\n# 3. Click \"Run\"\n\n# Option B: Using psql (if available)\npsql $DATABASE_URL -f extensions/family-calendar/schema.sql\n```\n\n### 2. Generate Your User ID\n\nThe extension needs a user ID to scope your data. Generate a UUID and save it in your credential tracker:\n\n```bash\n# macOS / Linux\nuuidgen | tr '[:upper:]' '[:lower:]'\n\n# Or use any UUID generator — the value just needs to be unique to you\n```\n\nSet it as an environment variable for your Edge Function:\n\n```bash\nsupabase secrets set DEFAULT_USER_ID=your-generated-uuid-here\n```\n\n> If you already set `DEFAULT_USER_ID` for a previous extension, you can skip this step — all extensions share the same user ID.\n\n### 3. Deploy the MCP Server\n\nFollow the [Deploy an Edge Function](/ob1/primitives/deploy-edge-function) guide using these values:\n\n| Setting | Value |\n|---------|-------|\n| Function name | `family-calendar-mcp` |\n| Download path | `extensions/family-calendar` |\n\n### 4. Connect to Your AI\n\nFollow the [Remote MCP Connection](/ob1/primitives/remote-mcp) guide to connect this extension to Claude Desktop, ChatGPT, Claude Code, or any other MCP client.\n\n| Setting | Value |\n|---------|-------|\n| Connector name | `Family Calendar` |\n| URL | Your **MCP Connection URL** from the credential tracker |\n\n### 5. Test It\n\nTry these prompts:\n\n```\nAdd my family members: me (Jonathan), spouse (Sarah), and two kids (Emma age 8, Noah age 5).\n\nAdd a recurring activity: Emma has soccer practice every Tuesday from 5-6pm at Lincoln Park, starting March 18.\n\nShow me our schedule for the week of March 17.\n\nAdd an important date: Emma's birthday is May 15, remind me 7 days before.\n\nWhat important dates are coming up in the next 30 days?\n```\n\n## Cross-Extension Integration\n\nThe family calendar sets up the `family_members` table that Meal Planning (Extension 4) depends on — knowing who's home this week determines how many meals to plan.\n\nThe multi-entity pattern (family_member → activities) is the same pattern you'll use for contacts → interactions in the Professional CRM (Extension 5).\n\nWhen you build the Household Knowledge Base (Extension 1), you can cross-reference it here: \"Who was Emma's pediatrician again?\" can query Extension 1's knowledge base, then \"Schedule Emma's checkup\" uses this calendar.\n\n## Expected Outcome\n\nYour agent can now:\n\n1. Track everyone's schedule in one place\n2. Surface upcoming events and important dates\n3. Spot scheduling conflicts (if two activities overlap)\n4. Answer questions like \"What does Emma have this week?\" or \"When is Noah's birthday?\"\n5. Remind you about important dates before they arrive\n\n## Troubleshooting\n\nFor common issues (connection errors, 401s, deployment problems), see [Common Troubleshooting](/ob1/primitives/troubleshooting).\n\n**Extension-specific issues:**\n\n**Activities not showing up in get_week_schedule**\n- Check that `start_date` and `end_date` are set correctly\n- For recurring activities, make sure `day_of_week` is lowercase ('monday', not 'Monday')\n- The week_start date should be a Monday in YYYY-MM-DD format\n\n## Next Steps\n\n**Extension 4: Meal Planning** — This is where things get interesting. You'll combine what you've learned about scheduling with Row Level Security and a shared MCP server. Your spouse will be able to view meal plans and check off grocery items without accessing your full Open Brain.\n\n**Key concepts in Extension 4:**\n- Row Level Security (first introduction to multi-user access)\n- Shared MCP server (separate server with limited, scoped access)\n- JSONB for complex data (ingredients, instructions)\n- Auto-generating derivative data (shopping lists from meal plans)\n- Cross-extension queries (checking who's home this week from the family calendar)\n\nContinue to [Extension 4: Meal Planning](/ob1/extensions/meal-planning)\n\n> **Context check:** With 3 extensions connected, you're now exposing ~15 MCP tools to your AI. This is still manageable, but Extension 4 adds 10 more. Now is a good time to read the [MCP Tool Audit & Optimization Guide](https://github.com/NateBJones-Projects/OB1/blob/main/docs/05-tool-audit.md) — it covers when to scope your servers, how to audit your tool surface, and patterns for keeping your AI sharp as you add complexity.\n"
+    },
+    {
+      "slug": "home-maintenance",
+      "category": "extensions",
+      "site_path": "/ob1/extensions/home-maintenance",
+      "name": "Home Maintenance Tracker",
+      "description": "Track recurring maintenance tasks, log completed work, and surface upcoming items before they become emergencies.",
+      "author": {
+        "name": "Nate B. Jones",
+        "github": "NateBJones"
+      },
+      "version": "1.0.0",
+      "tags": [
+        "home",
+        "maintenance",
+        "scheduling",
+        "tracking"
+      ],
+      "difficulty": "beginner",
+      "estimated_time": "30 minutes",
+      "created": "2026-03-12",
+      "updated": "2026-03-12",
+      "learning_order": 2,
+      "compatibility": {
+        "open_brain": "required"
+      },
+      "requirements": {
+        "services": [],
+        "tools": [
+          "Supabase CLI"
+        ]
+      },
+      "dependencies": {
+        "skills": [],
+        "primitives": [
+          "deploy-edge-function",
+          "remote-mcp"
+        ]
+      },
+      "reverse_dependencies": {
+        "skills": [],
+        "primitives": []
+      },
+      "urls": {
+        "github_folder": "https://github.com/NateBJones-Projects/OB1/tree/main/extensions/home-maintenance",
+        "github_readme": "https://github.com/NateBJones-Projects/OB1/blob/main/extensions/home-maintenance/README.md"
+      },
+      "readme_markdown": "# Extension 2: Home Maintenance Tracker\n\n## Why This Matters\n\nThe HVAC tech mentioned the pump was showing wear 18 months ago. The warranty on the water heater expires next month. The gutters haven't been cleaned since... when exactly? Without a system, these connections never get made — you just get expensive surprises. Your agent can track every maintenance task, remind you what's coming due, and keep a complete history so nothing slips through.\n\n## Learning Path: Extension 2 of 6\n\n| Extension | Name | Status |\n|-----------|------|--------|\n| 1 | Household Knowledge Base | Complete |\n| **2** | **Home Maintenance Tracker** | **<-- You are here** |\n| 3 | Family Calendar | Not started |\n| 4 | Meal Planning & Recipes | Not started |\n| 5 | Professional CRM | Not started |\n| 6 | Job Hunt Pipeline | Not started |\n\n## What It Does\n\nA maintenance scheduling and history system. Track recurring tasks, log completed work, and let your agent surface what needs attention before it becomes an emergency.\n\n## What You'll Learn\n\n- Date handling and scheduling logic in PostgreSQL\n- One-to-many relationships (task → multiple log entries)\n- Automatic timestamp updates with triggers\n- Time-based queries (upcoming tasks, date ranges)\n- Computed fields (calculating next_due based on frequency)\n- Historical logging patterns\n\n## Prerequisites\n\n- Working Open Brain setup\n- Supabase project configured\n- Supabase CLI installed and linked to your project\n- Extension 1 recommended but not required\n\n## Credential Tracker\n\nYou'll reference these values during setup. Copy this block into a text editor and fill it in as you go.\n\n> **Already have your Supabase credentials from the [Setup Guide](https://github.com/NateBJones-Projects/OB1/blob/main/docs/01-getting-started.md)?** You just need the same Project URL and Secret key.\n\n```text\nHOME MAINTENANCE -- CREDENTIAL TRACKER\n--------------------------------------\n\nSUPABASE (from your Open Brain setup)\n  Project URL:           ____________\n  Secret key:            ____________\n  Project ref:           ____________\n\nGENERATED DURING SETUP\n  Default User ID:       ____________\n  MCP Access Key:        ____________  (same key for all extensions)\n  MCP Server URL:        ____________\n  MCP Connection URL:    ____________\n\n--------------------------------------\n```\n\n## Steps\n\n### 1. Set Up the Database Schema\n\nRun the SQL in `schema.sql` in your Supabase SQL Editor:\n\n```bash\n# Navigate to your Supabase project SQL editor\n# https://supabase.com/dashboard/project/YOUR_PROJECT_ID/sql/new\n```\n\nCopy and paste the contents of `schema.sql` and click Run.\n\n### 2. Generate Your User ID\n\nThe extension needs a user ID to scope your data. Generate a UUID and save it in your credential tracker:\n\n```bash\n# macOS / Linux\nuuidgen | tr '[:upper:]' '[:lower:]'\n\n# Or use any UUID generator — the value just needs to be unique to you\n```\n\nSet it as an environment variable for your Edge Function:\n\n```bash\nsupabase secrets set DEFAULT_USER_ID=your-generated-uuid-here\n```\n\n> If you already set `DEFAULT_USER_ID` for a previous extension, you can skip this step — all extensions share the same user ID.\n\n### 3. Deploy the MCP Server\n\nFollow the [Deploy an Edge Function](/ob1/primitives/deploy-edge-function) guide using these values:\n\n| Setting | Value |\n|---------|-------|\n| Function name | `home-maintenance-mcp` |\n| Download path | `extensions/home-maintenance` |\n\n### 4. Connect to Your AI\n\nFollow the [Remote MCP Connection](/ob1/primitives/remote-mcp) guide to connect this extension to Claude Desktop, ChatGPT, Claude Code, or any other MCP client.\n\n| Setting | Value |\n|---------|-------|\n| Connector name | `Home Maintenance` |\n| URL | Your **MCP Connection URL** from the credential tracker |\n\n### 5. Test the Extension\n\nTry these commands with Claude:\n\n```\nAdd a maintenance task: HVAC filter replacement, every 90 days, next due April 15th\n```\n\n```\nLog maintenance: I just changed the HVAC filter, cost $45, did it myself\n```\n\n```\nWhat maintenance is coming up in the next 30 days?\n```\n\n```\nShow me the history for HVAC maintenance\n```\n\n## Cross-Extension Integration\n\nThe maintenance tracker introduces patterns you'll see throughout the remaining extensions:\n\n- **Task → Log entries pattern**: A parent record (maintenance_task) with multiple child records (maintenance_logs). This same one-to-many pattern appears in:\n  - Extension 5 (Professional CRM): contact → interaction logs\n  - Extension 6 (Job Hunt Pipeline): application → interview logs\n\n- **Auto-calculated dates**: The `log_maintenance` tool automatically updates `last_completed` and calculates `next_due` based on `frequency_days`. This computed field pattern shows how your database can maintain derived state without manual updates.\n\n- **Time-based queries**: The `get_upcoming_maintenance` tool demonstrates how to query for records in a date range — essential for calendar systems (Extension 3) and deadline tracking (Extension 6).\n\n- **Historical search**: The `search_maintenance_history` tool shows how to search across both parent and child tables with date filtering.\n\n### Connection to Extension 1\n\nIf you built Extension 1 (Household Knowledge Base), you can reference your `household_vendors` when logging maintenance. The `performed_by` field in maintenance logs can store vendor names, creating an informal link between systems. In a production setup, you might add a foreign key to make this relationship explicit.\n\n## Expected Outcome\n\nAfter completing this extension, you should be able to:\n\n1. Create recurring and one-time maintenance tasks\n2. Log completed maintenance with cost and notes\n3. Automatically calculate next due dates based on frequency\n4. Query upcoming maintenance within a time window\n5. Search maintenance history by task, category, or date range\n\nYour agent will be able to answer questions like:\n- \"What maintenance is due this month?\"\n- \"When did we last service the HVAC?\"\n- \"How much have we spent on plumbing maintenance this year?\"\n- \"What did the electrician recommend last time?\"\n\n## Troubleshooting\n\nFor common issues (connection errors, 401s, deployment problems), see [Common Troubleshooting](/ob1/primitives/troubleshooting).\n\n**Extension-specific issues:**\n\n**\"next_due not updating after logging maintenance\"**\n- Verify that the task has a `frequency_days` value set\n- Check that the `log_maintenance` tool completed successfully\n- For one-time tasks (frequency_days = null), next_due remains null\n\n**\"Date parsing errors\"**\n- Ensure dates are in ISO 8601 format: `YYYY-MM-DD` or `YYYY-MM-DDTHH:MM:SSZ`\n\n## Next Steps\n\n**Extension 3: Family Calendar** — Build on your date-handling skills to create a shared calendar system with event reminders and conflict detection. The calendar extends the time-based query patterns you learned here and introduces more complex date logic (recurring events, all-day vs. timed events, timezone handling).\n\n[Continue to Extension 3 →](/ob1/extensions/family-calendar)\n\n> **Tip:** You now have two MCP servers connected. As you add more, consider which ones to keep active per conversation. The [MCP Tool Audit & Optimization Guide](https://github.com/NateBJones-Projects/OB1/blob/main/docs/05-tool-audit.md) covers strategies for managing your tool surface area.\n"
+    },
+    {
+      "slug": "household-knowledge",
+      "category": "extensions",
+      "site_path": "/ob1/extensions/household-knowledge",
+      "name": "Household Knowledge Base",
+      "description": "Store and retrieve household facts — paint colors, appliance details, vendor contacts, measurements, and more.",
+      "author": {
+        "name": "Nate B. Jones",
+        "github": "NateBJones"
+      },
+      "version": "1.0.0",
+      "tags": [
+        "household",
+        "home",
+        "knowledge-base",
+        "beginner"
+      ],
+      "difficulty": "beginner",
+      "estimated_time": "30 minutes",
+      "created": "2026-03-12",
+      "updated": "2026-03-12",
+      "learning_order": 1,
+      "compatibility": {
+        "open_brain": "required"
+      },
+      "requirements": {
+        "services": [],
+        "tools": [
+          "Supabase CLI"
+        ]
+      },
+      "dependencies": {
+        "skills": [],
+        "primitives": [
+          "deploy-edge-function",
+          "remote-mcp"
+        ]
+      },
+      "reverse_dependencies": {
+        "skills": [],
+        "primitives": []
+      },
+      "urls": {
+        "github_folder": "https://github.com/NateBJones-Projects/OB1/tree/main/extensions/household-knowledge",
+        "github_readme": "https://github.com/NateBJones-Projects/OB1/blob/main/extensions/household-knowledge/README.md"
+      },
+      "readme_markdown": "# Extension 1: Household Knowledge Base\n\n## Why This Matters\n\nYou're at the paint store and can't remember what shade of blue is in the living room. Your kid's shoe size changed and you're ordering online from memory. The plumber who fixed the leak last year — what was their number? Every household accumulates hundreds of small facts that matter at exactly the wrong moment. Your Open Brain agent can hold all of them and surface them when you need them.\n\n## Learning Path: Extension 1 of 6\n\n| Extension | Name | Status |\n|-----------|------|--------|\n| **1** | **Household Knowledge Base** | **<-- You are here** |\n| 2 | Home Maintenance Tracker | Not started |\n| 3 | Family Calendar | Not started |\n| 4 | Meal Planning & Recipes | Not started |\n| 5 | Professional CRM | Not started |\n| 6 | Job Hunt Pipeline | Not started |\n\n## What It Does\n\nA database and MCP server for storing and retrieving household facts — paint colors, appliance details, vendor contacts, measurements, warranty info, and anything else about your home and family that you'd otherwise forget.\n\n## What You'll Learn\n\n- Basic table design with PostgreSQL\n- User-scoped data isolation with environment variables\n- Simple MCP tool creation\n- JSONB patterns for flexible metadata storage\n- Text search with ILIKE patterns\n- Building a Supabase-backed MCP server\n\n## Prerequisites\n\n- Working Open Brain setup\n- Supabase project configured\n- Supabase CLI installed and linked to your project\n\n## Credential Tracker\n\nYou'll reference these values during setup. Copy this block into a text editor and fill it in as you go.\n\n> **Already have your Supabase credentials from the [Setup Guide](https://github.com/NateBJones-Projects/OB1/blob/main/docs/01-getting-started.md)?** You just need the same Project URL and Secret key.\n\n```text\nHOUSEHOLD KNOWLEDGE -- CREDENTIAL TRACKER\n--------------------------------------\n\nSUPABASE (from your Open Brain setup)\n  Project URL:           ____________\n  Secret key:            ____________\n  Project ref:           ____________\n\nGENERATED DURING SETUP\n  Default User ID:       ____________\n  MCP Access Key:        ____________  (same key for all extensions)\n  MCP Server URL:        ____________\n  MCP Connection URL:    ____________\n\n--------------------------------------\n```\n\n## Steps\n\n### 1. Set Up the Database Schema\n\nRun the SQL in `schema.sql` in your Supabase SQL Editor:\n\n```bash\n# Navigate to your Supabase project SQL editor\n# https://supabase.com/dashboard/project/YOUR_PROJECT_ID/sql/new\n```\n\nCopy and paste the contents of `schema.sql` and click Run.\n\n### 2. Generate Your User ID\n\nThe extension needs a user ID to scope your data. Generate a UUID and save it in your credential tracker:\n\n```bash\n# macOS / Linux\nuuidgen | tr '[:upper:]' '[:lower:]'\n\n# Or use any UUID generator — the value just needs to be unique to you\n```\n\nSet it as an environment variable for your Edge Function:\n\n```bash\nsupabase secrets set DEFAULT_USER_ID=your-generated-uuid-here\n```\n\n### 3. Deploy the MCP Server\n\nFollow the [Deploy an Edge Function](/ob1/primitives/deploy-edge-function) guide using these values:\n\n| Setting | Value |\n|---------|-------|\n| Function name | `household-knowledge-mcp` |\n| Download path | `extensions/household-knowledge` |\n\n### 4. Connect to Your AI\n\nFollow the [Remote MCP Connection](/ob1/primitives/remote-mcp) guide to connect this extension to Claude Desktop, ChatGPT, Claude Code, or any other MCP client.\n\n| Setting | Value |\n|---------|-------|\n| Connector name | `Household Knowledge` |\n| URL | Your **MCP Connection URL** from the credential tracker |\n\n### 5. Test the Extension\n\nTry these commands with Claude:\n\n```\nAdd a household item: living room paint is Sherwin Williams Sea Salt SW 6204\n```\n\n```\nSearch for paint colors in my household items\n```\n\n```\nAdd a vendor: Mike's Plumbing, phone 555-1234, last used them in December 2025\n```\n\n```\nList all my plumbers\n```\n\n## Cross-Extension Integration\n\nThis is the foundation. Future extensions build on the pattern you learn here:\n\n- **JSONB flexibility pattern**: The `details` field in `household_items` uses JSONB to store arbitrary key-value pairs. You'll see this same pattern in Extension 4 (Meal Planning) for recipe ingredients and in Extension 5 (Professional CRM) for contact metadata.\n\n- **Vendor tracking pattern**: The `household_vendors` table introduces a contact management pattern that evolves into full contact tracking in Extension 5 (Professional CRM).\n\n- **User-scoped data**: Every query filters by `user_id`. This pattern is consistent across all extensions and ensures data isolation in multi-user environments.\n\n## Expected Outcome\n\nAfter completing this extension, you should be able to:\n\n1. Store household facts with flexible metadata\n2. Search items by name, category, or location\n3. Track service providers with contact information\n4. Retrieve specific item details on demand\n\nYour agent will be able to answer questions like:\n- \"What's the model number of my dishwasher?\"\n- \"When did we last use the electrician?\"\n- \"What paint color is in the bedroom?\"\n- \"Who's a good plumber we've used before?\"\n\n## Troubleshooting\n\nFor common issues (connection errors, 401s, deployment problems), see [Common Troubleshooting](/ob1/primitives/troubleshooting).\n\n**Extension-specific issues:**\n\n**\"Permission denied\" or foreign key errors on insert**\n- Verify `DEFAULT_USER_ID` is set: `supabase secrets list` should show it\n- The service role key bypasses RLS, so permission errors usually mean a missing env var\n- If you ran an older version of `schema.sql` that had `REFERENCES auth.users(id)`, drop and recreate the tables with the updated schema\n\n## Next Steps\n\n**Extension 2: Home Maintenance Tracker** — Learn how to handle recurring tasks, date-based scheduling, and historical logging. The maintenance tracker introduces one-to-many relationships (task → multiple log entries) and time-based queries that surface upcoming work.\n\n[Continue to Extension 2 →](/ob1/extensions/home-maintenance)\n\n> **As you add extensions**, each one adds MCP tool definitions to your AI's context window. By Extension 3–4, it's worth thinking about which servers you keep connected. See the [MCP Tool Audit & Optimization Guide](https://github.com/NateBJones-Projects/OB1/blob/main/docs/05-tool-audit.md) for strategies.\n"
+    },
+    {
+      "slug": "job-hunt",
+      "category": "extensions",
+      "site_path": "/ob1/extensions/job-hunt",
+      "name": "Job Hunt Pipeline",
+      "description": "Complete job search management — companies, applications, interviews, and pipeline analytics with CRM integration.",
+      "author": {
+        "name": "Nate B. Jones",
+        "github": "NateBJones"
+      },
+      "version": "1.0.0",
+      "tags": [
+        "job-hunt",
+        "career",
+        "pipeline",
+        "interviews",
+        "applications",
+        "rls"
+      ],
+      "difficulty": "advanced",
+      "estimated_time": "1 hour",
+      "created": "2026-03-12",
+      "updated": "2026-03-12",
+      "learning_order": 6,
+      "compatibility": {
+        "open_brain": "required"
+      },
+      "requirements": {
+        "services": [],
+        "tools": [
+          "Supabase CLI"
+        ]
+      },
+      "dependencies": {
+        "skills": [],
+        "primitives": [
+          "deploy-edge-function",
+          "remote-mcp",
+          "rls"
+        ]
+      },
+      "reverse_dependencies": {
+        "skills": [],
+        "primitives": []
+      },
+      "urls": {
+        "github_folder": "https://github.com/NateBJones-Projects/OB1/tree/main/extensions/job-hunt",
+        "github_readme": "https://github.com/NateBJones-Projects/OB1/blob/main/extensions/job-hunt/README.md"
+      },
+      "readme_markdown": "# Extension 6: Job Hunt Pipeline\n\n## Why This Matters\n\nJob hunting is an emotional grinder. You think you're failing because you got 3 rejections this week. But your agent can show you that your actual interview conversion rate is 40% — well above average. It can catch that you haven't followed up with the hiring manager at Company X in 8 days. It can normalize compensation across 4 different offer structures so you're comparing apples to apples. The data doesn't lie, and having an agent that can reason across your entire pipeline turns an emotional process into a manageable one.\n\n## Learning Path: Extension 6 of 6\n\n| Extension | Name | Status |\n|-----------|------|--------|\n| 1 | Household Knowledge Base | Completed |\n| 2 | Home Maintenance Tracker | Completed |\n| 3 | Family Calendar | Completed |\n| 4 | Meal Planning & Recipes | Completed |\n| 5 | Professional CRM | Completed |\n| **6** | **Job Hunt Pipeline** | **<-- You are here** |\n\n## What It Does\n\nA complete job search management system — companies, postings, applications, interviews, and contacts. The most complex extension in the learning path, with 5 RLS-protected tables and sophisticated cross-extension integration to your Professional CRM (Extension 5). This extension demonstrates advanced multi-table relationships, pipeline tracking, and data analysis patterns.\n\n## What You'll Learn\n\n- Most complex multi-table schema design (5 tables with cascading relationships)\n- Pipeline/funnel tracking with status transitions\n- Cross-extension integration with Extension 5 (Professional CRM)\n- Advanced queries (conversion rates, timeline analysis, upcoming events)\n- Bridge tables for linking separate data domains\n- Handling nullable foreign keys and optional relationships\n\n## Prerequisites\n\n- Working Open Brain setup\n- Extension 5 (Professional CRM) strongly recommended — cross-extension linking depends on it\n- Supabase CLI installed and linked to your project\n- **Required reading:** [Row Level Security](/ob1/primitives/rls) primitive\n\n## Credential Tracker\n\nYou'll reference these values during setup. Copy this block into a text editor and fill it in as you go.\n\n> **Already have your Supabase credentials from the [Setup Guide](https://github.com/NateBJones-Projects/OB1/blob/main/docs/01-getting-started.md)?** You just need the same Project ref, Secret key, and MCP Access Key — reuse the key from your core setup.\n\n```text\nJOB HUNT PIPELINE -- CREDENTIAL TRACKER\n--------------------------------------\n\nSUPABASE (from your Open Brain setup)\n  Project ref:           ____________\n  Secret key:            ____________\n\nMCP SERVER (new for this extension)\n  Default User ID:       ____________\n  MCP Access Key:        ____________  (same key for all extensions)\n  MCP Server URL:        ____________\n  MCP Connection URL:    ____________\n\n--------------------------------------\n```\n\n## Steps\n\n### 1. Set Up the Database Schema\n\nRun the SQL in `schema.sql` in your Supabase SQL Editor:\n\n```bash\n# Navigate to your Supabase project SQL editor\n# https://supabase.com/dashboard/project/YOUR_PROJECT_ID/sql/new\n```\n\nCopy and paste the contents of `schema.sql` and click Run. This creates five RLS-enabled tables with proper foreign key relationships and cascading deletes.\n\n### 2. Generate Your User ID\n\nThe extension needs a user ID to scope your data. Generate a UUID and save it in your credential tracker:\n\n```bash\n# macOS / Linux\nuuidgen | tr '[:upper:]' '[:lower:]'\n\n# Or use any UUID generator — the value just needs to be unique to you\n```\n\nSet it as an environment variable for your Edge Function:\n\n```bash\nsupabase secrets set DEFAULT_USER_ID=your-generated-uuid-here\n```\n\n> If you already set `DEFAULT_USER_ID` for a previous extension, you can skip this step — all extensions share the same user ID.\n\n### 3. Deploy the MCP Server\n\nFollow the [Deploy an Edge Function](/ob1/primitives/deploy-edge-function) guide using these values:\n\n| Setting | Value |\n|---------|-------|\n| Function name | `job-hunt-mcp` |\n| Download path | `extensions/job-hunt` |\n\n### 4. Connect to Your AI\n\nFollow the [Remote MCP Connection](/ob1/primitives/remote-mcp) guide to connect this extension to Claude Desktop, ChatGPT, Claude Code, or any other MCP client.\n\n| Setting | Value |\n|---------|-------|\n| Connector name | `Job Hunt Pipeline` |\n| URL | Your **MCP Connection URL** from the credential tracker |\n\n### 5. Test the Extension\n\nTry these commands with Claude:\n\n```\nAdd a company I'm tracking: TechCorp, enterprise software company, remote-first, San Francisco\n```\n\n```\nAdd a job posting at TechCorp: Senior AI Engineer, $150k-$200k, posted on LinkedIn\n```\n\n```\nSubmit an application for the TechCorp AI Engineer role, used resume v3\n```\n\n```\nSchedule a phone screen interview for my TechCorp application, tomorrow at 2pm\n```\n\n```\nShow me my pipeline overview - how many applications, what stages, upcoming interviews\n```\n\n```\nAdd a job contact at TechCorp: Jessica Lee, recruiter, jessica@techcorp.com\n```\n\n```\nShow me my TechCorp job contacts\n```\n\n```\nLink the TechCorp recruiter to my professional CRM\n```\n\n## Cross-Extension Integration\n\n**This is the most sophisticated cross-extension integration in the learning path.**\n\n### `link_contact_to_professional_crm` — The Bridge Tool\n\nA recruiter you're talking to during the job search is also a professional contact worth maintaining. Your agent can create the CRM record automatically — the recruiter's name, company, and interaction history carry over. When you land the job (or don't), those contacts don't disappear from your network. They're already in your CRM, ready for the long-term relationship.\n\n**Example workflow:**\n\n1. You add a job contact with `add_job_contact`: \"Jessica Lee, TechCorp recruiter, jessica@techcorp.com\"\n2. You have multiple interactions: phone screen, interview coordination, offer negotiation\n3. If you need to recover the contact later, your agent uses `search_job_contacts` to find the right `job_contact_id`\n4. Your agent uses `link_contact_to_professional_crm` to create a professional_contacts record in Extension 5\n5. The `professional_crm_contact_id` field is set, creating a bidirectional link\n6. After the job search ends, Jessica is already in your CRM with full context: company, role, all notes from the job search\n\n**How it works technically:**\n\nThe bridge tool takes a `job_contact_id` from the `job_contacts` table. In normal use, your agent creates that row with `add_job_contact`, and if it needs to recover the UUID later it can call `search_job_contacts` first. Once it has the ID, it retrieves the contact details and creates a corresponding record in Extension 5's `professional_contacts` table. The `professional_crm_contact_id` field stores the link — this is application-managed rather than a database foreign key, because the two extensions live in separate table domains and you might install one without the other. This means:\n\n- Future interactions in the job hunt also appear in the CRM context\n- You can track the relationship long-term in Extension 5\n- Your networking doesn't restart from zero after the job search\n\n### Integration with Extensions 1-4\n\nYour agent has even more context when you're job hunting:\n\n- **Extension 1 (Household Knowledge):** Knows your current location, family situation relevant to relocation decisions\n- **Extension 2 (Home Maintenance):** Understands timing constraints (e.g., \"I can't start until after the roof replacement in May\")\n- **Extension 3 (Family Calendar):** Can schedule interviews around existing commitments, factor in family obligations\n- **Extension 4 (Meal Planning):** Knows your dietary needs for interview lunches, can plan around busy interview days\n\nThis is the power of a fully interconnected Open Brain — context flows across domains.\n\n## Available Tools\n\n1. **`add_company`** — Add a company to track (name, industry, website, size, location, remote_policy, notes, glassdoor_rating)\n2. **`add_job_posting`** — Add a specific role at a company (company_id, title, url, salary_min, salary_max, requirements, nice_to_haves, source, posted_date)\n3. **`add_job_contact`** — Add a recruiter, hiring manager, referral, or interviewer to `job_contacts` (company_id, name, title, email, phone, linkedin_url, role_in_process, notes, last_contacted)\n4. **`submit_application`** — Record a submitted application (job_posting_id, status, applied_date, resume_version, cover_letter_notes, referral_contact)\n5. **`schedule_interview`** — Schedule an interview for an application (application_id, interview_type, scheduled_at, duration_minutes, interviewer_name, interviewer_title, notes)\n6. **`log_interview_notes`** — Add feedback/notes after an interview, update status to completed (interview_id, feedback, rating 1-5)\n7. **`get_pipeline_overview`** — Dashboard summary: counts by application status, upcoming interviews in next N days, recent activity. This is your \"how's it going?\" tool.\n8. **`get_upcoming_interviews`** — List interviews in the next N days with full company/role context\n9. **`search_job_contacts`** — Search or list job contacts to recover recruiter/interviewer records and IDs before linking or follow-up\n10. **`link_contact_to_professional_crm`** — **CROSS-EXTENSION BRIDGE** — Takes a job_contact_id, creates/links to a professional_contacts record in Extension 5, sets professional_crm_contact_id\n\n## Expected Outcome\n\nAfter completing this extension, you should be able to:\n\n1. Track companies and roles across your entire job search\n2. Manage application status through the pipeline (applied → screening → interviewing → offer → accepted/rejected)\n3. Schedule and log interviews with detailed notes and ratings\n4. Track contacts (recruiters, hiring managers, interviewers) with CRM integration\n5. Get pipeline analytics: conversion rates, stage distribution, interview performance\n6. Bridge job search contacts into your long-term professional network\n\nYour agent will be able to answer questions like:\n- \"Show me my pipeline overview\"\n- \"What interviews do I have this week?\"\n- \"What's my conversion rate from phone screen to technical interview?\"\n- \"Which applications are in the proposal stage?\"\n- \"Who's the recruiter at TechCorp and when did I last talk to them?\"\n- \"Link all my TechCorp contacts to my professional CRM\"\n\n## Troubleshooting\n\nFor common issues (connection errors, 401s, deployment problems), see [Common Troubleshooting](/ob1/primitives/troubleshooting).\n\n**Extension-specific issues:**\n\n**\"Foreign key violation\" errors**\n- Ensure parent records exist before creating child records (company → job_posting → application → interview)\n- Verify UUIDs are correct and belong to the same user_id\n- Deleting a company will cascade-delete all related postings, applications, and interviews\n\n**\"Extension 5 not found\" when linking contacts**\n- Verify Extension 5 (Professional CRM) is installed and its tables exist\n- Check that the `professional_contacts` table is accessible\n- Ensure both extensions are using the same Supabase project\n\n## Next Steps\n\n**You've completed all 6 extensions!**\n\nAt this point, your agent has a comprehensive, interconnected system:\n\n- **Extension 1:** Household knowledge (paint colors, appliances, vendors)\n- **Extension 2:** Home maintenance (recurring tasks, service logs)\n- **Extension 3:** Family calendar (events, recurring schedules)\n- **Extension 4:** Meal planning (recipes, shopping lists, meal schedules)\n- **Extension 5:** Professional CRM (contacts, interactions, opportunities)\n- **Extension 6:** Job hunt pipeline (companies, applications, interviews)\n\nAll wired together through your Open Brain, with cross-extension tools that let context flow between domains.\n\n### What's Next?\n\n1. **Audit and optimize your tools** — You now have ~40 MCP tool definitions across 6 extensions. That's a lot of context weight. Run the [MCP Tool Audit & Optimization Guide](https://github.com/NateBJones-Projects/OB1/blob/main/docs/05-tool-audit.md) to identify redundancies, merge CRUD tools, and scope your servers by workflow. This is the single highest-impact thing you can do to keep your AI performing well.\n2. **Build your own extensions** — Use these 6 as templates for domains specific to your life\n3. **Explore primitives** — Dive deeper into [Row Level Security](/ob1/primitives/rls), [Remote MCP](/ob1/primitives/remote-mcp), and other patterns\n4. **Create compound queries** — Build tools that reason across multiple extensions simultaneously\n5. **Share your extensions** — Contribute back to the OB1 community\n\n[Explore Primitives →](/ob1/primitives)\n"
+    },
+    {
+      "slug": "meal-planning",
+      "category": "extensions",
+      "site_path": "/ob1/extensions/meal-planning",
+      "name": "Meal Planning",
+      "description": "Recipes, weekly meal plans, and shared shopping lists with RLS and a dedicated shared MCP server for household access.",
+      "author": {
+        "name": "Nate B. Jones",
+        "github": "NateBJones"
+      },
+      "version": "1.0.0",
+      "tags": [
+        "meal-planning",
+        "recipes",
+        "shopping",
+        "sharing",
+        "rls"
+      ],
+      "difficulty": "intermediate",
+      "estimated_time": "1 hour",
+      "created": "2026-03-12",
+      "updated": "2026-03-12",
+      "learning_order": 4,
+      "compatibility": {
+        "open_brain": "required"
+      },
+      "requirements": {
+        "services": [],
+        "tools": [
+          "Supabase CLI"
+        ]
+      },
+      "dependencies": {
+        "skills": [],
+        "primitives": [
+          "deploy-edge-function",
+          "remote-mcp",
+          "rls",
+          "shared-mcp"
+        ]
+      },
+      "reverse_dependencies": {
+        "skills": [],
+        "primitives": []
+      },
+      "urls": {
+        "github_folder": "https://github.com/NateBJones-Projects/OB1/tree/main/extensions/meal-planning",
+        "github_readme": "https://github.com/NateBJones-Projects/OB1/blob/main/extensions/meal-planning/README.md"
+      },
+      "readme_markdown": "# Extension 4: Meal Planning\n\n## Why This Matters\n\nYour agent can reason across five datasets — what you've cooked before, what's in the pantry, who's home this week (from your family calendar), what people actually liked, and what you need to buy. That's meal planning that actually works. And your spouse needs access too — not to your whole brain, just to the meal plan and the shopping list. This is where you learn to share specific parts of your system with someone else.\n\n## Learning Path: Extension 4 of 6\n\n| Extension | Name | Status |\n|-----------|------|--------|\n| 1 | Household Knowledge Base | Complete |\n| 2 | Home Maintenance Tracker | Complete |\n| 3 | Family Calendar | Complete |\n| **4** | **Meal Planning** | **<-- You are here** |\n| 5 | Professional CRM | Not started |\n| 6 | Job Hunt Pipeline | Not started |\n\n## What You'll Learn\n\n- Row Level Security (first introduction to multi-user access)\n- Shared MCP server (separate server with limited, scoped access)\n- JSONB for complex data (ingredients, instructions)\n- Auto-generating derivative data (shopping lists from meal plans)\n- Cross-extension queries (checking who's home this week from the family calendar)\n\n## What It Does\n\nA complete meal planning system with recipes, weekly meal plans, and auto-generated shopping lists. Includes a separate shared MCP server so your partner can view plans and check off grocery items without accessing your full Open Brain.\n\n**Tables:**\n- `recipes` — Your recipe collection with JSONB ingredients and instructions\n- `meal_plans` — Weekly meal planning linked to recipes\n- `shopping_lists` — Auto-generated grocery lists from meal plans\n\n**Primary MCP Tools (full access):**\n- `add_recipe` — Add a recipe with ingredients and instructions\n- `search_recipes` — Search by name, cuisine, tags, or ingredient\n- `update_recipe` — Update an existing recipe\n- `create_meal_plan` — Plan meals for a week\n- `get_meal_plan` — View the meal plan for a given week\n- `generate_shopping_list` — Auto-generate shopping list from meal plan\n\n**Shared MCP Tools (household access):**\n- `view_meal_plan` — View meal plans (read-only)\n- `view_recipes` — Browse recipes (read-only)\n- `view_shopping_list` — View shopping list\n- `mark_item_purchased` — Toggle item purchased status\n\n## Prerequisites\n\n- Working Open Brain setup\n- Extensions 1-3 recommended (Extension 3's family_members table is referenced for cross-extension integration)\n- Supabase CLI installed and linked to your project\n- **Required reading:** [Row Level Security](/ob1/primitives/rls) primitive\n- **Required reading:** [Shared MCP Server](/ob1/primitives/shared-mcp) primitive\n\n## Credential Tracker\n\nYou'll reference these values during setup. Copy this block into a text editor and fill it in as you go.\n\n> **Already have your Supabase credentials from the [Setup Guide](https://github.com/NateBJones-Projects/OB1/blob/main/docs/01-getting-started.md)?** You just need the same Project URL and Secret key.\n\n```text\nMEAL PLANNING -- CREDENTIAL TRACKER\n--------------------------------------\n\nSUPABASE (from your Open Brain setup)\n  Project URL:           ____________\n  Secret key:            ____________\n  Project ref:           ____________\n\nGENERATED DURING SETUP\n  Default User ID:             ____________\n  MCP Access Key:              ____________  (same key for all extensions)\n  MCP Server URL:              ____________\n  MCP Connection URL:          ____________\n\nFOR SHARED SERVER\n  Household Access Key:        ____________\n  Household Key (Supabase):    ____________\n  Shared Server URL:           ____________\n  Shared Connection URL:       ____________\n\nNOTE: This extension uses TWO Edge Functions:\n  1. Primary (meal-planning-mcp) — your full access\n  2. Shared (meal-planning-shared-mcp) — household read + shopping list\n\n--------------------------------------\n```\n\n## Steps\n\n> **No JSON config files. No local Node.js server. Same pattern as your core Open Brain setup.**\n\n### 1. Create the Database Schema\n\nRun the SQL in `schema.sql` against your Supabase database. This creates three RLS-enabled tables:\n\n```bash\n# Using Supabase SQL Editor (recommended)\n# 1. Open https://supabase.com/dashboard/project/YOUR_PROJECT_ID/sql/new\n# 2. Paste the contents of schema.sql\n# 3. Click \"Run\"\n```\n\n**Important:** The schema includes Row Level Security policies. Make sure you understand what RLS does before proceeding (see the [RLS primitive](/ob1/primitives/rls)).\n\n### 2. Generate Your User ID\n\nThe extension needs a user ID to scope your data. Generate a UUID and save it in your credential tracker:\n\n```bash\n# macOS / Linux\nuuidgen | tr '[:upper:]' '[:lower:]'\n\n# Or use any UUID generator — the value just needs to be unique to you\n```\n\nSet it as an environment variable for your Edge Function:\n\n```bash\nsupabase secrets set DEFAULT_USER_ID=your-generated-uuid-here\n```\n\n> If you already set `DEFAULT_USER_ID` for a previous extension, you can skip this step — all extensions share the same user ID.\n\n### 3. Deploy the Primary MCP Server\n\nFollow the [Deploy an Edge Function](/ob1/primitives/deploy-edge-function) guide using these values:\n\n| Setting | Value |\n|---------|-------|\n| Function name | `meal-planning-mcp` |\n| Download path | `extensions/meal-planning` |\n\n### 4. Connect to Your AI\n\nFollow the [Remote MCP Connection](/ob1/primitives/remote-mcp) guide to connect this extension to Claude Desktop, ChatGPT, Claude Code, or any other MCP client.\n\n| Setting | Value |\n|---------|-------|\n| Connector name | `Meal Planning` |\n| URL | Your **MCP Connection URL** from the credential tracker |\n\n### 5. Test the Primary Server\n\nTry these prompts in Claude Desktop:\n\n```\nAdd a recipe: Chicken Stir-Fry. Ingredients: 1 lb chicken breast, 2 cups broccoli, 1 cup bell peppers, 3 tbsp soy sauce, 2 tbsp oil. Instructions: 1) Cut chicken into cubes. 2) Heat oil in wok. 3) Cook chicken 5 min. 4) Add vegetables, cook 3 min. 5) Add soy sauce, toss well. Tags: quick, healthy, asian. Prep 10 min, cook 15 min, serves 4.\n\nPlan meals for the week of March 17: Monday dinner is the chicken stir-fry, Tuesday dinner is pasta night (custom meal, no recipe), Wednesday dinner is tacos.\n\nGenerate a shopping list for the week of March 17.\n```\n\n## Setting Up the Shared Server\n\nThe shared server gives household members limited access — they can view meal plans, browse recipes, and manage the shopping list without accessing your full Open Brain.\n\n### 1. Create a Household Member Role in Supabase\n\nThe RLS policies check for `auth.jwt() ->> 'role' = 'household_member'`. You need to create a JWT with this claim:\n\n**Option A: Create a separate Supabase user for your spouse**\n1. Go to Supabase Dashboard → Authentication → Users\n2. Create a new user with your spouse's email\n3. In the SQL Editor, grant the household_member role:\n\n```sql\n-- Create a custom claim for this user\nUPDATE auth.users\nSET raw_app_meta_data = jsonb_set(\n  COALESCE(raw_app_meta_data, '{}'),\n  '{role}',\n  '\"household_member\"'\n)\nWHERE email = 'spouse@example.com';\n```\n\n**Option B: Use a shared service account**\n1. Create a new Supabase API key in Settings → API with limited permissions\n2. This is simpler but less granular than per-user authentication\n\nFor this guide, we'll use Option B (shared service account).\n\n### 2. Deploy the Shared Edge Function\n\nFollow the [Deploy an Edge Function](/ob1/primitives/deploy-edge-function) guide with these differences:\n\n| Setting | Value |\n|---------|-------|\n| Function name | `meal-planning-shared-mcp` |\n| Download path | `extensions/meal-planning` |\n| Server file | `shared-server.ts` (not `index.ts`) |\n| Access key secret name | `MCP_HOUSEHOLD_ACCESS_KEY` (not `MCP_ACCESS_KEY`) |\n\nYou'll also need to set the household Supabase key:\n\n```bash\nsupabase secrets set SUPABASE_HOUSEHOLD_KEY=household-scoped-api-key\n```\n\n### 3. Connect Your Household Member\n\nYour spouse/partner follows the [Remote MCP Connection](/ob1/primitives/remote-mcp) guide on their device:\n\n| Setting | Value |\n|---------|-------|\n| Connector name | `Meal Planning (Shared)` |\n| URL | The shared server's MCP Connection URL |\n\nThey can view meal plans and check off grocery items. They cannot create recipes, modify meal plans, or access other parts of your Open Brain.\n\n### 4. Test the Shared Server\n\nYour spouse can now use prompts like:\n\n```\nWhat's for dinner this week?\nShow me the shopping list for this week.\nMark \"chicken breast\" as purchased.\nSearch recipes tagged \"quick\".\n```\n\n## Cross-Extension Integration\n\n**With Family Calendar (Extension 3):**\nYour agent can check who's home this week via the `family_members` and `activities` tables to adjust serving sizes. Example prompt:\n\n```\nWho's home for dinner this week? Adjust the meal plan servings accordingly.\n```\n\n**With Household Knowledge Base (Extension 1):**\nCross-reference pantry inventory: \"Do we have the ingredients for chicken stir-fry?\" queries both the recipe's ingredients and your knowledge base entries about pantry stock.\n\n**Pattern reuse:**\nThe RLS patterns you learn here apply directly to Extensions 5 (Professional CRM) and 6 (Job Hunt Pipeline). The shared MCP server pattern is reusable for any future extension where you want to give someone else partial access.\n\n## Expected Outcome\n\nYour agent can now:\n\n- Store and search your recipe collection\n- Plan weekly meals with a mix of recipes and custom entries\n- Auto-generate shopping lists by aggregating recipe ingredients\n- Let your spouse view plans and check off grocery items without full system access\n\nThe shared server demonstrates a key Open Brain principle: your data, your rules. You control exactly what someone else can see and do.\n\n## Troubleshooting\n\nFor common issues (connection errors, 401s, deployment problems), see [Common Troubleshooting](/ob1/primitives/troubleshooting).\n\n**Extension-specific issues:**\n\n**RLS policies blocking queries on the shared server**\n- Verify your user has the `household_member` role set in `raw_app_meta_data`\n- Check the RLS policies match the schema.sql\n- Test with service role key first to confirm it's not an RLS issue\n\n**JSONB ingredient search not working**\n- The `search_recipes` tool uses `.cs.` (contains) operator for JSONB — ingredient names must match exactly (case-insensitive)\n- For more flexible search, consider adding a GIN index on the ingredients JSONB column\n\n**Shopping list aggregation is wrong**\n- The current implementation does simple string concatenation for quantities (e.g., \"1 cup + 2 cups\")\n- For production use, you'd want smarter quantity aggregation\n\n**Shared server can see all data**\n- Double-check that RLS policies are enabled (`ALTER TABLE ... ENABLE ROW LEVEL SECURITY`)\n- Verify the `household_member` role is set correctly in the JWT claims\n- Test by trying to insert/delete from the shared server (should fail)\n\n## Next Steps\n\n**Extension 5: Professional CRM** — You'll apply the RLS skills you just learned to protect professional contact data. The shared server pattern isn't needed here (your work contacts are private), but the multi-entity relationship (contacts → interactions) is the same pattern you used in Extension 3 (family members → activities).\n\n**Key concepts in Extension 5:**\n- Contact management with interaction history\n- Relationship tracking and follow-up reminders\n- RLS for sensitive professional data\n- Integration with calendar (Extension 3) for scheduling follow-ups\n\nContinue to [Extension 5: Professional CRM](/ob1/extensions/professional-crm)\n\n> **Tool surface area:** This extension introduced the concept of scoped servers — a primary server with full access and a shared server with limited tools. That same principle applies to how you organize all your MCP tools. With ~25 tools across 4 extensions now, consider running the [MCP Tool Audit & Optimization Guide](https://github.com/NateBJones-Projects/OB1/blob/main/docs/05-tool-audit.md) to identify which servers to connect per workflow and whether any tools can be consolidated.\n"
+    },
+    {
+      "slug": "professional-crm",
+      "category": "extensions",
+      "site_path": "/ob1/extensions/professional-crm",
+      "name": "Professional CRM",
+      "description": "Track professional contacts, log interactions, manage opportunities, and connect your network to your thoughts.",
+      "author": {
+        "name": "Nate B. Jones",
+        "github": "NateBJones"
+      },
+      "version": "1.0.0",
+      "tags": [
+        "crm",
+        "contacts",
+        "networking",
+        "professional",
+        "rls"
+      ],
+      "difficulty": "intermediate",
+      "estimated_time": "45 minutes",
+      "created": "2026-03-12",
+      "updated": "2026-03-12",
+      "learning_order": 5,
+      "compatibility": {
+        "open_brain": "required"
+      },
+      "requirements": {
+        "services": [],
+        "tools": [
+          "Supabase CLI"
+        ]
+      },
+      "dependencies": {
+        "skills": [],
+        "primitives": [
+          "deploy-edge-function",
+          "remote-mcp",
+          "rls"
+        ]
+      },
+      "reverse_dependencies": {
+        "skills": [],
+        "primitives": []
+      },
+      "urls": {
+        "github_folder": "https://github.com/NateBJones-Projects/OB1/tree/main/extensions/professional-crm",
+        "github_readme": "https://github.com/NateBJones-Projects/OB1/blob/main/extensions/professional-crm/README.md"
+      },
+      "readme_markdown": "# Extension 5: Professional CRM\n\n## Why This Matters\n\nYou ran into someone at a conference six months ago. They mentioned they were looking for exactly what you do. You said you'd follow up. You didn't. That connection is gone — not because you're bad at networking, but because no human can track hundreds of professional relationships in their head. Your agent could have surfaced that contact three days after the conversation and reminded you to follow up. It could tell you, before your next meeting with someone, every interaction you've had and every note you've captured about them.\n\n## Learning Path: Extension 5 of 6\n\n| Extension | Name | Status |\n|-----------|------|--------|\n| 1 | Household Knowledge Base | Completed |\n| 2 | Home Maintenance Tracker | Completed |\n| 3 | Family Calendar | Completed |\n| 4 | Meal Planning & Recipes | Completed |\n| **5** | **Professional CRM** | **<-- You are here** |\n| 6 | Job Hunt Pipeline | Not started |\n\n## What It Does\n\nA professional contact management system with interaction logging, opportunity tracking, and follow-up reminders. RLS-protected so your professional network stays private. This extension introduces multi-level relationships (contacts → interactions → opportunities) and cross-extension integration with your core Open Brain thoughts table.\n\n## What You'll Learn\n\n- Applying RLS patterns (practiced in Extension 4)\n- Multi-level relationships across three tables\n- Pipeline/opportunity tracking with stage management\n- Auto-updating timestamps (last_contacted)\n- Cross-extension integration with the core Open Brain\n- Bridge tools that connect different data domains\n\n## Prerequisites\n\n- Working Open Brain setup\n- Extensions 1-4 recommended (RLS concepts from Extension 4 are required knowledge)\n- Supabase CLI installed and linked to your project\n- **Required reading:** [Row Level Security](/ob1/primitives/rls) primitive\n\n## Credential Tracker\n\nYou'll reference these values during setup. Copy this block into a text editor and fill it in as you go.\n\n> **Already have your Supabase credentials from the [Setup Guide](https://github.com/NateBJones-Projects/OB1/blob/main/docs/01-getting-started.md)?** You just need the same Project URL, Secret key, and MCP Access Key — reuse the key from your core setup.\n\n```text\nPROFESSIONAL CRM -- CREDENTIAL TRACKER\n--------------------------------------\n\nSUPABASE (from your Open Brain setup)\n  Project ref:           ____________\n  Project URL:           ____________\n  Secret key:            ____________\n\nMCP SERVER (you'll create these)\n  Default User ID:       ____________\n  MCP Access Key:        ____________  (same key for all extensions)\n  MCP Server URL:        ____________\n  MCP Connection URL:    ____________\n\n--------------------------------------\n```\n\n## Steps\n\n### 1. Set Up the Database Schema\n\nRun the SQL in `schema.sql` in your Supabase SQL Editor:\n\n```bash\n# Navigate to your Supabase project SQL editor\n# https://supabase.com/dashboard/project/YOUR_PROJECT_ID/sql/new\n```\n\nCopy and paste the contents of `schema.sql` and click Run. This creates three RLS-enabled tables with proper foreign key relationships.\n\n### 2. Generate Your User ID\n\nThe extension needs a user ID to scope your data. Generate a UUID and save it in your credential tracker:\n\n```bash\n# macOS / Linux\nuuidgen | tr '[:upper:]' '[:lower:]'\n\n# Or use any UUID generator — the value just needs to be unique to you\n```\n\nSet it as an environment variable for your Edge Function:\n\n```bash\nsupabase secrets set DEFAULT_USER_ID=your-generated-uuid-here\n```\n\n> If you already set `DEFAULT_USER_ID` for a previous extension, you can skip this step — all extensions share the same user ID.\n\n### 3. Deploy the MCP Server\n\nFollow the [Deploy an Edge Function](/ob1/primitives/deploy-edge-function) guide using these values:\n\n| Setting | Value |\n|---------|-------|\n| Function name | `professional-crm-mcp` |\n| Download path | `extensions/professional-crm` |\n\n### 4. Connect to Your AI\n\nFollow the [Remote MCP Connection](/ob1/primitives/remote-mcp) guide to connect this extension to Claude Desktop, ChatGPT, Claude Code, or any other MCP client.\n\n| Setting | Value |\n|---------|-------|\n| Connector name | `Professional CRM` |\n| URL | Your **MCP Connection URL** from the credential tracker |\n\n### 5. Test the Extension\n\nTry these commands with Claude:\n\n```\nAdd a professional contact: Sarah Chen, works at DataCorp as VP of Engineering, met at AI Summit 2026\n```\n\n```\nLog an interaction: had coffee with Sarah Chen yesterday, discussed their RAG pipeline needs, follow up needed\n```\n\n```\nShow me everyone I need to follow up with this week\n```\n\n```\nCreate an opportunity: DataCorp consulting project, linked to Sarah Chen, in conversation stage, estimated $50k\n```\n\n## Cross-Extension Integration\n\n**This is where extensions start to compound in power.**\n\n### `link_thought_to_contact` — The Bridge Tool\n\nYour core Open Brain captures thoughts all day long. Some of those thoughts mention people. This tool bridges the gap — your agent sees a thought about someone and can surface it before your next meeting with them.\n\n**Example workflow:**\n\n1. You capture a thought: \"Ran into Sarah Chen at the AI meetup — she's looking for someone to help with their RAG pipeline.\"\n2. Your agent uses `link_thought_to_contact` to add this to Sarah's contact record (stored in the contact's notes or tags)\n3. Next time you look up Sarah or have a follow-up due, that thought appears in context\n4. Before your next meeting with Sarah, your agent surfaces: \"Last interaction: coffee 2 weeks ago. Note from recent thought: looking for RAG pipeline help.\"\n\n**How it works technically:**\n\nThe tool takes a `thought_id` (from the core Open Brain `thoughts` table) and a `contact_id` (from `professional_contacts`). It retrieves the thought content and appends it to the contact's notes with a timestamp and reference. This creates a bidirectional link — the contact record gains context, and the thought gains a professional relationship tag.\n\n### Integration with Extension 6 (Job Hunt Pipeline)\n\nIf you build Extension 6, the `link_contact_to_professional_crm` tool works in reverse — recruiters and hiring managers from your job search automatically become professional contacts. Your networking doesn't stop when the job search ends. Those relationships persist in your CRM, ready for the long-term connection.\n\n## Available Tools\n\n1. **`add_professional_contact`** — Add a contact (name, company, title, email, phone, linkedin_url, how_we_met, tags, notes)\n2. **`search_contacts`** — Search by name, company, or tags with ILIKE\n3. **`log_interaction`** — Log a touchpoint (contact_id, interaction_type, summary, follow_up_needed, follow_up_notes). Auto-updates contact's last_contacted timestamp.\n4. **`get_contact_history`** — Get a contact's full profile + all interactions ordered by date\n5. **`create_opportunity`** — Create an opportunity/deal linked to a contact (title, description, stage, value, expected_close_date)\n6. **`get_follow_ups_due`** — List contacts with follow_up_date in the past or next N days\n7. **`update_professional_contact`** — Update only the fields you provide on an existing contact, including setting or clearing `follow_up_date`\n8. **`link_thought_to_contact`** — **CROSS-EXTENSION BRIDGE** — Takes a thought_id and contact_id, retrieves the thought from your core Open Brain, and links it to the contact record\n\n## Expected Outcome\n\nAfter completing this extension, you should be able to:\n\n1. Maintain a professional contact database with rich context\n2. Log every interaction with timestamps and follow-up tracking\n3. Track opportunities through a pipeline (identified → in_conversation → proposal → negotiation → won/lost)\n4. Connect thoughts from your Open Brain to specific contacts\n5. Get proactive follow-up reminders before relationships go cold\n\nYour agent will be able to answer questions like:\n- \"Who do I need to follow up with this week?\"\n- \"Show me my full history with Sarah Chen\"\n- \"What opportunities are in the proposal stage?\"\n- \"Find contacts I met at conferences who work in AI\"\n- \"Which thoughts have I captured about John's project?\"\n\n## Troubleshooting\n\nFor common issues (connection errors, 401s, deployment problems), see [Common Troubleshooting](/ob1/primitives/troubleshooting).\n\n**Extension-specific issues:**\n\n**\"Foreign key violation\" when logging interactions**\n- Ensure the contact exists before logging an interaction\n- Verify the `contact_id` UUID is correct\n- Check that the contact belongs to the same user_id\n\n**\"Thought not found\" when linking**\n- Verify the thought_id exists in your core Open Brain `thoughts` table\n- Check that the user has permission to access that thought\n\n## Next Steps\n\n**Extension 6: Job Hunt Pipeline** — The most complex build in the learning path. You'll create a complete job search management system with 5 RLS-protected tables (companies, postings, applications, interviews, contacts) and bridge it back to this CRM. You'll learn advanced pipeline tracking, conversion rate analysis, and cross-extension integration at scale.\n\n[Continue to Extension 6 →](/ob1/extensions/job-hunt)\n\n> **32 tools and counting.** With 5 extensions connected, your AI is holding ~32 tool definitions in context. If you're noticing the AI picking the wrong tool or ignoring some entirely, the [MCP Tool Audit & Optimization Guide](https://github.com/NateBJones-Projects/OB1/blob/main/docs/05-tool-audit.md) has prompt kits that audit your tools, suggest merges, and help you scope servers by workflow (capture vs. query vs. admin).\n"
+    }
+  ]
+}

--- a/scripts/build_catalog.py
+++ b/scripts/build_catalog.py
@@ -1,0 +1,471 @@
+#!/usr/bin/env python3
+"""Build resources/ob1-catalog.json from repo contents.
+
+Scans every non-template contribution under the seven canonical category
+folders, validates it against generator-time rules, rewrites intra-repo
+links in README markdown, and emits a single site-ready JSON artifact.
+
+Usage:
+    python3 scripts/build_catalog.py          # rebuild and write the artifact
+    python3 scripts/build_catalog.py --check  # fail if the artifact is stale
+
+The --check mode is what the OB1 PR gate runs. It exits non-zero if
+regenerating would produce a file that differs from what is committed.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import pathlib
+import re
+import sys
+from typing import Any
+
+REPO_OWNER = "NateBJones-Projects"
+REPO_NAME = "OB1"
+REPO_URL = f"https://github.com/{REPO_OWNER}/{REPO_NAME}"
+BLOB_URL = f"{REPO_URL}/blob/main"
+TREE_URL = f"{REPO_URL}/tree/main"
+RAW_URL = f"https://raw.githubusercontent.com/{REPO_OWNER}/{REPO_NAME}/main"
+
+CATEGORIES = [
+    "recipes",
+    "schemas",
+    "dashboards",
+    "integrations",
+    "skills",
+    "primitives",
+    "extensions",
+]
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+CATALOG_PATH = ROOT / "resources" / "ob1-catalog.json"
+SCHEMA_VERSION = "1.0.0"
+
+
+class ValidationError(Exception):
+    def __init__(self, where: str, message: str) -> None:
+        super().__init__(f"{where}: {message}")
+        self.where = where
+        self.message = message
+
+
+def discover_contributions() -> list[dict[str, Any]]:
+    """Walk each category folder and return a record per contribution."""
+    entries = []
+    for cat in CATEGORIES:
+        cat_dir = ROOT / cat
+        if not cat_dir.is_dir():
+            continue
+        for d in sorted(cat_dir.iterdir()):
+            if not d.is_dir() or d.name.startswith("_"):
+                continue
+            meta_path = d / "metadata.json"
+            readme_path = d / "README.md"
+            if not meta_path.exists() or not readme_path.exists():
+                continue
+            entries.append(
+                {
+                    "category": cat,
+                    "slug": d.name,
+                    "dir": d,
+                    "meta_path": meta_path,
+                    "readme_path": readme_path,
+                }
+            )
+    return entries
+
+
+_IMAGE_RE = re.compile(r"!\[([^\]]*)\]\(([^)\s]+)(\s+\"[^\"]*\")?\)")
+_LINK_RE = re.compile(r"(?<!!)\[([^\]]+)\]\(([^)\s]+)(\s+\"[^\"]*\")?\)")
+_HTML_IMG_RE = re.compile(r'(<img[^>]*?\ssrc=[\"\'])([^\"\']+)([\"\'])', re.IGNORECASE)
+
+
+def _resolve_repo_path(ref_path: str, source_dir: pathlib.Path) -> pathlib.Path:
+    """Resolve a relative link ref (relative to the source README) to a repo path."""
+    target = (source_dir / ref_path).resolve()
+    return target
+
+
+def _rewrite_target(
+    ref: str, source_dir: pathlib.Path, catalog_slugs: set[tuple[str, str]]
+) -> tuple[str, str | None]:
+    """Rewrite one link/image target.
+
+    Returns (new_target, error) where error is a human-readable string if
+    the target is a broken intra-repo link. Absolute URLs and anchor-only
+    refs pass through unchanged.
+    """
+    if not ref:
+        return ref, None
+    # Anchor-only
+    if ref.startswith("#"):
+        return ref, None
+    # mailto, tel, data, etc.
+    if ":" in ref.split("/")[0] and "://" not in ref and not ref.startswith("//"):
+        # e.g. mailto:foo, but also x-y-z-tag
+        scheme = ref.split(":", 1)[0].lower()
+        if scheme in {"mailto", "tel", "data", "javascript"}:
+            return ref, None
+    # Absolute URL — leave alone
+    if ref.startswith("http://") or ref.startswith("https://") or ref.startswith("//"):
+        return ref, None
+
+    # Strip anchor fragment for resolution, preserve for output
+    anchor = ""
+    bare = ref
+    if "#" in ref:
+        bare, anchor = ref.split("#", 1)
+        anchor = "#" + anchor
+    if not bare:
+        return ref, None
+
+    target_abs = _resolve_repo_path(bare, source_dir)
+    try:
+        rel_to_root = target_abs.relative_to(ROOT)
+    except ValueError:
+        return ref, f"link {ref!r} escapes repo root"
+
+    if not target_abs.exists():
+        return ref, f"broken link {ref!r} → {rel_to_root} does not exist"
+
+    parts = rel_to_root.parts
+
+    # Category index folder or index README
+    if (
+        len(parts) == 1
+        and parts[0] in CATEGORIES
+        and target_abs.is_dir()
+    ):
+        return f"/ob1/{parts[0]}" + anchor, None
+    if (
+        len(parts) == 2
+        and parts[0] in CATEGORIES
+        and parts[1] == "README.md"
+    ):
+        return f"/ob1/{parts[0]}" + anchor, None
+
+    # Contribution folder or its README
+    if len(parts) >= 2 and parts[0] in CATEGORIES and not parts[1].startswith("_"):
+        category, slug = parts[0], parts[1]
+        is_contribution = (category, slug) in catalog_slugs
+        if is_contribution:
+            if len(parts) == 2 and target_abs.is_dir():
+                return f"/ob1/{category}/{slug}" + anchor, None
+            if len(parts) == 3 and parts[2] == "README.md":
+                return f"/ob1/{category}/{slug}" + anchor, None
+            # Deeper file inside a contribution folder — link to the raw file on GitHub
+            return f"{BLOB_URL}/{rel_to_root.as_posix()}" + anchor, None
+
+    # Images and other assets — send to raw GitHub so they load on the site
+    if target_abs.is_file() and _is_asset(parts[-1]):
+        return f"{RAW_URL}/{rel_to_root.as_posix()}" + anchor, None
+
+    # Everything else (docs/, root markdown, etc.) — send to GitHub blob/tree
+    if target_abs.is_dir():
+        return f"{TREE_URL}/{rel_to_root.as_posix()}" + anchor, None
+    return f"{BLOB_URL}/{rel_to_root.as_posix()}" + anchor, None
+
+
+_ASSET_EXTS = {
+    ".png",
+    ".jpg",
+    ".jpeg",
+    ".gif",
+    ".svg",
+    ".webp",
+    ".avif",
+    ".ico",
+    ".mp4",
+    ".mov",
+    ".webm",
+    ".pdf",
+    ".zip",
+}
+
+
+def _is_asset(name: str) -> bool:
+    ext = pathlib.Path(name).suffix.lower()
+    return ext in _ASSET_EXTS
+
+
+def rewrite_readme(
+    raw: str, source_dir: pathlib.Path, catalog_slugs: set[tuple[str, str]]
+) -> tuple[str, list[str]]:
+    """Rewrite all intra-repo links/images in a README. Returns (new_text, errors)."""
+    errors: list[str] = []
+
+    def handle_link(match: re.Match) -> str:
+        text, target, title = match.group(1), match.group(2), match.group(3) or ""
+        new_target, err = _rewrite_target(target, source_dir, catalog_slugs)
+        if err:
+            errors.append(err)
+        return f"[{text}]({new_target}{title})"
+
+    def handle_image(match: re.Match) -> str:
+        alt, target, title = match.group(1), match.group(2), match.group(3) or ""
+        new_target, err = _rewrite_target(target, source_dir, catalog_slugs)
+        if err:
+            errors.append(err)
+        return f"![{alt}]({new_target}{title})"
+
+    def handle_html_img(match: re.Match) -> str:
+        prefix, target, suffix = match.group(1), match.group(2), match.group(3)
+        new_target, err = _rewrite_target(target, source_dir, catalog_slugs)
+        if err:
+            errors.append(err)
+        return f"{prefix}{new_target}{suffix}"
+
+    result = _IMAGE_RE.sub(handle_image, raw)
+    result = _LINK_RE.sub(handle_link, result)
+    result = _HTML_IMG_RE.sub(handle_html_img, result)
+    return result, errors
+
+
+def validate_metadata(meta: dict[str, Any], category: str, slug: str) -> list[str]:
+    """Generator-time validation beyond the JSON schema.
+
+    The JSON schema already enforces shape. These rules catch semantic
+    issues that the schema cannot: category mismatches, malformed
+    dependency declarations, and so on.
+    """
+    errors: list[str] = []
+
+    if meta.get("category") != category:
+        errors.append(
+            f"metadata.category={meta.get('category')!r} does not match folder category {category!r}"
+        )
+
+    requires = meta.get("requires") or {}
+    ob = requires.get("open_brain")
+    if ob not in {"required", "optional"}:
+        errors.append(
+            f"requires.open_brain must be 'required' or 'optional' (got {ob!r})"
+        )
+
+    # Non-skills contributions shouldn't declare requires_skills unless they truly do
+    # (we don't block it, just don't emit structural errors here).
+
+    # learning_order is extensions-only
+    if "learning_order" in meta and category != "extensions":
+        errors.append(
+            "learning_order is only allowed on extensions"
+        )
+
+    return errors
+
+
+def build_entry(
+    record: dict[str, Any],
+    meta: dict[str, Any],
+    readme_body: str,
+) -> dict[str, Any]:
+    category = record["category"]
+    slug = record["slug"]
+    site_path = f"/ob1/{category}/{slug}"
+    github_folder_url = f"{TREE_URL}/{category}/{slug}"
+    github_readme_url = f"{BLOB_URL}/{category}/{slug}/README.md"
+    requires = meta.get("requires") or {}
+    return {
+        "slug": slug,
+        "category": category,
+        "site_path": site_path,
+        "name": meta.get("name"),
+        "description": meta.get("description"),
+        "author": meta.get("author") or {},
+        "version": meta.get("version"),
+        "tags": meta.get("tags") or [],
+        "difficulty": meta.get("difficulty"),
+        "estimated_time": meta.get("estimated_time"),
+        "created": meta.get("created"),
+        "updated": meta.get("updated"),
+        "learning_order": meta.get("learning_order"),
+        "compatibility": {
+            "open_brain": requires.get("open_brain"),
+        },
+        "requirements": {
+            "services": requires.get("services") or [],
+            "tools": requires.get("tools") or [],
+        },
+        "dependencies": {
+            "skills": meta.get("requires_skills") or [],
+            "primitives": meta.get("requires_primitives") or [],
+        },
+        "reverse_dependencies": {
+            "skills": [],
+            "primitives": [],
+        },
+        "urls": {
+            "github_folder": github_folder_url,
+            "github_readme": github_readme_url,
+        },
+        "readme_markdown": readme_body,
+    }
+
+
+def build_catalog() -> dict[str, Any]:
+    records = discover_contributions()
+    catalog_slugs = {(r["category"], r["slug"]) for r in records}
+
+    # Phase 1: load + metadata validation + README rewriting
+    entries: list[dict[str, Any]] = []
+    all_errors: list[str] = []
+
+    for record in records:
+        cat, slug = record["category"], record["slug"]
+        where = f"{cat}/{slug}"
+        try:
+            meta = json.loads(record["meta_path"].read_text())
+        except json.JSONDecodeError as e:
+            all_errors.append(f"{where}/metadata.json: invalid JSON — {e}")
+            continue
+
+        meta_errors = validate_metadata(meta, cat, slug)
+        for err in meta_errors:
+            all_errors.append(f"{where}/metadata.json: {err}")
+
+        raw_readme = record["readme_path"].read_text()
+        readme_body, rewrite_errors = rewrite_readme(
+            raw_readme, record["dir"], catalog_slugs
+        )
+        for err in rewrite_errors:
+            all_errors.append(f"{where}/README.md: {err}")
+
+        entry = build_entry(record, meta, readme_body)
+        entries.append(entry)
+
+    # Phase 2: dependency resolution + reverse dep graph
+    by_key = {(e["category"], e["slug"]): e for e in entries}
+
+    for entry in entries:
+        where = f"{entry['category']}/{entry['slug']}"
+        for dep_slug in entry["dependencies"]["skills"]:
+            key = ("skills", dep_slug)
+            if key not in by_key:
+                all_errors.append(
+                    f"{where}: requires_skills references {dep_slug!r} "
+                    f"but skills/{dep_slug}/ is not a valid contribution"
+                )
+                continue
+            by_key[key]["reverse_dependencies"]["skills"].append(
+                {"category": entry["category"], "slug": entry["slug"], "name": entry["name"]}
+            )
+        for dep_slug in entry["dependencies"]["primitives"]:
+            key = ("primitives", dep_slug)
+            if key not in by_key:
+                all_errors.append(
+                    f"{where}: requires_primitives references {dep_slug!r} "
+                    f"but primitives/{dep_slug}/ is not a valid contribution"
+                )
+                continue
+            by_key[key]["reverse_dependencies"]["primitives"].append(
+                {"category": entry["category"], "slug": entry["slug"], "name": entry["name"]}
+            )
+
+    # Phase 3: uniqueness of site_path (category+slug already unique by construction,
+    # but we guard the invariant explicitly).
+    seen: dict[str, str] = {}
+    for entry in entries:
+        existing = seen.get(entry["site_path"])
+        if existing:
+            all_errors.append(
+                f"{entry['category']}/{entry['slug']}: duplicate site_path {entry['site_path']} "
+                f"(also produced by {existing})"
+            )
+        else:
+            seen[entry["site_path"]] = f"{entry['category']}/{entry['slug']}"
+
+    if all_errors:
+        raise ValidationError(
+            "catalog",
+            "validation failed:\n  - " + "\n  - ".join(all_errors),
+        )
+
+    # Stable sort: category ordering from CATEGORIES then slug
+    cat_rank = {c: i for i, c in enumerate(CATEGORIES)}
+    entries.sort(key=lambda e: (cat_rank[e["category"]], e["slug"]))
+
+    # Sort reverse deps for determinism
+    for e in entries:
+        e["reverse_dependencies"]["skills"].sort(
+            key=lambda r: (r["category"], r["slug"])
+        )
+        e["reverse_dependencies"]["primitives"].sort(
+            key=lambda r: (r["category"], r["slug"])
+        )
+
+    # Category index
+    categories_index = []
+    for cat in CATEGORIES:
+        cat_entries = [e for e in entries if e["category"] == cat]
+        required = sum(1 for e in cat_entries if e["compatibility"]["open_brain"] == "required")
+        optional = sum(1 for e in cat_entries if e["compatibility"]["open_brain"] == "optional")
+        categories_index.append(
+            {
+                "slug": cat,
+                "site_path": f"/ob1/{cat}",
+                "count": len(cat_entries),
+                "required_count": required,
+                "optional_count": optional,
+            }
+        )
+
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "generated_from": {
+            "repo": f"{REPO_OWNER}/{REPO_NAME}",
+            "branch": "main",
+        },
+        "categories": categories_index,
+        "entries": entries,
+    }
+
+
+def serialize(catalog: dict[str, Any]) -> str:
+    return json.dumps(catalog, indent=2, sort_keys=False, ensure_ascii=False) + "\n"
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help="Exit non-zero if the committed catalog is stale.",
+    )
+    args = parser.parse_args()
+
+    try:
+        catalog = build_catalog()
+    except ValidationError as e:
+        print(f"error: {e}", file=sys.stderr)
+        return 2
+
+    new_text = serialize(catalog)
+
+    if args.check:
+        if not CATALOG_PATH.exists():
+            print(f"error: {CATALOG_PATH} does not exist", file=sys.stderr)
+            return 3
+        existing = CATALOG_PATH.read_text()
+        if existing != new_text:
+            print(
+                "error: committed catalog is stale. Run "
+                "`python3 scripts/build_catalog.py` and commit the result.",
+                file=sys.stderr,
+            )
+            return 4
+        print(f"catalog is up to date ({len(catalog['entries'])} entries)")
+        return 0
+
+    CATALOG_PATH.parent.mkdir(parents=True, exist_ok=True)
+    CATALOG_PATH.write_text(new_text)
+    print(
+        f"wrote {CATALOG_PATH.relative_to(ROOT)} "
+        f"({len(catalog['entries'])} entries, {len(new_text):,} bytes)"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- Ships `scripts/build_catalog.py` — the generator that scans every non-template contribution folder and emits a site-ready JSON artifact with rewritten READMEs, resolved dependency edges, and per-entry compatibility metadata.
- Commits the first `resources/ob1-catalog.json` artifact (59 entries, ~570 KB).
- Wires a drift check into `.github/workflows/ob1-gate.yml` — any PR that touches contribution content, the generator, or the artifact must also update the artifact or the gate fails.

## Stacked on PR #186
This PR's base is `contrib/jonathanedwards/ob1-compatibility-catalog` (PR #186) because the generator relies on the new `requires.open_brain` string enum. **Merge #186 first**, then retarget this to `main` and merge.

## Why the generator runs at commit time (not site build time)
- Deterministic site builds (natejones.com just reads one JSON file).
- Generator-time validation catches repo semantics (missing deps, broken relative links, duplicate site paths) — the site loader only validates artifact shape.
- The gate's drift check means a contributor cannot land a contribution without also regenerating and committing the artifact.

## Generator-time validation (the contract)
1. `category` in `metadata.json` matches the folder category.
2. `requires.open_brain` is one of `required` | `optional`.
3. `learning_order` is only present on extensions.
4. Every `requires_skills` / `requires_primitives` slug resolves to a real contribution.
5. No two entries share the same `site_path`.
6. Every relative intra-repo link in a contribution README resolves to an existing file.

The loader on the site side only has to validate artifact shape, not repo semantics.

## Link rewriting rules
- Relative links to contribution folders / READMEs → `/ob1/<category>/<slug>`
- Links to category index folders / READMEs → `/ob1/<category>`
- Deeper relative files inside a contribution folder → raw GitHub blob URL
- Image / asset refs → `raw.githubusercontent.com` (so they render on the site)
- Other intra-repo paths (e.g. `docs/`, root markdown) → GitHub blob/tree URL
- Absolute URLs, anchors, and `mailto:` / `tel:` — pass through untouched

## Site loader precedence (documented here; implemented in the site PR)
- `OB1_CATALOG_LOCAL_PATH` env var takes precedence when set (local dev override)
- Otherwise fetch from `raw.githubusercontent.com/.../main/resources/ob1-catalog.json`
- Missing or invalid artifact must fail the site build

## Pre-existing fix included
`recipes/email-history-import/README.md` linked to `primitives/content-fingerprint-dedup/` — that directory does not exist; the fingerprint dedup logic lives in `recipes/content-fingerprint-dedup/`. The generator's strict relative-link check flagged it. Fixed the link rather than loosening the rule, per the plan.

## Catalog breakdown (first artifact)
| Category | Count | Required | Optional |
| --- | --- | --- | --- |
| recipes | 29 | 29 | 0 |
| schemas | 1 | 1 | 0 |
| dashboards | 2 | 2 | 0 |
| integrations | 3 | 3 | 0 |
| skills | 13 | 4 | 9 |
| primitives | 5 | 5 | 0 |
| extensions | 6 | 6 | 0 |

## Test plan
- [x] Generator emits a clean `ob1-catalog.json` on the current tree (59 entries, no validation errors).
- [x] `--check` mode returns 0 on the committed artifact.
- [x] Reverse dependency graph is populated (verified: `skills/auto-capture` shows `recipes/auto-capture` as a reverse dep).
- [x] Sample optional skill (`skills/panning-for-gold`) serializes with `compatibility.open_brain = "optional"`.
- [x] Sample required skill (`skills/auto-capture`) serializes with `compatibility.open_brain = "required"`.
- [x] Link rewriting verified against `recipes/auto-capture` README: `skills/auto-capture/` → `/ob1/skills/auto-capture`, `docs/01-getting-started.md` → GitHub blob URL.
- [ ] Post-merge: gate drift check triggers correctly on the next contribution PR.

## In-flight contribution impact
Any open contribution PR that adds a new folder under `recipes/`, `skills/`, etc. will now need `resources/ob1-catalog.json` regenerated in the same PR. The error message includes the exact command to run. Maintainer-side fix on merge is fine for current volume.

🤖 Generated with [Claude Code](https://claude.com/claude-code)