### PR TITLE
[docs] Document Edge Function redeploy step in OpenRouter rotation FAQ

### DIFF
--- a/docs/03-faq.md
+++ b/docs/03-faq.md
@@ -176,7 +176,10 @@ When you generate a new key on openrouter.ai/keys, the old key is revoked immedi
 
    ```bash
    supabase secrets set OPENROUTER_API_KEY=sk-or-v1-your-new-key
+   supabase functions deploy open-brain-mcp --no-verify-jwt
    ```
+
+   `secrets set` stores the new value, but Edge Functions read environment variables once at cold start and cache them. Already-running ("warm") instances keep using the old key until they recycle — which can take minutes and produce intermittent 401s in the meantime. Redeploying forces a fresh boot so the new key takes effect immediately. If you've deployed extension functions that also read `OPENROUTER_API_KEY`, redeploy each of them too (or run `supabase functions deploy` with no arg to redeploy all).
 
 2. **Local `.env` files** — Any recipes or integrations you run locally (e.g., `recipes/chatgpt-conversation-import/.env`). Open each one and replace the old key value.
 


### PR DESCRIPTION
## Contribution Type

- [x] Repo improvement (docs, CI, templates)

## What does this do?

Closes a gap in the OpenRouter API key rotation FAQ (`docs/03-faq.md`). The checklist previously stopped at `supabase secrets set`, but Edge Functions read environment variables once at cold start and cache them — already-running ("warm") instances keep using the old key until they recycle, producing intermittent 401s for several minutes after a rotation.

This PR adds the paired `supabase functions deploy open-brain-mcp --no-verify-jwt` command and a short paragraph explaining the warm-instance caching behavior, plus a note for users running extension functions that also consume `OPENROUTER_API_KEY`.

The Step 6.5 callout in `docs/01-getting-started.md` already points readers to "the FAQ on key rotation for the full checklist," so it inherits this fix automatically — no second edit needed.

## Requirements

None. Documentation-only change.

## Checklist

- [x] I've read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [ ] My contribution has a `README.md` with prerequisites, step-by-step instructions, and expected outcome — *N/A, edits an existing doc*
- [ ] My `metadata.json` has all required fields — *N/A, edits an existing doc*
- [ ] If my contribution depends on a skill or primitive, I declared it in metadata.json and linked it in the README — *N/A*
- [x] I tested this on my own Open Brain instance — *verified the documented behavior on my own deployment: rotating OpenRouter and running `secrets set` alone produces intermittent 401s until the function redeploys; pairing with `functions deploy` resolves immediately*
- [x] No credentials, API keys, or secrets are included
