### PR TITLE
Add Docker Compose single-machine deployment to integrations/docker-l…

### DIFF
--- a/integrations/docker-local/.env.example
+++ b/integrations/docker-local/.env.example
@@ -1,0 +1,26 @@
+# Copy this file to .env and fill in real values.
+# Never commit .env.
+
+POSTGRES_USER=postgres
+POSTGRES_PASSWORD=change-this-local-db-password
+POSTGRES_DB=openbrain
+
+# Used by MCP clients as the x-brain-key header.
+MCP_ACCESS_KEY=change-this-random-secret
+
+# Option A: direct OpenAI API, OpenAI-compatible endpoints.
+EMBEDDING_API_BASE=https://api.openai.com/v1
+EMBEDDING_API_KEY=sk-your-key-here
+EMBEDDING_MODEL=text-embedding-3-small
+
+CHAT_API_BASE=https://api.openai.com/v1
+CHAT_API_KEY=sk-your-key-here
+CHAT_MODEL=gpt-4o-mini
+
+# Option B: OpenRouter example. Uncomment and adjust if you intentionally use OpenRouter.
+# EMBEDDING_API_BASE=https://openrouter.ai/api/v1
+# EMBEDDING_API_KEY=sk-or-your-key-here
+# EMBEDDING_MODEL=openai/text-embedding-3-small
+# CHAT_API_BASE=https://openrouter.ai/api/v1
+# CHAT_API_KEY=sk-or-your-key-here
+# CHAT_MODEL=openai/gpt-4o-mini

--- a/integrations/docker-local/README.md
+++ b/integrations/docker-local/README.md
@@ -1,0 +1,64 @@
+# OpenBrain local Docker Compose setup
+
+This is a single-machine Docker Compose adaptation of the OB1 Kubernetes self-hosted deployment.
+
+It runs:
+
+- `db`: local PostgreSQL + pgvector
+- `mcp`: OpenBrain MCP HTTP server running on Deno
+
+The database is persisted at:
+
+```text
+./data/postgres
+```
+
+## Start
+
+```bash
+cp .env.example .env
+# edit .env and set secrets/API keys
+
+docker compose up -d --build
+./test-tools-list.sh
+```
+
+## MCP endpoint
+
+```text
+http://localhost:8000
+```
+
+Required auth header:
+
+```text
+x-brain-key: value-from-MCP_ACCESS_KEY
+```
+
+## Important data note
+
+The PostgreSQL data stays local, but the MCP server sends thought text to the configured embedding API and chat API:
+
+- `/embeddings` for semantic vectors
+- `/chat/completions` for metadata extraction
+
+Use only providers approved for the data you capture.
+
+## Changing embedding models
+
+The default schema uses `vector(1536)`, matching OpenAI `text-embedding-3-small`.
+
+If you use a model with a different embedding dimension, update every `vector(1536)` in `init/init.sql` before first run. If the DB already exists, changing `init.sql` will not reinitialize it; you need to migrate the table or delete `./data/postgres` and start fresh.
+
+## Stop
+
+```bash
+docker compose down
+```
+
+## Delete local stored data
+
+```bash
+docker compose down
+rm -rf ./data/postgres
+```

--- a/integrations/docker-local/docker-compose.yml
+++ b/integrations/docker-local/docker-compose.yml
@@ -1,0 +1,53 @@
+services:
+  db:
+    image: ankane/pgvector:v0.5.1
+    container_name: openbrain-db
+    restart: unless-stopped
+    environment:
+      POSTGRES_USER: ${POSTGRES_USER:-postgres}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:?POSTGRES_PASSWORD is required}
+      POSTGRES_DB: ${POSTGRES_DB:-openbrain}
+    ports:
+      # Bind to localhost only. Change to "5432:5432" only if you intentionally want LAN access.
+      - "127.0.0.1:5432:5432"
+    volumes:
+      # Persistent local database files. This survives container rebuilds/restarts.
+      - ./data/postgres:/var/lib/postgresql/data
+      # Runs only the first time the database directory is initialized.
+      - ./init/init.sql:/docker-entrypoint-initdb.d/init.sql:ro
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER:-postgres} -d ${POSTGRES_DB:-openbrain}"]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+
+  mcp:
+    build:
+      context: ./mcp-server
+    container_name: openbrain-mcp
+    restart: unless-stopped
+    depends_on:
+      db:
+        condition: service_healthy
+    environment:
+      DB_HOST: db
+      DB_PORT: 5432
+      DB_NAME: ${POSTGRES_DB:-openbrain}
+      DB_USER: ${POSTGRES_USER:-postgres}
+      DB_PASSWORD: ${POSTGRES_PASSWORD:?POSTGRES_PASSWORD is required}
+      MCP_ACCESS_KEY: ${MCP_ACCESS_KEY:?MCP_ACCESS_KEY is required}
+      PORT: 8000
+
+      # OpenAI-compatible embedding endpoint.
+      EMBEDDING_API_BASE: ${EMBEDDING_API_BASE:-https://api.openai.com/v1}
+      EMBEDDING_API_KEY: ${EMBEDDING_API_KEY:?EMBEDDING_API_KEY is required}
+      EMBEDDING_MODEL: ${EMBEDDING_MODEL:-text-embedding-3-small}
+
+      # OpenAI-compatible chat endpoint used only for metadata extraction.
+      # Leave equal to embedding provider if your provider supports /chat/completions.
+      CHAT_API_BASE: ${CHAT_API_BASE:-https://api.openai.com/v1}
+      CHAT_API_KEY: ${CHAT_API_KEY:-${EMBEDDING_API_KEY}}
+      CHAT_MODEL: ${CHAT_MODEL:-gpt-4o-mini}
+    ports:
+      # Bind to localhost only for safer first testing.
+      - "127.0.0.1:8000:8000"

--- a/integrations/docker-local/init/init.sql
+++ b/integrations/docker-local/init/init.sql
@@ -1,0 +1,85 @@
+CREATE EXTENSION IF NOT EXISTS vector;
+
+CREATE TABLE IF NOT EXISTS thoughts (
+  id BIGSERIAL PRIMARY KEY,
+  content TEXT NOT NULL,
+  content_fingerprint TEXT,
+  embedding vector(1536),
+  metadata JSONB DEFAULT '{}'::jsonb,
+  created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
+  updated_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_thoughts_fingerprint
+  ON thoughts (content_fingerprint)
+  WHERE content_fingerprint IS NOT NULL;
+
+CREATE INDEX IF NOT EXISTS idx_thoughts_created_at ON thoughts (created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_thoughts_metadata ON thoughts USING GIN (metadata);
+CREATE INDEX IF NOT EXISTS idx_thoughts_embedding ON thoughts USING hnsw (embedding vector_cosine_ops);
+
+CREATE OR REPLACE FUNCTION update_updated_at()
+RETURNS TRIGGER AS $$
+BEGIN
+  NEW.updated_at = CURRENT_TIMESTAMP;
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER thoughts_updated_at
+  BEFORE UPDATE ON thoughts
+  FOR EACH ROW
+  EXECUTE FUNCTION update_updated_at();
+
+CREATE OR REPLACE FUNCTION upsert_thought(p_content TEXT, p_metadata JSONB DEFAULT '{}')
+RETURNS BIGINT AS $$
+DECLARE
+  v_fingerprint TEXT;
+  v_id BIGINT;
+BEGIN
+  v_fingerprint := encode(sha256(convert_to(
+    lower(trim(regexp_replace(p_content, '\s+', ' ', 'g'))),
+    'UTF8'
+  )), 'hex');
+
+  INSERT INTO thoughts (content, content_fingerprint, metadata)
+  VALUES (p_content, v_fingerprint, p_metadata)
+  ON CONFLICT (content_fingerprint) WHERE content_fingerprint IS NOT NULL DO UPDATE
+  SET updated_at = CURRENT_TIMESTAMP,
+      metadata = thoughts.metadata || EXCLUDED.metadata
+  RETURNING id INTO v_id;
+
+  RETURN v_id;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE OR REPLACE FUNCTION match_thoughts(
+  query_embedding vector(1536),
+  match_threshold FLOAT DEFAULT 0.5,
+  match_count INT DEFAULT 10,
+  filter JSONB DEFAULT '{}'::jsonb
+)
+RETURNS TABLE (
+  id BIGINT,
+  content TEXT,
+  metadata JSONB,
+  similarity FLOAT,
+  created_at TIMESTAMP WITH TIME ZONE
+)
+LANGUAGE plpgsql
+AS $$
+BEGIN
+  RETURN QUERY
+  SELECT
+    t.id,
+    t.content,
+    t.metadata,
+    (1 - (t.embedding <=> query_embedding))::FLOAT AS similarity,
+    t.created_at
+  FROM thoughts t
+  WHERE 1 - (t.embedding <=> query_embedding) >= match_threshold
+    AND (filter = '{}'::jsonb OR t.metadata @> filter)
+  ORDER BY t.embedding <=> query_embedding
+  LIMIT match_count;
+END;
+$$;

--- a/integrations/docker-local/mcp-server/Dockerfile
+++ b/integrations/docker-local/mcp-server/Dockerfile
@@ -1,0 +1,13 @@
+FROM denoland/deno:2.3.3
+
+WORKDIR /app
+
+COPY deno.json ./
+RUN deno install
+
+COPY index.ts ./
+
+USER deno
+EXPOSE 8000
+
+CMD ["deno", "run", "--allow-net", "--allow-env", "--allow-read", "index.ts"]

--- a/integrations/docker-local/mcp-server/deno.json
+++ b/integrations/docker-local/mcp-server/deno.json
@@ -1,0 +1,9 @@
+{
+  "imports": {
+    "@hono/mcp": "npm:@hono/mcp@0.1.1",
+    "@modelcontextprotocol/sdk": "npm:@modelcontextprotocol/sdk@1.24.3",
+    "hono": "npm:hono@4.9.2",
+    "zod": "npm:zod@4.1.13",
+    "postgres": "https://deno.land/x/postgres@v0.19.3/mod.ts"
+  }
+}

--- a/integrations/docker-local/mcp-server/index.ts
+++ b/integrations/docker-local/mcp-server/index.ts
@@ -1,0 +1,341 @@
+/**
+ * OpenBrain MCP Server - Docker Compose local version.
+ * Adapted from the OB1 Kubernetes self-hosted version.
+ *
+ * Environment variables:
+ * DB_HOST, DB_PORT, DB_NAME, DB_USER, DB_PASSWORD
+ * EMBEDDING_API_BASE, EMBEDDING_API_KEY, EMBEDDING_MODEL
+ * CHAT_API_BASE, CHAT_API_KEY, CHAT_MODEL
+ * MCP_ACCESS_KEY
+ */
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { StreamableHTTPTransport } from "@hono/mcp";
+import { Hono } from "hono";
+import { z } from "zod";
+import { Pool } from "postgres";
+
+const DB_HOST = Deno.env.get("DB_HOST") || "db";
+const DB_PORT = parseInt(Deno.env.get("DB_PORT") || "5432", 10);
+const DB_NAME = Deno.env.get("DB_NAME") || "openbrain";
+const DB_USER = Deno.env.get("DB_USER") || "postgres";
+const DB_PASSWORD = Deno.env.get("DB_PASSWORD") || "";
+
+const EMBEDDING_API_BASE = Deno.env.get("EMBEDDING_API_BASE") || "https://api.openai.com/v1";
+const EMBEDDING_API_KEY = Deno.env.get("EMBEDDING_API_KEY") || "";
+const EMBEDDING_MODEL = Deno.env.get("EMBEDDING_MODEL") || "text-embedding-3-small";
+
+const CHAT_API_BASE = Deno.env.get("CHAT_API_BASE") || EMBEDDING_API_BASE;
+const CHAT_API_KEY = Deno.env.get("CHAT_API_KEY") || EMBEDDING_API_KEY;
+const CHAT_MODEL = Deno.env.get("CHAT_MODEL") || "gpt-4o-mini";
+
+const MCP_ACCESS_KEY = Deno.env.get("MCP_ACCESS_KEY") || "";
+
+if (!DB_PASSWORD) throw new Error("DB_PASSWORD is required");
+if (!MCP_ACCESS_KEY) throw new Error("MCP_ACCESS_KEY is required");
+if (!EMBEDDING_API_KEY) throw new Error("EMBEDDING_API_KEY is required");
+
+const pool = new Pool(
+  {
+    hostname: DB_HOST,
+    port: DB_PORT,
+    database: DB_NAME,
+    user: DB_USER,
+    password: DB_PASSWORD,
+  },
+  20,
+);
+
+type Metadata = Record<string, unknown>;
+
+async function getEmbedding(text: string): Promise<number[]> {
+  const r = await fetch(`${EMBEDDING_API_BASE}/embeddings`, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${EMBEDDING_API_KEY}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({ model: EMBEDDING_MODEL, input: text }),
+  });
+
+  if (!r.ok) {
+    const msg = await r.text().catch(() => "");
+    throw new Error(`Embedding API failed: ${r.status} ${msg}`);
+  }
+
+  const d = await r.json();
+  return d.data[0].embedding;
+}
+
+async function extractMetadata(text: string): Promise<Metadata> {
+  const r = await fetch(`${CHAT_API_BASE}/chat/completions`, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${CHAT_API_KEY}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      model: CHAT_MODEL,
+      response_format: { type: "json_object" },
+      messages: [
+        {
+          role: "system",
+          content:
+            `Extract metadata from the user's captured thought.
+Return JSON with:
+- "people": array of people mentioned (empty if none)
+- "action_items": array of implied to-dos (empty if none)
+- "dates_mentioned": array of dates YYYY-MM-DD (empty if none)
+- "topics": array of 1-3 short topic tags (always at least one)
+- "type": one of "observation", "task", "idea", "reference", "person_note"
+Only extract what's explicitly there.`,
+        },
+        { role: "user", content: text },
+      ],
+    }),
+  });
+
+  if (!r.ok) {
+    const msg = await r.text().catch(() => "");
+    throw new Error(`Chat metadata API failed: ${r.status} ${msg}`);
+  }
+
+  const d = await r.json();
+  try {
+    return JSON.parse(d.choices[0].message.content);
+  } catch {
+    return { topics: ["uncategorized"], type: "observation" };
+  }
+}
+
+const server = new McpServer({ name: "open-brain", version: "1.0.0" });
+
+server.registerTool(
+  "search_thoughts",
+  {
+    title: "Search Thoughts",
+    description: "Search captured thoughts by meaning.",
+    inputSchema: {
+      query: z.string().describe("What to search for"),
+      limit: z.number().optional().default(10),
+      threshold: z.number().optional().default(0.5),
+    },
+  },
+  async ({ query, limit, threshold }) => {
+    try {
+      const qEmb = await getEmbedding(query);
+      const embStr = `[${qEmb.join(",")}]`;
+      const client = await pool.connect();
+      try {
+        const result = await client.queryObject<{
+          content: string;
+          metadata: Metadata;
+          similarity: number;
+          created_at: string;
+        }>(
+          `SELECT content, metadata, created_at,
+                  1 - (embedding <=> $1::vector) AS similarity
+             FROM thoughts
+            WHERE 1 - (embedding <=> $1::vector) >= $2
+            ORDER BY embedding <=> $1::vector
+            LIMIT $3`,
+          [embStr, threshold, limit],
+        );
+
+        if (!result.rows.length) {
+          return { content: [{ type: "text" as const, text: `No thoughts found matching "${query}".` }] };
+        }
+
+        const results = result.rows.map((t, i) => {
+          const m = t.metadata || {};
+          const parts = [
+            `--- Result ${i + 1} (${(t.similarity * 100).toFixed(1)}% match) ---`,
+            `Captured: ${new Date(t.created_at).toLocaleDateString()}`,
+            `Type: ${String(m.type || "unknown")}`,
+          ];
+          if (Array.isArray(m.topics) && m.topics.length) parts.push(`Topics: ${m.topics.join(", ")}`);
+          if (Array.isArray(m.people) && m.people.length) parts.push(`People: ${m.people.join(", ")}`);
+          if (Array.isArray(m.action_items) && m.action_items.length) parts.push(`Actions: ${m.action_items.join("; ")}`);
+          parts.push(`\n${t.content}`);
+          return parts.join("\n");
+        });
+
+        return { content: [{ type: "text" as const, text: `Found ${result.rows.length} thought(s):\n\n${results.join("\n\n")}` }] };
+      } finally {
+        client.release();
+      }
+    } catch (err) {
+      return { content: [{ type: "text" as const, text: `Error: ${(err as Error).message}` }], isError: true };
+    }
+  },
+);
+
+server.registerTool(
+  "list_thoughts",
+  {
+    title: "List Recent Thoughts",
+    description: "List recently captured thoughts with optional filters by type, topic, person, or time range.",
+    inputSchema: {
+      limit: z.number().optional().default(10),
+      type: z.string().optional().describe("Filter by type"),
+      topic: z.string().optional().describe("Filter by topic tag"),
+      person: z.string().optional().describe("Filter by person mentioned"),
+      days: z.number().optional().describe("Only thoughts from the last N days"),
+    },
+  },
+  async ({ limit, type, topic, person, days }) => {
+    try {
+      const conditions: string[] = [];
+      const params: unknown[] = [];
+      let paramIdx = 1;
+
+      if (type) {
+        conditions.push(`metadata->>'type' = $${paramIdx}`);
+        params.push(type);
+        paramIdx++;
+      }
+      if (topic) {
+        conditions.push(`metadata->'topics' ? $${paramIdx}`);
+        params.push(topic);
+        paramIdx++;
+      }
+      if (person) {
+        conditions.push(`metadata->'people' ? $${paramIdx}`);
+        params.push(person);
+        paramIdx++;
+      }
+      if (days) {
+        conditions.push(`created_at >= NOW() - ($${paramIdx} * INTERVAL '1 day')`);
+        params.push(Math.floor(Number(days)));
+        paramIdx++;
+      }
+
+      const whereClause = conditions.length ? `WHERE ${conditions.join(" AND ")}` : "";
+      const client = await pool.connect();
+      try {
+        const result = await client.queryObject<{ content: string; metadata: Metadata; created_at: string }>(
+          `SELECT content, metadata, created_at
+             FROM thoughts
+             ${whereClause}
+            ORDER BY created_at DESC
+            LIMIT $${paramIdx}`,
+          [...params, limit],
+        );
+
+        if (!result.rows.length) return { content: [{ type: "text" as const, text: "No thoughts found." }] };
+
+        const results = result.rows.map((t, i) => {
+          const m = t.metadata || {};
+          const tags = Array.isArray(m.topics) ? m.topics.join(", ") : "";
+          return `${i + 1}. [${new Date(t.created_at).toLocaleDateString()}] (${String(m.type || "??")}${tags ? " - " + tags : ""})\n ${t.content}`;
+        });
+
+        return { content: [{ type: "text" as const, text: `${result.rows.length} recent thought(s):\n\n${results.join("\n\n")}` }] };
+      } finally {
+        client.release();
+      }
+    } catch (err) {
+      return { content: [{ type: "text" as const, text: `Error: ${(err as Error).message}` }], isError: true };
+    }
+  },
+);
+
+server.registerTool(
+  "thought_stats",
+  {
+    title: "Thought Statistics",
+    description: "Get a summary of all captured thoughts: totals, types, top topics, and people.",
+    inputSchema: {},
+  },
+  async () => {
+    try {
+      const client = await pool.connect();
+      try {
+        const countResult = await client.queryObject<{ count: number }>("SELECT COUNT(*)::int AS count FROM thoughts");
+        const dataResult = await client.queryObject<{ metadata: Metadata; created_at: string }>("SELECT metadata, created_at FROM thoughts ORDER BY created_at DESC");
+        const count = countResult.rows[0]?.count || 0;
+        const data = dataResult.rows;
+        const types: Record<string, number> = {};
+        const topics: Record<string, number> = {};
+        const people: Record<string, number> = {};
+
+        for (const r of data) {
+          const m = r.metadata || {};
+          if (m.type) types[String(m.type)] = (types[String(m.type)] || 0) + 1;
+          if (Array.isArray(m.topics)) for (const t of m.topics) topics[String(t)] = (topics[String(t)] || 0) + 1;
+          if (Array.isArray(m.people)) for (const p of m.people) people[String(p)] = (people[String(p)] || 0) + 1;
+        }
+
+        const sort = (o: Record<string, number>) => Object.entries(o).sort((a, b) => b[1] - a[1]).slice(0, 10);
+        const lines = [
+          `Total thoughts: ${count}`,
+          `Date range: ${data.length ? new Date(data[data.length - 1].created_at).toLocaleDateString() + " -> " + new Date(data[0].created_at).toLocaleDateString() : "N/A"}`,
+          "",
+          "Types:",
+          ...sort(types).map(([k, v]) => ` ${k}: ${v}`),
+        ];
+
+        if (Object.keys(topics).length) lines.push("", "Top topics:", ...sort(topics).map(([k, v]) => ` ${k}: ${v}`));
+        if (Object.keys(people).length) lines.push("", "People mentioned:", ...sort(people).map(([k, v]) => ` ${k}: ${v}`));
+
+        return { content: [{ type: "text" as const, text: lines.join("\n") }] };
+      } finally {
+        client.release();
+      }
+    } catch (err) {
+      return { content: [{ type: "text" as const, text: `Error: ${(err as Error).message}` }], isError: true };
+    }
+  },
+);
+
+server.registerTool(
+  "capture_thought",
+  {
+    title: "Capture Thought",
+    description: "Save a new thought to OpenBrain. Generates an embedding and extracts metadata automatically.",
+    inputSchema: { content: z.string().describe("The thought to capture") },
+  },
+  async ({ content }) => {
+    try {
+      const [embedding, metadata] = await Promise.all([getEmbedding(content), extractMetadata(content)]);
+      const embStr = `[${embedding.join(",")}]`;
+      const meta = { ...metadata, source: "mcp" };
+      const client = await pool.connect();
+      try {
+        const upsertResult = await client.queryObject<{ id: bigint }>(
+          "SELECT upsert_thought($1, $2::jsonb) AS id",
+          [content, JSON.stringify(meta)],
+        );
+        const id = upsertResult.rows[0]?.id;
+        if (id !== undefined) {
+          await client.queryObject(
+            "UPDATE thoughts SET embedding = $1::vector WHERE id = $2",
+            [embStr, id],
+          );
+        }
+      } finally {
+        client.release();
+      }
+
+      let confirmation = `Captured as ${String(meta.type || "thought")}`;
+      if (Array.isArray(meta.topics) && meta.topics.length) confirmation += ` -- ${meta.topics.join(", ")}`;
+      if (Array.isArray(meta.people) && meta.people.length) confirmation += ` | People: ${meta.people.join(", ")}`;
+      if (Array.isArray(meta.action_items) && meta.action_items.length) confirmation += ` | Actions: ${meta.action_items.join("; ")}`;
+      return { content: [{ type: "text" as const, text: confirmation }] };
+    } catch (err) {
+      return { content: [{ type: "text" as const, text: `Error: ${(err as Error).message}` }], isError: true };
+    }
+  },
+);
+
+const app = new Hono();
+
+app.all("*", async (c) => {
+  const provided = c.req.header("x-brain-key") || new URL(c.req.url).searchParams.get("key");
+  if (!provided || provided !== MCP_ACCESS_KEY) return c.json({ error: "Invalid or missing access key" }, 401);
+
+  const transport = new StreamableHTTPTransport();
+  await server.connect(transport);
+  return transport.handleRequest(c);
+});
+
+Deno.serve({ port: parseInt(Deno.env.get("PORT") || "8000", 10) }, app.fetch);

--- a/integrations/docker-local/test-tools-list.sh
+++ b/integrations/docker-local/test-tools-list.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ ! -f .env ]]; then
+  echo "Missing .env. Copy .env.example to .env and fill it in first." >&2
+  exit 1
+fi
+
+set -a
+source .env
+set +a
+
+curl -sS -X POST http://localhost:8000 \
+  -H "x-brain-key: ${MCP_ACCESS_KEY}" \
+  -H "Content-Type: application/json" \
+  -d '{"jsonrpc":"2.0","method":"tools/list","id":1}' | python3 -m json.tool


### PR DESCRIPTION
…ocal

Adapted from the OB1 Kubernetes self-hosted version. Runs a local PostgreSQL+pgvector container and a Deno MCP server container with multi-provider embedding support (OpenAI or OpenRouter).

Fixes applied vs the generated version:
- Swap ivfflat index for hnsw (works correctly on empty databases)
- Add content_fingerprint + upsert_thought() for deduplication
- Add updated_at column and trigger
- Fix days filter to use parameterized query instead of interpolation
- Restore filter JSONB support in match_thoughts()

## Contribution Type

<!-- Check one -->
- [ ] Recipe (`/recipes`)
- [ ] Schema (`/schemas`)
- [ ] Dashboard (`/dashboards`)
- [ ] Integration (`/integrations`)
- [ ] Skill (`/skills`)
- [ ] Repo improvement (docs, CI, templates)

## What does this do?

<!-- 1-3 sentences describing what this contribution adds or changes -->

## Requirements

<!-- What external services, tools, or APIs does this need? (e.g., Gmail API, Node.js 18+) -->
<!-- If this depends on a canonical skill or primitive, mention it here and declare it in metadata.json -->

## Checklist

- [ ] I've read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [ ] My contribution has a `README.md` with prerequisites, step-by-step instructions, and expected outcome
- [ ] My `metadata.json` has all required fields
- [ ] If my contribution depends on a skill or primitive, I declared it in metadata.json and linked it in the README
- [ ] I tested this on my own Open Brain instance
- [ ] No credentials, API keys, or secrets are included
