### PR TITLE
[dashboards] open-brain-dashboard-next: fix Sign Out button hidden behind iOS Safari URL bar

### DIFF
--- a/dashboards/open-brain-dashboard-next/components/Sidebar.tsx
+++ b/dashboards/open-brain-dashboard-next/components/Sidebar.tsx
@@ -26,7 +26,7 @@ export function Sidebar({ isOpen = false, onClose }: SidebarProps) {
 
   return (
     <aside
-      className={`fixed left-0 top-0 h-screen w-56 bg-bg-surface border-r border-border flex flex-col z-50
+      className={`fixed left-0 top-0 h-dvh w-56 bg-bg-surface border-r border-border flex flex-col z-50
         hidden md:flex
         ${isOpen ? "!flex" : ""}
       `}


### PR DESCRIPTION
## Contribution Type

- [x] Dashboard (`/dashboards`)

## What does this do?

One-character CSS fix in `components/Sidebar.tsx`: `h-screen` → `h-dvh`.

The sidebar uses `h-screen` (`height: 100vh`), which on iOS Safari is the *largest* viewport — the height when the URL bar is collapsed. While the URL bar is visible, the actual visible area is shorter, so the bottom of the sidebar — including the **Sign Out button** — renders below the fold and is effectively unreachable until you scroll-trigger the URL bar to collapse. On a fresh page load you can't sign out.

`h-dvh` (`height: 100dvh`, dynamic viewport height) makes the sidebar bound itself to the *currently* visible viewport, so the Sign Out button stays in view regardless of browser chrome state. Tailwind v4 supports the `h-dvh` utility natively — no config changes needed, no other code touched.

### Repro / verification

- Before: open the dashboard on an iPhone in Safari with the URL bar visible — open the sidebar — the bottom (RestrictedToggle + Sign Out) is below the fold.
- After: same conditions — bottom of sidebar sits flush with the visible viewport — Sign Out reachable on first tap.

I tested this on my own deploy (Cloudflare Worker via OpenNext, current iOS Safari) before opening this PR.

## Requirements

None — pure CSS class change. No new deps, no behavior change on desktop or other mobile browsers (`h-dvh` falls back gracefully where supported, and Mobile Safari has supported `dvh` since iOS 15.4).

## Checklist

- [x] I've read CONTRIBUTING.md
- [x] No credentials, API keys, or secrets are included
- [x] I tested this on my own Open Brain instance (live deploy, real iPhone, real URL bar)