### PR TITLE
[security] Pin GitHub Actions to commit SHAs

### DIFF
--- a/.github/workflows/auto-label.yml
+++ b/.github/workflows/auto-label.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Detect contribution types and apply labels
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
         with:
           script: |
             const { data: files } = await github.rest.pulls.listFiles({

--- a/.github/workflows/claude-issue-triage.yml
+++ b/.github/workflows/claude-issue-triage.yml
@@ -13,7 +13,7 @@ jobs:
   triage:
     runs-on: ubuntu-latest
     steps:
-      - uses: anthropics/claude-code-action@v1
+      - uses: anthropics/claude-code-action@86eb26bf0139bdd75acd15ea5f00f45ee0a284c2 # v1.0.122
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -29,7 +29,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           fetch-depth: 0
 
@@ -58,7 +58,7 @@ jobs:
           git checkout "pr-$PR_NUMBER"
 
       - name: Run Claude review
-        uses: anthropics/claude-code-action@v1
+        uses: anthropics/claude-code-action@86eb26bf0139bdd75acd15ea5f00f45ee0a284c2 # v1.0.122
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}

--- a/.github/workflows/markdown-lint.yml
+++ b/.github/workflows/markdown-lint.yml
@@ -15,13 +15,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout PR head safely
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           ref: refs/pull/${{ github.event.pull_request.number }}/head
           fetch-depth: 1
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: '22'
 

--- a/.github/workflows/ob1-gate.yml
+++ b/.github/workflows/ob1-gate.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout PR head safely
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           ref: refs/pull/${{ github.event.pull_request.number }}/head
           fetch-depth: 0
@@ -658,7 +658,7 @@ jobs:
 
       - name: Upload gate artifact
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: ob1-pr-gate-context
           path: gate-artifact/

--- a/.github/workflows/ob1-pr-followups.yml
+++ b/.github/workflows/ob1-pr-followups.yml
@@ -24,7 +24,7 @@ jobs:
 
     steps:
       - name: Checkout base repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           ref: ${{ github.event.repository.default_branch }}
           fetch-depth: 1
@@ -72,7 +72,7 @@ jobs:
 
       - name: Post gate summary and sync security label
         if: steps.artifact.outputs.found == 'true'
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
         env:
           PR_NUMBER: ${{ steps.context.outputs.pr_number }}
           SUMMARY_FILE: ${{ steps.context.outputs.summary_file }}
@@ -172,7 +172,7 @@ jobs:
 
       - name: Sync maintainer triage label
         if: steps.artifact.outputs.found == 'true'
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
         env:
           PR_NUMBER: ${{ steps.context.outputs.pr_number }}
           OVER_QUOTA: ${{ steps.policy.outputs.over_quota }}
@@ -217,7 +217,7 @@ jobs:
           steps.context.outputs.is_draft != 'true' &&
           steps.policy.outputs.trusted == 'true' &&
           steps.policy.outputs.over_quota != 'true'
-        uses: anthropics/claude-code-action@v1
+        uses: anthropics/claude-code-action@86eb26bf0139bdd75acd15ea5f00f45ee0a284c2 # v1.0.122
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -13,6 +13,6 @@ jobs:
   update-release-draft:
     runs-on: ubuntu-latest
     steps:
-      - uses: release-drafter/release-drafter@v6
+      - uses: release-drafter/release-drafter@6a93d829887aa2e0748befe2e808c66c0ec6e4c7 # v6.4.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/welcome-new-contributors.yml
+++ b/.github/workflows/welcome-new-contributors.yml
@@ -16,7 +16,7 @@ jobs:
     steps:
       - name: Check if first-time contributor
         id: check
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
         with:
           script: |
             const creator = context.payload.sender.login;
@@ -47,7 +47,7 @@ jobs:
 
       - name: Welcome message
         if: steps.check.outputs.is_first == 'true'
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
         with:
           script: |
             const eventType = '${{ steps.check.outputs.event_type }}';


### PR DESCRIPTION
## Summary

Replaces mutable major-version tags (`@v4`, `@v6`, `@v7`, `@v1`) across all 8 workflows with the exact commit SHA each tag currently resolves to, with a readable version comment. No version changes — just freezing each action at a known-good commit.

| Action | Was | Now |
|---|---|---|
| `actions/checkout` | `@v4` | `@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1` |
| `actions/github-script` | `@v7` | `@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0` |
| `actions/setup-node` | `@v4` | `@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0` |
| `actions/upload-artifact` | `@v4` | `@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2` |
| `anthropics/claude-code-action` | `@v1` | `@86eb26bf0139bdd75acd15ea5f00f45ee0a284c2 # v1.0.122` |
| `release-drafter/release-drafter` | `@v6` | `@6a93d829887aa2e0748befe2e808c66c0ec6e4c7 # v6.4.0` |

Touches: `auto-label.yml`, `claude-issue-triage.yml`, `claude-review.yml`, `markdown-lint.yml`, `ob1-gate.yml`, `ob1-pr-followups.yml`, `release-drafter.yml`, `welcome-new-contributors.yml`.

`discord-announce.yml` has no `uses:` and was not touched.

## Why

A mutable tag like `@v4` silently follows the publisher's pointer. If a publisher's npm or GitHub credentials are phished, the next CI run on every dependent workflow ingests whatever the attacker pushed. The **TanStack npm compromise on 2026-05-11** ([GHSA-g7cv-rxg3-hmpx](https://github.com/TanStack/router/security/advisories/GHSA-g7cv-rxg3-hmpx)) is a recent example of that attack class — same vector exists on the GitHub Actions registry.

This is especially worth doing for `anthropics/claude-code-action` and `actions/github-script`, which run arbitrary code with access to `secrets.ANTHROPIC_API_KEY` and `secrets.GITHUB_TOKEN` respectively.

## Trade-off

SHA pinning means we no longer auto-receive patch upgrades. To keep these fresh, Dependabot or Renovate can be configured to bump the SHAs on a controlled schedule (e.g., monthly) with a tested upgrade PR. Manual bumps via `gh api repos/<owner>/<repo>/commits/<tag>` are easy too — that's how this PR was generated.

## Test plan

- [ ] CI passes (ob1-gate.yml + markdown-lint on this PR will validate the pinned actions actually resolve and run)
- [ ] `claude-review.yml` workflow_dispatch on this PR runs successfully against the pinned `anthropics/claude-code-action`
- [ ] No diff in behavior for `auto-label`, `welcome-new-contributors`, `release-drafter`

🤖 Generated with [Claude Code](https://claude.com/claude-code)