### PR TITLE
[security] Add ignore-scripts=true to dashboards and openclaw .npmrc

### DIFF
--- a/dashboards/open-brain-dashboard/.npmrc
+++ b/dashboards/open-brain-dashboard/.npmrc
@@ -1,1 +1,2 @@
 engine-strict=true
+ignore-scripts=true

--- a/integrations/openclaw-agent-memory/plugin/.npmrc
+++ b/integrations/openclaw-agent-memory/plugin/.npmrc
@@ -1,1 +1,2 @@
 omit=peer
+ignore-scripts=true


### PR DESCRIPTION
## Summary

Adds `ignore-scripts=true` to two `.npmrc` files that were missing it:
- `dashboards/open-brain-dashboard/.npmrc`
- `integrations/openclaw-agent-memory/plugin/.npmrc`

## Why

Closes the install-time lifecycle-script execution path that supply-chain attacks rely on. This is exactly how the **TanStack npm compromise on 2026-05-11** ([GHSA-g7cv-rxg3-hmpx](https://github.com/TanStack/router/security/advisories/GHSA-g7cv-rxg3-hmpx)) ran its payload — a ~2.3 MB `router_init.js` dropped from a malicious `optionalDependency` and executed via the `prepare` lifecycle script during `npm install`.

With `ignore-scripts=true`, that payload would not have executed.

OB1 was **not affected** by that specific incident (we don't use `@tanstack/react-router` or `@tanstack/start`), but this is a cheap precaution against the same attack class.

## Trade-off

`ignore-scripts=true` also blocks legitimate post-install scripts (e.g., `husky` git-hook installation, native binary downloads like `node-pre-gyp`). For the two subprojects touched here, neither needs install scripts to function — the change is safe. Any future dep that does need them can be explicitly rebuilt with `pnpm rebuild <pkg>` after install.

## Test plan

- [ ] CI passes (markdown lint + ob1-gate)
- [ ] `pnpm install` in `dashboards/open-brain-dashboard/` still succeeds and the dashboard runs
- [ ] `pnpm install` in `integrations/openclaw-agent-memory/plugin/` still succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)