### PR TITLE
[recipes] Load .env into wiki-compiler child processes

### DIFF
--- a/recipes/wiki-compiler/compile-wiki.mjs
+++ b/recipes/wiki-compiler/compile-wiki.mjs
@@ -179,7 +179,7 @@ function formatCommand(args) {
 }
 
 function spawnNode(scriptPath, scriptArgs, envOverrides = {}) {
-  const childEnv = { ...process.env, ...envOverrides };
+  const childEnv = { ...loadEnv(), ...envOverrides };
   return new Promise((resolve, reject) => {
     const child = spawn(process.execPath, [scriptPath, ...scriptArgs], {
       cwd: REPO_ROOT,


### PR DESCRIPTION
## Contribution Type

- [x] Repo improvement (bug fix in an existing recipe)

## What does this do?

Fixes an env-resolution mismatch in `recipes/wiki-compiler/compile-wiki.mjs`. The `spawnNode()` helper was passing `process.env` to child scripts, so any variable set in `.env` or `.env.local` (and loaded by the parent via `loadEnv()`) was silently dropped before reaching the spawned subprocess. The parent would read `OPENROUTER_API_KEY` from `.env` and run fine; the child would see `undefined` and fail or skip silently.

The fix is a one-line change: children now also receive `loadEnv()` (which merges `.env`, `.env.local`, and `process.env`), matching the env resolution the rest of the script already uses.

## Requirements

None — no new dependencies, no schema changes. Affects only the existing `wiki-compiler` recipe.

## Checklist

- [x] I've read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] I tested this on my own Open Brain instance
- [x] No credentials, API keys, or secrets are included

Checklist items that don't apply:
- README / metadata.json updates — this is a one-line bug fix inside an existing recipe, no surface-level docs change needed