### PR TITLE
fix: add schema_version to writeback method (closes OB1 writeback failure)

### DIFF
--- a/integrations/openclaw-agent-memory/plugin/src/client.ts
+++ b/integrations/openclaw-agent-memory/plugin/src/client.ts
@@ -62,6 +62,7 @@ export class AgentMemoryClient {
       body: {
         workspace_id: this.config.workspaceId,
         project_id: this.config.projectId ?? null,
+        schema_version: "openbrain.openclaw.writeback.v1",
         ...input,
         provenance: {
           default_status: "generated",


### PR DESCRIPTION
## Bug Summary

The `nbj-ob1-agent-memory` plugin v0.1.1 `writeback()` method silently fails because it doesn't send `schema_version` in the request body.

The agent-memory-api server expects `schema_version: "openbrain.openclaw.writeback.v1"` as a required field. Without it, writeback calls fail validation.

## The Fix

Added `schema_version: "openbrain.openclaw.writeback.v1"` to the writeback body object, mirroring the pattern already used in the `recall()` method.

## Impact

- Affects all 3 nodes: Slate, Clay, Doctor (all running v0.1.1)
- `recall()` works because schema_version is included there
- `writeback()` broken — session-end capture fails silently
- Workaround: direct REST calls with correct schema string work fine

## Test

```bash
curl -X POST "https://gjclaovlofzdmawbbaly.supabase.co/functions/v1/agent-memory-api/writeback" \
  -H "Content-Type: application/json" \
  -H "Authorization: Bearer <access_key>" \
  -d '{"schema_version":"openbrain.openclaw.writeback.v1","workspace_id":"test","memory_payload":{},"provenance":{}}'
```
