### PR TITLE
[integrations] OpenClaw plugin: inject schema_version + surface error details in client

### DIFF
--- a/integrations/openclaw-agent-memory/plugin/dist/index.js
+++ b/integrations/openclaw-agent-memory/plugin/dist/index.js
@@ -27,7 +27,8 @@ var AgentMemoryClient = class {
     const text = await response.text();
     const data = text ? JSON.parse(text) : {};
     if (!response.ok) {
-      throw new Error(`OB1 Agent Memory API ${response.status}: ${data.error || text}`);
+      const detail = data && typeof data === "object" && data.details !== void 0 ? ` ${JSON.stringify(data.details)}` : "";
+      throw new Error(`OB1 Agent Memory API ${response.status}: ${data?.error || text}${detail}`);
     }
     return data;
   }
@@ -35,6 +36,7 @@ var AgentMemoryClient = class {
     return this.request("/recall", {
       method: "POST",
       body: {
+        schema_version: "openbrain.openclaw.recall.v1",
         workspace_id: this.config.workspaceId,
         project_id: this.config.projectId ?? null,
         ...input,
@@ -49,6 +51,7 @@ var AgentMemoryClient = class {
     return this.request("/writeback", {
       method: "POST",
       body: {
+        schema_version: "openbrain.openclaw.writeback.v1",
         workspace_id: this.config.workspaceId,
         project_id: this.config.projectId ?? null,
         ...input,

--- a/integrations/openclaw-agent-memory/plugin/src/client.ts
+++ b/integrations/openclaw-agent-memory/plugin/src/client.ts
@@ -36,7 +36,10 @@ export class AgentMemoryClient {
     const text = await response.text();
     const data = text ? JSON.parse(text) : {};
     if (!response.ok) {
-      throw new Error(`OB1 Agent Memory API ${response.status}: ${data.error || text}`);
+      const detail = data && typeof data === "object" && data.details !== undefined
+        ? ` ${JSON.stringify(data.details)}`
+        : "";
+      throw new Error(`OB1 Agent Memory API ${response.status}: ${data?.error || text}${detail}`);
     }
     return data;
   }
@@ -45,6 +48,7 @@ export class AgentMemoryClient {
     return this.request("/recall", {
       method: "POST",
       body: {
+        schema_version: "openbrain.openclaw.recall.v1",
         workspace_id: this.config.workspaceId,
         project_id: this.config.projectId ?? null,
         ...input,
@@ -60,6 +64,7 @@ export class AgentMemoryClient {
     return this.request("/writeback", {
       method: "POST",
       body: {
+        schema_version: "openbrain.openclaw.writeback.v1",
         workspace_id: this.config.workspaceId,
         project_id: this.config.projectId ?? null,
         ...input,


### PR DESCRIPTION
## Contribution Type

<!-- Check one -->
- [x] Integration (`/integrations`) — bug fix to existing `integrations/openclaw-agent-memory/` plugin

## What does this do?

Fixes two defects in the OpenClaw plugin's API client (`integrations/openclaw-agent-memory/plugin/src/client.ts`):

1. **`schema_version` not injected.** The Edge Function's `recallSchema` and `writebackSchema` both require `schema_version` (no default), but `client.recall()` and `client.writeback()` never injected it — so every call from the plugin to the live API failed with `400 "Invalid recall payload"` (or the writeback equivalent) before reaching any business logic. Adds the default to both methods, mirroring the existing auto-fill pattern for `workspace_id` and `project_id`. Caller-supplied values still win (preserves the existing `agent-memory-api/smoke/live-smoke.mjs` payload shape, which hardcodes `schema_version` directly).
2. **`data.details` dropped from thrown errors.** `request()` used `data.error || text` and ignored `data.details`, so `details.fieldErrors` (which names exactly which fields failed validation) never reached the caller — making payload-shape mismatches opaque to debug. Includes `details` in the thrown error message.

No changes outside `integrations/openclaw-agent-memory/plugin/`. `metadata.json`, `README.md`, tool definitions, manifest, and the Edge Function are all unchanged.

## Repro on current `main`

```bash
# Without schema_version → 400
curl -sX POST "$ENDPOINT/recall" \
  -H "x-brain-key: $KEY" -H 'content-type: application/json' \
  -d '{"workspace_id":"my-ws","query":"test"}'
# {"error":"Invalid recall payload","details":{"fieldErrors":{"schema_version":["Invalid input"]}}}

# With schema_version added → 200
curl -sX POST "$ENDPOINT/recall" \
  -H "x-brain-key: $KEY" -H 'content-type: application/json' \
  -d '{"schema_version":"openbrain.openclaw.recall.v1","workspace_id":"my-ws","query":"test"}'
# {"request_id":"<uuid>","memories":[...],...}
```

## Why this slipped past existing tests

`integrations/agent-memory-api/smoke/live-smoke.mjs` validates the API directly with `schema_version` hardcoded in each request body, bypassing the plugin client. The Edge Function was proven correct end-to-end at deploy, but the plugin → API call path was never exercised.

## Requirements

None new. Same services as the existing OpenClaw Agent Memory integration:
- Supabase (Edge Functions + database)
- OpenRouter API (for embeddings)
- OpenClaw 2026.3.24-beta.2+ (existing peer dep, unchanged)

## Checklist

- [x] I've read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] Existing `README.md` and `metadata.json` are unchanged (fix to existing files only)
- [x] I tested this on my own Open Brain instance — applied to a live OpenClaw cockpit (CLI 2026.5.9-beta.1, plugin 0.1.1) on 2026-05-09. End-to-end call from the in-cockpit agent succeeds: recall returns scoped memories, writeback creates pending review items, recall trace + usage-reporting paths intact.
- [x] No credentials, API keys, or secrets are included
- [x] All changes are within `integrations/openclaw-agent-memory/plugin/` (rule 12 scope check)

## Related issue not in this PR (worth flagging)

When debugging the original 400, I found a second defect in the same area this PR does **not** fix: `openbrain_recall` and `openbrain_writeback` in `plugin/src/index.ts` declare `parameters: Type.Record(Type.String(), Type.Any())`, which collapses to a no-args schema at the MCP/LLM tool boundary — the LLM can't supply *any* arguments through these tools (so even with this PR's `schema_version` fix, the LLM-driven path still 400s on missing `query` / `memory_payload`).

Holding that as a separate follow-up PR because it's a larger, more opinionated change (rewriting two parameter schemas to mirror the API's zod schemas) and I didn't want to slow this small fix down. Happy to send the second PR alongside this if you'd prefer them bundled.