### PR TITLE
docs: fix outdated primitives section in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,9 @@ Some concepts show up in multiple extensions. Learn them once, apply them everyw
 
 | Primitive | What It Teaches | Used By |
 | --------- | --------------- | ------- |
+| [Deploy an Edge Function](primitives/deploy-edge-function/) | Deploying any extension as a Supabase Edge Function | All extensions |
+| [Remote MCP Connection](primitives/remote-mcp/) | Connecting to Claude Desktop, ChatGPT, Claude Code, Cursor, and other clients | All extensions |
+| [Common Troubleshooting](primitives/troubleshooting/) | Solutions for connection, deployment, and database issues | All extensions |
 | [Row Level Security](primitives/rls/) | PostgreSQL policies for multi-user data isolation | Extensions 4, 5, 6 |
 | [Shared MCP Server](primitives/shared-mcp/) | Giving others scoped access to parts of your brain | Extension 4 |
 
@@ -144,12 +147,6 @@ Tables and sidecars that extend the base `thoughts` model without replacing it.
 | Schema | What It Does | Contributor |
 | ------ | ------------ | ----------- |
 | [Agent Memory](schemas/agent-memory/) | Provenance, review, use-policy, source-reference, relation, recall-trace, and audit sidecars for agent workflow memory | OB1 Team |
-
-### [`/primitives`](primitives/) — Reusable Patterns
-
-| Primitive | What It Does | Contributor |
-| --------- | ------------ | ----------- |
-| [Content Fingerprint Dedup](primitives/content-fingerprint-dedup/) | SHA-256 deduplication for thought ingestion — prevents duplicates across all import recipes | [@alanshurafa](https://github.com/alanshurafa) |
 
 ## Using a Contribution
 


### PR DESCRIPTION
- Add 3 missing primitives to 'Concepts That Compound' table: Deploy an Edge Function, Remote MCP Connection, Common Troubleshooting
- Remove stale Community Contributions primitives/ subsection (content-fingerprint-dedup doesn't exist in primitives/; it's in recipes/)

## Contribution Type

<!-- Check one -->
- [ ] Recipe (`/recipes`)
- [ ] Schema (`/schemas`)
- [ ] Dashboard (`/dashboards`)
- [ ] Integration (`/integrations`)
- [ ] Skill (`/skills`)
- [x] Repo improvement (docs, CI, templates)

## What does this do?

<!-- 1-3 sentences describing what this contribution adds or changes -->
Fixes an outdated primitives section in the main README:

1. **Adds 3 missing primitives** to the "Primitives: Concepts That Compound" table, which previously only listed 2 of the 5 primitives documented in `primitives/README.md`:
   - Deploy an Edge Function
   - Remote MCP Connection
   - Common Troubleshooting

2. **Removes a stale Community Contributions subsection** (`/primitives/ — Reusable Patterns`) that linked to `content-fingerprint-dedup/`, which doesn't exist in `primitives/` (it's correctly listed already under `recipes/`).

## Requirements

<!-- What external services, tools, or APIs does this need? (e.g., Gmail API, Node.js 18+) -->
<!-- If this depends on a canonical skill or primitive, mention it here and declare it in metadata.json -->
None.

## Checklist

- [x] I've read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] No credentials, API keys, or secrets are included