### PR TITLE
[docs] Consolidate agent instructions: move universal content to AGENTS.md, pointer in CLAUDE.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,61 @@
 # OB1 Agent Instructions
 
+## What This Repo Is
+
+Open Brain is a persistent AI memory system — one database (Supabase + pgvector), one MCP protocol, any AI client. This repo contains the extensions, recipes, schemas, dashboards, integrations, and skills that the community builds on top of the core Open Brain setup.
+
+**License:** FSL-1.1-MIT. No commercial derivative works. Keep this in mind when generating code or suggesting dependencies.
+
+## Repo Structure
+
+```
+extensions/     — Curated, ordered learning path (6 builds). Do NOT add without maintainer approval.
+primitives/     — Reusable concept guides (must be referenced by 2+ extensions). Curated.
+recipes/        — Standalone capability builds. Open for community contributions.
+schemas/        — Database table extensions. Open.
+dashboards/     — Frontend templates (Vercel/Netlify). Open.
+integrations/   — MCP extensions, webhooks, capture sources. Open.
+skills/         — Reusable AI client skills and prompt packs. Open.
+docs/           — Setup guides, FAQ, companion prompts.
+resources/      — Official companion files and packaged exports.
+```
+
+Every contribution lives in its own subfolder under the right category and must include `README.md` + `metadata.json`.
+
+## Guard Rails
+
+- **Never modify the core `thoughts` table structure.** Adding columns is fine; altering or dropping existing ones is not.
+- **No credentials, API keys, or secrets in any file.** Use environment variables.
+- **No binary blobs** over 1MB. No `.exe`, `.dmg`, `.zip`, `.tar.gz`.
+- **No `DROP TABLE`, `DROP DATABASE`, `TRUNCATE`, or unqualified `DELETE FROM`** in SQL files.
+- **Avoid profanity in all content.** Keep docs, examples, seed data, UI copy, prompts, walkthroughs, and generated assets clean and professional.
+- **MCP servers must be remote (Supabase Edge Functions), not local.** No local Node.js servers or local transport configurations. All extensions deploy as Edge Functions. See `docs/01-getting-started.md` Step 7 for the pattern.
+
+## PR Standards
+
+- **Title format:** `[category] Short description` (e.g., `[recipes] Email history import via Gmail API`, `[skills] Panning for Gold standalone skill pack`)
+- **Branch convention:** `contrib/<github-username>/<short-description>`
+- **Commit prefixes:** `[category]` matching the contribution type
+- Every PR must pass the automated review checks in `.github/workflows/ob1-review.yml` before human review
+- See `CONTRIBUTING.md` for the full review process, metadata.json template, and README requirements
+
+## Key Files
+
+- `CONTRIBUTING.md` — Source of truth for contribution rules, metadata format, and the review process
+- `.github/workflows/ob1-review.yml` — Automated PR review
+- `.github/metadata.schema.json` — JSON schema for metadata.json validation
+- `.github/PULL_REQUEST_TEMPLATE.md` — PR description template
+- `LICENSE.md` — FSL-1.1-MIT terms
+
+## Local GSD Execution Layer
+
+This repo also has a maintainer-local GSD layer in `.planning/`.
+
+- If `.planning/` exists, use it for local brownfield planning and phased execution.
+- Start with `.planning/STATE.md`, then read `.planning/PROJECT.md`, `.planning/ROADMAP.md`, and the relevant `.planning/codebase/*.md` documents.
+- Keep `.planning/` local. It is gitignored intentionally and is not part of the public contribution contract or upstream PR scope.
+- Public contributor rules still come from `AGENTS.md`, `CONTRIBUTING.md`, and the committed repo files.
+
 ## Required Step: Update Linear
 
 - For feature work tied to a Linear issue, update Linear at the start of the work, at meaningful checkpoints, and before handing back to the user.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,59 +1,7 @@
-# CLAUDE.md — Agent Instructions for Open Brain
+# CLAUDE.md
 
-This file helps AI coding tools (Claude Code, Codex, Cursor, etc.) work effectively in this repo.
+All agent instructions for this repo live in @AGENTS.md. Please read and follow that file.
 
-## What This Repo Is
+### One Claude-specific implementation note
 
-Open Brain is a persistent AI memory system — one database (Supabase + pgvector), one MCP protocol, any AI client. This repo contains the extensions, recipes, schemas, dashboards, integrations, and skills that the community builds on top of the core Open Brain setup.
-
-**License:** FSL-1.1-MIT. No commercial derivative works. Keep this in mind when generating code or suggesting dependencies.
-
-## Repo Structure
-
-```
-extensions/     — Curated, ordered learning path (6 builds). Do NOT add without maintainer approval.
-primitives/     — Reusable concept guides (must be referenced by 2+ extensions). Curated.
-recipes/        — Standalone capability builds. Open for community contributions.
-schemas/        — Database table extensions. Open.
-dashboards/     — Frontend templates (Vercel/Netlify). Open.
-integrations/   — MCP extensions, webhooks, capture sources. Open.
-skills/         — Reusable AI client skills and prompt packs. Open.
-docs/           — Setup guides, FAQ, companion prompts.
-resources/      — Official companion files and packaged exports.
-```
-
-Every contribution lives in its own subfolder under the right category and must include `README.md` + `metadata.json`.
-
-## Guard Rails
-
-- **Never modify the core `thoughts` table structure.** Adding columns is fine; altering or dropping existing ones is not.
-- **No credentials, API keys, or secrets in any file.** Use environment variables.
-- **No binary blobs** over 1MB. No `.exe`, `.dmg`, `.zip`, `.tar.gz`.
-- **No `DROP TABLE`, `DROP DATABASE`, `TRUNCATE`, or unqualified `DELETE FROM`** in SQL files.
-- **Avoid profanity in all content.** Keep docs, examples, seed data, UI copy, prompts, walkthroughs, and generated assets clean and professional.
-- **MCP servers must be remote (Supabase Edge Functions), not local.** Never use `claude_desktop_config.json`, `StdioServerTransport`, or local Node.js servers. All extensions deploy as Edge Functions and connect via Claude Desktop's custom connectors UI (Settings → Connectors → Add custom connector → paste URL). See `docs/01-getting-started.md` Step 7 for the pattern.
-
-## PR Standards
-
-- **Title format:** `[category] Short description` (e.g., `[recipes] Email history import via Gmail API`, `[skills] Panning for Gold standalone skill pack`)
-- **Branch convention:** `contrib/<github-username>/<short-description>`
-- **Commit prefixes:** `[category]` matching the contribution type
-- Every PR must pass the automated review checks in `.github/workflows/ob1-review.yml` before human review
-- See `CONTRIBUTING.md` for the full review process, metadata.json template, and README requirements
-
-## Key Files
-
-- `CONTRIBUTING.md` — Source of truth for contribution rules, metadata format, and the review process
-- `.github/workflows/ob1-review.yml` — Automated PR review
-- `.github/metadata.schema.json` — JSON schema for metadata.json validation
-- `.github/PULL_REQUEST_TEMPLATE.md` — PR description template
-- `LICENSE.md` — FSL-1.1-MIT terms
-
-## Local GSD Execution Layer
-
-This repo also has a maintainer-local GSD layer in `.planning/`.
-
-- If `.planning/` exists, use it for local brownfield planning and phased execution.
-- Start with `.planning/STATE.md`, then read `.planning/PROJECT.md`, `.planning/ROADMAP.md`, and the relevant `.planning/codebase/*.md` documents.
-- Keep `.planning/` local. It is gitignored intentionally and is not part of the public contribution contract or upstream PR scope.
-- Public contributor rules still come from `CLAUDE.md`, `AGENTS.md`, `CONTRIBUTING.md`, and the committed repo files.
+When connecting an MCP extension from Claude Desktop: go to **Settings → Connectors → Add custom connector → paste Edge Function URL**. The CLAUDE.md rule is still the same: MCP servers must be remote (Supabase Edge Functions), never local.


### PR DESCRIPTION
## Contribution Type

<!-- Check one -->
- [ ] Recipe (`/recipes`)
- [ ] Schema (`/schemas`)
- [ ] Dashboard (`/dashboards`)
- [ ] Integration (`/integrations`)
- [ ] Skill (`/skills`)
- [x] Repo improvement (docs, CI, templates)

## What does this do?

Consolidates all agent instructions into `AGENTS.md` as the single source of truth. `CLAUDE.md` is now a thin pointer that references `AGENTS.md`, with only the Claude Desktop-specific MCP connector path preserved. Removes duplicated content (repo structure, guard rails, PR standards, key files, GSD layer) between the two files.

## Requirements

None — this is a docs-only change.

## Checklist

- [x] I've read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] No credentials, API keys, or secrets are included