### PR TITLE
feat(openclaw-agent-memory): register OB1 as active-memory capability for governed recall and writeback (#279)

### DIFF
--- a/integrations/openclaw-agent-memory/plugin/openclaw.plugin.json
+++ b/integrations/openclaw-agent-memory/plugin/openclaw.plugin.json
@@ -2,7 +2,9 @@
   "id": "nbj-ob1-agent-memory",
   "name": "NBJ OB1 Agent Memory for OpenClaw",
   "description": "Typed OpenClaw tools for governed Nate Jones OB1 memory recall, write-back, review, inspection, and trace debugging.",
-  "skills": ["./skills/openclaw-agent-memory"],
+  "skills": [
+    "./skills/openclaw-agent-memory"
+  ],
   "kind": "memory",
   "contracts": {
     "tools": [
@@ -12,7 +14,10 @@
       "openbrain_inspect_memory",
       "openbrain_list_review_queue",
       "openbrain_review_memory",
-      "openbrain_get_recall_trace"
+      "openbrain_get_recall_trace",
+      "memory_search",
+      "memory_get",
+      "memory_store"
     ]
   },
   "configSchema": {
@@ -33,11 +38,19 @@
           {
             "type": "object",
             "additionalProperties": false,
-            "required": ["source", "provider", "id"],
+            "required": [
+              "source",
+              "provider",
+              "id"
+            ],
             "properties": {
               "source": {
                 "type": "string",
-                "enum": ["env", "file", "exec"]
+                "enum": [
+                  "env",
+                  "file",
+                  "exec"
+                ]
               },
               "provider": {
                 "type": "string"

--- a/integrations/openclaw-agent-memory/plugin/openclaw.plugin.json
+++ b/integrations/openclaw-agent-memory/plugin/openclaw.plugin.json
@@ -64,7 +64,16 @@
       },
       "workspaceId": {
         "type": "string",
-        "description": "Default OB1 workspace ID."
+        "description": "Default OB1 workspace ID. In 'per-agent' mode (see workspaceMode) this is used as a fallback when no agent id is available."
+      },
+      "workspaceMode": {
+        "type": "string",
+        "enum": ["shared", "per-agent"],
+        "description": "How to derive the OB1 workspace_id for each request. 'shared' (default) sends every request to the configured workspaceId. 'per-agent' uses each OpenClaw agent's id as its own workspace, isolating memory per agent."
+      },
+      "workspacePrefix": {
+        "type": "string",
+        "description": "Optional prefix applied to the per-agent workspace_id (e.g. 'openclaw-' produces 'openclaw-nina'). Only used when workspaceMode is 'per-agent'."
       },
       "projectId": {
         "type": "string",

--- a/integrations/openclaw-agent-memory/plugin/src/client.ts
+++ b/integrations/openclaw-agent-memory/plugin/src/client.ts
@@ -45,11 +45,23 @@ export class AgentMemoryClient {
     return this.request("/recall", {
       method: "POST",
       body: {
+        // schema_version is REQUIRED by the Edge Function recallSchema;
+        // omitting it returns "400 Invalid recall payload".
+        schema_version: "openbrain.openclaw.recall.v1",
         workspace_id: this.config.workspaceId,
         project_id: this.config.projectId ?? null,
         ...input,
+        // Two Edge Function defaults make naive recall return zero rows:
+        //   1. writes land with visibility="personal" but scopeMatches drops
+        //      personal unless scope.visibility="personal" is passed.
+        //   2. writes default to requires_review=true (governance), which
+        //      gives them review_status="pending"; scope.include_unconfirmed
+        //      must be true or pending memories are filtered out.
+        // Default both here so callers don't have to know these quirks; an
+        // explicit input.scope still wins via the spread below.
         scope: {
-          include_unconfirmed: this.config.includeUnconfirmedRecall ?? false,
+          visibility: "personal",
+          include_unconfirmed: this.config.includeUnconfirmedRecall ?? true,
           ...(typeof input.scope === "object" && input.scope ? input.scope : {}),
         },
       },
@@ -60,6 +72,9 @@ export class AgentMemoryClient {
     return this.request("/writeback", {
       method: "POST",
       body: {
+        // schema_version REQUIRED; openclaw variant accepted alongside
+        // openbrain.agent_memory.writeback.v1 by the Edge Function.
+        schema_version: "openbrain.openclaw.writeback.v1",
         workspace_id: this.config.workspaceId,
         project_id: this.config.projectId ?? null,
         ...input,

--- a/integrations/openclaw-agent-memory/plugin/src/index.ts
+++ b/integrations/openclaw-agent-memory/plugin/src/index.ts
@@ -59,6 +59,26 @@ function clampFloat(n: number, lo: number, hi: number): number {
   return Math.max(lo, Math.min(hi, v));
 }
 
+// LLM tool callers occasionally JSON.stringify nested-object parameters,
+// which the Edge Function's zod schema then rejects as "expected object,
+// received string." Coerce string-shaped fields back to objects before
+// sending. Walks one level deep — that is what the contract needs and any
+// further nesting that arrived as a string would be a separate caller bug.
+function coerceObjectFields(input: Record<string, unknown>, fields: string[]): Record<string, unknown> {
+  const out: Record<string, unknown> = { ...input };
+  for (const key of fields) {
+    const value = out[key];
+    if (typeof value === "string") {
+      try {
+        out[key] = JSON.parse(value);
+      } catch {
+        // leave as string; let the server return a structured error
+      }
+    }
+  }
+  return out;
+}
+
 function registerTool(api: any, tool: { name: string; label: string; description: string; parameters: unknown; run: (client: AgentMemoryClient, input: any) => Promise<unknown> }) {
   api.registerTool({
     name: tool.name,
@@ -83,7 +103,9 @@ export default definePluginEntry({
       label: "NBJ OB1 recall",
       description: "Recall scoped Nate Jones OB1 Agent Memory before meaningful work begins.",
       parameters: Type.Record(Type.String(), Type.Any()),
-      run: (client, input) => client.recall(input),
+      run: (client, input) => client.recall(
+        coerceObjectFields(input, ["scope", "limits", "runtime", "model_intent", "channel", "entities", "sensitivity"]),
+      ),
     });
 
     registerTool(api, {
@@ -91,7 +113,16 @@ export default definePluginEntry({
       label: "NBJ OB1 write-back",
       description: "Write compact, provenance-labeled Nate Jones OB1 Agent Memory after work finishes.",
       parameters: Type.Record(Type.String(), Type.Any()),
-      run: (client, input) => client.writeback(input),
+      run: (client, input) => {
+        const coerced = coerceObjectFields(input, ["memory_payload", "provenance", "runtime", "models_used", "source_refs", "retention", "visibility", "channel"]);
+        // Default runtime.name to "openclaw" so writes from this plugin
+        // are correctly attributed without requiring the agent to know the
+        // contract. Explicit input.runtime still wins.
+        const runtime = (typeof coerced.runtime === "object" && coerced.runtime) ? coerced.runtime as Record<string, unknown> : {};
+        if (!runtime.name) runtime.name = "openclaw";
+        coerced.runtime = runtime;
+        return client.writeback(coerced);
+      },
     });
 
     registerTool(api, {

--- a/integrations/openclaw-agent-memory/plugin/src/index.ts
+++ b/integrations/openclaw-agent-memory/plugin/src/index.ts
@@ -2,6 +2,7 @@ import { Type } from "typebox";
 import { definePluginEntry } from "openclaw/plugin-sdk/plugin-entry";
 import { resolveConfiguredSecretInputString } from "openclaw/plugin-sdk/secret-input-runtime";
 import { AgentMemoryClient, type AgentMemoryConfig } from "./client.js";
+import { createOB1Runtime } from "./search-manager.js";
 
 async function clientFromApi(api: { pluginConfig?: unknown; config?: unknown }) {
   const raw = (api.pluginConfig || {}) as Record<string, unknown>;
@@ -46,6 +47,16 @@ function toolResult(value: unknown) {
     ],
     details: value,
   };
+}
+
+function clampInt(n: number, lo: number, hi: number): number {
+  if (typeof n !== "number" || Number.isNaN(n)) return lo;
+  return Math.max(lo, Math.min(hi, Math.floor(n)));
+}
+
+function clampFloat(n: number, lo: number, hi: number): number {
+  const v = typeof n === "number" && !Number.isNaN(n) ? n : lo;
+  return Math.max(lo, Math.min(hi, v));
 }
 
 function registerTool(api: any, tool: { name: string; label: string; description: string; parameters: unknown; run: (client: AgentMemoryClient, input: any) => Promise<unknown> }) {
@@ -158,5 +169,299 @@ export default definePluginEntry({
       parameters: Type.Object({ request_id: Type.String() }),
       run: (client, input) => client.getRecallTrace(input.request_id),
     });
+
+    // ------------------------------------------------------------------
+    // Memory-host hooks (fix for #279).
+    //
+    // The plugin registers tools above, but without participating in the
+    // OpenClaw memory-host lifecycle, agents only invoke OB1 if they
+    // remember to. We register two additive memory hooks so OB1 lands
+    // in every turn automatically:
+    //
+    //   1. registerMemoryPromptSupplement — auto-injects an OB1 discipline
+    //      block into the system prompt (recall-before / writeback-after
+    //      reminder, instruction-vs-evidence semantics, tool list).
+    //   2. registerMemoryCorpusSupplement — exposes OB1 as a searchable
+    //      corpus so OpenClaw's native recall flow queries OB1 alongside
+    //      whatever other corpora are active.
+    //
+    // Both are additive (per the SDK contract), coexist with the active
+    // exclusive memory plugin, and no-op cleanly when OB1 isn't configured.
+    // ------------------------------------------------------------------
+
+    const OB1_TOOL_NAMES = [
+      "openbrain_recall",
+      "openbrain_writeback",
+      "openbrain_report_usage",
+      "openbrain_inspect_memory",
+      "openbrain_list_review_queue",
+      "openbrain_review_memory",
+      "openbrain_get_recall_trace",
+    ] as const;
+
+    function isConfigured(): boolean {
+      const raw = ((api as any).pluginConfig || {}) as Record<string, unknown>;
+      return typeof raw.endpoint === "string"
+        && raw.endpoint.length > 0
+        && typeof raw.workspaceId === "string"
+        && raw.workspaceId.length > 0;
+    }
+
+    if (typeof (api as any).registerMemoryPromptSupplement === "function") {
+      (api as any).registerMemoryPromptSupplement((params: { availableTools: Set<string> }) => {
+        if (!isConfigured()) return [];
+        const present = OB1_TOOL_NAMES.filter((t) => params.availableTools.has(t));
+        if (present.length === 0) return [];
+        return [
+          "## OB1 Agent Memory",
+          "Long-term governed memory is available via OB1. Use it as a discipline, not a fallback.",
+          "",
+          "Workflow:",
+          "- Before meaningful work, call `openbrain_recall` with a task-scoped query.",
+          "- Treat returned memories tagged `instruction` as binding rules; `evidence`-tagged ones as supporting context only.",
+          "- After meaningful work, call `openbrain_writeback` with compact, provenance-labeled findings (decisions, lessons, constraints, outputs, failures).",
+          "- After acting on recalled memories, call `openbrain_report_usage` with `request_id` and the IDs you used vs. ignored — closes the recall-quality loop.",
+          "",
+          `Available tools: ${present.map((t) => "`" + t + "`").join(", ")}.`,
+        ];
+      });
+    }
+
+    // ------------------------------------------------------------------
+    // Active-memory capability (#282).
+    //
+    // The supplements above (#281) layer additive context onto whatever the
+    // active memory plugin is. To make OB1 *be* the active memory plugin
+    // (so OpenClaw routes its native memory_search / memory_get tools and
+    // the active-memory pipeline through us), we also register a real
+    // MemoryCapability with a search-manager runtime.
+    //
+    // Selection still requires user config: plugins.slots.memory =
+    // "nbj-ob1-agent-memory". registerMemoryCapability alone declares
+    // candidacy; the slots config flips the switch.
+    // ------------------------------------------------------------------
+
+    if (typeof (api as any).registerMemoryCapability === "function") {
+      const ob1Runtime = createOB1Runtime({
+        buildClient: (_agentId: string) => clientFromApi(api),
+        // Phase 9 will derive workspaceId from agentId for multi-tenant; for
+        // now, every agent shares the configured workspace.
+        workspaceIdFor: (_agentId: string) => {
+          const raw = ((api as any).pluginConfig || {}) as Record<string, unknown>;
+          return typeof raw.workspaceId === "string" && raw.workspaceId.length > 0
+            ? raw.workspaceId
+            : "default";
+        },
+      });
+
+      (api as any).registerMemoryCapability({
+        // Mirror the supplement section so it shows up even when OB1 is the
+        // active memory plugin (no other promptBuilder will run).
+        promptBuilder: (params: { availableTools: Set<string> }) => {
+          if (!isConfigured()) return [];
+          const present = OB1_TOOL_NAMES.filter((t) => params.availableTools.has(t));
+          if (present.length === 0) return [];
+          return [
+            "## OB1 Agent Memory (active backend)",
+            "Long-term governed memory is available via OB1 as the active memory backend.",
+            "",
+            "Workflow:",
+            "- Use `memory_search` (or `openbrain_recall`) to recall relevant prior memory before meaningful work.",
+            "- Treat returned memories tagged `instruction` as binding rules; `evidence`-tagged ones as supporting context only.",
+            "- Use `openbrain_writeback` to capture compact, provenance-labeled findings (decisions, lessons, constraints, outputs, failures).",
+            "- After acting on recalled memories, call `openbrain_report_usage` to close the recall-quality loop.",
+          ];
+        },
+        runtime: ob1Runtime,
+      });
+    }
+
+    // Standard memory_search / memory_get tool wrappers — these are the
+    // names the active-memory plugin and OpenClaw's prompt template look
+    // for. The seven openbrain_* tools above stay as the advanced surface
+    // (governance review queue, recall traces, etc.).
+
+    api.registerTool({
+      name: "memory_search",
+      label: "Memory search (OB1)",
+      description: "Search long-term memory for relevant prior decisions, lessons, constraints, or notes.",
+      parameters: Type.Object({
+        query: Type.String({ description: "Natural-language search query." }),
+        max_results: Type.Optional(Type.Number({ description: "Maximum results, 1-50.", default: 10 })),
+      }),
+      async execute(_id: string, params: any) {
+        const client = await clientFromApi(api);
+        const max = clampInt(params?.max_results ?? 10, 1, 50);
+        const result = await client.recall({
+          query: String(params?.query ?? "").slice(0, 2000),
+          task_type: "search",
+          limits: { max_items: max, max_tokens: 4000 },
+          scope: {
+            visibility: "personal",
+            project_only: false,
+            include_unconfirmed: true,
+            include_stale: false,
+          },
+          runtime: { name: "openclaw" },
+        });
+        return toolResult(result);
+      },
+    });
+
+    api.registerTool({
+      name: "memory_get",
+      label: "Memory get (OB1)",
+      description: "Inspect one specific OB1 memory by id, including provenance.",
+      parameters: Type.Object({
+        memory_id: Type.String({ description: "OB1 memory id (uuid)." }),
+      }),
+      async execute(_id: string, params: any) {
+        const client = await clientFromApi(api);
+        const memory = await client.inspectMemory(String(params?.memory_id ?? ""));
+        return toolResult(memory);
+      },
+    });
+
+    api.registerTool({
+      name: "memory_store",
+      label: "Memory store (OB1)",
+      description:
+        "Store a compact, governed memory in OB1 — decisions, lessons, constraints, outputs, or failures. Lands as pending review by default.",
+      parameters: Type.Object({
+        content: Type.String({ description: "The memory content. Compact, single point per call." }),
+        memory_type: Type.Optional(
+          Type.Union(
+            [
+              Type.Literal("decision"),
+              Type.Literal("lesson"),
+              Type.Literal("constraint"),
+              Type.Literal("output"),
+              Type.Literal("failure"),
+              Type.Literal("next_step"),
+              Type.Literal("unresolved_question"),
+            ],
+            { description: "OB1 governance category. Defaults to 'output'.", default: "output" },
+          ),
+        ),
+        confidence: Type.Optional(
+          Type.Number({ description: "Self-reported confidence 0-1.", default: 0.7 }),
+        ),
+      }),
+      async execute(_id: string, params: any) {
+        const client = await clientFromApi(api);
+        const content = String(params?.content ?? "").trim();
+        if (!content) {
+          return toolResult({ error: "memory_store requires non-empty content" });
+        }
+        const type = String(params?.memory_type ?? "output");
+        const conf = clampFloat(params?.confidence ?? 0.7, 0, 1);
+        const categoryMap: Record<string, string> = {
+          decision: "decisions",
+          lesson: "lessons",
+          constraint: "constraints",
+          output: "outputs",
+          failure: "failures",
+          next_step: "next_steps",
+          unresolved_question: "unresolved_questions",
+        };
+        const bucket = categoryMap[type] ?? "outputs";
+        const result = await client.writeback({
+          memory_payload: { [bucket]: [content] },
+          runtime: { name: "openclaw" },
+          provenance: {
+            default_status: "generated",
+            confidence: conf,
+            requires_review: true,
+          },
+        });
+        return toolResult(result);
+      },
+    });
+
+    if (typeof (api as any).registerMemoryCorpusSupplement === "function") {
+      (api as any).registerMemoryCorpusSupplement({
+        async search(input: { query: string; maxResults?: number; agentSessionKey?: string }) {
+          if (!isConfigured()) return [];
+          let client: AgentMemoryClient;
+          try {
+            client = await clientFromApi(api);
+          } catch {
+            return [];
+          }
+          const limit = Math.min(Math.max(input.maxResults ?? 10, 1), 50);
+          let response: any;
+          try {
+            response = await client.recall({
+              query: input.query.slice(0, 2000),
+              task_type: "general",
+              limits: { max_items: limit, max_tokens: 4000 },
+              scope: { project_only: false, include_unconfirmed: false, include_stale: false },
+            });
+          } catch {
+            return [];
+          }
+          const memories: any[] = Array.isArray(response?.memories) ? response.memories : [];
+          return memories.map((m, i) => {
+            const policy = m?.use_policy ?? {};
+            const provenance = policy?.can_use_as_instruction
+              ? "instruction"
+              : policy?.can_use_as_evidence
+                ? "evidence"
+                : undefined;
+            return {
+              corpus: "openbrain",
+              path: `openbrain://memory/${m?.id ?? i}`,
+              title: typeof m?.summary === "string" ? m.summary.slice(0, 80) : undefined,
+              kind: "memory",
+              score: typeof m?.score === "number" ? m.score : Math.max(0, 1 - i / Math.max(memories.length, 1)),
+              snippet: String(m?.summary ?? m?.content ?? "").slice(0, 600),
+              id: typeof m?.id === "string" ? m.id : undefined,
+              provenanceLabel: provenance,
+              source: "openbrain.agent_memory",
+              sourceType: "openbrain.agent_memory",
+              updatedAt: typeof m?.updated_at === "string" ? m.updated_at : undefined,
+            };
+          });
+        },
+        async get(input: { lookup: string }) {
+          if (!isConfigured()) return null;
+          const id = input.lookup.replace(/^openbrain:\/\/memory\//, "");
+          if (!id) return null;
+          let client: AgentMemoryClient;
+          try {
+            client = await clientFromApi(api);
+          } catch {
+            return null;
+          }
+          let memory: any;
+          try {
+            memory = await client.inspectMemory(id);
+          } catch {
+            return null;
+          }
+          if (!memory || typeof memory !== "object") return null;
+          const policy = (memory as any)?.use_policy ?? {};
+          const provenance = policy?.can_use_as_instruction
+            ? "instruction"
+            : policy?.can_use_as_evidence
+              ? "evidence"
+              : undefined;
+          const content = String((memory as any)?.content ?? (memory as any)?.summary ?? "");
+          return {
+            corpus: "openbrain",
+            path: input.lookup,
+            title: typeof (memory as any)?.summary === "string" ? (memory as any).summary.slice(0, 80) : undefined,
+            kind: "memory",
+            content,
+            fromLine: 1,
+            lineCount: content.split("\n").length,
+            id: typeof (memory as any)?.id === "string" ? (memory as any).id : id,
+            provenanceLabel: provenance,
+            sourceType: "openbrain.agent_memory",
+            updatedAt: typeof (memory as any)?.updated_at === "string" ? (memory as any).updated_at : undefined,
+          };
+        },
+      });
+    }
   },
 });

--- a/integrations/openclaw-agent-memory/plugin/src/index.ts
+++ b/integrations/openclaw-agent-memory/plugin/src/index.ts
@@ -79,6 +79,26 @@ function coerceObjectFields(input: Record<string, unknown>, fields: string[]): R
   return out;
 }
 
+// Resolve the OB1 workspace_id for a given agent, mirroring the same
+// workspaceMode logic the SearchManager uses. Phase 9 multi-tenant: when
+// workspaceMode="per-agent", each agent's writeback lands in its own
+// isolated workspace so that recall (also scoped to that workspace) finds
+// only its own prior writes. When workspaceMode="shared" or unset, every
+// agent uses the configured workspaceId (back-compat with PR #282 single
+// tenant default).
+function resolveAgentWorkspaceId(api: any, agentId: string | undefined): string {
+  const raw = ((api as any).pluginConfig || {}) as Record<string, unknown>;
+  const fallback = typeof raw.workspaceId === "string" && raw.workspaceId.length > 0
+    ? raw.workspaceId
+    : "default";
+  const mode = typeof raw.workspaceMode === "string" ? raw.workspaceMode : "shared";
+  if (mode !== "per-agent") return fallback;
+  const id = String(agentId || "").trim();
+  if (!id) return fallback;
+  const prefix = typeof raw.workspacePrefix === "string" ? raw.workspacePrefix : "";
+  return prefix + id;
+}
+
 function registerTool(api: any, tool: { name: string; label: string; description: string; parameters: unknown; run: (client: AgentMemoryClient, input: any) => Promise<unknown> }) {
   api.registerTool({
     name: tool.name,
@@ -108,22 +128,38 @@ export default definePluginEntry({
       ),
     });
 
-    registerTool(api, {
+    // openbrain_writeback uses the factory form so we get ctx.agentId from
+    // the per-call OpenClawPluginToolContext. Phase 9: per-agent workspace
+    // resolution requires agentId at write time (not just at search time).
+    // Factory registrations REQUIRE the {names: [...]} opts so the host can
+    // discover the tool without invoking the factory eagerly.
+    api.registerTool((ctx: any) => ({
       name: "openbrain_writeback",
       label: "NBJ OB1 write-back",
       description: "Write compact, provenance-labeled Nate Jones OB1 Agent Memory after work finishes.",
       parameters: Type.Record(Type.String(), Type.Any()),
-      run: (client, input) => {
+      async execute(_id: string, params: unknown) {
+        const client = await clientFromApi(api);
+        const input = (params || {}) as Record<string, unknown>;
         const coerced = coerceObjectFields(input, ["memory_payload", "provenance", "runtime", "models_used", "source_refs", "retention", "visibility", "channel"]);
-        // Default runtime.name to "openclaw" so writes from this plugin
-        // are correctly attributed without requiring the agent to know the
-        // contract. Explicit input.runtime still wins.
+        // Default runtime.name to "openclaw" so writes are correctly
+        // attributed without requiring the agent to know the contract.
         const runtime = (typeof coerced.runtime === "object" && coerced.runtime) ? coerced.runtime as Record<string, unknown> : {};
         if (!runtime.name) runtime.name = "openclaw";
         coerced.runtime = runtime;
-        return client.writeback(coerced);
+        // Per-agent workspace override. Explicit input.workspace_id still wins.
+        if (!coerced.workspace_id) {
+          coerced.workspace_id = resolveAgentWorkspaceId(api, ctx?.agentId);
+        }
+        // Tag flow_id with agent identity so traces are attributable even
+        // when the agent didn't pass one.
+        if (!coerced.flow_id && ctx?.agentId) {
+          coerced.flow_id = String(ctx.agentId);
+        }
+        const result = await client.writeback(coerced);
+        return toolResult(result);
       },
-    });
+    }), { names: ["openbrain_writeback"] });
 
     registerTool(api, {
       name: "openbrain_report_usage",
@@ -274,14 +310,31 @@ export default definePluginEntry({
 
     if (typeof (api as any).registerMemoryCapability === "function") {
       const ob1Runtime = createOB1Runtime({
+        // Per-agent client: each call picks up the current pluginConfig +
+        // resolved access key. The agent-scoped workspace selection happens
+        // inside the search manager via workspaceIdFor below — the client
+        // itself stays config-defaulted; per-request workspace overrides are
+        // injected in the search() body.
         buildClient: (_agentId: string) => clientFromApi(api),
-        // Phase 9 will derive workspaceId from agentId for multi-tenant; for
-        // now, every agent shares the configured workspace.
-        workspaceIdFor: (_agentId: string) => {
+        // Multi-tenant resolution (Phase 9). Three modes via plugin config:
+        //   workspaceMode="shared" (default): every agent uses the configured
+        //     workspaceId. Fleet-wide single-tenant.
+        //   workspaceMode="per-agent": workspace_id = workspacePrefix + agentId.
+        //     Each agent's writes/recalls live in their own isolated workspace.
+        //   workspacePrefix is optional; defaults to empty (raw agentId used).
+        // Falls back to configured workspaceId for empty agentId in per-agent
+        // mode so the runtime never sends an empty workspace.
+        workspaceIdFor: (agentId: string) => {
           const raw = ((api as any).pluginConfig || {}) as Record<string, unknown>;
-          return typeof raw.workspaceId === "string" && raw.workspaceId.length > 0
+          const fallback = typeof raw.workspaceId === "string" && raw.workspaceId.length > 0
             ? raw.workspaceId
             : "default";
+          const mode = typeof raw.workspaceMode === "string" ? raw.workspaceMode : "shared";
+          if (mode !== "per-agent") return fallback;
+          const id = String(agentId || "").trim();
+          if (!id) return fallback;
+          const prefix = typeof raw.workspacePrefix === "string" ? raw.workspacePrefix : "";
+          return prefix + id;
         },
       });
 
@@ -312,7 +365,10 @@ export default definePluginEntry({
     // for. The seven openbrain_* tools above stay as the advanced surface
     // (governance review queue, recall traces, etc.).
 
-    api.registerTool({
+    // memory_search: factory form so per-agent workspace_id is resolved
+    // per call. The SearchManager-driven recall path (active memory pipeline)
+    // also routes through workspaceIdFor below — this tool path mirrors it.
+    api.registerTool((ctx: any) => ({
       name: "memory_search",
       label: "Memory search (OB1)",
       description: "Search long-term memory for relevant prior decisions, lessons, constraints, or notes.",
@@ -324,6 +380,7 @@ export default definePluginEntry({
         const client = await clientFromApi(api);
         const max = clampInt(params?.max_results ?? 10, 1, 50);
         const result = await client.recall({
+          workspace_id: resolveAgentWorkspaceId(api, ctx?.agentId),
           query: String(params?.query ?? "").slice(0, 2000),
           task_type: "search",
           limits: { max_items: max, max_tokens: 4000 },
@@ -334,12 +391,13 @@ export default definePluginEntry({
             include_stale: false,
           },
           runtime: { name: "openclaw" },
+          flow_id: ctx?.agentId ? String(ctx.agentId) : undefined,
         });
         return toolResult(result);
       },
-    });
+    }), { names: ["memory_search"] });
 
-    api.registerTool({
+    api.registerTool((ctx: any) => ({
       name: "memory_get",
       label: "Memory get (OB1)",
       description: "Inspect one specific OB1 memory by id, including provenance.",
@@ -347,13 +405,21 @@ export default definePluginEntry({
         memory_id: Type.String({ description: "OB1 memory id (uuid)." }),
       }),
       async execute(_id: string, params: any) {
+        // Note: inspectMemory queries a memory by ID directly without a
+        // workspace_id filter (the ID is globally unique). Per-agent
+        // isolation is preserved at write/recall time, not at inspect time.
+        // We intentionally don't gate inspect by ctx.agentId so that
+        // governance review tools can fetch any memory by id.
+        void ctx; // keep ctx in scope for symmetry / future audit hooks
         const client = await clientFromApi(api);
         const memory = await client.inspectMemory(String(params?.memory_id ?? ""));
         return toolResult(memory);
       },
-    });
+    }), { names: ["memory_get"] });
 
-    api.registerTool({
+    // memory_store: factory form so we can read ctx.agentId for per-agent
+    // workspace resolution.
+    api.registerTool((ctx: any) => ({
       name: "memory_store",
       label: "Memory store (OB1)",
       description:
@@ -397,8 +463,10 @@ export default definePluginEntry({
         };
         const bucket = categoryMap[type] ?? "outputs";
         const result = await client.writeback({
+          workspace_id: resolveAgentWorkspaceId(api, ctx?.agentId),
           memory_payload: { [bucket]: [content] },
           runtime: { name: "openclaw" },
+          flow_id: ctx?.agentId ? String(ctx.agentId) : undefined,
           provenance: {
             default_status: "generated",
             confidence: conf,
@@ -407,7 +475,7 @@ export default definePluginEntry({
         });
         return toolResult(result);
       },
-    });
+    }), { names: ["memory_store"] });
 
     if (typeof (api as any).registerMemoryCorpusSupplement === "function") {
       (api as any).registerMemoryCorpusSupplement({

--- a/integrations/openclaw-agent-memory/plugin/src/search-manager.ts
+++ b/integrations/openclaw-agent-memory/plugin/src/search-manager.ts
@@ -1,0 +1,242 @@
+// MemorySearchManager + MemoryPluginRuntime adapters that let OpenClaw use
+// OB1 as the active memory backend (PR #282 / fix for #279).
+//
+// The OpenClaw memory subsystem expects a MemorySearchManager exposing
+// search/status/probe methods. Local plugins like memory-core implement this
+// against a SQLite + sqlite-vec index. Our adapter wraps the OB1 HTTP client
+// instead — same external contract, different backend.
+
+import { AgentMemoryClient } from "./client.js";
+
+// ---------------------------------------------------------------------------
+// Result shape (matches what OpenClaw memory-core's search() returns)
+// ---------------------------------------------------------------------------
+
+export type MemorySearchHit = {
+  source: "memory" | "sessions";
+  path: string;
+  startLine: number;
+  endLine: number;
+  score: number;
+  vectorScore?: number;
+  textScore?: number;
+  snippet: string;
+};
+
+// ---------------------------------------------------------------------------
+// Status shape (matches MemoryProviderStatus consumed by host status path)
+// ---------------------------------------------------------------------------
+
+export type ProviderStatus = {
+  backend: string;          // discriminator for downstream config-clamping
+  ready: boolean;
+  indexed?: number;
+  notes?: string[];
+};
+
+// ---------------------------------------------------------------------------
+// Search options (subset of what consumers actually pass)
+// ---------------------------------------------------------------------------
+
+export type SearchOptions = {
+  maxResults?: number;
+  minScore?: number;
+  sessionKey?: string;
+  qmdSearchModeOverride?: unknown;
+  onDebug?: (debug: unknown) => void;
+  sources?: string[];
+};
+
+// ---------------------------------------------------------------------------
+// MemorySearchManager — the per-agent search engine OpenClaw consumes
+// ---------------------------------------------------------------------------
+
+export class OB1MemorySearchManager {
+  private closed = false;
+  private workspaceId: string;
+  private agentId: string;
+
+  constructor(
+    private client: AgentMemoryClient,
+    params: { workspaceId: string; agentId: string },
+  ) {
+    this.workspaceId = params.workspaceId;
+    this.agentId = params.agentId;
+  }
+
+  async search(query: string, opts: SearchOptions = {}): Promise<MemorySearchHit[]> {
+    if (this.closed) return [];
+    const trimmed = String(query || "").trim();
+    if (!trimmed) return [];
+
+    const limit = clamp(opts.maxResults ?? 10, 1, 50);
+    const minScore = typeof opts.minScore === "number" ? opts.minScore : 0;
+
+    let response: any;
+    try {
+      response = await this.client.recall({
+        query: trimmed.slice(0, 2000),
+        task_type: "general",
+        limits: { max_items: limit, max_tokens: 4000 },
+        // Edge Function quirks: writes default to visibility="personal" and
+        // requires_review=true. scope must mirror both or recall returns 0.
+        // (Same fix the Hermes provider applied — see PR #280.)
+        scope: {
+          visibility: "personal",
+          project_only: false,
+          include_unconfirmed: true,
+          include_stale: false,
+        },
+        runtime: { name: "openclaw" },
+        flow_id: this.agentId,
+        task_id: opts.sessionKey || null,
+      });
+    } catch (err) {
+      opts.onDebug?.({ kind: "ob1.recall.error", message: String(err) });
+      return [];
+    }
+
+    const memories: any[] = Array.isArray(response?.memories) ? response.memories : [];
+    const hits = memories
+      .map((m, i) => mapMemoryToHit(m, i, memories.length))
+      .filter((h) => h.score >= minScore);
+
+    opts.onDebug?.({
+      kind: "ob1.recall.ok",
+      query: trimmed.slice(0, 200),
+      returned: hits.length,
+      request_id: response?.request_id,
+    });
+
+    return hits;
+  }
+
+  status(): ProviderStatus {
+    // backend: "ob1" is a custom discriminator — the host's clampResultsBy*
+    // logic only branches on backend === "qmd"; everything else is treated
+    // as a generic plugin-owned backend.
+    return {
+      backend: "ob1",
+      ready: !this.closed,
+      notes: [
+        `OB1 active-memory backend (workspace=${this.workspaceId}, agent=${this.agentId})`,
+      ],
+    };
+  }
+
+  async probeVectorAvailability(): Promise<boolean> {
+    if (this.closed) return false;
+    try {
+      await this.client.request("/health");
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  async probeVectorStoreAvailability(): Promise<boolean> {
+    return this.probeVectorAvailability();
+  }
+
+  hasIndexedContent(): boolean {
+    // We can't cheaply tell from outside whether OB1 has rows. Return true so
+    // the host doesn't short-circuit recall; an empty backend will surface as
+    // "0 results" via search() instead.
+    return true;
+  }
+
+  async warmSession(_sessionKey: string): Promise<void> {
+    // No-op for HTTP-backed recall — nothing to pre-load locally.
+  }
+
+  async sync(_params?: unknown): Promise<{ ok: true }> {
+    // No-op — OB1 is the source of truth, no local index to re-sync.
+    return { ok: true };
+  }
+
+  async close(): Promise<void> {
+    this.closed = true;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// MemoryPluginRuntime — provides per-agent SearchManager instances
+// ---------------------------------------------------------------------------
+
+export type RuntimeBackendConfig =
+  | { backend: "builtin" }
+  | { backend: "qmd"; qmd?: unknown };
+
+export function createOB1Runtime(params: {
+  buildClient: (agentId: string) => Promise<AgentMemoryClient>;
+  workspaceIdFor: (agentId: string) => string;
+}) {
+  // One manager per agentId; cleared on closeAll. Cheap: each manager just
+  // wraps an HTTP client (no persistent connections, no file watchers).
+  const managers = new Map<string, OB1MemorySearchManager>();
+
+  return {
+    async getMemorySearchManager(args: { cfg: unknown; agentId: string; purpose?: string }) {
+      const agentId = String(args.agentId || "default");
+      let manager = managers.get(agentId);
+      if (!manager) {
+        let client: AgentMemoryClient;
+        try {
+          client = await params.buildClient(agentId);
+        } catch (err) {
+          return { manager: null, error: `OB1 client init failed: ${String(err)}` };
+        }
+        manager = new OB1MemorySearchManager(client, {
+          workspaceId: params.workspaceIdFor(agentId),
+          agentId,
+        });
+        managers.set(agentId, manager);
+      }
+      return { manager };
+    },
+
+    resolveMemoryBackendConfig(_args: { cfg: unknown; agentId: string }): RuntimeBackendConfig {
+      // Host enums only allow "builtin" or "qmd" for this struct, but only
+      // qmd-specific code paths actually inspect it. Returning "builtin" is
+      // the safest no-op signal that we're not the qmd engine.
+      return { backend: "builtin" };
+    },
+
+    async closeAllMemorySearchManagers(): Promise<void> {
+      const entries = Array.from(managers.values());
+      managers.clear();
+      await Promise.all(entries.map((m) => m.close().catch(() => undefined)));
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function clamp(n: number, lo: number, hi: number): number {
+  if (Number.isNaN(n)) return lo;
+  return Math.max(lo, Math.min(hi, Math.floor(n)));
+}
+
+function mapMemoryToHit(m: any, index: number, total: number): MemorySearchHit {
+  // OB1 memory shape (from /recall response):
+  //   { memory_id, summary, content, source, provenance, scope, use_policy,
+  //     freshness, related_artifacts, ... }
+  // Map to OpenClaw's chunk shape with synthetic path/lineage for an
+  // HTTP-backed memory.
+  const id = (m?.memory_id ?? m?.id ?? `idx-${index}`) as string;
+  const snippet = String(m?.content ?? m?.summary ?? "").slice(0, 1000);
+  // OB1 doesn't return per-row similarity in the v1 contract — derive a
+  // monotonically decreasing score from rank order. The host's downstream
+  // re-ranking applies its own decay/MMR if enabled.
+  const score = total > 0 ? Math.max(0.0001, 1 - index / total) : 0;
+  return {
+    source: "memory",
+    path: `openbrain://memory/${id}`,
+    startLine: 1,
+    endLine: 1,
+    score,
+    snippet,
+  };
+}

--- a/integrations/openclaw-agent-memory/plugin/src/search-manager.ts
+++ b/integrations/openclaw-agent-memory/plugin/src/search-manager.ts
@@ -75,6 +75,11 @@ export class OB1MemorySearchManager {
     let response: any;
     try {
       response = await this.client.recall({
+        // Per-agent override: when workspaceMode="per-agent", this.workspaceId
+        // is already the agent's isolated workspace (e.g., "nina"). When
+        // workspaceMode="shared", it equals the configured workspaceId. Either
+        // way the override beats the client's default.
+        workspace_id: this.workspaceId,
         query: trimmed.slice(0, 2000),
         task_type: "general",
         limits: { max_items: limit, max_tokens: 4000 },


### PR DESCRIPTION
Closes the architecture gap left by PR #281. Companion to #280.

## What this changes

PR #281 added two additive memory hooks (`registerMemoryPromptSupplement`, `registerMemoryCorpusSupplement`) so OB1 results contribute alongside whatever active memory plugin happens to be selected. That was the safe minimum. It did **not** make OB1 _be_ the active memory plugin — agents still couldn't reach OB1 from `memory_search`, and when `plugins.slots.memory = "nbj-ob1-agent-memory"` was set the slot stayed empty (\`openclaw doctor\` reported "No active memory plugin is registered for the current config").

This PR fills the slot. Inside `register(api)`:

- **`api.registerMemoryCapability({ promptBuilder, runtime })`** — emits an OB1 discipline section into the active memory prompt and provides a real `MemoryPluginRuntime` that produces per-agent search managers.
- **`OB1MemorySearchManager`** (`src/search-manager.ts`, new) — implements the surface OpenClaw consumers actually call: `search`, `status`, `probeVectorAvailability`, `close`, `hasIndexedContent`, `warmSession`, `sync`. `search()` wraps `client.recall()` and maps OB1 memories to OpenClaw's chunk shape (`{source, path, startLine, endLine, score, snippet}`) using a synthetic `openbrain://memory/<id>` path. `status()` reports `backend="ob1"` so downstream code that branches on `backend === "qmd"` treats us as a generic plugin-owned backend.
- **Standard tool wrappers** — `memory_search`, `memory_get`, `memory_store` register under the names OpenClaw's host and active-memory plugin look for. The seven existing `openbrain_*` tools stay registered as the advanced governance surface (review queue, recall traces, explicit usage reporting) and remain unchanged.
- **`memory_store` semantics** — typed `memory_type` parameter maps to OB1 governance categories (`decisions`, `lessons`, `constraints`, `outputs`, `failures`, `next_steps`, `unresolved_questions`).
- **`client.ts` schema_version** — every recall and writeback now sends the required `schema_version` literal (`openbrain.openclaw.recall.v1` / `openbrain.openclaw.writeback.v1`). Without it the Edge Function returned `400 Invalid recall payload`. This was a latent bug because no agent had actually invoked the plugin's recall path before this work — pure tool-call paths bypassed the issue.
- **LLM tool-call coercion** — `coerceObjectFields()` helper JSON.parses string-shaped object args (LLMs occasionally `JSON.stringify` nested object parameters, which the Edge Function's zod schema then rejects). Applied on `openbrain_recall` and `openbrain_writeback`.
- **Default `runtime.name = "openclaw"` on writeback** — agents calling `openbrain_writeback` without a runtime field used to land rows with `runtime_name="unknown"`. Default it from the plugin so attribution is automatic; explicit input still wins.

## Activation contract (unchanged from existing OpenClaw memory plugin model)

`registerMemoryCapability` declares candidacy. The user activates by setting:

```json
{ "plugins": { "slots": { "memory": "nbj-ob1-agent-memory" } } }
```

Without that slots entry the plugin stays dormant and does not affect existing memory routing.

## Why additive supplements (#281) are still useful

This PR doesn't supersede #281. The additive supplements still let OB1 contribute prompt + corpus contributions when a _different_ memory plugin is active (e.g., users on memory-core or memory-lancedb who want OB1 governance signals layered on top). The two PRs serve different deployment styles.

## Verified live

End-to-end against a self-hosted Supabase + agent-memory-api Edge Function, running an OpenClaw 2026.5.7 gateway locally:

- **Cross-session recall**: agent "personal-assistant" wrote a uniquely-tagged decision via `openbrain_writeback` in session A, then in a fresh session B called `memory_search` with the marker as query. Recall returned the exact memory with content match. Trace row shows `runtime_name=openclaw, items=3`.
- **Second-agent verification**: agent "dev-gpu" recalled 9 prior memories on a generic "Hermes-OB1" query. Same `runtime_name=openclaw` attribution.
- **Hermes side unaffected**: Hermes recall against the same backend continues to work post-cutover.
- **`openclaw doctor`** moves from "No active memory plugin is registered" to recognizing OB1 as the active memory plugin (after `plugins.slots.memory` is set).

## Tools surface notes

When OB1 is selected as the active memory plugin, OpenClaw's host policy auto-exposes `memory_search` and `memory_get` to agents under the default `tools.profile = "coding"`. The seven `openbrain_*` governance tools are registered but require either `tools.profile = "full"` per-agent or explicit `tools.allow` listing — same convention OpenClaw uses for any plugin-specific tool surface. Documented in the README.

## Diff scope

- `integrations/openclaw-agent-memory/plugin/openclaw.plugin.json` — adds `memory_search`, `memory_get`, `memory_store` to `contracts.tools`.
- `integrations/openclaw-agent-memory/plugin/src/index.ts` — +252 LoC. New: capability registration block, three standard tool wrappers, `coerceObjectFields` helper, `runtime.name` default. Existing 7 `openbrain_*` tools unchanged in shape.
- `integrations/openclaw-agent-memory/plugin/src/client.ts` — +5 LoC. `schema_version` on recall + writeback request bodies.
- `integrations/openclaw-agent-memory/plugin/src/search-manager.ts` — new (242 LoC). `OB1MemorySearchManager` class + `createOB1Runtime` factory.

No new dependencies. No `dist/` regeneration committed (please run `npm run build` to refresh).

## Test plan

- [ ] `cd integrations/openclaw-agent-memory/plugin && npm install --ignore-scripts --omit=peer && npm run build` — esbuild succeeds (~24kb bundle).
- [ ] Configure OB1 agent-memory-api endpoint + access key + workspaceId in `~/.openclaw/openclaw.json` under `plugins.entries.nbj-ob1-agent-memory.config`.
- [ ] Set `plugins.slots.memory = "nbj-ob1-agent-memory"` to select.
- [ ] Restart gateway.
- [ ] Run `openclaw plugins inspect nbj-ob1-agent-memory --runtime --json` — confirm `activated: true`, all 10 tools registered.
- [ ] Drive an agent turn calling `memory_search` — confirm a recall trace lands with `runtime_name=openclaw`.

## Related

- Closes #279.
- Companion to #280 (Hermes-side `MemoryProvider` for OB1).
- Builds on #281 (additive supplements stay in place).