### PR TITLE
Improve ChatGPT MCP compatibility

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -128,6 +128,7 @@ grant select, insert, update, delete on table public.your_table to service_role;
 - **"Cross-Extension Integration"** prominently documenting connections to other extensions
 - **"Next Steps"** linking to the next extension
 - **Tool audit link** — Any extension or integration that exposes MCP tools must link to the [MCP Tool Audit & Optimization Guide](docs/05-tool-audit.md) in its "Next Steps" or closing section. This helps users manage their tool surface area as they add extensions. The link is checked by the automated review.
+- **MCP tool annotations** — Any extension or integration that exposes MCP tools must mark read-only tools with `annotations: { readOnlyHint: true }` and write tools with `annotations: { readOnlyHint: false, openWorldHint: false, destructiveHint: false }` unless the tool really can touch arbitrary external resources or destroy data. ChatGPT uses this metadata to distinguish read tools from write actions.
 - **Remote MCP setup** — MCP servers must be deployed as Supabase Edge Functions and connected via custom connectors (URL-based). Do NOT use local Node.js servers or `claude_desktop_config.json`. See the [extension template](extensions/_template/) for the correct pattern.
 
 **Primitives** additionally require:
@@ -298,3 +299,4 @@ Every PR is checked against these rules. All must pass before human review.
 13. **Internal links** — All relative links in READMEs resolve to existing files
 14. **Remote MCP pattern** — Extensions and integrations must use remote MCP via Supabase Edge Functions. No `claude_desktop_config.json`, no local Node.js stdio servers. See the [Getting Started guide](docs/01-getting-started.md) for the correct pattern
 15. **Tool audit link** — Extensions and integrations must link to the [MCP Tool Audit & Optimization Guide](docs/05-tool-audit.md) in their README. This ensures users are aware of tool surface area management as they add capabilities
+16. **MCP tool annotations** — Read-only tools include `readOnlyHint: true`; write tools include `readOnlyHint: false`, `openWorldHint`, and `destructiveHint`

--- a/docs/01-getting-started.md
+++ b/docs/01-getting-started.md
@@ -298,7 +298,7 @@ Copy the output — it'll look something like `a3f8b2c1d4e5...` (64 characters).
 
 ![Step 6](https://img.shields.io/badge/Step_6-Deploy_the_MCP_Server-1E88E5?style=for-the-badge)
 
-One Edge Function. Four MCP tools: semantic search, browse recent thoughts, stats, and capture. This gives any MCP-connected AI the ability to read and write to your brain.
+One Edge Function. Four core MCP tools: semantic search, browse recent thoughts, stats, and capture. It also exposes read-only `search` and `fetch` aliases for ChatGPT compatibility. Full-MCP-capable AI clients can read and write to your brain; restricted ChatGPT sessions can still use the standard read-only search/fetch path.
 
 > [!WARNING]
 > **Tried this before and starting over?** If you have a `supabase/` folder in your home directory from a previous attempt, delete it first — it will silently hijack your setup. Run `rm -rf ~/supabase` (Mac/Linux) or `Remove-Item -Recurse ~\supabase` (Windows) to clean it out.
@@ -414,6 +414,8 @@ supabase secrets set OPENROUTER_API_KEY=your-openrouter-key-here
 
 > [!NOTE]
 > `SUPABASE_URL` and `SUPABASE_SERVICE_ROLE_KEY` are automatically available inside Edge Functions — you don't need to set them.
+>
+> Optional: if you have an Open Brain dashboard or another stable page for viewing individual thoughts, set `OPEN_BRAIN_CITATION_BASE_URL` to that base URL. ChatGPT's `search`/`fetch` compatibility tools use it when returning citation URLs.
 
 <!-- -->
 
@@ -594,6 +596,8 @@ supabase secrets set OPENROUTER_API_KEY=your-openrouter-key-here
 
 > [!NOTE]
 > `SUPABASE_URL` and `SUPABASE_SERVICE_ROLE_KEY` are automatically available inside Edge Functions — you don't need to set them.
+>
+> Optional: if you have an Open Brain dashboard or another stable page for viewing individual thoughts, set `OPEN_BRAIN_CITATION_BASE_URL` to that base URL. ChatGPT's `search`/`fetch` compatibility tools use it when returning citation URLs.
 
 <!-- -->
 
@@ -699,6 +703,8 @@ That's it. Start a new conversation, and Claude will have access to your Open Br
 
 > [!WARNING]
 > Requires a paid ChatGPT plan (Plus, Pro, Business, Enterprise, or Edu). Works on the web at [chatgpt.com](https://chatgpt.com) only — not available on mobile.
+>
+> ChatGPT's custom MCP support is still beta, plan-sensitive, and sometimes model-sensitive. As of May 2026, OpenAI's docs list Developer Mode for Plus, Pro, Business, Enterprise, and Edu, while workspace app publishing and action controls are documented mainly for Business, Enterprise, and Edu. In practice, some Pro model variants expose fewer custom tools than thinking models.
 
 **Enable Developer Mode (one-time setup):**
 
@@ -720,6 +726,8 @@ That's it. Start a new conversation, and Claude will have access to your Open Br
 
 > [!TIP]
 > ChatGPT is less intuitive than Claude at picking the right MCP tool automatically. If it doesn't use your brain on its own, be explicit: "Use the Open Brain search_thoughts tool to find my notes about project planning." After it gets the pattern once or twice in a conversation, it usually picks up the habit.
+>
+> If ChatGPT says an Open Brain tool is unavailable and your Supabase Edge Function logs show zero requests, the connector did not reach your server. Refresh or recreate the ChatGPT app, start a fresh chat, select the Open Brain app in Developer Mode, and try a thinking model. On restricted Pro sessions, expect read tools, especially `search` and `fetch`, to be more reliable than the write tool (`capture_thought`).
 
 </details>
 
@@ -811,7 +819,7 @@ Every MCP client handles remote servers slightly differently. The server accepts
 
 </details>
 
-✅ **Done when:** You can start a conversation in your AI client and it has access to Open Brain tools (search_thoughts, list_thoughts, thought_stats, capture_thought).
+✅ **Done when:** You can start a conversation in your AI client and it has access to Open Brain tools (`search_thoughts`, `list_thoughts`, `thought_stats`, `capture_thought`). ChatGPT may also show `search` and `fetch` compatibility tools.
 
 ---
 
@@ -866,6 +874,10 @@ On the official macOS/Windows Claude Desktop app, make sure you added the connec
 **❌ ChatGPT doesn't use the Open Brain tools**
 
 First, confirm Developer Mode is enabled (Settings → Apps & Connectors → Advanced settings). Without it, ChatGPT only exposes limited MCP functionality that won't cover Open Brain's full toolset. Next, check that the connector is active for your current conversation — look for it in the tools/apps panel. If it's connected but ChatGPT ignores it, be direct: "Use the Open Brain search_thoughts tool to search for [topic]." ChatGPT often needs explicit tool references the first few times before it starts picking them up automatically.
+
+**❌ ChatGPT says an Open Brain tool is unavailable**
+
+Check Supabase dashboard → Edge Functions → `open-brain-mcp` → Logs. If no request appears when ChatGPT fails, your server is not the problem. ChatGPT did not expose that tool to the current chat. Redeploy the current MCP server, refresh or recreate the ChatGPT app so it pulls updated tool metadata, start a fresh chat, and try a thinking model. On Pro, the read-only `search`/`fetch` compatibility tools may work where `capture_thought` is hidden or blocked because full MCP/write access is plan-dependent.
 
 **❌ "Permission denied for table thoughts"**
 

--- a/docs/03-faq.md
+++ b/docs/03-faq.md
@@ -30,6 +30,18 @@ Fair warning: if you've been a heavy ChatGPT user, the export is A LOT of data. 
 
 ChatGPT is less intuitive than Claude at picking the right MCP tool on its own. Be explicit the first few times: "Use the Open Brain search_thoughts tool to find my notes about [topic]." After it gets the pattern once or twice in a conversation, it usually starts picking them up automatically.
 
+### "ChatGPT says the Open Brain tool is not available"
+
+First check Supabase dashboard → Edge Functions → `open-brain-mcp` → Logs. If you see **zero requests** while ChatGPT is failing, stop debugging keys, URLs, and Edge Function code. ChatGPT never called your server; the problem is the tools exposed to that chat session.
+
+As of May 2026, OpenAI's ChatGPT developer-mode docs are in beta and the plan/model behavior is not perfectly stable. The important implementation detail: ChatGPT treats MCP tools without `readOnlyHint` as write actions. Open Brain now marks `search_thoughts`, `list_thoughts`, `thought_stats`, `search`, and `fetch` as read-only. It marks `capture_thought` as a bounded, non-destructive write action.
+
+After updating your deployed MCP server, redeploy it, then refresh or recreate the ChatGPT app so ChatGPT pulls the new tool metadata. Expected behavior:
+
+- Full MCP-capable chats should expose the four core tools, plus ChatGPT compatibility aliases (`search` and `fetch`).
+- Restricted Pro/read-only sessions may expose only read tools and hide or block `capture_thought`.
+- If a Pro chat exposes none of the tools, switch that chat to a thinking model, start a fresh chat, and make sure the Open Brain app is selected in Developer Mode.
+
 ### "I'm stuck and Claude is rewriting my edge function code to fix the connection"
 
 Pause. The problems are almost never in the code. They're in the configuration: a secret that doesn't match, a URL that's missing the key, a step that got skipped. Letting an AI rewrite working code when the issue is a mismatched environment variable will make things harder to debug, not easier.

--- a/docs/05-tool-audit.md
+++ b/docs/05-tool-audit.md
@@ -24,6 +24,8 @@ Every MCP tool you expose sends its full definition — name, description, param
 
 The bottom line: fewer, smarter tools beat many narrow ones.
 
+**ChatGPT-specific gotcha:** mark every retrieval/reporting tool with `annotations: { readOnlyHint: true }` and every write tool with `annotations: { readOnlyHint: false, openWorldHint: false, destructiveHint: false }` unless the tool really can touch arbitrary external resources or destroy data. ChatGPT uses these hints to classify tools. If you omit them, ChatGPT can treat the tool as a write action, which makes Pro/read-only MCP sessions more likely to hide it entirely. For restricted ChatGPT surfaces, exact `search` and `fetch` read tools are safer than only exposing custom names like `search_thoughts`.
+
 ---
 
 ## 1. Auditing Your Tools

--- a/extensions/_template/AGENT_SPEC.md
+++ b/extensions/_template/AGENT_SPEC.md
@@ -171,6 +171,10 @@ server.registerTool(
   {
     title: "Human-Readable Tool Name",
     description: "When should the AI use this tool? Be specific about triggers.",
+    annotations: {
+      readOnlyHint: true, // Set false for tools that create, update, or delete data.
+      // For write tools, also include openWorldHint and destructiveHint.
+    },
     inputSchema: {
       param_name: z.string().describe("What this parameter is for"),
       optional_param: z.number().optional().default(10),
@@ -210,8 +214,9 @@ server.registerTool(
 2. **Every tool must have a try/catch** that returns `isError: true` on failure.
 3. **Tool descriptions should describe WHEN to use the tool**, not what it does technically. The AI reads these to decide which tool to call.
 4. **Use Zod for input validation.** Every parameter needs `.describe()` for the AI to understand it.
-5. **Minimum tools per extension:** one for adding data, one for retrieving/searching data.
-6. **The service role key bypasses RLS.** If the extension uses RLS and needs user-scoped queries, the tool must accept a `user_id` parameter or derive it from context.
+5. **Every tool must include MCP annotations.** Use `readOnlyHint: true` for retrieval/search/reporting tools. For write tools, use `readOnlyHint: false`, `openWorldHint: false` when the write is scoped to your own tables, and `destructiveHint: false` unless the tool deletes, overwrites, or performs irreversible actions. ChatGPT uses this metadata to distinguish read tools from write actions.
+6. **Minimum tools per extension:** one for adding data, one for retrieving/searching data.
+7. **The service role key bypasses RLS.** If the extension uses RLS and needs user-scoped queries, the tool must accept a `user_id` parameter or derive it from context.
 
 ### Extensions That Need OpenRouter
 

--- a/integrations/kubernetes-deployment/index.ts
+++ b/integrations/kubernetes-deployment/index.ts
@@ -14,6 +14,7 @@
  *   CHAT_API_KEY - API key for chat service (defaults to EMBEDDING_API_KEY)
  *   CHAT_MODEL - Model name for metadata extraction (default: gpt-4o-mini)
  *   MCP_ACCESS_KEY - Authentication key for MCP endpoint
+ *   OPEN_BRAIN_CITATION_BASE_URL - Optional base URL for search/fetch citation links
  */
 
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
@@ -49,6 +50,35 @@ const pool = new Pool({
   user: DB_USER,
   password: DB_PASSWORD,
 }, 20);
+
+type ThoughtMatch = {
+  id: string;
+  content: string;
+  metadata: Record<string, unknown>;
+  similarity: number;
+  created_at: string;
+};
+
+type ThoughtRecord = {
+  id: string;
+  content: string;
+  metadata: Record<string, unknown>;
+  created_at: string;
+  updated_at?: string | null;
+};
+
+const CITATION_BASE_URL =
+  Deno.env.get("OPEN_BRAIN_CITATION_BASE_URL") || "https://openbrain.local/thoughts";
+
+function thoughtTitle(content: string, createdAt?: string): string {
+  const firstLine = content.replace(/\s+/g, " ").trim().slice(0, 80);
+  const datePrefix = createdAt ? new Date(createdAt).toLocaleDateString() : "Open Brain";
+  return firstLine ? `${datePrefix} - ${firstLine}` : `${datePrefix} thought`;
+}
+
+function thoughtUrl(id: string): string {
+  return `${CITATION_BASE_URL.replace(/\/$/, "")}/${id}`;
+}
 
 // --- Embedding & Metadata Extraction ---
 
@@ -112,6 +142,119 @@ const server = new McpServer({
   version: "1.0.0",
 });
 
+// ChatGPT compatibility: restricted connector surfaces, company knowledge, and deep
+// research look for exact read-only `search` and `fetch` tool shapes.
+server.registerTool(
+  "search",
+  {
+    title: "Search Open Brain",
+    description:
+      "Search Open Brain memories by meaning. Use this read-only compatibility tool when ChatGPT needs search/fetch-style access to stored thoughts.",
+    annotations: {
+      readOnlyHint: true,
+    },
+    inputSchema: {
+      query: z.string().describe("The search query to run against Open Brain thoughts"),
+    },
+  },
+  async ({ query }) => {
+    try {
+      const qEmb = await getEmbedding(query);
+      const embStr = `[${qEmb.join(",")}]`;
+
+      const client = await pool.connect();
+      try {
+        const result = await client.queryObject<ThoughtMatch>(
+          `SELECT id, content, metadata, created_at,
+                  1 - (embedding <=> $1::vector) AS similarity
+           FROM thoughts
+           WHERE 1 - (embedding <=> $1::vector) >= $2
+           ORDER BY embedding <=> $1::vector
+           LIMIT $3`,
+          [embStr, 0.5, 10]
+        );
+
+        const results = result.rows.map((t) => ({
+          id: t.id,
+          title: thoughtTitle(t.content, t.created_at),
+          url: thoughtUrl(t.id),
+        }));
+
+        return {
+          content: [{ type: "text" as const, text: JSON.stringify({ results }) }],
+        };
+      } finally {
+        client.release();
+      }
+    } catch (err: unknown) {
+      return {
+        content: [{ type: "text" as const, text: `Error: ${(err as Error).message}` }],
+        isError: true,
+      };
+    }
+  }
+);
+
+server.registerTool(
+  "fetch",
+  {
+    title: "Fetch Open Brain Thought",
+    description:
+      "Fetch one Open Brain thought by ID after using search. Use this read-only compatibility tool to retrieve the full text and metadata for citation.",
+    annotations: {
+      readOnlyHint: true,
+    },
+    inputSchema: {
+      id: z.string().describe("The Open Brain thought ID returned by the search tool"),
+    },
+  },
+  async ({ id }) => {
+    try {
+      const client = await pool.connect();
+      try {
+        const result = await client.queryObject<ThoughtRecord>(
+          `SELECT id, content, metadata, created_at, updated_at
+           FROM thoughts
+           WHERE id = $1
+           LIMIT 1`,
+          [id]
+        );
+
+        const thought = result.rows[0];
+        if (!thought) {
+          return {
+            content: [{ type: "text" as const, text: `No thought found for ID ${id}.` }],
+            isError: true,
+          };
+        }
+
+        const document = {
+          id: thought.id,
+          title: thoughtTitle(thought.content, thought.created_at),
+          text: thought.content,
+          url: thoughtUrl(thought.id),
+          metadata: {
+            ...thought.metadata,
+            created_at: thought.created_at,
+            updated_at: thought.updated_at,
+          },
+        };
+
+        return {
+          content: [{ type: "text" as const, text: JSON.stringify(document) }],
+        };
+      } finally {
+        client.release();
+      }
+    } catch (err: unknown) {
+      return {
+        content: [{ type: "text" as const, text: `Error: ${(err as Error).message}` }],
+        isError: true,
+      };
+    }
+  }
+);
+
 // Tool 1: Semantic Search (replaces supabase.rpc with raw SQL)
 server.registerTool(
   "search_thoughts",
@@ -119,6 +262,9 @@ server.registerTool(
     title: "Search Thoughts",
     description:
       "Search captured thoughts by meaning. Use this when the user asks about a topic, person, or idea they've previously captured.",
+    annotations: {
+      readOnlyHint: true,
+    },
     inputSchema: {
       query: z.string().describe("What to search for"),
       limit: z.number().optional().default(10),
@@ -132,13 +278,8 @@ server.registerTool(
 
       const client = await pool.connect();
       try {
-        const result = await client.queryObject<{
-          content: string;
-          metadata: Record<string, unknown>;
-          similarity: number;
-          created_at: string;
-        }>(
-          `SELECT content, metadata, created_at,
+        const result = await client.queryObject<ThoughtMatch>(
+          `SELECT id, content, metadata, created_at,
                   1 - (embedding <=> $1::vector) AS similarity
            FROM thoughts
            WHERE 1 - (embedding <=> $1::vector) >= $2
@@ -197,6 +338,9 @@ server.registerTool(
     title: "List Recent Thoughts",
     description:
       "List recently captured thoughts with optional filters by type, topic, person, or time range.",
+    annotations: {
+      readOnlyHint: true,
+    },
     inputSchema: {
       limit: z.number().optional().default(10),
       type: z.string().optional().describe("Filter by type: observation, task, idea, reference, person_note"),
@@ -283,6 +427,9 @@ server.registerTool(
   {
     title: "Thought Statistics",
     description: "Get a summary of all captured thoughts: totals, types, top topics, and people.",
+    annotations: {
+      readOnlyHint: true,
+    },
     inputSchema: {},
   },
   async () => {
@@ -365,6 +512,12 @@ server.registerTool(
     title: "Capture Thought",
     description:
       "Save a new thought to the Open Brain. Generates an embedding and extracts metadata automatically.",
+    annotations: {
+      readOnlyHint: false,
+      openWorldHint: false,
+      destructiveHint: false,
+      idempotentHint: false,
+    },
     inputSchema: {
       content: z.string().describe("The thought to capture"),
     },
@@ -377,7 +530,7 @@ server.registerTool(
       ]);
 
       const embStr = `[${embedding.join(",")}]`;
-      const meta = { ...metadata, source: "mcp" };
+      const meta: Record<string, unknown> = { ...metadata, source: "mcp" };
 
       const client = await pool.connect();
       try {

--- a/primitives/remote-mcp/README.md
+++ b/primitives/remote-mcp/README.md
@@ -28,6 +28,8 @@ Start a new conversation and enable the connector via the "+" button at the bott
 
 Requires a paid ChatGPT plan (Plus, Pro, Business, Enterprise, or Edu). Works on the web at chatgpt.com — not available on mobile.
 
+> ChatGPT custom MCP support is still beta, plan-sensitive, and sometimes model-sensitive. As of May 2026, OpenAI's docs list Developer Mode for Plus, Pro, Business, Enterprise, and Edu, while workspace app publishing and action controls are documented mainly for Business, Enterprise, and Edu. Mark read-only tools with the MCP `readOnlyHint` annotation, and expose exact `search`/`fetch` read tools when you want compatibility with restricted ChatGPT or company-knowledge style surfaces.
+
 **Enable Developer Mode (one-time setup):**
 
 1. Go to chatgpt.com → click your profile icon → **Settings**
@@ -46,6 +48,8 @@ Requires a paid ChatGPT plan (Plus, Pro, Business, Enterprise, or Edu). Works on
 6. Click **Create**
 
 **Using it:** Start a new conversation and make sure the connector is enabled in the tools/apps panel. ChatGPT sometimes needs explicit tool references: "Use the search_household_items tool to find my paint colors."
+
+If ChatGPT says a tool is unavailable and your server logs show zero requests, the request never reached your MCP server. Refresh or recreate the ChatGPT app so it pulls the latest tool metadata, start a fresh chat, select the app in Developer Mode, and try a thinking model. On restricted Pro sessions, exact `search`/`fetch` read tools are more likely to appear than write tools.
 
 ## Claude Code
 
@@ -111,6 +115,7 @@ Every MCP client handles remote servers slightly differently. Your extension acc
 - Confirm Developer Mode is enabled (Settings → Apps & Connectors → Advanced settings)
 - Check that the connector is active for your current conversation in the tools/apps panel
 - Be explicit: "Use the [tool_name] tool to [do thing]." ChatGPT often needs direct tool references the first few times.
+- If server logs show zero requests, refresh or recreate the ChatGPT app and try a thinking model; the tool may not be exposed to that chat session.
 
 **Getting 401 errors**
 - The access key doesn't match what's stored in Supabase secrets

--- a/recipes/entity-wiki/README.md
+++ b/recipes/entity-wiki/README.md
@@ -1,7 +1,6 @@
 # Entity Wiki Pages
 
 > ⚠️ **Requires the entity-extraction companion PRs — not yet merged into OB1 `main`.** This recipe reads `public.entities`, `public.thought_entities`, and `public.edges`. Those tables are introduced by the in-flight entity-extraction schema + worker PRs (tracking: [#197](https://github.com/NateBJones-Projects/OB1/pull/197) schema, [#199](https://github.com/NateBJones-Projects/OB1/pull/199) worker). On the current `main` branch those tables do not exist and every query in `generate-wiki.mjs` will fail with `relation "public.entities" does not exist`. Do not try to install this recipe until both companion PRs are merged. See [Prerequisites](#prerequisites) for details.
-
 > Auto-generate per-entity markdown wiki pages by aggregating every thought linked to a person, project, topic, organization, tool, or place — then synthesizing a structured narrative with an LLM.
 
 ## What It Does

--- a/recipes/thought-enrichment/README.md
+++ b/recipes/thought-enrichment/README.md
@@ -27,25 +27,25 @@ Retroactively classify and enrich your existing thoughts with structured metadat
 
 Classifies each thought using an LLM and writes structured metadata back to Supabase.
 
-3. Preview what the enrichment will do (no writes):
+1. Preview what the enrichment will do (no writes):
 
    ```bash
    node enrich-thoughts.mjs --dry-run --limit 10
    ```
 
-4. Run enrichment for real:
+2. Run enrichment for real:
 
    ```bash
    node enrich-thoughts.mjs --apply --concurrency 5
    ```
 
-5. Check progress at any time:
+3. Check progress at any time:
 
    ```bash
    node enrich-thoughts.mjs --status
    ```
 
-6. Retry any previously failed thoughts:
+4. Retry any previously failed thoughts:
 
    ```bash
    node enrich-thoughts.mjs --apply --retry-failed
@@ -57,13 +57,13 @@ Classifies each thought using an LLM and writes structured metadata back to Supa
 
 Fixes thoughts where the top-level `type` column is still `reference` but `metadata.type` contains a valid different type.
 
-7. Preview:
+1. Preview:
 
    ```bash
    node backfill-type.mjs --dry-run
    ```
 
-8. Apply:
+2. Apply:
 
    ```bash
    node backfill-type.mjs
@@ -73,13 +73,13 @@ Fixes thoughts where the top-level `type` column is still `reference` but `metad
 
 Scans thought content for patterns matching SSNs, credit cards, API keys, passwords, medications, health data, and financial details. Upgrades `sensitivity_tier` from `standard` to `personal` or `restricted` as appropriate.
 
-9. Preview:
+1. Preview:
 
    ```bash
    node backfill-sensitivity.mjs --dry-run
    ```
 
-10. Apply:
+2. Apply:
 
     ```bash
     node backfill-sensitivity.mjs --apply
@@ -87,10 +87,10 @@ Scans thought content for patterns matching SSNs, credit cards, API keys, passwo
 
 ## Recommended execution order
 
-11. Run `backfill-type.mjs` first to fix any type mismatches from prior imports.
-12. Run `backfill-sensitivity.mjs` to tag sensitive content before enrichment.
-13. Run `enrich-thoughts.mjs --dry-run --limit 20` to preview LLM classifications.
-14. Run `enrich-thoughts.mjs --apply` to enrich all remaining thoughts.
+1. Run `backfill-type.mjs` first to fix any type mismatches from prior imports.
+2. Run `backfill-sensitivity.mjs` to tag sensitive content before enrichment.
+3. Run `enrich-thoughts.mjs --dry-run --limit 20` to preview LLM classifications.
+4. Run `enrich-thoughts.mjs --apply` to enrich all remaining thoughts.
 
 ## Cost expectations
 

--- a/recipes/typed-edge-classifier/README.md
+++ b/recipes/typed-edge-classifier/README.md
@@ -174,6 +174,7 @@ This recipe ships with a **`--mirror-supersedes`** flag that is **OFF by default
 - **Best-effort, no preflight.** Mirror is best-effort. If the column doesn't exist (e.g. `schemas/provenance-chains/` hasn't been applied), the edge still writes successfully and a `[warn] Mirror to thoughts.supersedes failed ...` line is logged. There is no startup preflight — PostgREST [does not expose `information_schema` over REST](https://docs.postgrest.org/en/latest/references/api/schemas.html), so a REST-based column probe is not available on standard Supabase deployments. Check logs for mirror warnings.
 - **Failure mode:** if the PATCH fails mid-run (column missing, network, 5xx, RLS), the edge is written but `thoughts.supersedes` is NOT updated. The run logs the warning and continues. Downstream readers that hit the edge table will see the relation; readers that hit `thoughts.supersedes` directly will not.
 - **Reconciliation (NOT automatic):** reruns will NOT retry a failed mirror PATCH. Once the `supersedes` edge exists in `thought_edges`, `processPair` short-circuits via `skip_already_classified` before reaching the mirror write, so `thought_edges_upsert` is never called and the PATCH is never re-issued. If the PATCH fails once, `thoughts.supersedes` stays stale until an operator runs the manual repair below. A one-off query to find all drifted rows:
+
   ```sql
   -- Supersedes edges whose mirror is missing or wrong.
   -- Contract: newer.supersedes = older (provenance-chains).

--- a/server/index.ts
+++ b/server/index.ts
@@ -14,6 +14,35 @@ const MCP_ACCESS_KEY = Deno.env.get("MCP_ACCESS_KEY")!;
 const OPENROUTER_BASE = "https://openrouter.ai/api/v1";
 const supabase = createClient(SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY);
 
+type ThoughtMatch = {
+  id: string;
+  content: string;
+  metadata: Record<string, unknown>;
+  similarity: number;
+  created_at: string;
+};
+
+type ThoughtRecord = {
+  id: string;
+  content: string;
+  metadata: Record<string, unknown>;
+  created_at: string;
+  updated_at?: string | null;
+};
+
+const CITATION_BASE_URL =
+  Deno.env.get("OPEN_BRAIN_CITATION_BASE_URL") || "https://openbrain.local/thoughts";
+
+function thoughtTitle(content: string, createdAt?: string): string {
+  const firstLine = content.replace(/\s+/g, " ").trim().slice(0, 80);
+  const datePrefix = createdAt ? new Date(createdAt).toLocaleDateString() : "Open Brain";
+  return firstLine ? `${datePrefix} - ${firstLine}` : `${datePrefix} thought`;
+}
+
+function thoughtUrl(id: string): string {
+  return `${CITATION_BASE_URL.replace(/\/$/, "")}/${id}`;
+}
+
 async function getEmbedding(text: string): Promise<number[]> {
   const r = await fetch(`${OPENROUTER_BASE}/embeddings`, {
     method: "POST",
@@ -74,6 +103,109 @@ const server = new McpServer({
   version: "1.0.0",
 });
 
+// ChatGPT compatibility: restricted connector surfaces, company knowledge, and deep
+// research look for exact read-only `search` and `fetch` tool shapes.
+server.registerTool(
+  "search",
+  {
+    title: "Search Open Brain",
+    description:
+      "Search Open Brain memories by meaning. Use this read-only compatibility tool when ChatGPT needs search/fetch-style access to stored thoughts.",
+    annotations: {
+      readOnlyHint: true,
+    },
+    inputSchema: {
+      query: z.string().describe("The search query to run against Open Brain thoughts"),
+    },
+  },
+  async ({ query }) => {
+    try {
+      const qEmb = await getEmbedding(query);
+      const { data, error } = await supabase.rpc("match_thoughts", {
+        query_embedding: qEmb,
+        match_threshold: 0.5,
+        match_count: 10,
+        filter: {},
+      });
+
+      if (error) {
+        return {
+          content: [{ type: "text" as const, text: `Search error: ${error.message}` }],
+          isError: true,
+        };
+      }
+
+      const results = ((data || []) as ThoughtMatch[]).map((t) => ({
+        id: t.id,
+        title: thoughtTitle(t.content, t.created_at),
+        url: thoughtUrl(t.id),
+      }));
+
+      return {
+        content: [{ type: "text" as const, text: JSON.stringify({ results }) }],
+      };
+    } catch (err: unknown) {
+      return {
+        content: [{ type: "text" as const, text: `Error: ${(err as Error).message}` }],
+        isError: true,
+      };
+    }
+  }
+);
+
+server.registerTool(
+  "fetch",
+  {
+    title: "Fetch Open Brain Thought",
+    description:
+      "Fetch one Open Brain thought by ID after using search. Use this read-only compatibility tool to retrieve the full text and metadata for citation.",
+    annotations: {
+      readOnlyHint: true,
+    },
+    inputSchema: {
+      id: z.string().describe("The Open Brain thought ID returned by the search tool"),
+    },
+  },
+  async ({ id }) => {
+    try {
+      const { data, error } = await supabase
+        .from("thoughts")
+        .select("id, content, metadata, created_at, updated_at")
+        .eq("id", id)
+        .single();
+
+      if (error) {
+        return {
+          content: [{ type: "text" as const, text: `Fetch error: ${error.message}` }],
+          isError: true,
+        };
+      }
+
+      const thought = data as ThoughtRecord;
+      const document = {
+        id: thought.id,
+        title: thoughtTitle(thought.content, thought.created_at),
+        text: thought.content,
+        url: thoughtUrl(thought.id),
+        metadata: {
+          ...thought.metadata,
+          created_at: thought.created_at,
+          updated_at: thought.updated_at,
+        },
+      };
+
+      return {
+        content: [{ type: "text" as const, text: JSON.stringify(document) }],
+      };
+    } catch (err: unknown) {
+      return {
+        content: [{ type: "text" as const, text: `Error: ${(err as Error).message}` }],
+        isError: true,
+      };
+    }
+  }
+);
+
 // Tool 1: Semantic Search
 server.registerTool(
   "search_thoughts",
@@ -81,6 +213,9 @@ server.registerTool(
     title: "Search Thoughts",
     description:
       "Search captured thoughts by meaning. Use this when the user asks about a topic, person, or idea they've previously captured.",
+    annotations: {
+      readOnlyHint: true,
+    },
     inputSchema: {
       query: z.string().describe("What to search for"),
       limit: z.number().optional().default(10),
@@ -112,12 +247,7 @@ server.registerTool(
 
       const results = data.map(
         (
-          t: {
-            content: string;
-            metadata: Record<string, unknown>;
-            similarity: number;
-            created_at: string;
-          },
+          t: ThoughtMatch,
           i: number
         ) => {
           const m = t.metadata || {};
@@ -161,6 +291,9 @@ server.registerTool(
     title: "List Recent Thoughts",
     description:
       "List recently captured thoughts with optional filters by type, topic, person, or time range.",
+    annotations: {
+      readOnlyHint: true,
+    },
     inputSchema: {
       limit: z.number().optional().default(10),
       type: z.string().optional().describe("Filter by type: observation, task, idea, reference, person_note"),
@@ -233,6 +366,9 @@ server.registerTool(
   {
     title: "Thought Statistics",
     description: "Get a summary of all captured thoughts: totals, types, top topics, and people.",
+    annotations: {
+      readOnlyHint: true,
+    },
     inputSchema: {},
   },
   async () => {
@@ -305,6 +441,12 @@ server.registerTool(
     title: "Capture Thought",
     description:
       "Save a new thought to the Open Brain. Generates an embedding and extracts metadata automatically. Use this when the user wants to save something to their brain directly from any AI client — notes, insights, decisions, or migrated content from other systems.",
+    annotations: {
+      readOnlyHint: false,
+      openWorldHint: false,
+      destructiveHint: false,
+      idempotentHint: false,
+    },
     inputSchema: {
       content: z.string().describe("The thought to capture — a clear, standalone statement that will make sense when retrieved later by any AI"),
     },
@@ -366,7 +508,7 @@ server.registerTool(
 
 const corsHeaders = {
   "Access-Control-Allow-Origin": "*",
-  "Access-Control-Allow-Headers": "authorization, x-client-info, apikey, content-type, x-brain-key, accept, mcp-session-id",
+  "Access-Control-Allow-Headers": "authorization, x-client-info, apikey, content-type, x-brain-key, accept, mcp-session-id, mcp-protocol-version, last-event-id",
   "Access-Control-Allow-Methods": "GET, POST, OPTIONS, DELETE",
 };
 


### PR DESCRIPTION
## Summary
- add read-only search/fetch compatibility tools for ChatGPT MCP surfaces
- complete MCP annotations for read and write OB1 tools
- update setup, FAQ, remote MCP, audit, template, and contributing docs around ChatGPT tool exposure

## Checks
- deno check --config server/deno.json server/index.ts
- deno check --config integrations/kubernetes-deployment/deno.json integrations/kubernetes-deployment/index.ts
- git diff --check
- markdownlint-cli2 on changed markdown files