### PR TITLE
[server][integrations] OAuth 2.1 for MCP + Cloudflare Worker proxy

### DIFF
--- a/docs/01-getting-started.md
+++ b/docs/01-getting-started.md
@@ -834,6 +834,80 @@ Every MCP client handles remote servers slightly differently. The server accepts
 
 ---
 
+![Step 7b](https://img.shields.io/badge/Step_7b-OAuth_(Optional)-5C6BC0?style=for-the-badge)
+
+> [!NOTE]
+> This step is **optional**. Your setup from Steps 1–7 already works. OAuth is for users who want to remove the `?key=` URL parameter (which leaks in proxy logs, browser history, and Referer headers) and use short-lived bearer tokens instead. Legacy `x-brain-key` header and `?key=` auth keep working when OAuth is enabled — this is strictly additive.
+
+<details>
+<summary>🔐 <strong>Why enable OAuth?</strong></summary>
+
+- **Kill the URL-param leak.** `?key=<your-brain-key>` shows up in server access logs, browser history, shell history, and every `Referer` header sent to sites you visit from Supabase dashboards. One leak = permanent credential compromise.
+- **Short-lived tokens.** Access tokens expire after 1 hour; you stay signed in via a refresh token (30 days). A stolen access token is only useful for an hour.
+- **Panic button.** Rotate `OAUTH_JWT_SECRET` and every outstanding token is invalidated instantly.
+- **Standard MCP auth.** Clients that speak OAuth (Claude Desktop, `mcp-remote`) will use it automatically — no `?key=` to paste.
+
+</details>
+
+### 7b.1 — Generate the secrets
+
+Run locally:
+
+```bash
+# Password you'll type in your browser during sign-in. Keep it in a password manager.
+export OAUTH_PASSWORD="$(openssl rand -base64 24)"
+
+# JWT signing secret — never type this anywhere, only server reads it.
+export OAUTH_JWT_SECRET="$(openssl rand -hex 32)"
+
+# Set both as Supabase secrets.
+supabase secrets set OAUTH_PASSWORD="$OAUTH_PASSWORD" OAUTH_JWT_SECRET="$OAUTH_JWT_SECRET" --project-ref YOUR_PROJECT_REF
+```
+
+Write `OAUTH_PASSWORD` down (or save it in your password manager) — you'll type it once per client during the OAuth sign-in. `OAUTH_JWT_SECRET` never leaves the server; you don't need to save it anywhere except Supabase secrets.
+
+### 7b.2 — Redeploy
+
+```bash
+supabase functions deploy open-brain-mcp --no-verify-jwt --project-ref YOUR_PROJECT_REF
+```
+
+Once the deploy finishes, OAuth endpoints are live:
+
+| Endpoint | Purpose |
+|----------|---------|
+| `GET /.well-known/oauth-authorization-server` | Discovery — clients fetch this automatically |
+| `POST /register` | Dynamic client registration |
+| `GET /authorize` | Password prompt (browser) |
+| `POST /token` | Code/refresh exchange |
+
+### 7b.3 — Connect clients without `?key=`
+
+For Claude Desktop, Cursor, `mcp-remote`, or any MCP client that supports OAuth: use your **MCP Server URL** (the one **without** `?key=`):
+
+```
+https://YOUR_PROJECT_REF.supabase.co/functions/v1/open-brain-mcp
+```
+
+The client will trigger OAuth discovery → open your browser to the `/authorize` page → you type `OAUTH_PASSWORD` → client receives a bearer token. No URL param, no header pasted by hand.
+
+### 7b.4 — If something goes wrong: the panic button
+
+If you suspect an access token has leaked or a client has gone rogue, rotate the JWT signing key:
+
+```bash
+supabase secrets set OAUTH_JWT_SECRET="$(openssl rand -hex 32)" --project-ref YOUR_PROJECT_REF
+```
+
+Every outstanding access and refresh token is invalidated. Every client will need to re-authorize (sign in again with the password). `OAUTH_PASSWORD` itself stays the same.
+
+> [!TIP]
+> **Rotating the password:** Changing `OAUTH_PASSWORD` prevents new sign-ins but does NOT invalidate existing refresh tokens until they expire (30 days). If you need an immediate cutover, rotate `OAUTH_JWT_SECRET` at the same time.
+
+✅ **Done when:** Your client connected with an OAuth URL (no `?key=`) and tools work. The old `?key=` URL and `x-brain-key` header still work too — you can migrate clients one at a time.
+
+---
+
 ![Step 8](https://img.shields.io/badge/Step_8-Use_It-8E24AA?style=for-the-badge)
 
 Ask your AI naturally. It picks the right tool automatically:
@@ -893,6 +967,9 @@ Your `service_role` doesn't have table-level permissions. This happens on newer 
 **❌ Claude Desktop JSON config: "Couldn't reach the MCP server"**
 
 If you're using `claude_desktop_config.json` with `mcp-remote`, switch to `supergateway --streamableHttp` instead. `mcp-remote` performs OAuth discovery against the Supabase domain (`/.well-known/oauth-authorization-server`), which returns a 404 that stalls the connection past Claude Desktop's startup timeout. `supergateway` connects directly with no OAuth handshake. See Step 7.1 for the config. (This does not affect Codex, which has a configurable `startup_timeout_sec` that gives `mcp-remote` enough time to fall back.)
+
+> [!TIP]
+> If you've completed **Step 7b (OAuth)**, discovery returns a real metadata document instead of a 404 and `mcp-remote` works fine — no need to switch to `supergateway`.
 
 **❌ Getting 401 errors**
 

--- a/docs/01-getting-started.md
+++ b/docs/01-getting-started.md
@@ -832,6 +832,9 @@ Every MCP client handles remote servers slightly differently. The server accepts
 
 ✅ **Done when:** You can start a conversation in your AI client and it has access to Open Brain tools (search_thoughts, list_thoughts, thought_stats, capture_thought).
 
+> [!TIP]
+> **Worried about the `?key=` in your URL?** The access key lands in proxy logs, browser history, and `Referer` headers — one leak is forever. For a token-based alternative that keeps Claude Desktop working, see [`integrations/cloudflare-oauth-proxy/`](../integrations/cloudflare-oauth-proxy/). Both paths stay supported; you can pick per client.
+
 ---
 
 ![Step 8](https://img.shields.io/badge/Step_8-Use_It-8E24AA?style=for-the-badge)

--- a/docs/01-getting-started.md
+++ b/docs/01-getting-started.md
@@ -883,7 +883,7 @@ Once the deploy finishes, OAuth endpoints are live:
 
 ### 7b.3 — Connect clients without `?key=`
 
-For Claude Desktop, Cursor, `mcp-remote`, or any MCP client that supports OAuth: use your **MCP Server URL** (the one **without** `?key=`):
+For path-aware MCP clients (Cursor with OAuth, custom curl-based tools, anything that respects the explicit `authorization_endpoint`/`token_endpoint` URLs from the discovery document): use your **MCP Server URL** (the one **without** `?key=`):
 
 ```
 https://YOUR_PROJECT_REF.supabase.co/functions/v1/open-brain-mcp
@@ -891,7 +891,18 @@ https://YOUR_PROJECT_REF.supabase.co/functions/v1/open-brain-mcp
 
 The client will trigger OAuth discovery → open your browser to the `/authorize` page → you type `OAUTH_PASSWORD` → client receives a bearer token. No URL param, no header pasted by hand.
 
-### 7b.4 — If something goes wrong: the panic button
+> [!IMPORTANT]
+> **Claude Desktop and `mcp-remote` require one more step** — they're built on the MCP TypeScript SDK, which strips the URL path during OAuth discovery. Since Supabase Edge Functions live under `/functions/v1/<name>/`, the SDK can't reach the OAuth endpoints directly and connection fails with "Couldn't reach the MCP server". See **Step 7b.5** below for the fix.
+
+### 7b.4 — OAuth proxy for Claude Desktop and `mcp-remote`
+
+The fix is a tiny Cloudflare Worker that gives each MCP server a clean, path-less origin URL. The Worker proxies every request to your Supabase Edge Function with `/functions/v1/<name>/` prepended; the MCP client sees no path and OAuth resolves correctly.
+
+Full setup (~15 min): [`integrations/cloudflare-oauth-proxy/`](../integrations/cloudflare-oauth-proxy/).
+
+After setup, your Claude Desktop connector URL becomes `https://ob-<name>.<your-cf-subdomain>.workers.dev` (no `?key=`, no `/functions/v1/` path). Your original Supabase URL still works unchanged for any path-aware client or legacy `?key=`/`x-brain-key` flows — the Worker is additive.
+
+### 7b.5 — If something goes wrong: the panic button
 
 If you suspect an access token has leaked or a client has gone rogue, rotate the JWT signing key:
 

--- a/integrations/cloudflare-oauth-proxy/.gitignore
+++ b/integrations/cloudflare-oauth-proxy/.gitignore
@@ -1,0 +1,4 @@
+.wrangler/
+node_modules/
+wrangler.toml
+*.log

--- a/integrations/cloudflare-oauth-proxy/README.md
+++ b/integrations/cloudflare-oauth-proxy/README.md
@@ -77,13 +77,31 @@ tracker.
 ### Step 3 — Tell the Edge Functions about their new origin
 
 Each MCP server needs to know its public URL is now the Worker, not the
-Supabase function. Set `OAUTH_ISSUER_URL` on each function **separately**.
-Use the Supabase Dashboard (the CLI sets project-wide secrets, which would
-collide between the two functions):
+Supabase function. Supabase secrets are **project-wide** (CLI and Dashboard
+both — there's no per-function scoping), so the core server uses the plain
+secret name and each additional server (extensions, recipes) takes an
+override.
 
-1. Open the dashboard → Project → **Edge Functions** → `open-brain-mcp` → **Secrets**.
-2. Add a secret: `OAUTH_ISSUER_URL` = the `WORKER_URL_CORE` from Step 2.
-3. Repeat for `life-crm-mcp` with `WORKER_URL_LIFE_CRM`.
+Open the Supabase Dashboard → Project → **Edge Functions** → **Secrets**
+(or `Project Settings → Edge Functions → Manage Secrets`).
+
+**Always set, for the core Open Brain server:**
+
+| Name | Value |
+|------|-------|
+| `OAUTH_ISSUER_URL` | `WORKER_URL_CORE` from Step 2 |
+
+**Additional extensions/recipes** (add one override per extra MCP server
+sharing the project):
+
+| Name | Value |
+|------|-------|
+| `OAUTH_ISSUER_URL_LIFE_CRM_MCP` | `WORKER_URL_LIFE_CRM` from Step 2 |
+
+The override name is the function name, uppercased with dashes replaced by
+underscores, prefixed with `OAUTH_ISSUER_URL_`. So `life-crm-mcp` becomes
+`OAUTH_ISSUER_URL_LIFE_CRM_MCP`. The core server (`open-brain-mcp`) just
+uses the plain `OAUTH_ISSUER_URL` — no override needed.
 
 No redeploy needed — secrets take effect on the next function invocation.
 

--- a/integrations/cloudflare-oauth-proxy/README.md
+++ b/integrations/cloudflare-oauth-proxy/README.md
@@ -1,0 +1,145 @@
+# Cloudflare OAuth Proxy
+
+A tiny Cloudflare Worker that gives your Supabase-hosted MCP server a clean,
+path-less origin URL so Claude Desktop (and other MCP TypeScript SDK clients
+like `mcp-remote`) can complete OAuth discovery.
+
+## What It Does
+
+MCP's OAuth flow is spec'd on top of RFC 8414 / RFC 9728. When an MCP client
+needs to discover the authorization server, the MCP TypeScript SDK composes
+the metadata URL by taking the authorization-server URL's **origin only** —
+it strips any path. Supabase Edge Functions are mounted under
+`/functions/v1/<function-name>/`, so the SDK tries URLs like
+`https://<ref>.supabase.co/.well-known/oauth-authorization-server` and
+`https://<ref>.supabase.co/register` — both of which hit the Supabase
+platform gateway and return 404. OAuth never completes.
+
+This Worker fixes it by proxying every request from a clean origin
+(`ob-<name>.<your-cf-account>.workers.dev`) to the Supabase Edge Function,
+prepending `/functions/v1/<name>` on the way out. The client sees no path,
+nothing to strip, OAuth resolves correctly, and the full PKCE flow works.
+
+```
+Claude Desktop ──▶ ob-life-crm.workers.dev/<anything>
+                           │
+                           ▼ (Worker re-fetches)
+      https://<ref>.supabase.co/functions/v1/life-crm-mcp/<anything>
+                           │
+                           ▼
+                (existing Edge Function runs as-is)
+```
+
+The Worker is a pure path-rewriter — no auth, no cache, no transforms. Your
+Edge Function is still the source of truth for authorization and tool
+handling; this just gives it a different advertised origin.
+
+## Prerequisites
+
+- A deployed Open Brain MCP server with OAuth enabled — complete Steps 1–7
+  and the optional Step 7b in `docs/01-getting-started.md` first.
+- A Cloudflare account (free tier works). Sign up at
+  [dash.cloudflare.com](https://dash.cloudflare.com).
+- `wrangler` CLI installed (`npm install -g wrangler`) and authenticated
+  (`wrangler login`).
+- Node.js 20+.
+
+## Credential Tracker
+
+| Field | Value |
+|-------|-------|
+| `SUPABASE_REF` | Your Supabase project ref (Step 1 of main setup) |
+| `WORKER_URL_CORE` | Filled in after deploy — `https://ob-core.<your-cf-subdomain>.workers.dev` |
+| `WORKER_URL_LIFE_CRM` | Filled in after deploy — `https://ob-life-crm.<your-cf-subdomain>.workers.dev` |
+
+## Setup
+
+### Step 1 — Configure
+
+```bash
+cd integrations/cloudflare-oauth-proxy
+cp wrangler.toml.example wrangler.toml
+```
+
+Open `wrangler.toml` and replace `<SUPABASE_REF>` in both `[env.core.vars]`
+and `[env.life-crm.vars]` with your Supabase project ref.
+
+### Step 2 — Deploy both Workers
+
+```bash
+wrangler deploy --env core
+wrangler deploy --env life-crm
+```
+
+Each command prints the published URL. Record them in the credential
+tracker.
+
+### Step 3 — Tell the Edge Functions about their new origin
+
+Each MCP server needs to know its public URL is now the Worker, not the
+Supabase function. Set `OAUTH_ISSUER_URL` on each function **separately**.
+Use the Supabase Dashboard (the CLI sets project-wide secrets, which would
+collide between the two functions):
+
+1. Open the dashboard → Project → **Edge Functions** → `open-brain-mcp` → **Secrets**.
+2. Add a secret: `OAUTH_ISSUER_URL` = the `WORKER_URL_CORE` from Step 2.
+3. Repeat for `life-crm-mcp` with `WORKER_URL_LIFE_CRM`.
+
+No redeploy needed — secrets take effect on the next function invocation.
+
+### Step 4 — Verify
+
+```bash
+# 1. Discovery document now advertises the Worker URL as the issuer
+curl -s "${WORKER_URL_LIFE_CRM}/.well-known/oauth-authorization-server" | jq .issuer
+# → "https://ob-life-crm.<your-cf-subdomain>.workers.dev"
+
+# 2. WWW-Authenticate points at the Worker-scoped resource_metadata URL
+curl -sI "${WORKER_URL_LIFE_CRM}/" | grep -i 'www-authenticate'
+
+# 3. Full OAuth flow end-to-end with mcp-remote
+npx mcp-remote "${WORKER_URL_LIFE_CRM}" --debug
+# Browser opens to the /authorize form → enter your OAUTH_PASSWORD → tools appear.
+```
+
+### Step 5 — Connect Claude Desktop
+
+In Claude Desktop: **Settings → Connectors → Add custom connector**, paste
+the Worker URL (no `?key=`, no trailing slash).
+
+Repeat for each MCP server you deployed a Worker for.
+
+## Expected Outcome
+
+- Claude Desktop can connect via OAuth — you type the password once per
+  client (and again whenever you rotate `OAUTH_JWT_SECRET`).
+- Every OAuth URL (discovery, `/register`, `/authorize`, `/token`) resolves
+  to the Worker, which forwards to Supabase transparently.
+- The original Supabase URL still works unchanged for any client hitting it
+  directly — `?key=` and `x-brain-key` / `x-access-key` header flows are
+  untouched by the Worker.
+
+## Troubleshooting
+
+**`wrangler deploy` errors with "not authenticated"**
+Run `wrangler login` and try again. Deploy won't work against an expired
+session.
+
+**Worker deploys but returns 404 on every request**
+Check that `UPSTREAM_BASE` and `FUNCTION_NAME` in `wrangler.toml` are
+correct. Test directly:
+`curl -s "${UPSTREAM_BASE}/functions/v1/${FUNCTION_NAME}/health"` — that
+should return JSON. If it doesn't, fix the upstream before worrying about
+the Worker.
+
+**`/.well-known/oauth-authorization-server` still shows the Supabase URL as issuer**
+`OAUTH_ISSUER_URL` isn't set on the Edge Function's secrets, or is set to the
+wrong value. Re-check Step 3, then make a fresh request (no HTTP caching —
+Claude Desktop caches discovery docs per-session, so re-open the connector).
+
+**OAuth flow redirects to `claude.ai/...couldn't connect`**
+Re-run `npx mcp-remote <worker-url> --debug` and inspect
+`/tmp/mcp-remote.log`. A `404` on `<worker-url>/.well-known/...` means the
+Worker is routing incorrectly. A `ServerError at registerClient` means the
+Worker isn't forwarding POSTs correctly — verify `redirect: "manual"` is
+present in `src/index.ts` and that you deployed the latest version.

--- a/integrations/cloudflare-oauth-proxy/README.md
+++ b/integrations/cloudflare-oauth-proxy/README.md
@@ -1,38 +1,60 @@
 # Cloudflare OAuth Proxy
 
 A tiny Cloudflare Worker that gives your Supabase-hosted MCP server a clean,
-path-less origin URL so Claude Desktop (and other MCP TypeScript SDK clients
-like `mcp-remote`) can complete OAuth discovery.
+path-less origin URL and serves the OAuth login form, so Claude Desktop
+(and other MCP TypeScript SDK clients like `mcp-remote`) can complete
+OAuth discovery and sign-in.
 
 ## What It Does
 
-MCP's OAuth flow is spec'd on top of RFC 8414 / RFC 9728. When an MCP client
-needs to discover the authorization server, the MCP TypeScript SDK composes
-the metadata URL by taking the authorization-server URL's **origin only** —
-it strips any path. Supabase Edge Functions are mounted under
+The Worker solves two concrete problems with hosting OAuth on a Supabase
+Edge Function:
+
+**1. Path-less origin for OAuth discovery.** MCP's OAuth flow is spec'd on
+top of RFC 8414 / RFC 9728. When an MCP client needs to discover the
+authorization server, the MCP TypeScript SDK composes the metadata URL by
+taking the authorization-server URL's **origin only** — it strips any
+path. Supabase Edge Functions are mounted under
 `/functions/v1/<function-name>/`, so the SDK tries URLs like
 `https://<ref>.supabase.co/.well-known/oauth-authorization-server` and
 `https://<ref>.supabase.co/register` — both of which hit the Supabase
 platform gateway and return 404. OAuth never completes.
 
-This Worker fixes it by proxying every request from a clean origin
-(`ob-<name>.<your-cf-account>.workers.dev`) to the Supabase Edge Function,
-prepending `/functions/v1/<name>` on the way out. The client sees no path,
-nothing to strip, OAuth resolves correctly, and the full PKCE flow works.
+**2. Serving HTML.** The OAuth login form (GET `/authorize`) has to render
+as HTML in the user's browser. Supabase Edge Functions force
+`Content-Type: text/plain` and a `default-src 'none'; sandbox` CSP on every
+response at the platform level, regardless of what the function code sets.
+Result: the form displays as raw source text and can't submit. Not
+overridable from inside the function.
+
+This Worker fixes both by sitting in front of the Edge Function on a clean
+origin (`ob-<name>.<your-cf-account>.workers.dev`). It:
+
+- Proxies every request to the Edge Function, prepending
+  `/functions/v1/<name>` on the way out — so the client sees no path and
+  the SDK can discover OAuth endpoints correctly.
+- **Serves GET `/authorize` itself** from Worker code (the one endpoint
+  that must return HTML). POST `/authorize` still proxies to Supabase for
+  password verification; everything else (discovery, `/register`, `/token`,
+  MCP calls) is a pure passthrough.
 
 ```
-Claude Desktop ──▶ ob-life-crm.workers.dev/<anything>
+Claude Desktop ──▶ ob-<name>.workers.dev/<anything>
                            │
-                           ▼ (Worker re-fetches)
-      https://<ref>.supabase.co/functions/v1/life-crm-mcp/<anything>
+                           ▼ (Worker)
+    GET /authorize  ─── render login form HTML ──▶ user's browser
+    everything else ──▶ proxy to Supabase
+                           │
+                           ▼
+    https://<ref>.supabase.co/functions/v1/<name>/<anything>
                            │
                            ▼
                 (existing Edge Function runs as-is)
 ```
 
-The Worker is a pure path-rewriter — no auth, no cache, no transforms. Your
-Edge Function is still the source of truth for authorization and tool
-handling; this just gives it a different advertised origin.
+Your Edge Function is still the source of truth for password
+verification, token issuance, and tool handling; the Worker just gives it
+a different advertised origin and renders the one HTML page.
 
 ## Prerequisites
 
@@ -49,8 +71,11 @@ handling; this just gives it a different advertised origin.
 | Field | Value |
 |-------|-------|
 | `SUPABASE_REF` | Your Supabase project ref (Step 1 of main setup) |
-| `WORKER_URL_CORE` | Filled in after deploy — `https://ob-core.<your-cf-subdomain>.workers.dev` |
-| `WORKER_URL_LIFE_CRM` | Filled in after deploy — `https://ob-life-crm.<your-cf-subdomain>.workers.dev` |
+| `WORKER_URL` | Filled in after deploy — `https://ob-core.<your-cf-subdomain>.workers.dev` |
+
+(If you're proxying more than one MCP server — e.g. a recipe or extension
+that runs as its own Edge Function — you'll record one Worker URL per
+server. See [Multiple MCP servers](#multiple-mcp-servers) below.)
 
 ## Setup
 
@@ -61,71 +86,91 @@ cd integrations/cloudflare-oauth-proxy
 cp wrangler.toml.example wrangler.toml
 ```
 
-Open `wrangler.toml` and replace `<SUPABASE_REF>` in both `[env.core.vars]`
-and `[env.life-crm.vars]` with your Supabase project ref.
+Open `wrangler.toml` and replace `<SUPABASE_REF>` with your Supabase
+project ref.
 
-### Step 2 — Deploy both Workers
+### Step 2 — Deploy
 
 ```bash
 wrangler deploy --env core
-wrangler deploy --env life-crm
 ```
 
-Each command prints the published URL. Record them in the credential
+`wrangler` prints the published URL. Record it as `WORKER_URL` in the
 tracker.
 
-### Step 3 — Tell the Edge Functions about their new origin
+### Step 3 — Tell the Edge Function about its new origin
 
-Each MCP server needs to know its public URL is now the Worker, not the
-Supabase function. Supabase secrets are **project-wide** (CLI and Dashboard
-both — there's no per-function scoping), so the core server uses the plain
-secret name and each additional server (extensions, recipes) takes an
-override.
+The MCP server needs to know its public URL is now the Worker, not the
+Supabase function. Set a single secret:
 
-Open the Supabase Dashboard → Project → **Edge Functions** → **Secrets**
-(or `Project Settings → Edge Functions → Manage Secrets`).
+```bash
+supabase secrets set \
+  OAUTH_ISSUER_URL="<WORKER_URL>" \
+  --project-ref YOUR_PROJECT_REF
+```
 
-**Always set, for the core Open Brain server:**
-
-| Name | Value |
-|------|-------|
-| `OAUTH_ISSUER_URL` | `WORKER_URL_CORE` from Step 2 |
-
-**Additional extensions/recipes** (add one override per extra MCP server
-sharing the project):
-
-| Name | Value |
-|------|-------|
-| `OAUTH_ISSUER_URL_LIFE_CRM_MCP` | `WORKER_URL_LIFE_CRM` from Step 2 |
-
-The override name is the function name, uppercased with dashes replaced by
-underscores, prefixed with `OAUTH_ISSUER_URL_`. So `life-crm-mcp` becomes
-`OAUTH_ISSUER_URL_LIFE_CRM_MCP`. The core server (`open-brain-mcp`) just
-uses the plain `OAUTH_ISSUER_URL` — no override needed.
-
-No redeploy needed — secrets take effect on the next function invocation.
+No redeploy needed — secrets take effect on the next function
+invocation. (The Supabase Dashboard's Edge Function Secrets UI works
+too if you'd rather click than type.)
 
 ### Step 4 — Verify
 
 ```bash
-# 1. Discovery document now advertises the Worker URL as the issuer
-curl -s "${WORKER_URL_LIFE_CRM}/.well-known/oauth-authorization-server" | jq .issuer
-# → "https://ob-life-crm.<your-cf-subdomain>.workers.dev"
+# 1. Discovery document advertises the Worker URL as the issuer
+curl -s "${WORKER_URL}/.well-known/oauth-authorization-server" | jq .issuer
+# → "https://ob-core.<your-cf-subdomain>.workers.dev"
 
 # 2. WWW-Authenticate points at the Worker-scoped resource_metadata URL
-curl -sI "${WORKER_URL_LIFE_CRM}/" | grep -i 'www-authenticate'
+curl -sI "${WORKER_URL}/" | grep -i 'www-authenticate'
 
 # 3. Full OAuth flow end-to-end with mcp-remote
-npx mcp-remote "${WORKER_URL_LIFE_CRM}" --debug
+npx mcp-remote "${WORKER_URL}" --debug
 # Browser opens to the /authorize form → enter your OAUTH_PASSWORD → tools appear.
 ```
 
 ### Step 5 — Connect Claude Desktop
 
 In Claude Desktop: **Settings → Connectors → Add custom connector**, paste
-the Worker URL (no `?key=`, no trailing slash).
+`WORKER_URL` (no `?key=`, no trailing slash).
 
-Repeat for each MCP server you deployed a Worker for.
+## Multiple MCP servers
+
+If you're running more than one MCP server in the same Supabase project
+(e.g., the core Open Brain plus a recipe or extension that deploys its
+own Edge Function), each server needs its own Worker and its own
+issuer-URL secret.
+
+**Add another deploy env to `wrangler.toml`:**
+
+```toml
+[env.my-extension]
+name = "ob-my-extension"
+
+[env.my-extension.vars]
+UPSTREAM_BASE = "https://<SUPABASE_REF>.supabase.co"
+FUNCTION_NAME = "my-extension-mcp"
+```
+
+**Deploy it:**
+
+```bash
+wrangler deploy --env my-extension
+```
+
+**Set a per-function secret.** Supabase secrets are project-wide, but the
+Edge Function code picks the right value per-function by looking up
+`OAUTH_ISSUER_URL_<FUNCTION_NAME>` first (uppercased, dashes replaced
+with underscores), then falling back to the plain `OAUTH_ISSUER_URL`.
+So the core server uses the plain name and each additional server sets
+an override:
+
+```bash
+supabase secrets set \
+  OAUTH_ISSUER_URL_MY_EXTENSION_MCP="<WORKER_URL_FOR_MY_EXTENSION>" \
+  --project-ref YOUR_PROJECT_REF
+```
+
+Repeat for as many MCP servers as you're proxying.
 
 ## Expected Outcome
 
@@ -134,8 +179,8 @@ Repeat for each MCP server you deployed a Worker for.
 - Every OAuth URL (discovery, `/register`, `/authorize`, `/token`) resolves
   to the Worker, which forwards to Supabase transparently.
 - The original Supabase URL still works unchanged for any client hitting it
-  directly — `?key=` and `x-brain-key` / `x-access-key` header flows are
-  untouched by the Worker.
+  directly — `?key=` and `x-brain-key` header flows are untouched by the
+  Worker.
 
 ## Troubleshooting
 
@@ -151,9 +196,10 @@ should return JSON. If it doesn't, fix the upstream before worrying about
 the Worker.
 
 **`/.well-known/oauth-authorization-server` still shows the Supabase URL as issuer**
-`OAUTH_ISSUER_URL` isn't set on the Edge Function's secrets, or is set to the
-wrong value. Re-check Step 3, then make a fresh request (no HTTP caching —
-Claude Desktop caches discovery docs per-session, so re-open the connector).
+`OAUTH_ISSUER_URL` (or the per-function override) isn't set on the Edge
+Function's secrets, or is set to the wrong value. Re-check Step 3, then
+make a fresh request. Claude Desktop caches discovery docs per-session,
+so remove and re-add the connector after fixing.
 
 **OAuth flow redirects to `claude.ai/...couldn't connect`**
 Re-run `npx mcp-remote <worker-url> --debug` and inspect
@@ -161,3 +207,9 @@ Re-run `npx mcp-remote <worker-url> --debug` and inspect
 Worker is routing incorrectly. A `ServerError at registerClient` means the
 Worker isn't forwarding POSTs correctly — verify `redirect: "manual"` is
 present in `src/index.ts` and that you deployed the latest version.
+
+**Login form displays as raw HTML source in the browser**
+The Worker isn't serving `GET /authorize` itself — it's falling through to
+Supabase, which forces `Content-Type: text/plain`. Make sure you deployed
+the latest `src/index.ts` (it should have a `renderAuthorizeForm` function
+and an early return for `GET /authorize`).

--- a/integrations/cloudflare-oauth-proxy/metadata.json
+++ b/integrations/cloudflare-oauth-proxy/metadata.json
@@ -1,0 +1,17 @@
+{
+  "name": "Cloudflare OAuth Proxy",
+  "description": "Thin Cloudflare Worker that gives Supabase-hosted MCP servers a path-less origin URL so the MCP TypeScript SDK's OAuth discovery works in Claude Desktop and mcp-remote.",
+  "category": "integrations",
+  "author": { "name": "Travis Swicegood", "github": "tswicegood" },
+  "version": "1.0.0",
+  "requires": {
+    "open_brain": true,
+    "services": ["Cloudflare Workers"],
+    "tools": ["wrangler", "Node.js 20+"]
+  },
+  "tags": ["oauth", "cloudflare", "worker", "proxy", "mcp", "claude-desktop"],
+  "difficulty": "intermediate",
+  "estimated_time": "15 minutes",
+  "created": "2026-04-17",
+  "updated": "2026-04-17"
+}

--- a/integrations/cloudflare-oauth-proxy/package.json
+++ b/integrations/cloudflare-oauth-proxy/package.json
@@ -4,10 +4,8 @@
   "private": true,
   "description": "Cloudflare Worker proxying Supabase-hosted MCP servers to a clean origin so MCP TypeScript SDK OAuth discovery works.",
   "scripts": {
-    "deploy:core": "wrangler deploy --env core",
-    "deploy:life-crm": "wrangler deploy --env life-crm",
-    "tail:core": "wrangler tail --env core",
-    "tail:life-crm": "wrangler tail --env life-crm"
+    "deploy": "wrangler deploy --env core",
+    "tail": "wrangler tail --env core"
   },
   "devDependencies": {
     "wrangler": "^3.90.0"

--- a/integrations/cloudflare-oauth-proxy/package.json
+++ b/integrations/cloudflare-oauth-proxy/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "ob-cloudflare-oauth-proxy",
+  "version": "1.0.0",
+  "private": true,
+  "description": "Cloudflare Worker proxying Supabase-hosted MCP servers to a clean origin so MCP TypeScript SDK OAuth discovery works.",
+  "scripts": {
+    "deploy:core": "wrangler deploy --env core",
+    "deploy:life-crm": "wrangler deploy --env life-crm",
+    "tail:core": "wrangler tail --env core",
+    "tail:life-crm": "wrangler tail --env life-crm"
+  },
+  "devDependencies": {
+    "wrangler": "^3.90.0"
+  }
+}

--- a/integrations/cloudflare-oauth-proxy/src/index.ts
+++ b/integrations/cloudflare-oauth-proxy/src/index.ts
@@ -1,0 +1,43 @@
+// Cloudflare Worker — OAuth origin proxy for Supabase-hosted MCP servers.
+//
+// Why this exists: the MCP TypeScript SDK (Claude Desktop, mcp-remote, and
+// others) strips the URL path when composing OAuth discovery and endpoint
+// URLs. Supabase Edge Functions mount under /functions/v1/<name>/, so the
+// SDK can't reach the OAuth endpoints directly. This Worker gives each MCP
+// function a path-less origin — the SDK has no path to strip, and OAuth
+// resolves cleanly.
+//
+// Pure path-rewriter: every request is forwarded to
+//   `${UPSTREAM_BASE}/functions/v1/${FUNCTION_NAME}${incoming-path}`
+// Response is returned verbatim. No auth, no caching, no transforms.
+
+export interface Env {
+  UPSTREAM_BASE: string;    // e.g. "https://<ref>.supabase.co"
+  FUNCTION_NAME: string;    // e.g. "open-brain-mcp" or "life-crm-mcp"
+}
+
+export default {
+  async fetch(request: Request, env: Env): Promise<Response> {
+    const incoming = new URL(request.url);
+    const target = new URL(
+      `${env.UPSTREAM_BASE.replace(/\/$/, "")}` +
+        `/functions/v1/${env.FUNCTION_NAME}${incoming.pathname}`,
+    );
+    target.search = incoming.search;
+
+    const init: RequestInit = {
+      method: request.method,
+      headers: request.headers,
+      body:
+        request.method === "GET" || request.method === "HEAD"
+          ? undefined
+          : request.body,
+      // Critical: without manual redirect handling, fetch() auto-follows the
+      // 302 that /authorize issues, and the OAuth callback to the MCP client
+      // is lost.
+      redirect: "manual",
+    };
+
+    return fetch(target.toString(), init);
+  },
+};

--- a/integrations/cloudflare-oauth-proxy/src/index.ts
+++ b/integrations/cloudflare-oauth-proxy/src/index.ts
@@ -7,9 +7,17 @@
 // function a path-less origin — the SDK has no path to strip, and OAuth
 // resolves cleanly.
 //
-// Pure path-rewriter: every request is forwarded to
+// Mostly a path-rewriter: forward every request to
 //   `${UPSTREAM_BASE}/functions/v1/${FUNCTION_NAME}${incoming-path}`
-// Response is returned verbatim. No auth, no caching, no transforms.
+// and return the response verbatim.
+//
+// One exception: GET /authorize. Supabase Edge Functions force
+// `content-type: text/plain` + `content-security-policy: default-src 'none';
+// sandbox` on any HTML response (a platform-level security policy we can't
+// override from inside the function). That breaks the OAuth login form. So
+// the Worker serves the form itself for GET /authorize; everything else
+// (POST /authorize password verification, /token, /register, /.well-known,
+// MCP calls) still proxies through to Supabase.
 
 export interface Env {
   UPSTREAM_BASE: string;    // e.g. "https://<ref>.supabase.co"
@@ -19,6 +27,11 @@ export interface Env {
 export default {
   async fetch(request: Request, env: Env): Promise<Response> {
     const incoming = new URL(request.url);
+
+    if (request.method === "GET" && incoming.pathname === "/authorize") {
+      return renderAuthorizeForm(incoming.searchParams);
+    }
+
     const target = new URL(
       `${env.UPSTREAM_BASE.replace(/\/$/, "")}` +
         `/functions/v1/${env.FUNCTION_NAME}${incoming.pathname}`,
@@ -41,3 +54,80 @@ export default {
     return fetch(target.toString(), init);
   },
 };
+
+const REQUIRED_PARAMS = [
+  "client_id",
+  "redirect_uri",
+  "code_challenge",
+  "code_challenge_method",
+  "state",
+] as const;
+
+function renderAuthorizeForm(q: URLSearchParams): Response {
+  for (const k of REQUIRED_PARAMS) {
+    if (!q.get(k)) return plain(`Missing query parameter: ${k}`, 400);
+  }
+  if (q.get("response_type") && q.get("response_type") !== "code") {
+    return plain("Only response_type=code is supported", 400);
+  }
+  if (q.get("code_challenge_method") !== "S256") {
+    return plain("Only code_challenge_method=S256 is supported", 400);
+  }
+
+  const params = Object.fromEntries(q.entries());
+  const error = q.get("error") === "invalid_password" ? "Incorrect password." : "";
+
+  return new Response(loginPage(params, error), {
+    status: 200,
+    headers: {
+      "Content-Type": "text/html; charset=UTF-8",
+      "Content-Security-Policy":
+        "default-src 'self'; style-src 'unsafe-inline'; form-action 'self'",
+      "X-Content-Type-Options": "nosniff",
+      "Cache-Control": "no-store",
+    },
+  });
+}
+
+function plain(body: string, status: number): Response {
+  return new Response(body, { status, headers: { "Content-Type": "text/plain" } });
+}
+
+function escapeHtml(s: string): string {
+  return s
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+}
+
+function loginPage(params: Record<string, string>, error: string): string {
+  const hidden = Object.entries(params)
+    .filter(([k]) => k !== "password" && k !== "error")
+    .map(([k, v]) => `<input type="hidden" name="${escapeHtml(k)}" value="${escapeHtml(v)}">`)
+    .join("\n        ");
+  const errHtml = error ? `<p style="color:#b00">${escapeHtml(error)}</p>` : "";
+  return `<!doctype html>
+<html><head><meta charset="utf-8"><title>Open Brain — Sign in</title>
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<style>
+  body{font-family:system-ui,-apple-system,sans-serif;max-width:400px;margin:4rem auto;padding:0 1rem;color:#222}
+  h1{font-size:1.4rem;margin-bottom:0.5rem}
+  p.lede{color:#666;margin-top:0}
+  form{display:flex;flex-direction:column;gap:0.75rem;margin-top:1.5rem}
+  input[type=password]{padding:0.6rem;font-size:1rem;border:1px solid #ccc;border-radius:4px}
+  button{padding:0.6rem;font-size:1rem;background:#111;color:#fff;border:0;border-radius:4px;cursor:pointer}
+  button:hover{background:#333}
+</style></head>
+<body>
+  <h1>Open Brain</h1>
+  <p class="lede">Enter your password to authorize this client.</p>
+  ${errHtml}
+  <form method="post" action="/authorize">
+    ${hidden}
+    <input type="password" name="password" autofocus required placeholder="Password">
+    <button type="submit">Authorize</button>
+  </form>
+</body></html>`;
+}

--- a/integrations/cloudflare-oauth-proxy/src/index.ts
+++ b/integrations/cloudflare-oauth-proxy/src/index.ts
@@ -81,8 +81,15 @@ function renderAuthorizeForm(q: URLSearchParams): Response {
     status: 200,
     headers: {
       "Content-Type": "text/html; charset=UTF-8",
+      // No form-action directive. CSP Level 3 doesn't fall form-action back
+      // to default-src, so omitting it leaves form submission unrestricted.
+      // The OAuth form must submit to /authorize on this origin AND follow a
+      // redirect to an arbitrary redirect_uri (the MCP client's callback URL,
+      // which can be localhost or any HTTPS host) — restricting form-action
+      // reliably enough to permit both has been fragile; the password itself
+      // is the real security control here.
       "Content-Security-Policy":
-        "default-src 'self'; style-src 'unsafe-inline'; form-action 'self'",
+        "default-src 'self'; style-src 'unsafe-inline'",
       "X-Content-Type-Options": "nosniff",
       "Cache-Control": "no-store",
     },

--- a/integrations/cloudflare-oauth-proxy/src/index.ts
+++ b/integrations/cloudflare-oauth-proxy/src/index.ts
@@ -21,7 +21,7 @@
 
 export interface Env {
   UPSTREAM_BASE: string;    // e.g. "https://<ref>.supabase.co"
-  FUNCTION_NAME: string;    // e.g. "open-brain-mcp" or "life-crm-mcp"
+  FUNCTION_NAME: string;    // e.g. "open-brain-mcp"
 }
 
 export default {

--- a/integrations/cloudflare-oauth-proxy/wrangler.toml.example
+++ b/integrations/cloudflare-oauth-proxy/wrangler.toml.example
@@ -1,8 +1,10 @@
-# Copy to wrangler.toml and substitute <SUPABASE_REF> with your Supabase
+# Copy to wrangler.toml and replace <SUPABASE_REF> with your Supabase
 # project ref (the random string in your Supabase dashboard URL).
 #
-# Two environments — one per MCP function. Each deploys to its own
-# workers.dev subdomain.
+# Each [env.*] block deploys as a separate Worker with its own
+# workers.dev subdomain. Start with [env.core] for the core Open Brain
+# MCP server; copy the block and rename to add a Worker for each
+# additional MCP server (recipe, extension, etc.) you want to proxy.
 
 name = "ob-proxy"
 main = "src/index.ts"
@@ -15,9 +17,12 @@ name = "ob-core"
 UPSTREAM_BASE = "https://<SUPABASE_REF>.supabase.co"
 FUNCTION_NAME = "open-brain-mcp"
 
-[env.life-crm]
-name = "ob-life-crm"
-
-[env.life-crm.vars]
-UPSTREAM_BASE = "https://<SUPABASE_REF>.supabase.co"
-FUNCTION_NAME = "life-crm-mcp"
+# Example: a second Worker for an additional MCP server. Uncomment and
+# rename to match the Edge Function you're proxying.
+#
+# [env.my-extension]
+# name = "ob-my-extension"
+#
+# [env.my-extension.vars]
+# UPSTREAM_BASE = "https://<SUPABASE_REF>.supabase.co"
+# FUNCTION_NAME = "my-extension-mcp"

--- a/integrations/cloudflare-oauth-proxy/wrangler.toml.example
+++ b/integrations/cloudflare-oauth-proxy/wrangler.toml.example
@@ -1,0 +1,23 @@
+# Copy to wrangler.toml and substitute <SUPABASE_REF> with your Supabase
+# project ref (the random string in your Supabase dashboard URL).
+#
+# Two environments — one per MCP function. Each deploys to its own
+# workers.dev subdomain.
+
+name = "ob-proxy"
+main = "src/index.ts"
+compatibility_date = "2026-04-17"
+
+[env.core]
+name = "ob-core"
+
+[env.core.vars]
+UPSTREAM_BASE = "https://<SUPABASE_REF>.supabase.co"
+FUNCTION_NAME = "open-brain-mcp"
+
+[env.life-crm]
+name = "ob-life-crm"
+
+[env.life-crm.vars]
+UPSTREAM_BASE = "https://<SUPABASE_REF>.supabase.co"
+FUNCTION_NAME = "life-crm-mcp"

--- a/server/deno.json
+++ b/server/deno.json
@@ -3,6 +3,7 @@
     "@hono/mcp": "npm:@hono/mcp@0.1.1",
     "@modelcontextprotocol/sdk": "npm:@modelcontextprotocol/sdk@1.24.3",
     "hono": "npm:hono@4.9.2",
+    "jose": "npm:jose@5.9.6",
     "zod": "npm:zod@4.1.13",
     "@supabase/supabase-js": "npm:@supabase/supabase-js@2.47.10"
   }

--- a/server/index.ts
+++ b/server/index.ts
@@ -5,6 +5,7 @@ import { StreamableHTTPTransport } from "@hono/mcp";
 import { Hono } from "hono";
 import { z } from "zod";
 import { createClient } from "@supabase/supabase-js";
+import { registerOAuthRoutes, verifyBearer } from "./oauth.ts";
 
 const SUPABASE_URL = Deno.env.get("SUPABASE_URL")!;
 const SUPABASE_SERVICE_ROLE_KEY = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY")!;
@@ -377,11 +378,26 @@ app.options("*", (c) => {
   return c.text("ok", 200, corsHeaders);
 });
 
+// OAuth 2.1 endpoints (/.well-known/oauth-authorization-server, /register,
+// /authorize, /token). Additive — legacy x-brain-key / ?key= paths below still
+// work. Registered before the catch-all so these routes don't get swallowed.
+registerOAuthRoutes(app, corsHeaders);
+
 app.all("*", async (c) => {
-  // Accept access key via header OR URL query parameter
-  const provided = c.req.header("x-brain-key") || new URL(c.req.url).searchParams.get("key");
-  if (!provided || provided !== MCP_ACCESS_KEY) {
-    return c.json({ error: "Invalid or missing access key" }, 401, corsHeaders);
+  // Auth — first match wins:
+  //   1. Authorization: Bearer <jwt>  (OAuth 2.1)
+  //   2. x-brain-key header           (legacy)
+  //   3. ?key= URL query param        (legacy, leaks in logs — discouraged)
+  const bearerOk = await verifyBearer(c.req.header("authorization"));
+  const legacyHeader = c.req.header("x-brain-key");
+  const legacyQuery = new URL(c.req.url).searchParams.get("key");
+  const legacyOk =
+    !!MCP_ACCESS_KEY &&
+    ((legacyHeader && legacyHeader === MCP_ACCESS_KEY) ||
+      (legacyQuery && legacyQuery === MCP_ACCESS_KEY));
+
+  if (!bearerOk && !legacyOk) {
+    return c.json({ error: "Invalid or missing credentials" }, 401, corsHeaders);
   }
 
   // Fix: Claude Desktop connectors don't send the Accept header that

--- a/server/index.ts
+++ b/server/index.ts
@@ -5,7 +5,7 @@ import { StreamableHTTPTransport } from "@hono/mcp";
 import { Hono } from "hono";
 import { z } from "zod";
 import { createClient } from "@supabase/supabase-js";
-import { registerOAuthRoutes, verifyBearer } from "./oauth.ts";
+import { buildWwwAuthenticate, registerOAuthRoutes, verifyBearer } from "./oauth.ts";
 
 const SUPABASE_URL = Deno.env.get("SUPABASE_URL")!;
 const SUPABASE_SERVICE_ROLE_KEY = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY")!;
@@ -369,6 +369,7 @@ const corsHeaders = {
   "Access-Control-Allow-Origin": "*",
   "Access-Control-Allow-Headers": "authorization, x-client-info, apikey, content-type, x-brain-key, accept, mcp-session-id",
   "Access-Control-Allow-Methods": "GET, POST, OPTIONS, DELETE",
+  "Access-Control-Expose-Headers": "WWW-Authenticate",
 };
 
 const app = new Hono();
@@ -397,7 +398,11 @@ app.all("*", async (c) => {
       (legacyQuery && legacyQuery === MCP_ACCESS_KEY));
 
   if (!bearerOk && !legacyOk) {
-    return c.json({ error: "Invalid or missing credentials" }, 401, corsHeaders);
+    return c.json(
+      { error: "Invalid or missing credentials" },
+      401,
+      { ...corsHeaders, "WWW-Authenticate": buildWwwAuthenticate(c) },
+    );
   }
 
   // Fix: Claude Desktop connectors don't send the Accept header that

--- a/server/oauth.ts
+++ b/server/oauth.ts
@@ -119,154 +119,174 @@ function corsJson(c: Context, body: unknown, status: number, corsHeaders: Record
 
 type CorsHeaders = Record<string, string>;
 
-export function registerOAuthRoutes(app: Hono, corsHeaders: CorsHeaders): void {
-  // RFC 8414 — authorization server metadata.
-  app.get("/.well-known/oauth-authorization-server", (c) => {
-    const base = new URL(c.req.url);
-    base.pathname = base.pathname.replace(/\/\.well-known\/oauth-authorization-server$/, "");
-    const root = base.origin + base.pathname.replace(/\/$/, "");
-    return c.json(
-      {
-        issuer: ISSUER,
-        authorization_endpoint: `${root}/authorize`,
-        token_endpoint: `${root}/token`,
-        registration_endpoint: `${root}/register`,
-        response_types_supported: ["code"],
-        grant_types_supported: ["authorization_code", "refresh_token"],
-        code_challenge_methods_supported: ["S256"],
-        token_endpoint_auth_methods_supported: ["none"],
-      },
+// Supabase Edge Functions mount at `/functions/v1/<name>/...`, so Hono sees
+// that full prefix. We match on path suffix instead of absolute routes so the
+// same module works for any function name without configuration.
+
+async function handleDiscovery(c: Context, corsHeaders: CorsHeaders, path: string) {
+  const base = new URL(c.req.url);
+  base.pathname = path.replace(/\/\.well-known\/oauth-authorization-server$/, "");
+  const root = base.origin + base.pathname.replace(/\/$/, "");
+  return c.json(
+    {
+      issuer: ISSUER,
+      authorization_endpoint: `${root}/authorize`,
+      token_endpoint: `${root}/token`,
+      registration_endpoint: `${root}/register`,
+      response_types_supported: ["code"],
+      grant_types_supported: ["authorization_code", "refresh_token"],
+      code_challenge_methods_supported: ["S256"],
+      token_endpoint_auth_methods_supported: ["none"],
+    },
+    200,
+    corsHeaders,
+  );
+}
+
+async function handleRegister(c: Context, corsHeaders: CorsHeaders) {
+  if (!oauthReady()) return corsJson(c, { error: "oauth_not_configured" }, 501, corsHeaders);
+  const body = await c.req.json().catch(() => ({}));
+  const clientId = crypto.randomUUID();
+  return c.json(
+    {
+      client_id: clientId,
+      client_id_issued_at: Math.floor(Date.now() / 1000),
+      token_endpoint_auth_method: "none",
+      redirect_uris: body.redirect_uris ?? [],
+      grant_types: ["authorization_code", "refresh_token"],
+      response_types: ["code"],
+    },
+    201,
+    corsHeaders,
+  );
+}
+
+async function handleAuthorizeGet(c: Context, corsHeaders: CorsHeaders) {
+  if (!oauthReady()) return c.text("OAuth not configured on this server.", 501, corsHeaders);
+  const q = c.req.query();
+  const required = ["client_id", "redirect_uri", "code_challenge", "code_challenge_method", "state"];
+  for (const k of required) {
+    if (!q[k]) return c.text(`Missing query parameter: ${k}`, 400, corsHeaders);
+  }
+  if (q.response_type && q.response_type !== "code") {
+    return c.text("Only response_type=code is supported", 400, corsHeaders);
+  }
+  if (q.code_challenge_method !== "S256") {
+    return c.text("Only code_challenge_method=S256 is supported", 400, corsHeaders);
+  }
+  return c.html(loginPage(q));
+}
+
+async function handleAuthorizePost(c: Context, corsHeaders: CorsHeaders) {
+  if (!oauthReady()) return c.text("OAuth not configured on this server.", 501, corsHeaders);
+  const form = await c.req.parseBody();
+  const asStr = (v: unknown): string => (typeof v === "string" ? v : "");
+  const password = asStr(form.password);
+  const params = {
+    client_id: asStr(form.client_id),
+    redirect_uri: asStr(form.redirect_uri),
+    code_challenge: asStr(form.code_challenge),
+    code_challenge_method: asStr(form.code_challenge_method),
+    state: asStr(form.state),
+  };
+
+  for (const [k, v] of Object.entries(params)) {
+    if (!v) return c.text(`Missing parameter: ${k}`, 400, corsHeaders);
+  }
+
+  if (!timingSafeEqual(password, OAUTH_PASSWORD)) {
+    return c.html(loginPage(params, "Incorrect password."), 401);
+  }
+
+  const code = await sign(
+    {
+      client_id: params.client_id,
+      redirect_uri: params.redirect_uri,
+      code_challenge: params.code_challenge,
+    },
+    "code",
+    CODE_TTL,
+  );
+
+  const redirect = new URL(params.redirect_uri);
+  redirect.searchParams.set("code", code);
+  redirect.searchParams.set("state", params.state);
+  return c.redirect(redirect.toString(), 302);
+}
+
+async function handleToken(c: Context, corsHeaders: CorsHeaders) {
+  if (!oauthReady()) return corsJson(c, { error: "oauth_not_configured" }, 501, corsHeaders);
+  const form = await c.req.parseBody();
+  const asStr = (v: unknown): string => (typeof v === "string" ? v : "");
+  const grantType = asStr(form.grant_type);
+
+  if (grantType === "authorization_code") {
+    const code = asStr(form.code);
+    const clientId = asStr(form.client_id);
+    const codeVerifier = asStr(form.code_verifier);
+    const redirectUri = asStr(form.redirect_uri);
+
+    if (!code || !clientId || !codeVerifier || !redirectUri) {
+      return corsJson(c, { error: "invalid_request" }, 400, corsHeaders);
+    }
+
+    const payload = await verify(code, "code");
+    if (!payload) return corsJson(c, { error: "invalid_grant" }, 400, corsHeaders);
+    if (payload.client_id !== clientId) return corsJson(c, { error: "invalid_grant" }, 400, corsHeaders);
+    if (payload.redirect_uri !== redirectUri) return corsJson(c, { error: "invalid_grant" }, 400, corsHeaders);
+
+    const expected = await sha256b64url(codeVerifier);
+    if (expected !== payload.code_challenge) {
+      return corsJson(c, { error: "invalid_grant" }, 400, corsHeaders);
+    }
+
+    const access = await sign({ aud: clientId }, "access", ACCESS_TTL);
+    const refresh = await sign({ aud: clientId }, "refresh", REFRESH_TTL);
+    return corsJson(
+      c,
+      { access_token: access, token_type: "Bearer", expires_in: ACCESS_TTL, refresh_token: refresh },
       200,
       corsHeaders,
     );
-  });
+  }
 
-  // RFC 7591 — dynamic client registration. Stateless: any client may register.
-  app.post("/register", async (c) => {
-    if (!oauthReady()) return corsJson(c, { error: "oauth_not_configured" }, 501, corsHeaders);
-    const body = await c.req.json().catch(() => ({}));
-    const clientId = crypto.randomUUID();
-    return c.json(
-      {
-        client_id: clientId,
-        client_id_issued_at: Math.floor(Date.now() / 1000),
-        token_endpoint_auth_method: "none",
-        redirect_uris: body.redirect_uris ?? [],
-        grant_types: ["authorization_code", "refresh_token"],
-        response_types: ["code"],
-      },
-      201,
+  if (grantType === "refresh_token") {
+    const refresh = asStr(form.refresh_token);
+    if (!refresh) return corsJson(c, { error: "invalid_request" }, 400, corsHeaders);
+    const payload = await verify(refresh, "refresh");
+    if (!payload) return corsJson(c, { error: "invalid_grant" }, 400, corsHeaders);
+    const aud = typeof payload.aud === "string" ? payload.aud : "";
+    const access = await sign({ aud }, "access", ACCESS_TTL);
+    return corsJson(
+      c,
+      { access_token: access, token_type: "Bearer", expires_in: ACCESS_TTL },
+      200,
       corsHeaders,
     );
-  });
+  }
 
-  // Render the password form.
-  app.get("/authorize", (c) => {
-    if (!oauthReady()) return c.text("OAuth not configured on this server.", 501, corsHeaders);
-    const q = c.req.query();
-    const required = ["client_id", "redirect_uri", "code_challenge", "code_challenge_method", "state"];
-    for (const k of required) {
-      if (!q[k]) return c.text(`Missing query parameter: ${k}`, 400, corsHeaders);
-    }
-    if (q.response_type && q.response_type !== "code") {
-      return c.text("Only response_type=code is supported", 400, corsHeaders);
-    }
-    if (q.code_challenge_method !== "S256") {
-      return c.text("Only code_challenge_method=S256 is supported", 400, corsHeaders);
-    }
-    return c.html(loginPage(q));
-  });
+  return corsJson(c, { error: "unsupported_grant_type" }, 400, corsHeaders);
+}
 
-  // Verify password, issue code.
-  app.post("/authorize", async (c) => {
-    if (!oauthReady()) return c.text("OAuth not configured on this server.", 501, corsHeaders);
-    const form = await c.req.parseBody();
-    const asStr = (v: unknown): string => (typeof v === "string" ? v : "");
-    const password = asStr(form.password);
-    const params = {
-      client_id: asStr(form.client_id),
-      redirect_uri: asStr(form.redirect_uri),
-      code_challenge: asStr(form.code_challenge),
-      code_challenge_method: asStr(form.code_challenge_method),
-      state: asStr(form.state),
-    };
+export function registerOAuthRoutes(app: Hono, corsHeaders: CorsHeaders): void {
+  app.use("*", async (c, next) => {
+    const path = new URL(c.req.url).pathname;
+    const method = c.req.method;
 
-    for (const [k, v] of Object.entries(params)) {
-      if (!v) return c.text(`Missing parameter: ${k}`, 400, corsHeaders);
+    if (method === "GET" && path.endsWith("/.well-known/oauth-authorization-server")) {
+      return await handleDiscovery(c, corsHeaders, path);
+    }
+    if (method === "POST" && path.endsWith("/register")) {
+      return await handleRegister(c, corsHeaders);
+    }
+    if (path.endsWith("/authorize")) {
+      if (method === "GET") return await handleAuthorizeGet(c, corsHeaders);
+      if (method === "POST") return await handleAuthorizePost(c, corsHeaders);
+    }
+    if (method === "POST" && path.endsWith("/token")) {
+      return await handleToken(c, corsHeaders);
     }
 
-    if (!timingSafeEqual(password, OAUTH_PASSWORD)) {
-      return c.html(loginPage(params, "Incorrect password."), 401);
-    }
-
-    const code = await sign(
-      {
-        client_id: params.client_id,
-        redirect_uri: params.redirect_uri,
-        code_challenge: params.code_challenge,
-      },
-      "code",
-      CODE_TTL,
-    );
-
-    const redirect = new URL(params.redirect_uri);
-    redirect.searchParams.set("code", code);
-    redirect.searchParams.set("state", params.state);
-    return c.redirect(redirect.toString(), 302);
-  });
-
-  // Token endpoint — authorization_code + refresh_token grants.
-  app.post("/token", async (c) => {
-    if (!oauthReady()) return corsJson(c, { error: "oauth_not_configured" }, 501, corsHeaders);
-    const form = await c.req.parseBody();
-    const asStr = (v: unknown): string => (typeof v === "string" ? v : "");
-    const grantType = asStr(form.grant_type);
-
-    if (grantType === "authorization_code") {
-      const code = asStr(form.code);
-      const clientId = asStr(form.client_id);
-      const codeVerifier = asStr(form.code_verifier);
-      const redirectUri = asStr(form.redirect_uri);
-
-      if (!code || !clientId || !codeVerifier || !redirectUri) {
-        return corsJson(c, { error: "invalid_request" }, 400, corsHeaders);
-      }
-
-      const payload = await verify(code, "code");
-      if (!payload) return corsJson(c, { error: "invalid_grant" }, 400, corsHeaders);
-      if (payload.client_id !== clientId) return corsJson(c, { error: "invalid_grant" }, 400, corsHeaders);
-      if (payload.redirect_uri !== redirectUri) return corsJson(c, { error: "invalid_grant" }, 400, corsHeaders);
-
-      const expected = await sha256b64url(codeVerifier);
-      if (expected !== payload.code_challenge) {
-        return corsJson(c, { error: "invalid_grant" }, 400, corsHeaders);
-      }
-
-      const access = await sign({ aud: clientId }, "access", ACCESS_TTL);
-      const refresh = await sign({ aud: clientId }, "refresh", REFRESH_TTL);
-      return corsJson(
-        c,
-        { access_token: access, token_type: "Bearer", expires_in: ACCESS_TTL, refresh_token: refresh },
-        200,
-        corsHeaders,
-      );
-    }
-
-    if (grantType === "refresh_token") {
-      const refresh = asStr(form.refresh_token);
-      if (!refresh) return corsJson(c, { error: "invalid_request" }, 400, corsHeaders);
-      const payload = await verify(refresh, "refresh");
-      if (!payload) return corsJson(c, { error: "invalid_grant" }, 400, corsHeaders);
-      const aud = typeof payload.aud === "string" ? payload.aud : "";
-      const access = await sign({ aud }, "access", ACCESS_TTL);
-      return corsJson(
-        c,
-        { access_token: access, token_type: "Bearer", expires_in: ACCESS_TTL },
-        200,
-        corsHeaders,
-      );
-    }
-
-    return corsJson(c, { error: "unsupported_grant_type" }, 400, corsHeaders);
+    await next();
   });
 }

--- a/server/oauth.ts
+++ b/server/oauth.ts
@@ -123,13 +123,34 @@ type CorsHeaders = Record<string, string>;
 // that full prefix. We match on path suffix instead of absolute routes so the
 // same module works for any function name without configuration.
 
+function publicRoot(c: Context, path: string): string {
+  // Supabase Edge Functions run behind a proxy: the Deno runtime sees URLs
+  // like `http://<ref>.supabase.co/<function-name>/...` (scheme downgraded,
+  // /functions/v1/ stripped). Rebuild the client-facing URL:
+  //   1. OAUTH_ISSUER_URL env var if explicitly configured
+  //   2. SUPABASE_URL + /functions/v1/<function-name>
+  //   3. X-Forwarded-* headers (self-hosting fallback)
+  const override = Deno.env.get("OAUTH_ISSUER_URL");
+  if (override) return override.replace(/\/$/, "");
+
+  const trimmed = path.replace(/\/\.well-known\/oauth-authorization-server$/, "");
+  const functionName = trimmed.split("/").filter(Boolean)[0] ?? "";
+
+  const supabaseUrl = Deno.env.get("SUPABASE_URL");
+  if (supabaseUrl && functionName) {
+    return `${supabaseUrl.replace(/\/$/, "")}/functions/v1/${functionName}`;
+  }
+
+  const proto = c.req.header("x-forwarded-proto") ?? "https";
+  const host = c.req.header("x-forwarded-host") ?? c.req.header("host") ?? "";
+  return `${proto}://${host}/functions/v1/${functionName}`;
+}
+
 async function handleDiscovery(c: Context, corsHeaders: CorsHeaders, path: string) {
-  const base = new URL(c.req.url);
-  base.pathname = path.replace(/\/\.well-known\/oauth-authorization-server$/, "");
-  const root = base.origin + base.pathname.replace(/\/$/, "");
+  const root = publicRoot(c, path);
   return c.json(
     {
-      issuer: ISSUER,
+      issuer: root,
       authorization_endpoint: `${root}/authorize`,
       token_endpoint: `${root}/token`,
       registration_endpoint: `${root}/register`,

--- a/server/oauth.ts
+++ b/server/oauth.ts
@@ -1,0 +1,272 @@
+// OAuth 2.1 authorization for the Open Brain MCP server.
+//
+// Single-user, stateless. One shared secret (OAUTH_PASSWORD) gates issuance of
+// short-lived bearer JWTs. No DB tables — codes/tokens are self-contained JWTs
+// signed with OAUTH_JWT_SECRET. Rotating that secret is the panic button.
+//
+// Additive: legacy x-brain-key / ?key= auth paths remain intact in index.ts.
+
+import type { Context, Hono } from "hono";
+import { SignJWT, jwtVerify } from "jose";
+
+const OAUTH_PASSWORD = Deno.env.get("OAUTH_PASSWORD") ?? Deno.env.get("MCP_ACCESS_KEY") ?? "";
+const OAUTH_JWT_SECRET = Deno.env.get("OAUTH_JWT_SECRET") ?? "";
+
+const ACCESS_TTL = 60 * 60;              // 1 hour
+const REFRESH_TTL = 60 * 60 * 24 * 30;   // 30 days
+const CODE_TTL = 60 * 5;                 // 5 min
+
+const ISSUER = "open-brain-mcp";
+const SUBJECT = "owner";
+
+type TokenType = "code" | "access" | "refresh";
+
+function jwtKey(): Uint8Array {
+  return new TextEncoder().encode(OAUTH_JWT_SECRET);
+}
+
+function oauthReady(): boolean {
+  return OAUTH_PASSWORD.length > 0 && OAUTH_JWT_SECRET.length > 0;
+}
+
+function timingSafeEqual(a: string, b: string): boolean {
+  const ab = new TextEncoder().encode(a);
+  const bb = new TextEncoder().encode(b);
+  if (ab.length !== bb.length) return false;
+  let diff = 0;
+  for (let i = 0; i < ab.length; i++) diff |= ab[i] ^ bb[i];
+  return diff === 0;
+}
+
+async function sha256b64url(input: string): Promise<string> {
+  const buf = await crypto.subtle.digest("SHA-256", new TextEncoder().encode(input));
+  const bytes = new Uint8Array(buf);
+  let s = "";
+  for (const b of bytes) s += String.fromCharCode(b);
+  return btoa(s).replace(/=+$/, "").replace(/\+/g, "-").replace(/\//g, "_");
+}
+
+async function sign(claims: Record<string, unknown>, typ: TokenType, ttl: number): Promise<string> {
+  return await new SignJWT({ ...claims, typ })
+    .setProtectedHeader({ alg: "HS256" })
+    .setIssuer(ISSUER)
+    .setSubject(SUBJECT)
+    .setIssuedAt()
+    .setExpirationTime(Math.floor(Date.now() / 1000) + ttl)
+    .sign(jwtKey());
+}
+
+async function verify(token: string, typ: TokenType): Promise<Record<string, unknown> | null> {
+  try {
+    const { payload } = await jwtVerify(token, jwtKey(), { issuer: ISSUER, subject: SUBJECT });
+    if (payload.typ !== typ) return null;
+    return payload as Record<string, unknown>;
+  } catch {
+    return null;
+  }
+}
+
+// Verify a Bearer token from an Authorization header. Returns true if valid.
+export async function verifyBearer(header: string | undefined): Promise<boolean> {
+  if (!header) return false;
+  const m = header.match(/^Bearer\s+(.+)$/i);
+  if (!m) return false;
+  if (!OAUTH_JWT_SECRET) return false;
+  return (await verify(m[1], "access")) !== null;
+}
+
+function escapeHtml(s: string): string {
+  return s
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+}
+
+function loginPage(params: Record<string, string>, error?: string): string {
+  const hidden = Object.entries(params)
+    .map(([k, v]) => `<input type="hidden" name="${escapeHtml(k)}" value="${escapeHtml(v)}">`)
+    .join("\n        ");
+  const errHtml = error ? `<p style="color:#b00">${escapeHtml(error)}</p>` : "";
+  return `<!doctype html>
+<html><head><meta charset="utf-8"><title>Open Brain — Sign in</title>
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<style>
+  body{font-family:system-ui,-apple-system,sans-serif;max-width:400px;margin:4rem auto;padding:0 1rem;color:#222}
+  h1{font-size:1.4rem;margin-bottom:0.5rem}
+  p.lede{color:#666;margin-top:0}
+  form{display:flex;flex-direction:column;gap:0.75rem;margin-top:1.5rem}
+  input[type=password]{padding:0.6rem;font-size:1rem;border:1px solid #ccc;border-radius:4px}
+  button{padding:0.6rem;font-size:1rem;background:#111;color:#fff;border:0;border-radius:4px;cursor:pointer}
+  button:hover{background:#333}
+</style></head>
+<body>
+  <h1>Open Brain</h1>
+  <p class="lede">Enter your password to authorize this client.</p>
+  ${errHtml}
+  <form method="post" action="">
+    ${hidden}
+    <input type="password" name="password" autofocus required placeholder="Password">
+    <button type="submit">Authorize</button>
+  </form>
+</body></html>`;
+}
+
+function corsJson(c: Context, body: unknown, status: number, corsHeaders: Record<string, string>) {
+  return c.json(body as Record<string, unknown>, status as 200, corsHeaders);
+}
+
+type CorsHeaders = Record<string, string>;
+
+export function registerOAuthRoutes(app: Hono, corsHeaders: CorsHeaders): void {
+  // RFC 8414 — authorization server metadata.
+  app.get("/.well-known/oauth-authorization-server", (c) => {
+    const base = new URL(c.req.url);
+    base.pathname = base.pathname.replace(/\/\.well-known\/oauth-authorization-server$/, "");
+    const root = base.origin + base.pathname.replace(/\/$/, "");
+    return c.json(
+      {
+        issuer: ISSUER,
+        authorization_endpoint: `${root}/authorize`,
+        token_endpoint: `${root}/token`,
+        registration_endpoint: `${root}/register`,
+        response_types_supported: ["code"],
+        grant_types_supported: ["authorization_code", "refresh_token"],
+        code_challenge_methods_supported: ["S256"],
+        token_endpoint_auth_methods_supported: ["none"],
+      },
+      200,
+      corsHeaders,
+    );
+  });
+
+  // RFC 7591 — dynamic client registration. Stateless: any client may register.
+  app.post("/register", async (c) => {
+    if (!oauthReady()) return corsJson(c, { error: "oauth_not_configured" }, 501, corsHeaders);
+    const body = await c.req.json().catch(() => ({}));
+    const clientId = crypto.randomUUID();
+    return c.json(
+      {
+        client_id: clientId,
+        client_id_issued_at: Math.floor(Date.now() / 1000),
+        token_endpoint_auth_method: "none",
+        redirect_uris: body.redirect_uris ?? [],
+        grant_types: ["authorization_code", "refresh_token"],
+        response_types: ["code"],
+      },
+      201,
+      corsHeaders,
+    );
+  });
+
+  // Render the password form.
+  app.get("/authorize", (c) => {
+    if (!oauthReady()) return c.text("OAuth not configured on this server.", 501, corsHeaders);
+    const q = c.req.query();
+    const required = ["client_id", "redirect_uri", "code_challenge", "code_challenge_method", "state"];
+    for (const k of required) {
+      if (!q[k]) return c.text(`Missing query parameter: ${k}`, 400, corsHeaders);
+    }
+    if (q.response_type && q.response_type !== "code") {
+      return c.text("Only response_type=code is supported", 400, corsHeaders);
+    }
+    if (q.code_challenge_method !== "S256") {
+      return c.text("Only code_challenge_method=S256 is supported", 400, corsHeaders);
+    }
+    return c.html(loginPage(q));
+  });
+
+  // Verify password, issue code.
+  app.post("/authorize", async (c) => {
+    if (!oauthReady()) return c.text("OAuth not configured on this server.", 501, corsHeaders);
+    const form = await c.req.parseBody();
+    const asStr = (v: unknown): string => (typeof v === "string" ? v : "");
+    const password = asStr(form.password);
+    const params = {
+      client_id: asStr(form.client_id),
+      redirect_uri: asStr(form.redirect_uri),
+      code_challenge: asStr(form.code_challenge),
+      code_challenge_method: asStr(form.code_challenge_method),
+      state: asStr(form.state),
+    };
+
+    for (const [k, v] of Object.entries(params)) {
+      if (!v) return c.text(`Missing parameter: ${k}`, 400, corsHeaders);
+    }
+
+    if (!timingSafeEqual(password, OAUTH_PASSWORD)) {
+      return c.html(loginPage(params, "Incorrect password."), 401);
+    }
+
+    const code = await sign(
+      {
+        client_id: params.client_id,
+        redirect_uri: params.redirect_uri,
+        code_challenge: params.code_challenge,
+      },
+      "code",
+      CODE_TTL,
+    );
+
+    const redirect = new URL(params.redirect_uri);
+    redirect.searchParams.set("code", code);
+    redirect.searchParams.set("state", params.state);
+    return c.redirect(redirect.toString(), 302);
+  });
+
+  // Token endpoint — authorization_code + refresh_token grants.
+  app.post("/token", async (c) => {
+    if (!oauthReady()) return corsJson(c, { error: "oauth_not_configured" }, 501, corsHeaders);
+    const form = await c.req.parseBody();
+    const asStr = (v: unknown): string => (typeof v === "string" ? v : "");
+    const grantType = asStr(form.grant_type);
+
+    if (grantType === "authorization_code") {
+      const code = asStr(form.code);
+      const clientId = asStr(form.client_id);
+      const codeVerifier = asStr(form.code_verifier);
+      const redirectUri = asStr(form.redirect_uri);
+
+      if (!code || !clientId || !codeVerifier || !redirectUri) {
+        return corsJson(c, { error: "invalid_request" }, 400, corsHeaders);
+      }
+
+      const payload = await verify(code, "code");
+      if (!payload) return corsJson(c, { error: "invalid_grant" }, 400, corsHeaders);
+      if (payload.client_id !== clientId) return corsJson(c, { error: "invalid_grant" }, 400, corsHeaders);
+      if (payload.redirect_uri !== redirectUri) return corsJson(c, { error: "invalid_grant" }, 400, corsHeaders);
+
+      const expected = await sha256b64url(codeVerifier);
+      if (expected !== payload.code_challenge) {
+        return corsJson(c, { error: "invalid_grant" }, 400, corsHeaders);
+      }
+
+      const access = await sign({ aud: clientId }, "access", ACCESS_TTL);
+      const refresh = await sign({ aud: clientId }, "refresh", REFRESH_TTL);
+      return corsJson(
+        c,
+        { access_token: access, token_type: "Bearer", expires_in: ACCESS_TTL, refresh_token: refresh },
+        200,
+        corsHeaders,
+      );
+    }
+
+    if (grantType === "refresh_token") {
+      const refresh = asStr(form.refresh_token);
+      if (!refresh) return corsJson(c, { error: "invalid_request" }, 400, corsHeaders);
+      const payload = await verify(refresh, "refresh");
+      if (!payload) return corsJson(c, { error: "invalid_grant" }, 400, corsHeaders);
+      const aud = typeof payload.aud === "string" ? payload.aud : "";
+      const access = await sign({ aud }, "access", ACCESS_TTL);
+      return corsJson(
+        c,
+        { access_token: access, token_type: "Bearer", expires_in: ACCESS_TTL },
+        200,
+        corsHeaders,
+      );
+    }
+
+    return corsJson(c, { error: "unsupported_grant_type" }, 400, corsHeaders);
+  });
+}

--- a/server/oauth.ts
+++ b/server/oauth.ts
@@ -128,14 +128,24 @@ type CorsHeaders = Record<string, string>;
 // (scheme downgraded, /functions/v1/ stripped). We rebuild the public URL
 // that clients actually used to reach us.
 function publicRoot(c: Context): string {
-  //   1. OAUTH_ISSUER_URL env var if explicitly configured
-  //   2. SUPABASE_URL + /functions/v1/<function-name>
-  //   3. X-Forwarded-* headers (self-hosting fallback)
-  const override = Deno.env.get("OAUTH_ISSUER_URL");
-  if (override) return override.replace(/\/$/, "");
+  //   1. OAUTH_ISSUER_URL_<FUNCTION_NAME> — per-function override. Needed when
+  //      an extension or recipe behind its own proxy shares a Supabase project
+  //      with the core server (Supabase secrets are project-wide).
+  //   2. OAUTH_ISSUER_URL — default for the core server.
+  //   3. SUPABASE_URL + /functions/v1/<function-name> — bare Supabase URL.
+  //   4. X-Forwarded-* headers — self-hosting fallback.
 
   // First path segment of the internal URL is the function name.
   const functionName = new URL(c.req.url).pathname.split("/").filter(Boolean)[0] ?? "";
+
+  if (functionName) {
+    const perFnKey = `OAUTH_ISSUER_URL_${functionName.toUpperCase().replace(/-/g, "_")}`;
+    const perFn = Deno.env.get(perFnKey);
+    if (perFn) return perFn.replace(/\/$/, "");
+  }
+
+  const override = Deno.env.get("OAUTH_ISSUER_URL");
+  if (override) return override.replace(/\/$/, "");
 
   const supabaseUrl = Deno.env.get("SUPABASE_URL");
   if (supabaseUrl && functionName) {

--- a/server/oauth.ts
+++ b/server/oauth.ts
@@ -75,44 +75,6 @@ export async function verifyBearer(header: string | undefined): Promise<boolean>
   return (await verify(m[1], "access")) !== null;
 }
 
-function escapeHtml(s: string): string {
-  return s
-    .replace(/&/g, "&amp;")
-    .replace(/</g, "&lt;")
-    .replace(/>/g, "&gt;")
-    .replace(/"/g, "&quot;")
-    .replace(/'/g, "&#39;");
-}
-
-function loginPage(params: Record<string, string>, error?: string): string {
-  const hidden = Object.entries(params)
-    .map(([k, v]) => `<input type="hidden" name="${escapeHtml(k)}" value="${escapeHtml(v)}">`)
-    .join("\n        ");
-  const errHtml = error ? `<p style="color:#b00">${escapeHtml(error)}</p>` : "";
-  return `<!doctype html>
-<html><head><meta charset="utf-8"><title>Open Brain — Sign in</title>
-<meta name="viewport" content="width=device-width,initial-scale=1">
-<style>
-  body{font-family:system-ui,-apple-system,sans-serif;max-width:400px;margin:4rem auto;padding:0 1rem;color:#222}
-  h1{font-size:1.4rem;margin-bottom:0.5rem}
-  p.lede{color:#666;margin-top:0}
-  form{display:flex;flex-direction:column;gap:0.75rem;margin-top:1.5rem}
-  input[type=password]{padding:0.6rem;font-size:1rem;border:1px solid #ccc;border-radius:4px}
-  button{padding:0.6rem;font-size:1rem;background:#111;color:#fff;border:0;border-radius:4px;cursor:pointer}
-  button:hover{background:#333}
-</style></head>
-<body>
-  <h1>Open Brain</h1>
-  <p class="lede">Enter your password to authorize this client.</p>
-  ${errHtml}
-  <form method="post" action="">
-    ${hidden}
-    <input type="password" name="password" autofocus required placeholder="Password">
-    <button type="submit">Authorize</button>
-  </form>
-</body></html>`;
-}
-
 function corsJson(c: Context, body: unknown, status: number, corsHeaders: Record<string, string>) {
   return c.json(body as Record<string, unknown>, status as 200, corsHeaders);
 }
@@ -217,34 +179,20 @@ async function handleRegister(c: Context, corsHeaders: CorsHeaders) {
   );
 }
 
-// Supabase Edge Functions inject a restrictive default:
-//   content-security-policy: default-src 'none'; sandbox
-//   x-content-type-options: nosniff
-//   content-type: text/plain   (overrides Hono's text/html)
-// These block browsers from rendering our login form as HTML and from
-// submitting it. We override all three explicitly on the /authorize GET
-// response so the password form renders and the POST can fire.
-const htmlHeaders = {
-  "Content-Type": "text/html; charset=UTF-8",
-  "Content-Security-Policy":
-    "default-src 'self'; style-src 'unsafe-inline'; form-action 'self'",
-  "X-Content-Type-Options": "nosniff",
-};
-
+// Supabase Edge Functions force `content-type: text/plain` and a
+// sandbox CSP on all HTML responses (platform-level, not overridable),
+// which breaks the OAuth login form. The Cloudflare Worker proxy
+// serves GET /authorize itself from its own origin, so this handler
+// is only hit if someone bypasses the Worker and talks to the Supabase
+// URL directly. We return plain text pointing them at the Worker.
 async function handleAuthorizeGet(c: Context, corsHeaders: CorsHeaders) {
-  if (!oauthReady()) return c.text("OAuth not configured on this server.", 501, corsHeaders);
-  const q = c.req.query();
-  const required = ["client_id", "redirect_uri", "code_challenge", "code_challenge_method", "state"];
-  for (const k of required) {
-    if (!q[k]) return c.text(`Missing query parameter: ${k}`, 400, corsHeaders);
-  }
-  if (q.response_type && q.response_type !== "code") {
-    return c.text("Only response_type=code is supported", 400, corsHeaders);
-  }
-  if (q.code_challenge_method !== "S256") {
-    return c.text("Only code_challenge_method=S256 is supported", 400, corsHeaders);
-  }
-  return c.body(loginPage(q), 200, htmlHeaders);
+  return c.text(
+    "OAuth login forms cannot be rendered directly from this Edge Function.\n" +
+      "Route /authorize through the Cloudflare Worker proxy — see\n" +
+      "integrations/cloudflare-oauth-proxy/README.md for setup.",
+    501,
+    corsHeaders,
+  );
 }
 
 async function handleAuthorizePost(c: Context, corsHeaders: CorsHeaders) {
@@ -265,7 +213,12 @@ async function handleAuthorizePost(c: Context, corsHeaders: CorsHeaders) {
   }
 
   if (!timingSafeEqual(password, OAUTH_PASSWORD)) {
-    return c.body(loginPage(params, "Incorrect password."), 401, htmlHeaders);
+    // Redirect back to GET /authorize?error=invalid_password&<original-params>.
+    // The Worker re-renders the login form with the error message. We use a
+    // relative path so the redirect resolves to the Worker origin that made
+    // the POST (not the Supabase origin the Edge Function lives on).
+    const qs = new URLSearchParams({ ...params, error: "invalid_password" });
+    return c.redirect(`/authorize?${qs.toString()}`, 302);
   }
 
   const code = await sign(

--- a/server/oauth.ts
+++ b/server/oauth.ts
@@ -9,8 +9,12 @@
 import type { Context, Hono } from "hono";
 import { SignJWT, jwtVerify } from "jose";
 
-const OAUTH_PASSWORD = Deno.env.get("OAUTH_PASSWORD") ?? Deno.env.get("MCP_ACCESS_KEY") ?? "";
-const OAUTH_JWT_SECRET = Deno.env.get("OAUTH_JWT_SECRET") ?? "";
+function getPassword(): string {
+  return Deno.env.get("OAUTH_PASSWORD") ?? Deno.env.get("MCP_ACCESS_KEY") ?? "";
+}
+function getJwtSecret(): string {
+  return Deno.env.get("OAUTH_JWT_SECRET") ?? "";
+}
 
 const ACCESS_TTL = 60 * 60;              // 1 hour
 const REFRESH_TTL = 60 * 60 * 24 * 30;   // 30 days
@@ -22,11 +26,11 @@ const SUBJECT = "owner";
 type TokenType = "code" | "access" | "refresh";
 
 function jwtKey(): Uint8Array {
-  return new TextEncoder().encode(OAUTH_JWT_SECRET);
+  return new TextEncoder().encode(getJwtSecret());
 }
 
 function oauthReady(): boolean {
-  return OAUTH_PASSWORD.length > 0 && OAUTH_JWT_SECRET.length > 0;
+  return getPassword().length > 0 && getJwtSecret().length > 0;
 }
 
 function timingSafeEqual(a: string, b: string): boolean {
@@ -71,7 +75,7 @@ export async function verifyBearer(header: string | undefined): Promise<boolean>
   if (!header) return false;
   const m = header.match(/^Bearer\s+(.+)$/i);
   if (!m) return false;
-  if (!OAUTH_JWT_SECRET) return false;
+  if (!getJwtSecret()) return false;
   return (await verify(m[1], "access")) !== null;
 }
 
@@ -212,11 +216,12 @@ async function handleAuthorizePost(c: Context, corsHeaders: CorsHeaders) {
     if (!v) return c.text(`Missing parameter: ${k}`, 400, corsHeaders);
   }
 
-  if (!timingSafeEqual(password, OAUTH_PASSWORD)) {
+  if (!timingSafeEqual(password, getPassword())) {
     // Redirect back to GET /authorize?error=invalid_password&<original-params>.
     // The Worker re-renders the login form with the error message. We use a
     // relative path so the redirect resolves to the Worker origin that made
     // the POST (not the Supabase origin the Edge Function lives on).
+    console.warn("[oauth] /authorize wrong password", { client_id: params.client_id });
     const qs = new URLSearchParams({ ...params, error: "invalid_password" });
     return c.redirect(`/authorize?${qs.toString()}`, 302);
   }

--- a/server/oauth.ts
+++ b/server/oauth.ts
@@ -123,18 +123,19 @@ type CorsHeaders = Record<string, string>;
 // that full prefix. We match on path suffix instead of absolute routes so the
 // same module works for any function name without configuration.
 
-function publicRoot(c: Context, path: string): string {
-  // Supabase Edge Functions run behind a proxy: the Deno runtime sees URLs
-  // like `http://<ref>.supabase.co/<function-name>/...` (scheme downgraded,
-  // /functions/v1/ stripped). Rebuild the client-facing URL:
+// Derive the client-facing URL root for this Edge Function.
+// Supabase sees URLs like `http://<ref>.supabase.co/<function-name>/...`
+// (scheme downgraded, /functions/v1/ stripped). We rebuild the public URL
+// that clients actually used to reach us.
+function publicRoot(c: Context): string {
   //   1. OAUTH_ISSUER_URL env var if explicitly configured
   //   2. SUPABASE_URL + /functions/v1/<function-name>
   //   3. X-Forwarded-* headers (self-hosting fallback)
   const override = Deno.env.get("OAUTH_ISSUER_URL");
   if (override) return override.replace(/\/$/, "");
 
-  const trimmed = path.replace(/\/\.well-known\/oauth-authorization-server$/, "");
-  const functionName = trimmed.split("/").filter(Boolean)[0] ?? "";
+  // First path segment of the internal URL is the function name.
+  const functionName = new URL(c.req.url).pathname.split("/").filter(Boolean)[0] ?? "";
 
   const supabaseUrl = Deno.env.get("SUPABASE_URL");
   if (supabaseUrl && functionName) {
@@ -146,8 +147,8 @@ function publicRoot(c: Context, path: string): string {
   return `${proto}://${host}/functions/v1/${functionName}`;
 }
 
-async function handleDiscovery(c: Context, corsHeaders: CorsHeaders, path: string) {
-  const root = publicRoot(c, path);
+async function handleDiscovery(c: Context, corsHeaders: CorsHeaders) {
+  const root = publicRoot(c);
   return c.json(
     {
       issuer: root,
@@ -162,6 +163,30 @@ async function handleDiscovery(c: Context, corsHeaders: CorsHeaders, path: strin
     200,
     corsHeaders,
   );
+}
+
+// RFC 9728 — OAuth 2.0 Protected Resource Metadata. MCP clients use this to
+// discover which authorization server guards this MCP endpoint. Triggered by
+// the WWW-Authenticate challenge on 401 (see buildWwwAuthenticate).
+async function handleProtectedResource(c: Context, corsHeaders: CorsHeaders) {
+  const root = publicRoot(c);
+  return c.json(
+    {
+      resource: root,
+      authorization_servers: [root],
+      bearer_methods_supported: ["header"],
+      scopes_supported: [],
+    },
+    200,
+    corsHeaders,
+  );
+}
+
+// Build a WWW-Authenticate: Bearer challenge header pointing at the
+// protected-resource metadata URL, per RFC 9728 §5.2.
+export function buildWwwAuthenticate(c: Context): string {
+  const root = publicRoot(c);
+  return `Bearer realm="${root}", resource_metadata="${root}/.well-known/oauth-protected-resource"`;
 }
 
 async function handleRegister(c: Context, corsHeaders: CorsHeaders) {
@@ -295,7 +320,10 @@ export function registerOAuthRoutes(app: Hono, corsHeaders: CorsHeaders): void {
     const method = c.req.method;
 
     if (method === "GET" && path.endsWith("/.well-known/oauth-authorization-server")) {
-      return await handleDiscovery(c, corsHeaders, path);
+      return await handleDiscovery(c, corsHeaders);
+    }
+    if (method === "GET" && path.endsWith("/.well-known/oauth-protected-resource")) {
+      return await handleProtectedResource(c, corsHeaders);
     }
     if (method === "POST" && path.endsWith("/register")) {
       return await handleRegister(c, corsHeaders);

--- a/server/oauth.ts
+++ b/server/oauth.ts
@@ -217,6 +217,20 @@ async function handleRegister(c: Context, corsHeaders: CorsHeaders) {
   );
 }
 
+// Supabase Edge Functions inject a restrictive default:
+//   content-security-policy: default-src 'none'; sandbox
+//   x-content-type-options: nosniff
+//   content-type: text/plain   (overrides Hono's text/html)
+// These block browsers from rendering our login form as HTML and from
+// submitting it. We override all three explicitly on the /authorize GET
+// response so the password form renders and the POST can fire.
+const htmlHeaders = {
+  "Content-Type": "text/html; charset=UTF-8",
+  "Content-Security-Policy":
+    "default-src 'self'; style-src 'unsafe-inline'; form-action 'self'",
+  "X-Content-Type-Options": "nosniff",
+};
+
 async function handleAuthorizeGet(c: Context, corsHeaders: CorsHeaders) {
   if (!oauthReady()) return c.text("OAuth not configured on this server.", 501, corsHeaders);
   const q = c.req.query();
@@ -230,7 +244,7 @@ async function handleAuthorizeGet(c: Context, corsHeaders: CorsHeaders) {
   if (q.code_challenge_method !== "S256") {
     return c.text("Only code_challenge_method=S256 is supported", 400, corsHeaders);
   }
-  return c.html(loginPage(q));
+  return c.body(loginPage(q), 200, htmlHeaders);
 }
 
 async function handleAuthorizePost(c: Context, corsHeaders: CorsHeaders) {
@@ -251,7 +265,7 @@ async function handleAuthorizePost(c: Context, corsHeaders: CorsHeaders) {
   }
 
   if (!timingSafeEqual(password, OAUTH_PASSWORD)) {
-    return c.html(loginPage(params, "Incorrect password."), 401);
+    return c.body(loginPage(params, "Incorrect password."), 401, htmlHeaders);
   }
 
   const code = await sign(


### PR DESCRIPTION
## Contribution Type

This PR spans two categories — checking both:

- [x] Integration (`/integrations`) — new Cloudflare Worker
- [x] Repo improvement — adds OAuth 2.1 to the core MCP server (`/server`)

(Not a recipe, schema, dashboard, or skill.)

## What does this do?

Adds OAuth 2.1 (RFC 6749 + PKCE, with RFC 9728 protected-resource metadata) to the core open-brain MCP endpoint, and adds a tiny Cloudflare Worker proxy that gives Supabase-hosted MCP servers a path-less origin so the MCP TypeScript SDK's OAuth discovery resolves correctly. Together, these let Claude Desktop (and other MCP TS SDK clients like `mcp-remote`) connect via OAuth instead of `?key=` URLs — the access key in `?key=` ends up in proxy logs, browser history, and `Referer` headers, so a token-based path is meaningfully safer.

The two pieces are separable in design but need each other in practice:

- **Server-only** (OAuth without the Worker) breaks for Claude Desktop because the SDK strips paths from the authorization-server URL when composing OAuth metadata URLs (`/.well-known/oauth-authorization-server`, `/register`, `/authorize`). Supabase Edge Functions are mounted under `/functions/v1/<name>/`, so those URLs hit the platform gateway and 404. The server work is also blocked by Supabase's platform-level forced `Content-Type: text/plain` and `default-src 'none'; sandbox` CSP on every response — fine for JSON, fatal for the HTML login form.
- **Worker-only** has nothing to authenticate against — the OAuth state, password verification, and token issuance all live in the Edge Function.

So they're presented as one PR with two parallel tracks merged at the top — `[server]` commits (OAuth on core MCP) and `[integrations]` commits (Worker proxy). The merge commits document the split intentionally.

The flow on a working install:

```
Claude Desktop ──▶ ob-core.<account>.workers.dev/<anything>
                           │
                           ▼ (Worker)
    GET /authorize  ─── render login form HTML ──▶ user's browser
    everything else ──▶ proxy to Supabase
                           │
                           ▼
    https://<ref>.supabase.co/functions/v1/open-brain-mcp/<anything>
                           │
                           ▼
                (Edge Function: OAuth state + password verify + tokens + MCP)
```

`?key=` continues to work unchanged — both paths stay supported per client.

## Requirements

- **Server side** (`server/oauth.ts`): no new dependencies. New env vars (all optional unless you opt into OAuth):
  - `OAUTH_PASSWORD` — shared secret users type into the login form
  - `OAUTH_JWT_SECRET` — HS256 signing key for issued access tokens
  - `OAUTH_ISSUER_URL` — public URL where the MCP server is reachable (set to the Worker URL)
  - `OAUTH_ISSUER_URL_<FUNCTION_NAME>` — per-function override for projects running multiple MCPs in one Supabase project
- **Worker side** (`integrations/cloudflare-oauth-proxy/`): a Cloudflare account (free tier works), `wrangler` CLI, Node.js 20+. No paid services.

Documentation:
- `integrations/cloudflare-oauth-proxy/README.md` — Worker setup, including a "Multiple MCP servers" section for projects running additional Edge Functions.
- `docs/01-getting-started.md` — added a new optional Step 7b for OAuth setup, plus a tip pointing to the Worker.

## Checklist

- [x] I've read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] My contribution has a `README.md` with prerequisites, step-by-step instructions, and expected outcome
- [x] My `metadata.json` has all required fields (Cloudflare Worker integration)
- [x] N/A — this contribution doesn't depend on a skill or primitive
- [x] I tested this on my own Open Brain instance (Claude Desktop OAuth flow end-to-end through the Worker against my deployed core MCP)
- [x] No credentials, API keys, or secrets are included (the local `wrangler.toml` is gitignored; only `wrangler.toml.example` ships)

## Test plan

- [ ] Deploy the Worker per `integrations/cloudflare-oauth-proxy/README.md` Steps 1–2
- [ ] Set `OAUTH_PASSWORD`, `OAUTH_JWT_SECRET`, and `OAUTH_ISSUER_URL` secrets on the Edge Function (Step 3)
- [ ] `curl -s "${WORKER_URL}/.well-known/oauth-authorization-server" | jq .issuer` — should return the Worker URL, not the Supabase URL
- [ ] `curl -sI "${WORKER_URL}/" | grep -i 'www-authenticate'` — RFC 9728 header should reference the Worker-scoped resource_metadata URL
- [ ] `npx mcp-remote "${WORKER_URL}" --debug` — full OAuth flow end-to-end, login form renders as HTML, password submission completes, tools list returns
- [ ] Add the Worker URL as a custom connector in Claude Desktop — tools appear without any `?key=` in the URL
- [ ] Sanity check that an existing `?key=` URL still works against the Supabase function directly (backwards compat)

🤖 Generated with [Claude Code](https://claude.com/claude-code)