### PR TITLE
fix(openclaw-agent-memory): wire memory-host hooks for auto-recall (#279)

### DIFF
--- a/integrations/openclaw-agent-memory/plugin/src/index.ts
+++ b/integrations/openclaw-agent-memory/plugin/src/index.ts
@@ -158,5 +158,148 @@ export default definePluginEntry({
       parameters: Type.Object({ request_id: Type.String() }),
       run: (client, input) => client.getRecallTrace(input.request_id),
     });
+
+    // ------------------------------------------------------------------
+    // Memory-host hooks (fix for #279).
+    //
+    // The plugin registers tools above, but without participating in the
+    // OpenClaw memory-host lifecycle, agents only invoke OB1 if they
+    // remember to. We register two additive memory hooks so OB1 lands
+    // in every turn automatically:
+    //
+    //   1. registerMemoryPromptSupplement — auto-injects an OB1 discipline
+    //      block into the system prompt (recall-before / writeback-after
+    //      reminder, instruction-vs-evidence semantics, tool list).
+    //   2. registerMemoryCorpusSupplement — exposes OB1 as a searchable
+    //      corpus so OpenClaw's native recall flow queries OB1 alongside
+    //      whatever other corpora are active.
+    //
+    // Both are additive (per the SDK contract), coexist with the active
+    // exclusive memory plugin, and no-op cleanly when OB1 isn't configured.
+    // ------------------------------------------------------------------
+
+    const OB1_TOOL_NAMES = [
+      "openbrain_recall",
+      "openbrain_writeback",
+      "openbrain_report_usage",
+      "openbrain_inspect_memory",
+      "openbrain_list_review_queue",
+      "openbrain_review_memory",
+      "openbrain_get_recall_trace",
+    ] as const;
+
+    function isConfigured(): boolean {
+      const raw = ((api as any).pluginConfig || {}) as Record<string, unknown>;
+      return typeof raw.endpoint === "string"
+        && raw.endpoint.length > 0
+        && typeof raw.workspaceId === "string"
+        && raw.workspaceId.length > 0;
+    }
+
+    if (typeof (api as any).registerMemoryPromptSupplement === "function") {
+      (api as any).registerMemoryPromptSupplement((params: { availableTools: Set<string> }) => {
+        if (!isConfigured()) return [];
+        const present = OB1_TOOL_NAMES.filter((t) => params.availableTools.has(t));
+        if (present.length === 0) return [];
+        return [
+          "## OB1 Agent Memory",
+          "Long-term governed memory is available via OB1. Use it as a discipline, not a fallback.",
+          "",
+          "Workflow:",
+          "- Before meaningful work, call `openbrain_recall` with a task-scoped query.",
+          "- Treat returned memories tagged `instruction` as binding rules; `evidence`-tagged ones as supporting context only.",
+          "- After meaningful work, call `openbrain_writeback` with compact, provenance-labeled findings (decisions, lessons, constraints, outputs, failures).",
+          "- After acting on recalled memories, call `openbrain_report_usage` with `request_id` and the IDs you used vs. ignored — closes the recall-quality loop.",
+          "",
+          `Available tools: ${present.map((t) => "`" + t + "`").join(", ")}.`,
+        ];
+      });
+    }
+
+    if (typeof (api as any).registerMemoryCorpusSupplement === "function") {
+      (api as any).registerMemoryCorpusSupplement({
+        async search(input: { query: string; maxResults?: number; agentSessionKey?: string }) {
+          if (!isConfigured()) return [];
+          let client: AgentMemoryClient;
+          try {
+            client = await clientFromApi(api);
+          } catch {
+            return [];
+          }
+          const limit = Math.min(Math.max(input.maxResults ?? 10, 1), 50);
+          let response: any;
+          try {
+            response = await client.recall({
+              query: input.query.slice(0, 2000),
+              task_type: "general",
+              limits: { max_items: limit, max_tokens: 4000 },
+              scope: { project_only: false, include_unconfirmed: false, include_stale: false },
+            });
+          } catch {
+            return [];
+          }
+          const memories: any[] = Array.isArray(response?.memories) ? response.memories : [];
+          return memories.map((m, i) => {
+            const policy = m?.use_policy ?? {};
+            const provenance = policy?.can_use_as_instruction
+              ? "instruction"
+              : policy?.can_use_as_evidence
+                ? "evidence"
+                : undefined;
+            return {
+              corpus: "openbrain",
+              path: `openbrain://memory/${m?.id ?? i}`,
+              title: typeof m?.summary === "string" ? m.summary.slice(0, 80) : undefined,
+              kind: "memory",
+              score: typeof m?.score === "number" ? m.score : Math.max(0, 1 - i / Math.max(memories.length, 1)),
+              snippet: String(m?.summary ?? m?.content ?? "").slice(0, 600),
+              id: typeof m?.id === "string" ? m.id : undefined,
+              provenanceLabel: provenance,
+              source: "openbrain.agent_memory",
+              sourceType: "openbrain.agent_memory",
+              updatedAt: typeof m?.updated_at === "string" ? m.updated_at : undefined,
+            };
+          });
+        },
+        async get(input: { lookup: string }) {
+          if (!isConfigured()) return null;
+          const id = input.lookup.replace(/^openbrain:\/\/memory\//, "");
+          if (!id) return null;
+          let client: AgentMemoryClient;
+          try {
+            client = await clientFromApi(api);
+          } catch {
+            return null;
+          }
+          let memory: any;
+          try {
+            memory = await client.inspectMemory(id);
+          } catch {
+            return null;
+          }
+          if (!memory || typeof memory !== "object") return null;
+          const policy = (memory as any)?.use_policy ?? {};
+          const provenance = policy?.can_use_as_instruction
+            ? "instruction"
+            : policy?.can_use_as_evidence
+              ? "evidence"
+              : undefined;
+          const content = String((memory as any)?.content ?? (memory as any)?.summary ?? "");
+          return {
+            corpus: "openbrain",
+            path: input.lookup,
+            title: typeof (memory as any)?.summary === "string" ? (memory as any).summary.slice(0, 80) : undefined,
+            kind: "memory",
+            content,
+            fromLine: 1,
+            lineCount: content.split("\n").length,
+            id: typeof (memory as any)?.id === "string" ? (memory as any).id : id,
+            provenanceLabel: provenance,
+            sourceType: "openbrain.agent_memory",
+            updatedAt: typeof (memory as any)?.updated_at === "string" ? (memory as any).updated_at : undefined,
+          };
+        },
+      });
+    }
   },
 });


### PR DESCRIPTION
Closes #279.

## The problem

The `nbj-ob1-agent-memory` plugin registers seven OB1 tools (`openbrain_recall`, `openbrain_writeback`, …) and declares `kind: "memory"`, but the runtime `register(api)` body never participates in the OpenClaw memory-host lifecycle. As a result agents only hit OB1 when something in the prompt, skill, or system message explicitly nudges them — recall-before / writeback-after never happens automatically.

## The fix

Adds two additive memory hooks inside `register(api)`:

1. **`registerMemoryPromptSupplement`** — auto-injects an OB1 discipline block into the system prompt every turn. The block lists currently-loaded `openbrain_*` tools, the recall-before / writeback-after workflow, and the instruction-vs-evidence reading rule for returned memories.
2. **`registerMemoryCorpusSupplement`** — exposes OB1 as a searchable corpus so OpenClaw's native recall flow queries OB1 alongside whatever else is active. `search()` maps `recall` responses onto `MemoryCorpusSearchResult`; `get()` maps `inspectMemory` onto `MemoryCorpusGetResult`. `provenanceLabel` reflects OB1's `use_policy` (`instruction` when `can_use_as_instruction`; `evidence` when `can_use_as_evidence`).

Both are **additive** per the SDK contract, so they coexist with the active exclusive memory plugin. Both no-op cleanly when OB1 is unconfigured (missing `endpoint` / `workspaceId`, unresolved access key, network failure) — never throws into the host.

The hooks are called via `(api as any).registerMemory*` and gated on `typeof === "function"` so this stays compatible with older OpenClaw releases that may not have these methods on the typed surface yet.

## Why additive (not exclusive)

`registerMemoryCapability` (the exclusive memory-plugin surface) requires implementing a full `MemorySearchManager` runtime, takes the slot from any other memory plugin, and forces existing users of OpenClaw's built-in memory or another exclusive provider to migrate. The additive supplements give the same agent-visible auto-invocation with zero migration cost. If you want an exclusive variant later, the additive pieces are reusable inside it.

## Diff

`integrations/openclaw-agent-memory/plugin/src/index.ts`: **+143 / -0** (one source file, no new dependencies, no new tooling).

`dist/index.js` is intentionally not in the diff — please run `npm run build` to regenerate.

## Test plan

- [ ] `cd integrations/openclaw-agent-memory/plugin && npm install --ignore-scripts --omit=peer && npm run build` (esbuild succeeds, ~13kb bundle)
- [ ] Install plugin into an OpenClaw profile with valid OB1 config (`endpoint`, `workspaceId`, `accessKey`)
- [ ] `openclaw --profile <p> agents run hello` and inspect the system prompt — should contain the "## OB1 Agent Memory" section
- [ ] Drive a turn that doesn't explicitly mention OB1, then check `agent_memories` for new rows linked by the agent's task — should land via the corpus supplement during native recall
- [ ] Remove `endpoint` from the config and re-run — both hooks should no-op (no errors, no prompt section, no corpus search calls)

## Behaviour summary

| Case | Before | After |
| --- | --- | --- |
| Configured plugin, agent with no OB1 prompting | tools registered but unused | prompt section + corpus supplement → auto-recall on every turn |
| Unconfigured plugin | tools registered but throw on call | tools still throw on call; supplements no-op silently |
| Network down or 5xx from API | tool calls bubble error to agent | tool calls bubble error; supplements return `[]` / `null`, host unaffected |
| Tools not loaded for the agent | prompt section absent (no nudge) | prompt section gated to only show currently-available tools |

## Related

This sits alongside #280, which adds `integrations/hermes-agent-memory/` — the Hermes-runtime equivalent. With both merged, OpenClaw agents and Hermes agents share one governed OB1 memory with auto-recall / auto-writeback parity on each side.