### PR TITLE
[recipes] Add wiki compiler orchestration recipe

### DIFF
--- a/recipes/README.md
+++ b/recipes/README.md
@@ -10,6 +10,7 @@ Step-by-step builds that add a new capability to your Open Brain. Follow the ins
 | [Email History Import](email-history-import/) | Pull your Gmail archive into searchable thoughts |
 | [ChatGPT Conversation Import](chatgpt-conversation-import/) | Ingest your ChatGPT data export |
 | [Daily Digest](daily-digest/) | Automated summary of recent thoughts via email or Slack |
+| [Wiki Compiler](wiki-compiler/) | Compiles graph-backed entity pages and topic synthesis into a regenerable wiki layer you can run on demand or on a schedule |
 | [Work Operating Model Activation](work-operating-model-activation/) | Interview-driven workflow that stores how you actually work and generates agent-ready operating files |
 | [World Model Diagnostic Activation](world-model-diagnostic-activation/) | Lightweight activation path for a 20-minute world-model diagnostic that uses the base OB1 connector and a direct-paste fallback |
 | [Research-to-Decision Workflow](research-to-decision-workflow/) | Compose canonical skills into operator and investor paths for analysis, synthesis, meetings, and decision documents |

--- a/recipes/wiki-compiler/README.md
+++ b/recipes/wiki-compiler/README.md
@@ -1,0 +1,276 @@
+# Wiki Compiler
+
+> The compiled view on demand layer for Open Brain: a recipe that turns structured thoughts and graph data into regenerable wiki artifacts you can run daily, weekly, or on demand.
+
+## What This Is
+
+This recipe is the composition layer Nate described in the video.
+
+It does **not** replace the Open Brain database. It sits on top of it and produces a browsable synthesis layer:
+
+- the SQL database stays the source of truth
+- the graph and wiki pages are generated artifacts
+- if a wiki page is wrong, you fix the underlying data and regenerate
+- the wiki is never the canonical store
+
+That gives you the Karpathy-style "readable compiled understanding" layer without turning markdown pages into the system of record.
+
+## What It Does
+
+`compile-wiki.mjs` orchestrates the graph/wiki stack that now exists on `main`:
+
+1. Triggers the **entity extraction worker** so new thoughts become entities, links, and evidence rows.
+2. Runs the **typed edge classifier** so the system can capture reasoning relations like `supports`, `contradicts`, and `supersedes`.
+3. Batch-generates **entity wiki pages** from linked thoughts and graph edges.
+4. Generates **topic wiki pages** from the core `thoughts` table.
+5. Optionally backfills **Gmail thread wiki pages**.
+
+The result is a compiled wiki directory plus a manifest of what ran.
+
+## Why This Matches The Promise
+
+This is the bridge between "Open Brain as durable structured memory" and "LLM wiki as compiled understanding."
+
+It gives you:
+
+- **compiled views on demand** via a single wrapper command
+- **scheduled compilation** via cron, Claude Code scheduled tasks, or any job runner
+- **graph-backed synthesis** because entity extraction + typed edges land before wiki generation
+- **filterable synthesis** because the underlying source is SQL, not raw files
+- **regenerable outputs** because the database remains authoritative
+
+That is the architecture Nate described: structured capture first, compiled wiki second.
+
+## Contributor Credit
+
+This recipe is intentionally a **composition layer over contributor work by Alan Shurafa**. The underlying graph/wiki components it orchestrates were authored in the following merged contributions:
+
+- [#197](https://github.com/NateBJones-Projects/OB1/pull/197) — entity extraction schema
+- [#199](https://github.com/NateBJones-Projects/OB1/pull/199) — entity extraction worker
+- [#208](https://github.com/NateBJones-Projects/OB1/pull/208) — typed reasoning edges + classifier
+- [#213](https://github.com/NateBJones-Projects/OB1/pull/213) — entity wiki pages
+- [#222](https://github.com/NateBJones-Projects/OB1/pull/222) — wiki synthesis
+
+This wrapper recipe packages those pieces into one reproducible workflow. It is not a rewrite of Alan's work.
+
+## Architecture
+
+```text
+Open Brain thoughts (SQL)
+        |
+        v
+entity-extraction trigger + worker
+        |
+        v
+entities / thought_entities / edges
+        |
+        +--------------------+
+        |                    |
+        v                    v
+typed-edge-classifier   entity-wiki
+        |                    |
+        v                    v
+thought_edges         per-entity wiki pages
+        |
+        +--------------------+
+        |                    |
+        v                    v
+wiki-synthesis         Gmail thread wikis
+        |
+        v
+compiled-wiki/ + compile-manifest.json
+```
+
+## Prerequisites
+
+- A working Open Brain install
+- The merged graph/wiki stack on `main`
+- Node.js 18+
+- A valid `.env.local` or shell env for the underlying recipes
+- A deployed `entity-extraction-worker` Edge Function if you want the wrapper to trigger extraction automatically
+
+### Required environment
+
+At minimum, the downstream recipes expect:
+
+```text
+OPEN_BRAIN_URL
+OPEN_BRAIN_SERVICE_KEY
+LLM_API_KEY
+```
+
+Additional environment varies by phase:
+
+- `LLM_MODEL`, `LLM_BASE_URL` for wiki synthesis
+- `ANTHROPIC_API_KEY` for typed-edge classification
+- `EMBEDDING_API_KEY` if you want semantic expansion or thought-mode entity dossiers
+- `MCP_ACCESS_KEY` or `ENTITY_EXTRACTION_MCP_ACCESS_KEY` if you want this wrapper to trigger the entity extraction worker automatically
+- `ENTITY_EXTRACTION_WORKER_URL` if you do not want the wrapper to derive it from `OPEN_BRAIN_URL`
+
+## Install
+
+Nothing extra to install. This recipe is a wrapper around merged in-repo scripts.
+
+Run it from the Open Brain repo root so the downstream recipes can read your root `.env.local`:
+
+```bash
+node recipes/wiki-compiler/compile-wiki.mjs --help
+```
+
+Done when: the help text prints and the referenced component scripts exist.
+
+## On-Demand Usage
+
+### 1. Standard compile pass
+
+This is the default "build the compiled understanding layer" run:
+
+```bash
+node recipes/wiki-compiler/compile-wiki.mjs
+```
+
+By default this:
+
+- tries to trigger entity extraction
+- runs typed-edge classification
+- generates entity wiki pages
+- generates the built-in `autobiography` topic wiki
+- writes outputs under `./compiled-wiki/`
+
+### 2. Dry run
+
+Use this before your first real compile:
+
+```bash
+node recipes/wiki-compiler/compile-wiki.mjs --dry-run
+```
+
+### 3. Compile entity pages only
+
+```bash
+node recipes/wiki-compiler/compile-wiki.mjs \
+  --skip-extraction \
+  --skip-edges \
+  --skip-topic-wiki
+```
+
+### 4. Compile topic pages only
+
+```bash
+node recipes/wiki-compiler/compile-wiki.mjs \
+  --skip-extraction \
+  --skip-edges \
+  --skip-entity-wiki \
+  --topic autobiography
+```
+
+### 5. Include Gmail thread wikis
+
+```bash
+node recipes/wiki-compiler/compile-wiki.mjs --gmail --gmail-limit 10
+```
+
+## Scheduling
+
+This is designed to run on demand **or** on a schedule.
+
+### Daily light compile
+
+```bash
+node recipes/wiki-compiler/compile-wiki.mjs \
+  --edge-limit 25 \
+  --entity-batch-limit 15 \
+  --topic autobiography \
+  --gmail \
+  --gmail-limit 5
+```
+
+### Weekly deep compile
+
+```bash
+node recipes/wiki-compiler/compile-wiki.mjs \
+  --edge-limit 150 \
+  --entity-batch-limit 75 \
+  --topic autobiography \
+  --gmail \
+  --re-evaluate
+```
+
+### Cron example
+
+```cron
+0 6 * * * cd /path/to/OB1 && /usr/bin/env node recipes/wiki-compiler/compile-wiki.mjs --edge-limit 25 --entity-batch-limit 15 --topic autobiography >> logs/wiki-compiler.log 2>&1
+```
+
+### Agent-driven schedule
+
+If you prefer Claude Code / Codex style scheduled runs, point the agent at:
+
+```bash
+node recipes/wiki-compiler/compile-wiki.mjs --edge-limit 25 --entity-batch-limit 15 --topic autobiography
+```
+
+The important contract is the same regardless of scheduler:
+
+- write new information into SQL first
+- regenerate the compiled wiki from the source tables
+- do not manually edit generated wiki pages
+
+## Output
+
+By default the wrapper writes to:
+
+```text
+compiled-wiki/
+  entities/               # entity-wiki output when using file mode
+  topics/                 # wiki-synthesis topic output
+  compile-manifest.json   # run summary and phase statuses
+```
+
+Other outputs are owned by the underlying recipes:
+
+- `data/wiki-synthesis-state.jsonl` for Gmail thread synthesis state
+- `public.thought_edges` for typed reasoning links
+- `public.entities`, `public.edges`, `public.thought_entities` for graph extraction
+
+## Important Design Rule
+
+Do **not** treat generated wiki pages as the source of truth.
+
+This recipe is built around the opposite rule:
+
+- capture raw facts and source material in Open Brain first
+- compile the wiki from that source
+- regenerate instead of manually patching summaries
+
+That is what prevents wiki drift.
+
+## Expected Outcome
+
+After a successful run you should have:
+
+- a refreshed entity graph fed by structured Open Brain data
+- reasoning edges in `thought_edges`
+- per-entity wiki pages
+- topic synthesis pages
+- optionally Gmail thread wiki artifacts
+- a manifest recording which phases ran and whether they succeeded
+
+At that point you can browse the compiled layer like a wiki while keeping SQL as the authority underneath it.
+
+## Troubleshooting
+
+**Issue: entity extraction phase skips itself**
+Solution: set `ENTITY_EXTRACTION_WORKER_URL` plus `ENTITY_EXTRACTION_MCP_ACCESS_KEY`, or define `OPEN_BRAIN_URL` plus `MCP_ACCESS_KEY` so the wrapper can derive the worker endpoint.
+
+**Issue: typed-edge classification fails**
+Solution: confirm `ANTHROPIC_API_KEY` is available and that the `typed-reasoning-edges` schema is installed on the target brain.
+
+**Issue: entity pages fail with missing relation/table errors**
+Solution: confirm the entity extraction schema and worker have been applied and allowed to populate `entities`, `edges`, and `thought_entities`.
+
+**Issue: Gmail wiki backfill fails**
+Solution: confirm your email thoughts use the expected Gmail metadata shape and that `thought_edges` exists.
+
+**Issue: topic synthesis writes the wrong pages**
+Solution: pass explicit `--topic` and `--scope key=value` flags so the wrapper only runs the slice you want.

--- a/recipes/wiki-compiler/compile-wiki.mjs
+++ b/recipes/wiki-compiler/compile-wiki.mjs
@@ -1,0 +1,418 @@
+#!/usr/bin/env node
+
+import fs from "node:fs";
+import path from "node:path";
+import { spawn } from "node:child_process";
+import { fileURLToPath } from "node:url";
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.resolve(HERE, "..", "..");
+const DEFAULT_OUT_DIR = path.join(REPO_ROOT, "compiled-wiki");
+
+const SCRIPT_PATHS = {
+  typedEdges: path.join(REPO_ROOT, "recipes", "typed-edge-classifier", "classify-edges.mjs"),
+  entityWiki: path.join(REPO_ROOT, "recipes", "entity-wiki", "generate-wiki.mjs"),
+  topicWiki: path.join(REPO_ROOT, "recipes", "wiki-synthesis", "scripts", "synthesize-wiki.mjs"),
+  gmailWiki: path.join(REPO_ROOT, "recipes", "wiki-synthesis", "scripts", "backfill-gmail-wikis.mjs"),
+};
+
+function parseEnvFile(filePath) {
+  if (!fs.existsSync(filePath)) return {};
+  const out = {};
+  const raw = fs.readFileSync(filePath, "utf8");
+  for (const line of raw.split(/\r?\n/)) {
+    const match = line.match(/^\s*([A-Z0-9_]+)\s*=\s*(.*?)\s*$/);
+    if (!match) continue;
+    out[match[1]] = match[2].replace(/^["']|["']$/g, "");
+  }
+  return out;
+}
+
+function loadEnv() {
+  return {
+    ...parseEnvFile(path.join(REPO_ROOT, ".env")),
+    ...parseEnvFile(path.join(REPO_ROOT, ".env.local")),
+    ...process.env,
+  };
+}
+
+function defaultArgs() {
+  return {
+    outDir: DEFAULT_OUT_DIR,
+    extractLimit: 25,
+    edgeLimit: 50,
+    edgeMinSupport: 2,
+    edgeMaxCostUsd: 2.0,
+    edgeParallelism: 3,
+    edgeMinConfidence: 0.75,
+    entityBatchLimit: 25,
+    entityBatchMinLinked: 3,
+    entityOutputMode: "file",
+    gmail: false,
+    gmailLimit: 0,
+    dryRun: false,
+    bestEffort: false,
+    mirrorSupersedes: false,
+    semanticExpand: false,
+    skipExtraction: false,
+    skipEdges: false,
+    skipEntityWiki: false,
+    skipTopicWiki: false,
+    skipGmailWiki: false,
+    requireExtraction: false,
+    topics: [],
+    scopes: [],
+  };
+}
+
+function parseArgs(argv) {
+  const args = defaultArgs();
+  for (let i = 0; i < argv.length; i++) {
+    const current = argv[i];
+    const next = () => argv[++i];
+    if (current === "--help" || current === "-h") args.help = true;
+    else if (current === "--dry-run") args.dryRun = true;
+    else if (current === "--best-effort") args.bestEffort = true;
+    else if (current === "--mirror-supersedes") args.mirrorSupersedes = true;
+    else if (current === "--semantic-expand") args.semanticExpand = true;
+    else if (current === "--gmail") args.gmail = true;
+    else if (current === "--re-evaluate") args.reEvaluate = true;
+    else if (current === "--skip-extraction") args.skipExtraction = true;
+    else if (current === "--skip-edges") args.skipEdges = true;
+    else if (current === "--skip-entity-wiki") args.skipEntityWiki = true;
+    else if (current === "--skip-topic-wiki") args.skipTopicWiki = true;
+    else if (current === "--skip-gmail-wiki") args.skipGmailWiki = true;
+    else if (current === "--require-extraction") args.requireExtraction = true;
+    else if (current === "--topic") args.topics.push(next());
+    else if (current === "--scope") args.scopes.push(next());
+    else if (current === "--out-dir") args.outDir = path.resolve(REPO_ROOT, next());
+    else if (current === "--extract-limit") args.extractLimit = Number(next()) || args.extractLimit;
+    else if (current === "--edge-limit") args.edgeLimit = Number(next()) || args.edgeLimit;
+    else if (current === "--edge-min-support") args.edgeMinSupport = Number(next()) || args.edgeMinSupport;
+    else if (current === "--edge-max-cost-usd") args.edgeMaxCostUsd = Number(next()) || args.edgeMaxCostUsd;
+    else if (current === "--edge-parallelism") args.edgeParallelism = Number(next()) || args.edgeParallelism;
+    else if (current === "--edge-min-confidence") args.edgeMinConfidence = Number(next()) || args.edgeMinConfidence;
+    else if (current === "--entity-batch-limit") args.entityBatchLimit = Number(next()) || args.entityBatchLimit;
+    else if (current === "--entity-batch-min-linked") args.entityBatchMinLinked = Number(next()) || args.entityBatchMinLinked;
+    else if (current === "--entity-output-mode") args.entityOutputMode = next();
+    else if (current === "--gmail-limit") args.gmailLimit = Number(next()) || 0;
+    else throw new Error(`Unknown flag: ${current}`);
+  }
+  if (!args.skipTopicWiki && args.topics.length === 0) {
+    args.topics.push("autobiography");
+  }
+  return args;
+}
+
+function printHelp() {
+  console.log(`Wiki Compiler — Open Brain compiled wiki wrapper
+
+Usage:
+  node recipes/wiki-compiler/compile-wiki.mjs [flags]
+
+Core behavior:
+  Runs the compiled wiki pipeline in phases:
+  1. Trigger entity extraction worker (optional remote step)
+  2. Classify typed reasoning edges into thought_edges
+  3. Batch-generate entity wiki pages
+  4. Generate topic wiki pages (defaults to autobiography)
+  5. Optionally synthesize Gmail thread wiki pages
+
+Flags:
+  --dry-run                    Preview where supported; skip writes when possible
+  --best-effort                Continue even if a phase fails
+  --out-dir <path>             Root output directory (default: ./compiled-wiki)
+  --topic <slug>               Topic synthesizer to run; repeatable
+  --scope key=value            Scope passed to every topic run; repeatable
+  --gmail                      Also run Gmail thread wiki synthesis
+  --gmail-limit <N>            Cap Gmail thread synthesis count
+  --re-evaluate                Re-check already-processed Gmail threads
+
+Phase toggles:
+  --skip-extraction            Do not trigger the entity extraction worker
+  --skip-edges                 Do not run typed-edge classification
+  --skip-entity-wiki           Do not batch-generate entity pages
+  --skip-topic-wiki            Do not run topic synthesis
+  --skip-gmail-wiki            Skip Gmail wiki synthesis even if --gmail is set
+  --require-extraction         Fail instead of warn if extraction worker credentials are missing
+
+Entity extraction:
+  --extract-limit <N>          Queue items to process (default: 25)
+
+Typed edges:
+  --edge-limit <N>             Candidate thought pairs (default: 50)
+  --edge-min-support <N>       Minimum shared entities (default: 2)
+  --edge-max-cost-usd <N>      Hard cap for classifier spend (default: 2.00)
+  --edge-parallelism <N>       Concurrent classifier calls (default: 3)
+  --edge-min-confidence <N>    Skip inserts below confidence (default: 0.75)
+  --mirror-supersedes          Also mirror supersedes into thoughts.supersedes
+
+Entity wiki:
+  --entity-batch-limit <N>     Max entities per run (default: 25)
+  --entity-batch-min-linked <N> Min linked thoughts (default: 3)
+  --entity-output-mode <mode>  file | entity-metadata | thought (default: file)
+  --semantic-expand            Enable semantic expansion for entity wiki runs
+
+Environment:
+  OPEN_BRAIN_URL
+  OPEN_BRAIN_SERVICE_KEY
+  ENTITY_EXTRACTION_WORKER_URL (optional; defaults from OPEN_BRAIN_URL)
+  ENTITY_EXTRACTION_MCP_ACCESS_KEY or MCP_ACCESS_KEY (for worker trigger)
+  LLM_API_KEY / LLM_MODEL / related vars used by the underlying recipes
+`);
+}
+
+function ensureScriptsExist() {
+  for (const [label, scriptPath] of Object.entries(SCRIPT_PATHS)) {
+    if (!fs.existsSync(scriptPath)) {
+      throw new Error(`Missing dependency script for ${label}: ${scriptPath}`);
+    }
+  }
+}
+
+function ensureDir(dirPath) {
+  fs.mkdirSync(dirPath, { recursive: true });
+}
+
+function formatCommand(args) {
+  return args.map((part) => (/[\s"]/u.test(part) ? JSON.stringify(part) : part)).join(" ");
+}
+
+function spawnNode(scriptPath, scriptArgs, envOverrides = {}) {
+  const childEnv = { ...process.env, ...envOverrides };
+  return new Promise((resolve, reject) => {
+    const child = spawn(process.execPath, [scriptPath, ...scriptArgs], {
+      cwd: REPO_ROOT,
+      env: childEnv,
+      stdio: "inherit",
+    });
+    child.on("error", reject);
+    child.on("exit", (code) => {
+      if (code === 0) resolve();
+      else reject(new Error(`Command failed (${code}): ${formatCommand([process.execPath, scriptPath, ...scriptArgs])}`));
+    });
+  });
+}
+
+async function triggerEntityExtraction(args, env) {
+  const workerUrl =
+    env.ENTITY_EXTRACTION_WORKER_URL ||
+    (env.OPEN_BRAIN_URL ? `${String(env.OPEN_BRAIN_URL).replace(/\/+$/, "")}/functions/v1/entity-extraction-worker` : null);
+  const accessKey = env.ENTITY_EXTRACTION_MCP_ACCESS_KEY || env.MCP_ACCESS_KEY || null;
+  if (!workerUrl || !accessKey) {
+    const missing = [];
+    if (!workerUrl) missing.push("ENTITY_EXTRACTION_WORKER_URL or OPEN_BRAIN_URL");
+    if (!accessKey) missing.push("ENTITY_EXTRACTION_MCP_ACCESS_KEY or MCP_ACCESS_KEY");
+    const message = `Skipping entity extraction trigger; missing ${missing.join(" and ")}.`;
+    if (args.requireExtraction) throw new Error(message);
+    console.warn(`[wiki-compiler] ${message}`);
+    return { skipped: true, reason: message };
+  }
+
+  const url = new URL(workerUrl);
+  url.searchParams.set("limit", String(args.extractLimit));
+  if (args.dryRun) url.searchParams.set("dry_run", "true");
+
+  console.log(`[wiki-compiler] triggering entity extraction worker: ${url.toString()}`);
+  const response = await fetch(url, {
+    method: "POST",
+    headers: { "x-brain-key": accessKey },
+  });
+  const bodyText = await response.text();
+  let payload = null;
+  try {
+    payload = bodyText ? JSON.parse(bodyText) : null;
+  } catch {
+    payload = { raw: bodyText };
+  }
+  if (!response.ok) {
+    throw new Error(`Entity extraction worker ${response.status}: ${bodyText.slice(0, 500)}`);
+  }
+  return payload;
+}
+
+function startManifest(args) {
+  return {
+    recipe: "wiki-compiler",
+    version: "1.0.0",
+    started_at: new Date().toISOString(),
+    repo_root: REPO_ROOT,
+    out_dir: args.outDir,
+    dry_run: args.dryRun,
+    topics: args.topics,
+    gmail: args.gmail && !args.skipGmailWiki,
+    steps: [],
+  };
+}
+
+function recordStep(manifest, name, status, details = {}) {
+  manifest.steps.push({
+    name,
+    status,
+    at: new Date().toISOString(),
+    ...details,
+  });
+}
+
+function writeManifest(manifest) {
+  ensureDir(manifest.out_dir);
+  const filePath = path.join(manifest.out_dir, "compile-manifest.json");
+  fs.writeFileSync(filePath, JSON.stringify(manifest, null, 2) + "\n", "utf8");
+  return filePath;
+}
+
+async function runStep(manifest, name, fn, bestEffort) {
+  try {
+    const result = await fn();
+    recordStep(manifest, name, "ok", result ? { result } : {});
+    return result;
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    recordStep(manifest, name, "failed", { error: message });
+    if (!bestEffort) throw error;
+    console.warn(`[wiki-compiler] ${name} failed but continuing (--best-effort): ${message}`);
+    return null;
+  }
+}
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+  if (args.help) {
+    printHelp();
+    return;
+  }
+
+  ensureScriptsExist();
+
+  const env = loadEnv();
+  const entityOutDir = path.join(args.outDir, "entities");
+  const topicOutDir = path.join(args.outDir, "topics");
+  ensureDir(args.outDir);
+  ensureDir(entityOutDir);
+  ensureDir(topicOutDir);
+
+  const manifest = startManifest(args);
+
+  console.log(`[wiki-compiler] repo=${REPO_ROOT}`);
+  console.log(`[wiki-compiler] out=${args.outDir}`);
+  console.log(`[wiki-compiler] topics=${args.topics.join(", ") || "(none)"}`);
+
+  if (!args.skipExtraction) {
+    await runStep(
+      manifest,
+      "entity-extraction",
+      () => triggerEntityExtraction(args, env),
+      args.bestEffort,
+    );
+  }
+
+  if (!args.skipEdges) {
+    const edgeArgs = [
+      "--limit", String(args.edgeLimit),
+      "--min-support", String(args.edgeMinSupport),
+      "--max-cost-usd", String(args.edgeMaxCostUsd),
+      "--parallelism", String(args.edgeParallelism),
+      "--min-confidence", String(args.edgeMinConfidence),
+    ];
+    if (args.dryRun) edgeArgs.push("--dry-run");
+    if (args.mirrorSupersedes) edgeArgs.push("--mirror-supersedes");
+
+    await runStep(
+      manifest,
+      "typed-edge-classifier",
+      async () => {
+        console.log(`[wiki-compiler] running typed-edge classifier`);
+        await spawnNode(SCRIPT_PATHS.typedEdges, edgeArgs);
+        return {
+          limit: args.edgeLimit,
+          min_support: args.edgeMinSupport,
+          max_cost_usd: args.edgeMaxCostUsd,
+        };
+      },
+      args.bestEffort,
+    );
+  }
+
+  if (!args.skipEntityWiki) {
+    const entityArgs = [
+      "--batch",
+      "--batch-min-linked", String(args.entityBatchMinLinked),
+      "--batch-limit", String(args.entityBatchLimit),
+      "--output-mode", args.entityOutputMode,
+      "--out-dir", entityOutDir,
+    ];
+    if (args.semanticExpand) entityArgs.push("--semantic-expand");
+    if (args.dryRun) entityArgs.push("--dry-run");
+
+    await runStep(
+      manifest,
+      "entity-wiki",
+      async () => {
+        console.log(`[wiki-compiler] generating entity wiki pages -> ${entityOutDir}`);
+        await spawnNode(SCRIPT_PATHS.entityWiki, entityArgs);
+        return {
+          output_mode: args.entityOutputMode,
+          out_dir: entityOutDir,
+          batch_limit: args.entityBatchLimit,
+        };
+      },
+      args.bestEffort,
+    );
+  }
+
+  if (!args.skipTopicWiki) {
+    for (const topic of args.topics) {
+      const topicArgs = ["--topic", topic];
+      for (const scope of args.scopes) topicArgs.push("--scope", scope);
+      if (args.dryRun) topicArgs.push("--dry-run");
+
+      await runStep(
+        manifest,
+        `topic-wiki:${topic}`,
+        async () => {
+          console.log(`[wiki-compiler] generating topic wiki "${topic}" -> ${topicOutDir}`);
+          await spawnNode(SCRIPT_PATHS.topicWiki, topicArgs, {
+            WIKI_OUTPUT_DIR: topicOutDir,
+          });
+          return {
+            topic,
+            out_dir: topicOutDir,
+            scopes: args.scopes,
+          };
+        },
+        args.bestEffort,
+      );
+    }
+  }
+
+  if (args.gmail && !args.skipGmailWiki) {
+    const gmailArgs = [];
+    if (args.dryRun) gmailArgs.push("--dry-run");
+    if (args.gmailLimit > 0) gmailArgs.push(`--limit=${args.gmailLimit}`);
+    if (args.reEvaluate) gmailArgs.push("--re-evaluate");
+
+    await runStep(
+      manifest,
+      "gmail-wiki",
+      async () => {
+        console.log(`[wiki-compiler] generating Gmail thread wiki pages`);
+        await spawnNode(SCRIPT_PATHS.gmailWiki, gmailArgs);
+        return {
+          limit: args.gmailLimit,
+          re_evaluate: Boolean(args.reEvaluate),
+        };
+      },
+      args.bestEffort,
+    );
+  }
+
+  manifest.finished_at = new Date().toISOString();
+  const manifestPath = writeManifest(manifest);
+  console.log(`[wiki-compiler] manifest -> ${manifestPath}`);
+}
+
+main().catch((error) => {
+  const message = error instanceof Error ? error.message : String(error);
+  console.error(`[wiki-compiler] FAILED: ${message}`);
+  process.exitCode = 1;
+});

--- a/recipes/wiki-compiler/metadata.json
+++ b/recipes/wiki-compiler/metadata.json
@@ -1,0 +1,20 @@
+{
+  "name": "Wiki Compiler",
+  "description": "Compiled wiki layer for Open Brain that orchestrates graph extraction, typed edges, entity pages, and topic synthesis into scheduled or on-demand wiki refreshes.",
+  "category": "recipes",
+  "author": {
+    "name": "Jonathan Edwards",
+    "github": "jonathanedwards"
+  },
+  "version": "1.0.0",
+  "requires": {
+    "open_brain": true,
+    "services": ["Supabase", "OpenRouter or Anthropic-compatible LLM APIs"],
+    "tools": ["Node.js 18+", "cron or any scheduled task runner"]
+  },
+  "tags": ["wiki", "compiler", "knowledge-graph", "scheduled-task", "automation", "synthesis"],
+  "difficulty": "advanced",
+  "estimated_time": "45 minutes",
+  "created": "2026-04-21",
+  "updated": "2026-04-21"
+}


### PR DESCRIPTION
## Summary

Adds a new `recipes/wiki-compiler/` recipe that packages the newly-merged graph/wiki stack into one reproducible workflow.

- `compile-wiki.mjs` orchestrates entity extraction, typed-edge classification, entity wiki generation, topic wiki synthesis, and optional Gmail thread wiki backfill.
- README frames this as the compiled-on-demand wiki layer Nate described in the video: SQL stays the source of truth, wiki artifacts are regenerable outputs.
- Explicit contributor-credit section calls out Alan Shurafa's merged building blocks (#197, #199, #208, #213, #222).
- Adds the recipe to `recipes/README.md`.

## Why

The merged component PRs give OB1 all the underlying pieces, but there was no single top-level recipe a user could point at to say "this is the graph-backed compiled wiki workflow." This PR creates that composition layer.

## Verification

- `node --check recipes/wiki-compiler/compile-wiki.mjs`
- `node recipes/wiki-compiler/compile-wiki.mjs --help`
- `markdownlint-cli2 --config .github/.markdownlint.jsonc recipes/wiki-compiler/README.md recipes/README.md`
- `jq empty recipes/wiki-compiler/metadata.json`
