### PR TITLE
[server] return JSON-RPC error envelopes on auth failure

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -370,6 +370,83 @@ const corsHeaders = {
   "Access-Control-Allow-Methods": "GET, POST, OPTIONS, DELETE",
 };
 
+// JSON-RPC error code for unauthorized requests.
+// Per the JSON-RPC 2.0 spec, the range -32099 to -32000 is reserved for
+// implementation-defined server errors. -32001 is the conventional
+// "Unauthorized" code used by MCP clients/servers in the wild.
+//
+// Why a JSON-RPC envelope (HTTP 200) instead of a bare HTTP 401?
+// Strict MCP hosts (Codex CLI, Claude Code) treat bare HTTP 4xx responses
+// as transport-level failures and tear the connection down rather than
+// surfacing the failure to the application layer. Wrapping the auth
+// rejection in a JSON-RPC error keeps the connection alive and lets
+// clients recover (e.g. prompt the user for a new key, refetch a stale
+// cache) instead of dying.
+const JSON_RPC_UNAUTHORIZED_CODE = -32001;
+const UNAUTHORIZED_MESSAGE = "Unauthorized: missing or invalid authentication.";
+
+/**
+ * Read the request body as text without consuming the original request's
+ * body stream for downstream handlers. Returns null on bodyless methods
+ * or read failure.
+ */
+async function readBodyText(req: Request): Promise<string | null> {
+  if (req.method === "GET" || req.method === "HEAD" || req.method === "DELETE") {
+    return null;
+  }
+  try {
+    return await req.text();
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Best-effort extraction of the JSON-RPC `id` from a raw request body.
+ * Returns null when the body is missing, not JSON, or not a JSON-RPC
+ * shape with an id. Per the JSON-RPC 2.0 spec, id may be a string,
+ * number, or null — we preserve any of those; anything else becomes null.
+ */
+function extractJsonRpcId(bodyText: string | null): string | number | null {
+  if (!bodyText) return null;
+  try {
+    const parsed = JSON.parse(bodyText);
+    if (parsed && typeof parsed === "object" && "id" in parsed) {
+      const id = (parsed as { id: unknown }).id;
+      if (typeof id === "string" || typeof id === "number" || id === null) {
+        return id;
+      }
+    }
+  } catch {
+    // fall through — malformed body
+  }
+  return null;
+}
+
+/**
+ * Build a JSON-RPC 2.0 error envelope response for auth failures.
+ * Returns HTTP 200 — the JSON-RPC layer expresses the error so that
+ * strict MCP clients keep the connection alive instead of treating
+ * the failure as a transport-level fault.
+ */
+function unauthorizedResponse(id: string | number | null): Response {
+  const body = {
+    jsonrpc: "2.0",
+    error: {
+      code: JSON_RPC_UNAUTHORIZED_CODE,
+      message: UNAUTHORIZED_MESSAGE,
+    },
+    id,
+  };
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    headers: {
+      "Content-Type": "application/json",
+      ...corsHeaders,
+    },
+  });
+}
+
 const app = new Hono();
 
 // CORS preflight — required for browser/Electron-based clients (Claude Desktop, claude.ai)
@@ -381,7 +458,14 @@ app.all("*", async (c) => {
   // Accept access key via header OR URL query parameter
   const provided = c.req.header("x-brain-key") || new URL(c.req.url).searchParams.get("key");
   if (!provided || provided !== MCP_ACCESS_KEY) {
-    return c.json({ error: "Invalid or missing access key" }, 401, corsHeaders);
+    // Return a JSON-RPC 2.0 error envelope (HTTP 200) instead of a bare
+    // HTTP 401 so strict MCP hosts treat this as an application-level
+    // error rather than a transport fault and keep the connection alive.
+    // Best-effort echo of the inbound request id keeps the response
+    // correlated; malformed/missing bodies fall back to id: null.
+    const bodyText = await readBodyText(c.req.raw);
+    const id = extractJsonRpcId(bodyText);
+    return unauthorizedResponse(id);
   }
 
   // Fix: Claude Desktop connectors don't send the Accept header that


### PR DESCRIPTION
## Problem

The reference MCP server returns a bare HTTP 401 on auth failure:

```ts
return c.json({ error: "Invalid or missing access key" }, 401, corsHeaders);
```

Strict MCP clients that follow the JSON-RPC 2.0 wire spec — Codex CLI, Claude Code, and anything else that distinguishes transport faults from application errors — interpret a bare HTTP 4xx as a transport-level failure and tear the connection down rather than surfacing the auth error to the application layer. The practical consequence is that scenarios like "wrong key — prompt the user to update it" or "stale cached key — refetch and retry" can't be handled gracefully: the client sees a dead connection, not a recoverable error.

This bug bites anyone wiring a fresh OB1 deployment up to a strict client and rotating keys (or fat-fingering the first one).

## Solution

Return HTTP 200 with a JSON-RPC 2.0 error envelope. The transport stays healthy, and the JSON-RPC layer carries the failure as an application-level error the client can handle:

```json
{ "jsonrpc": "2.0", "error": { "code": -32001, "message": "Unauthorized: missing or invalid authentication." }, "id": <inbound id or null> }
```

`-32001` lives in JSON-RPC's `-32099..-32000` "implementation-defined server error" range and is the conventional code MCP servers use for "Unauthorized" in the wild. The inbound request `id` is best-effort extracted and echoed back so the response correlates with the call; malformed or missing bodies fall back to `id: null`.

## Backward compatibility

- **Success path unchanged.** Authenticated requests behave exactly as before — same StreamableHTTPTransport handoff, same Accept-header patch, same CORS.
- **Lenient clients still work.** A client that doesn't validate JSON-RPC envelopes still gets a 200 with a parseable JSON body containing `error`. It can read the message or ignore it.
- **Strict clients now recover gracefully** instead of dying on a transport fault.

## Edge cases handled

- **Bodyless methods (GET / HEAD / DELETE):** body read is skipped, `id` defaults to `null`.
- **Malformed JSON body:** parse failure swallowed, `id` defaults to `null`.
- **Non-JSON-RPC body shape:** missing/non-id-typed `id` falls back to `null` (only `string | number | null` are accepted, per the JSON-RPC 2.0 spec).
- **CORS preflight (`OPTIONS`):** unchanged — still returns `ok` 200 with CORS headers before auth runs.
- **Body consumed on auth failure:** safe — on the rejection path we return immediately and never forward to the transport, so consuming the body to read the id has no downstream effect.

## Implementation

Three small helpers added next to the existing `corsHeaders` block:

- `readBodyText(req)` — best-effort body read, returns `null` on bodyless methods or read failure.
- `extractJsonRpcId(bodyText)` — best-effort JSON-RPC id extraction, returns `null` on anything malformed.
- `unauthorizedResponse(id)` — builds the HTTP 200 + JSON-RPC error envelope with CORS headers attached.

The auth check in `app.all("*", ...)` calls those helpers in place of the bare `c.json(...)` 401.

## Tested

- `deno check server/index.ts` — no type errors.
- Reviewed against the original report from the downstream MCP host (Codex CLI) where bare-401 originally tripped the transport-fault path. The same envelope-shaped response is what fixed the symptom downstream.
- Verified by inspection that the success path, the Accept-header patch, CORS preflight, and the StreamableHTTPTransport handoff are byte-for-byte unchanged.

A wire-level diagnosis of why bare 4xx breaks strict MCP hosts (and why a JSON-RPC envelope is the right fix) was written up separately during the downstream investigation. Happy to share or adapt the relevant parts as a `docs/` note if useful — let me know.

## Files touched

- `server/index.ts` — only file changed. +85 / -1.