### PR TITLE
[codex] Add VS Code workspace tasks

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,16 @@
+{
+  "recommendations": [
+    "denoland.vscode-deno",
+    "dbaeumer.vscode-eslint",
+    "esbenp.prettier-vscode",
+    "bradlc.vscode-tailwindcss",
+    "svelte.svelte-vscode",
+    "ms-playwright.playwright",
+    "github.vscode-github-actions",
+    "github.vscode-pull-request-github",
+    "mikestead.dotenv",
+    "yzhang.markdown-all-in-one",
+    "bierner.markdown-mermaid",
+    "streetsidesoftware.code-spell-checker"
+  ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,71 @@
+{
+  "editor.formatOnSave": true,
+  "editor.codeActionsOnSave": {
+    "source.fixAll.eslint": "explicit"
+  },
+  "deno.enablePaths": [
+    "supabase/functions"
+  ],
+  "deno.lint": true,
+  "deno.unstable": [
+    "bare-node-builtins",
+    "byonm",
+    "sloppy-imports",
+    "unsafe-proto",
+    "webgpu",
+    "broadcast-channel",
+    "worker-options",
+    "cron",
+    "kv",
+    "ffi",
+    "fs",
+    "http",
+    "net"
+  ],
+  "[javascript]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
+  },
+  "[javascriptreact]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
+  },
+  "[typescript]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
+  },
+  "[typescriptreact]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
+  },
+  "[svelte]": {
+    "editor.defaultFormatter": "svelte.svelte-vscode"
+  },
+  "[json]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
+  },
+  "[markdown]": {
+    "editor.defaultFormatter": "yzhang.markdown-all-in-one"
+  },
+  "files.associations": {
+    "*.env.example": "dotenv"
+  },
+  "typescript.tsdk": "dashboards/open-brain-dashboard-next/node_modules/typescript/lib",
+  "typescript.enablePromptUseWorkspaceTsdk": true,
+  "eslint.workingDirectories": [
+    {
+      "directory": "dashboards/open-brain-dashboard-next",
+      "changeProcessCWD": true
+    }
+  ],
+  "search.exclude": {
+    "**/.next": true,
+    "**/node_modules": true,
+    "**/package-lock.json": true,
+    "**/*.zip": true,
+    "**/*.xlsx": true
+  },
+  "files.watcherExclude": {
+    "**/.next/**": true,
+    "**/node_modules/**": true,
+    "**/.git/objects/**": true,
+    "**/.git/subtree-cache/**": true
+  },
+  "terminal.integrated.cwd": "${workspaceFolder}/dashboards/open-brain-dashboard-next"
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,57 @@
+{
+  "version": "2.0.0",
+  "tasks": [
+    {
+      "label": "Dashboard: dev",
+      "type": "shell",
+      "command": "npm run dev",
+      "options": {
+        "cwd": "${workspaceFolder}/dashboards/open-brain-dashboard-next"
+      },
+      "isBackground": true,
+      "problemMatcher": {
+        "owner": "next",
+        "pattern": {
+          "regexp": "^(.*)$",
+          "message": 1
+        },
+        "background": {
+          "activeOnStart": true,
+          "beginsPattern": ".*",
+          "endsPattern": "Ready in|Local:"
+        }
+      }
+    },
+    {
+      "label": "Dashboard: lint",
+      "type": "shell",
+      "command": "npm run lint",
+      "options": {
+        "cwd": "${workspaceFolder}/dashboards/open-brain-dashboard-next"
+      },
+      "problemMatcher": "$eslint-stylish"
+    },
+    {
+      "label": "Dashboard: build",
+      "type": "shell",
+      "command": "npm run build",
+      "options": {
+        "cwd": "${workspaceFolder}/dashboards/open-brain-dashboard-next",
+        "env": {
+          "SESSION_SECRET": "local-vscode-build-only-please-replace-1234567890",
+          "NEXT_PUBLIC_API_URL": "http://localhost:54321/functions/v1/open-brain-rest"
+        }
+      },
+      "problemMatcher": "$tsc"
+    },
+    {
+      "label": "Dashboard: install",
+      "type": "shell",
+      "command": "npm install",
+      "options": {
+        "cwd": "${workspaceFolder}/dashboards/open-brain-dashboard-next"
+      },
+      "problemMatcher": []
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- Add workspace-level VS Code settings for the OB1 repo
- Add VS Code tasks for dashboard install, dev, lint, and build
- Configure dashboard-focused ESLint working directory, TypeScript SDK, search excludes, file watcher excludes, and default terminal path

## Validation
- `npm run lint`
- `SESSION_SECRET='local-vscode-build-only-please-replace-1234567890' NEXT_PUBLIC_API_URL='http://localhost:54321/functions/v1/open-brain-rest' npm run build`

## Notes
- This PR intentionally includes only `.vscode` workspace files.
- Existing uncommitted dashboard component/package changes in the local checkout were not staged or committed.
