### PR TITLE
Add config-driven extension hook for sidebar

### DIFF
--- a/dashboards/open-brain-dashboard-next/EXTENSIONS.md
+++ b/dashboards/open-brain-dashboard-next/EXTENSIONS.md
@@ -1,0 +1,84 @@
+# Dashboard Extensions
+
+The Open Brain dashboard supports drop-in extensions that add a new route
+and a sidebar entry **without modifying any core dashboard file**.
+
+## Anatomy
+
+An extension is:
+
+1. A folder under `app/<route>/` containing one or more `page.tsx` files
+   (Next.js App Router conventions apply). The folder name becomes the URL.
+2. One entry in `extensions.config.ts` adding a sidebar nav item.
+
+That's it. Extensions own their own API helpers (live in the extension
+folder, not `lib/api.ts`) and their own types.
+
+## Minimal example
+
+```
+app/
+  hello/
+    page.tsx          ← extension page
+    api.ts            ← extension's own data layer (optional)
+```
+
+```ts
+// extensions.config.ts
+export const EXTENSIONS: ExtensionNavEntry[] = [
+  { href: "/hello", label: "Hello", icon: "sparkles" },
+];
+```
+
+`page.tsx` imports its own helpers from `./api` (or wherever), and the
+extension is live after `npm run build && vercel deploy --prod`.
+
+## Auth
+
+Extension pages use the same session helpers as core pages:
+
+```tsx
+import { requireSessionOrRedirect } from "@/lib/auth";
+
+export default async function Page() {
+  const { apiKey } = await requireSessionOrRedirect();
+  // ...
+}
+```
+
+`apiKey` is the OB1 access key the user logged in with — pass it as the
+`x-brain-key` header when calling Edge Functions.
+
+## Backend routes
+
+Extensions that need their own REST endpoints have two clean options:
+
+- **Sidecar Edge Function.** Deploy a separate function (e.g.
+  `my-extension-api`). Derive its URL on the dashboard side by string-
+  replacing `open-brain-rest` in `NEXT_PUBLIC_API_URL` (`agent-memory-api`
+  does this — see `lib/agent-memory.ts`).
+- **Add routes to `open-brain-rest`.** Acceptable when the data lives in a
+  table that's tightly coupled to OB1's core surface area.
+
+## Icon registry
+
+Extensions reference icons by string name because `extensions.config.ts`
+is plain TypeScript (no JSX). Supported keys are declared in
+`extensions.config.ts` as `ExtensionIcon`. To add a new icon:
+
+1. Add the key to the `ExtensionIcon` union.
+2. Implement the SVG component in `components/Sidebar.tsx`.
+3. Map the key in `EXTENSION_ICONS`.
+
+## Position in the sidebar
+
+Extensions render in declaration order, between the core nav items
+(Dashboard, Thoughts, Workflow, Agent Memory, Search, Audit, Duplicates)
+and the trailing "Add" entry.
+
+## Versioning
+
+The extension contract is small (one config file, one folder layout
+convention) so it's intentionally not versioned. Breaking changes — if
+ever — would surface as TypeScript errors in `extensions.config.ts`,
+which is the right place to catch them.

--- a/dashboards/open-brain-dashboard-next/components/Sidebar.tsx
+++ b/dashboards/open-brain-dashboard-next/components/Sidebar.tsx
@@ -1,11 +1,22 @@
 "use client";
 
+import type { ComponentType } from "react";
 import Image from "next/image";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { RestrictedToggle } from "@/components/RestrictedToggle";
+import { EXTENSIONS, type ExtensionIcon } from "@/extensions.config";
 
-const nav = [
+type IconComponent = ComponentType<{ active: boolean }>;
+
+const EXTENSION_ICONS: Record<ExtensionIcon, IconComponent> = {
+  clock: ClockIcon,
+  folder: FolderIcon,
+  plug: PlugIcon,
+  sparkles: SparklesIcon,
+};
+
+const coreNav: { href: string; label: string; icon: IconComponent }[] = [
   { href: "/", label: "Dashboard", icon: DashboardIcon },
   { href: "/thoughts", label: "Thoughts", icon: ThoughtsIcon },
   { href: "/kanban", label: "Workflow", icon: KanbanIcon },
@@ -13,7 +24,20 @@ const nav = [
   { href: "/search", label: "Search", icon: SearchIcon },
   { href: "/audit", label: "Audit", icon: AuditIcon },
   { href: "/duplicates", label: "Duplicates", icon: DuplicatesIcon },
+];
+
+const trailingNav: { href: string; label: string; icon: IconComponent }[] = [
   { href: "/ingest", label: "Add", icon: AddIcon },
+];
+
+const nav: { href: string; label: string; icon: IconComponent }[] = [
+  ...coreNav,
+  ...EXTENSIONS.map((e) => ({
+    href: e.href,
+    label: e.label,
+    icon: EXTENSION_ICONS[e.icon],
+  })),
+  ...trailingNav,
 ];
 
 interface SidebarProps {
@@ -166,6 +190,40 @@ function AddIcon({ active }: { active: boolean }) {
     <svg width="18" height="18" viewBox="0 0 18 18" fill="none" className={active ? "text-violet" : "text-text-muted"}>
       <circle cx="9" cy="9" r="7.5" stroke="currentColor" strokeWidth="1.5" />
       <path d="M9 5.5v7M5.5 9h7" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" />
+    </svg>
+  );
+}
+
+function ClockIcon({ active }: { active: boolean }) {
+  return (
+    <svg width="18" height="18" viewBox="0 0 18 18" fill="none" className={active ? "text-violet" : "text-text-muted"}>
+      <circle cx="9" cy="9" r="7" stroke="currentColor" strokeWidth="1.5" />
+      <path d="M9 4.5V9l3 2" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
+    </svg>
+  );
+}
+
+function FolderIcon({ active }: { active: boolean }) {
+  return (
+    <svg width="18" height="18" viewBox="0 0 18 18" fill="none" className={active ? "text-violet" : "text-text-muted"}>
+      <path d="M2 5.5A1.5 1.5 0 013.5 4h3l1.5 2h6.5A1.5 1.5 0 0116 7.5v6A1.5 1.5 0 0114.5 15h-11A1.5 1.5 0 012 13.5v-8z" stroke="currentColor" strokeWidth="1.5" strokeLinejoin="round" />
+    </svg>
+  );
+}
+
+function PlugIcon({ active }: { active: boolean }) {
+  return (
+    <svg width="18" height="18" viewBox="0 0 18 18" fill="none" className={active ? "text-violet" : "text-text-muted"}>
+      <path d="M6 2v4M12 2v4M4 6h10v3a5 5 0 01-5 5 5 5 0 01-5-5V6zM9 14v2.5" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
+    </svg>
+  );
+}
+
+function SparklesIcon({ active }: { active: boolean }) {
+  return (
+    <svg width="18" height="18" viewBox="0 0 18 18" fill="none" className={active ? "text-violet" : "text-text-muted"}>
+      <path d="M9 2l1.5 4L14.5 7.5 10.5 9 9 13 7.5 9 3.5 7.5 7.5 6 9 2z" stroke="currentColor" strokeWidth="1.5" strokeLinejoin="round" />
+      <path d="M14 12l.7 1.8 1.8.7-1.8.7L14 17l-.7-1.8-1.8-.7 1.8-.7L14 12z" stroke="currentColor" strokeWidth="1.2" strokeLinejoin="round" />
     </svg>
   );
 }

--- a/dashboards/open-brain-dashboard-next/extensions.config.ts
+++ b/dashboards/open-brain-dashboard-next/extensions.config.ts
@@ -1,0 +1,31 @@
+/**
+ * Dashboard Extension Registry
+ * ============================
+ *
+ * Drop-in extensions register here. Each entry adds one nav item to the
+ * sidebar, in declaration order, between the core nav and the trailing
+ * "Add" entry. Extension pages live under `app/<route>/` and may declare
+ * their own local helpers — no other dashboard file needs to change.
+ *
+ * To install an extension:
+ *   1. Drop its `app/<route>/` folder into the dashboard
+ *   2. Add one entry below
+ *   3. `npm run build && vercel deploy --prod`
+ *
+ * To uninstall, remove both. No other file is touched.
+ *
+ * See EXTENSIONS.md for the full convention.
+ */
+
+export type ExtensionIcon = "clock" | "folder" | "plug" | "sparkles";
+
+export interface ExtensionNavEntry {
+  /** Route the extension owns, e.g. "/sessions". */
+  href: string;
+  /** Sidebar label. */
+  label: string;
+  /** Icon key resolved against the registry in Sidebar.tsx. */
+  icon: ExtensionIcon;
+}
+
+export const EXTENSIONS: ExtensionNavEntry[] = [];

--- a/dashboards/open-brain-dashboard-next/lib/api.ts
+++ b/dashboards/open-brain-dashboard-next/lib/api.ts
@@ -23,7 +23,13 @@ function headers(apiKey: string): HeadersInit {
   };
 }
 
-async function apiFetch<T>(
+/**
+ * Authenticated JSON fetch against the open-brain-rest Edge Function.
+ *
+ * Exported so dashboard extensions (see EXTENSIONS.md) can reuse the auth
+ * header + error-translation plumbing without duplicating it.
+ */
+export async function apiFetch<T>(
   apiKey: string,
   path: string,
   init?: RequestInit


### PR DESCRIPTION


## Contribution Type

<!-- Check one -->
- [ ] Recipe (`/recipes`)
- [ ] Schema (`/schemas`)
- [x] Dashboard (`/dashboards`)
- [ ] Integration (`/integrations`)
- [ ] Skill (`/skills`)
- [ ] Repo improvement (docs, CI, templates)

## What does this do?

Adds a small drop-in extension surface so dashboard add-ons can register a new route + sidebar entry without touching core files:

  - extensions.config.ts: typed registry, empty by default
  - components/Sidebar.tsx: splits nav into core + extensions + trailing, resolves icon keys via a registry; adds clock/folder/plug/sparkles
  - lib/api.ts: exports apiFetch so extension pages can reuse the authenticated JSON fetch + error plumbing
  - EXTENSIONS.md: convention doc (folder layout, auth, icon registry, sidecar vs in-tree REST routes)

After this change, future extensions touch only their own folder under app/<route>/ and a single entry in extensions.config.ts.

## Requirements

No new dependencies. No new external services. Compatible with the existing
Next.js App Router stack already in `open-brain-dashboard-next`. Does not
depend on any canonical skill or primitive — this is an in-tree convention
for the dashboard itself.

## Checklist

- [x] I've read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [N/A] My contribution has a `README.md` with prerequisites, step-by-step instructions, and expected outcome
- [N/A] My `metadata.json` has all required fields
- [N/A] If my contribution depends on a skill or primitive, I declared it in metadata.json and linked it in the README
- [x] I tested this on my own Open Brain instance
- [x] No credentials, API keys, or secrets are included

> **Note on the N/A items:** This PR modifies an *existing* contribution
> (`dashboards/open-brain-dashboard-next`) rather than adding a new one,
> so the README / metadata.json checklist items don't apply in the usual
> sense — the existing dashboard's README + metadata.json continue to
> cover it. The new convention doc is `EXTENSIONS.md` inside the dashboard
> folder, sibling to its existing README.