### PR TITLE
dashboards(next): enable standalone output for Docker builds

### DIFF
--- a/dashboards/open-brain-dashboard-next/next.config.ts
+++ b/dashboards/open-brain-dashboard-next/next.config.ts
@@ -2,10 +2,6 @@ import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
   allowedDevOrigins: ["192.168.0.140"],
-  // Enables the .next/standalone output, which packages only the files needed
-  // to run the dashboard. Required for clean multi-stage Docker builds
-  // (~150 MB runtime image vs ~500 MB without). No-op on Vercel deploys —
-  // Vercel uses its own bundling pipeline and ignores this setting.
   output: "standalone",
 };
 

--- a/dashboards/open-brain-dashboard-next/next.config.ts
+++ b/dashboards/open-brain-dashboard-next/next.config.ts
@@ -2,6 +2,11 @@ import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
   allowedDevOrigins: ["192.168.0.140"],
+  // Enables the .next/standalone output, which packages only the files needed
+  // to run the dashboard. Required for clean multi-stage Docker builds
+  // (~150 MB runtime image vs ~500 MB without). No-op on Vercel deploys —
+  // Vercel uses its own bundling pipeline and ignores this setting.
+  output: "standalone",
 };
 
 export default nextConfig;


### PR DESCRIPTION
## Summary

Adds `output: "standalone"` to `dashboards/open-brain-dashboard-next/next.config.ts` so the dashboard can be Dockerized cleanly via multi-stage builds.

## Motivation

The Next.js dashboard currently has no `output` set, so a default build emits the full bundle into `.next/server`. That's fine for Vercel, which has its own bundling pipeline, but Dockerizing the dashboard becomes painful: even with multi-stage builds the runtime image lands at roughly 500 MB because there's no self-contained server bundle to copy.

`output: "standalone"` produces `.next/standalone` (a minimal node server bundle) plus `.next/static`, which is the upstream-recommended Next.js pattern for production Node deploys. A multi-stage Dockerfile can then copy just those, plus `public/`, into a clean `node:22-alpine` runtime. In my case the image dropped from 500 MB to about 150 MB without functional change.

## Impact on existing users

No-op for Vercel deploys. Vercel's build pipeline uses its own bundling and ignores the `output` setting (this is explicitly documented in the Next.js docs).

For self-hosted deployers (Docker, Coolify, Dokku, plain `next start`), this enables the recommended production pattern with no extra opt-in.

## Test plan

- [x] `npm run build` succeeds locally with the patch applied
- [x] Deployed via multi-stage Dockerfile (node:22-alpine builder + runtime) behind a Cloudflare tunnel
- [x] `node server.js` binds correctly via the standalone server (PORT/HOSTNAME env vars)
- [x] All dashboard pages (Dashboard, Browse, Search, Workflow Kanban, Detail, Audit, Duplicates, Add to Brain) render against a live `open-brain-rest` gateway with real data
- [x] Login flow via iron-session cookie works correctly over HTTPS

## Context

I'm self-hosting OB1 on my homelab (Debian, Cloudflare tunnel, Docker). Trying to keep my brain on hardware I own. This was the single nontrivial patch I needed on top of `main` to get the dashboard running, and it felt like a "should be upstream" kind of change rather than a local fork situation.