### PR TITLE
Tighten OpenClaw agent memory recall/writeback tool schemas

### DIFF
--- a/integrations/openclaw-agent-memory/plugin/dist/index.js
+++ b/integrations/openclaw-agent-memory/plugin/dist/index.js
@@ -135,6 +135,98 @@ function registerTool(api, tool) {
     }
   });
 }
+var channelSchema = Type.Object({
+  kind: Type.String(),
+  id: Type.String(),
+  thread_id: Type.Optional(Type.String())
+});
+var runtimeSchema = Type.Object({
+  name: Type.String(),
+  version: Type.Optional(Type.String())
+});
+var modelRefSchema = Type.Object({
+  provider: Type.String(),
+  model: Type.String(),
+  role: Type.Optional(Type.String())
+});
+var sourceRefSchema = Type.Object({
+  kind: Type.String(),
+  uri: Type.Optional(Type.String()),
+  title: Type.Optional(Type.String()),
+  source_timestamp: Type.Optional(Type.String()),
+  metadata: Type.Optional(Type.Record(Type.String(), Type.Any()))
+});
+var visibilitySchema = Type.Object({
+  workspace: Type.Optional(Type.String()),
+  project: Type.Optional(Type.String()),
+  channel: Type.Optional(Type.String())
+});
+var writebackSchema = Type.Object({
+  schema_version: Type.String(),
+  workspace_id: Type.Optional(Type.String()),
+  project_id: Type.Optional(Type.String()),
+  task_id: Type.String(),
+  step_id: Type.Optional(Type.String()),
+  flow_id: Type.Optional(Type.String()),
+  idempotency_key: Type.Optional(Type.String()),
+  channel: Type.Optional(channelSchema),
+  runtime: Type.Optional(runtimeSchema),
+  models_used: Type.Optional(Type.Array(modelRefSchema)),
+  source_refs: Type.Optional(Type.Array(sourceRefSchema)),
+  memory_payload: Type.Object({
+    decisions: Type.Optional(Type.Array(Type.String())),
+    outputs: Type.Optional(Type.Array(Type.String())),
+    lessons: Type.Optional(Type.Array(Type.String())),
+    constraints: Type.Optional(Type.Array(Type.String())),
+    unresolved_questions: Type.Optional(Type.Array(Type.String())),
+    next_steps: Type.Optional(Type.Array(Type.String())),
+    failures: Type.Optional(Type.Array(Type.String())),
+    artifacts: Type.Optional(Type.Array(Type.Object({
+      kind: Type.String(),
+      uri: Type.Optional(Type.String()),
+      description: Type.Optional(Type.String()),
+      metadata: Type.Optional(Type.Record(Type.String(), Type.Any()))
+    }))),
+    entities: Type.Optional(Type.Record(Type.String(), Type.Any()))
+  }),
+  provenance: Type.Optional(Type.Object({
+    default_status: Type.Optional(Type.String()),
+    confidence: Type.Optional(Type.Number()),
+    requires_review: Type.Optional(Type.Boolean())
+  })),
+  retention: Type.Optional(Type.Object({
+    stale_after_days: Type.Optional(Type.Number())
+  })),
+  visibility: Type.Optional(visibilitySchema)
+});
+var recallSchema = Type.Object({
+  schema_version: Type.String(),
+  workspace_id: Type.Optional(Type.String()),
+  project_id: Type.Optional(Type.String()),
+  task_id: Type.Optional(Type.String()),
+  task_type: Type.Optional(Type.String()),
+  channel: Type.Optional(channelSchema),
+  runtime: Type.Optional(runtimeSchema),
+  model_intent: Type.Optional(modelRefSchema),
+  query: Type.String(),
+  entities: Type.Optional(Type.Record(Type.String(), Type.Any())),
+  scope: Type.Optional(Type.Object({
+    visibility: Type.Optional(Type.String()),
+    project_only: Type.Optional(Type.Boolean()),
+    include_unconfirmed: Type.Optional(Type.Boolean()),
+    include_stale: Type.Optional(Type.Boolean())
+  })),
+  limits: Type.Optional(Type.Object({
+    max_items: Type.Optional(Type.Number()),
+    max_tokens: Type.Optional(Type.Number()),
+    recency_days: Type.Optional(Type.Number())
+  })),
+  sensitivity: Type.Optional(Type.Object({
+    contains_code: Type.Optional(Type.Boolean()),
+    contains_customer_data: Type.Optional(Type.Boolean()),
+    contains_private_meeting_data: Type.Optional(Type.Boolean())
+  }))
+});
 var index_default = definePluginEntry({
   id: "nbj-ob1-agent-memory",
   name: "NBJ OB1 Agent Memory for OpenClaw",
@@ -145,14 +237,14 @@ var index_default = definePluginEntry({
       name: "openbrain_recall",
       label: "NBJ OB1 recall",
       description: "Recall scoped Nate Jones OB1 Agent Memory before meaningful work begins.",
-      parameters: Type.Record(Type.String(), Type.Any()),
+      parameters: recallSchema,
       run: (client, input) => client.recall(input)
     });
     registerTool(api, {
       name: "openbrain_writeback",
       label: "NBJ OB1 write-back",
       description: "Write compact, provenance-labeled Nate Jones OB1 Agent Memory after work finishes.",
-      parameters: Type.Record(Type.String(), Type.Any()),
+      parameters: writebackSchema,
       run: (client, input) => client.writeback(input)
     });
     registerTool(api, {

--- a/integrations/openclaw-agent-memory/plugin/src/index.ts
+++ b/integrations/openclaw-agent-memory/plugin/src/index.ts
@@ -61,6 +61,105 @@ function registerTool(api: any, tool: { name: string; label: string; description
   });
 }
 
+const channelSchema = Type.Object({
+  kind: Type.String(),
+  id: Type.String(),
+  thread_id: Type.Optional(Type.String()),
+});
+
+const runtimeSchema = Type.Object({
+  name: Type.String(),
+  version: Type.Optional(Type.String()),
+});
+
+const modelRefSchema = Type.Object({
+  provider: Type.String(),
+  model: Type.String(),
+  role: Type.Optional(Type.String()),
+});
+
+const sourceRefSchema = Type.Object({
+  kind: Type.String(),
+  uri: Type.Optional(Type.String()),
+  title: Type.Optional(Type.String()),
+  source_timestamp: Type.Optional(Type.String()),
+  metadata: Type.Optional(Type.Record(Type.String(), Type.Any())),
+});
+
+const visibilitySchema = Type.Object({
+  workspace: Type.Optional(Type.String()),
+  project: Type.Optional(Type.String()),
+  channel: Type.Optional(Type.String()),
+});
+
+const writebackSchema = Type.Object({
+  schema_version: Type.String(),
+  workspace_id: Type.Optional(Type.String()),
+  project_id: Type.Optional(Type.String()),
+  task_id: Type.String(),
+  step_id: Type.Optional(Type.String()),
+  flow_id: Type.Optional(Type.String()),
+  idempotency_key: Type.Optional(Type.String()),
+  channel: Type.Optional(channelSchema),
+  runtime: Type.Optional(runtimeSchema),
+  models_used: Type.Optional(Type.Array(modelRefSchema)),
+  source_refs: Type.Optional(Type.Array(sourceRefSchema)),
+  memory_payload: Type.Object({
+    decisions: Type.Optional(Type.Array(Type.String())),
+    outputs: Type.Optional(Type.Array(Type.String())),
+    lessons: Type.Optional(Type.Array(Type.String())),
+    constraints: Type.Optional(Type.Array(Type.String())),
+    unresolved_questions: Type.Optional(Type.Array(Type.String())),
+    next_steps: Type.Optional(Type.Array(Type.String())),
+    failures: Type.Optional(Type.Array(Type.String())),
+    artifacts: Type.Optional(Type.Array(Type.Object({
+      kind: Type.String(),
+      uri: Type.Optional(Type.String()),
+      description: Type.Optional(Type.String()),
+      metadata: Type.Optional(Type.Record(Type.String(), Type.Any())),
+    }))),
+    entities: Type.Optional(Type.Record(Type.String(), Type.Any())),
+  }),
+  provenance: Type.Optional(Type.Object({
+    default_status: Type.Optional(Type.String()),
+    confidence: Type.Optional(Type.Number()),
+    requires_review: Type.Optional(Type.Boolean()),
+  })),
+  retention: Type.Optional(Type.Object({
+    stale_after_days: Type.Optional(Type.Number()),
+  })),
+  visibility: Type.Optional(visibilitySchema),
+});
+
+const recallSchema = Type.Object({
+  schema_version: Type.String(),
+  workspace_id: Type.Optional(Type.String()),
+  project_id: Type.Optional(Type.String()),
+  task_id: Type.Optional(Type.String()),
+  task_type: Type.Optional(Type.String()),
+  channel: Type.Optional(channelSchema),
+  runtime: Type.Optional(runtimeSchema),
+  model_intent: Type.Optional(modelRefSchema),
+  query: Type.String(),
+  entities: Type.Optional(Type.Record(Type.String(), Type.Any())),
+  scope: Type.Optional(Type.Object({
+    visibility: Type.Optional(Type.String()),
+    project_only: Type.Optional(Type.Boolean()),
+    include_unconfirmed: Type.Optional(Type.Boolean()),
+    include_stale: Type.Optional(Type.Boolean()),
+  })),
+  limits: Type.Optional(Type.Object({
+    max_items: Type.Optional(Type.Number()),
+    max_tokens: Type.Optional(Type.Number()),
+    recency_days: Type.Optional(Type.Number()),
+  })),
+  sensitivity: Type.Optional(Type.Object({
+    contains_code: Type.Optional(Type.Boolean()),
+    contains_customer_data: Type.Optional(Type.Boolean()),
+    contains_private_meeting_data: Type.Optional(Type.Boolean()),
+  })),
+});
+
 export default definePluginEntry({
   id: "nbj-ob1-agent-memory",
   name: "NBJ OB1 Agent Memory for OpenClaw",
@@ -71,7 +170,7 @@ export default definePluginEntry({
       name: "openbrain_recall",
       label: "NBJ OB1 recall",
       description: "Recall scoped Nate Jones OB1 Agent Memory before meaningful work begins.",
-      parameters: Type.Record(Type.String(), Type.Any()),
+      parameters: recallSchema,
       run: (client, input) => client.recall(input),
     });
 
@@ -79,7 +178,7 @@ export default definePluginEntry({
       name: "openbrain_writeback",
       label: "NBJ OB1 write-back",
       description: "Write compact, provenance-labeled Nate Jones OB1 Agent Memory after work finishes.",
-      parameters: Type.Record(Type.String(), Type.Any()),
+      parameters: writebackSchema,
       run: (client, input) => client.writeback(input),
     });
 


### PR DESCRIPTION
## Summary
- Replace broad `Type.Record(Type.String(), Type.Any())` schemas for `openbrain_recall` and `openbrain_writeback` with structured TypeBox object schemas.
- Keep the existing runtime API contract and pass-through client behavior unchanged.
- Improve tool-call reliability for models that struggle with unconstrained record schemas.

## Why
During isolated OpenClaw profile testing, stronger models such as Claude Sonnet 4.6 handled the current loose schemas correctly, but weaker/smaller models frequently sent `{}` or malformed arguments to `openbrain_writeback` / `openbrain_recall`, producing API errors like:

- `400 Invalid write-back payload`
- `400 Invalid recall payload`

The plugin already knows the expected v1 contract shape well enough to expose more helpful schema guidance to OpenClaw/model tool selection. Tightening the schemas substantially improved reliability without changing the API endpoints or payload semantics.

## What changed
- Added reusable TypeBox schemas for:
  - channel metadata
  - runtime metadata
  - model references
  - source references
  - visibility policy
  - writeback payload
  - recall payload
- Swapped:
  - `openbrain_writeback`: `Type.Record(Type.String(), Type.Any())` → `writebackSchema`
  - `openbrain_recall`: `Type.Record(Type.String(), Type.Any())` → `recallSchema`
- Rebuilt `plugin/dist/index.js` from `src/index.ts`.

## Validation
Tested in an isolated OpenClaw profile (`ob1-agent-memory`) against a deployed OB1 Agent Memory API.

### Build / inspect
- `npm run build` ✅
- `git diff --check` ✅
- `openclaw --profile ob1-agent-memory plugins inspect nbj-ob1-agent-memory --runtime --json` ✅
  - Plugin status: `loaded`
  - Diagnostics: `[]`
  - All seven `openbrain_*` tools registered

### Smoke tests after schema tightening

**GLM-5.1** ✅
```json
{
  "ok": true,
  "run_id": "glm51-tight-20260512162422",
  "model": "glm-5.1",
  "writeback_memory_count": 5,
  "recall_memory_count": 5,
  "report_usage_called": true,
  "review_status_after": "evidence_only",
  "trace_item_count": 5,
  "blockers": []
}
```

**GLM-5-Turbo** ✅
```json
{
  "ok": true,
  "run_id": "glmturbo-tight-20260512162712",
  "model": "glm-5-turbo",
  "writeback_memory_count": 5,
  "recall_memory_count": 10,
  "report_usage_called": true,
  "review_status_after": "evidence_only",
  "trace_item_count": 10,
  "blockers": []
}
```

**Claude Sonnet 4.6 baseline** ✅
```json
{
  "ok": true,
  "run_id": "sonnet46-20260512161615",
  "writeback_memory_count": 5,
  "recall_memory_count": 4,
  "report_usage_called": true,
  "review_status_after": "evidence_only",
  "trace_item_count": 4,
  "blockers": []
}
```

Smoke-test memories were cleaned up afterward by marking the test project rows rejected.

## Notes / compatibility
This does not intentionally narrow the server-side API contract; it only gives OpenClaw/model callers a structured tool schema. Some nested fields remain flexible via `Type.Record(Type.String(), Type.Any())` where appropriate, especially `entities` and metadata.
