### PR TITLE
[recipes] obsidian-vault-import: --source-label to override metadata.source

### DIFF
--- a/recipes/obsidian-vault-import/README.md
+++ b/recipes/obsidian-vault-import/README.md
@@ -228,6 +228,22 @@ After a successful import, searching your Open Brain for topics from your vault 
 
 You can filter by source to find only Obsidian-imported thoughts: search with `{"source": "obsidian"}` as a metadata filter.
 
+### Customizing the source label
+
+The default `source` value is `"obsidian"` — useful when you want to filter all
+Obsidian-imported thoughts as one group. If you have multiple upstream tools
+feeding into Obsidian-style markdown (e.g. an Apple Journal exporter, a
+Day One exporter, an old Roam dump), pass `--source-label` to distinguish
+them in OB1:
+
+```bash
+python import-obsidian.py /path/to/journal-vault --source-label apple-journal
+python import-obsidian.py /path/to/dayone-vault   --source-label day-one
+```
+
+After this, your metadata filter becomes `{"source": "apple-journal"}` to
+retrieve only Apple Journal entries, etc.
+
 ## Troubleshooting
 
 **Issue: `python-frontmatter` not found**

--- a/recipes/obsidian-vault-import/import-obsidian.py
+++ b/recipes/obsidian-vault-import/import-obsidian.py
@@ -484,6 +484,13 @@ def main():
                         help="Show detailed progress")
     parser.add_argument("--report", action="store_true",
                         help="Generate a markdown summary report")
+    parser.add_argument("--source-label", type=str, default="obsidian",
+                        help="Value to stamp in metadata.source for every "
+                             "imported thought (default: 'obsidian'). Useful "
+                             "when one vault aggregates notes from multiple "
+                             "upstream tools and you want to filter by origin "
+                             "in OB1 — e.g. 'apple-journal', 'day-one', "
+                             "'roam-export'.")
     args = parser.parse_args()
 
     vault_root = Path(args.vault_path).expanduser().resolve()
@@ -692,7 +699,7 @@ def main():
                 'content': content,
                 'fingerprint': content_fingerprint(content),
                 'metadata': {
-                    'source': 'obsidian',
+                    'source': args.source_label,
                     'title': note['title'],
                     'folder': note['folder'],
                     'tags': note['tags'],


### PR DESCRIPTION
## Summary

Adds a `--source-label` flag to `recipes/obsidian-vault-import/import-obsidian.py` so the operator can stamp a more specific origin tag in `metadata.source`. Default is unchanged (`obsidian`), so existing scripts behave identically.

## Motivation

The recipe currently hardcodes `metadata.source = "obsidian"`. That's accurate when the vault is a hand-curated Obsidian vault, but increasingly people pipeline other tools (Apple Journal exporters, Day One exporters, Roam dumps) **through** Obsidian-style markdown and into OB1 via this recipe.

After import, all those thoughts read as just `"obsidian"` — provenance is lost. There's no way to query "all Apple Journal entries" or "all Day One imports" separately.

## Change

```diff
+ parser.add_argument("--source-label", type=str, default="obsidian", ...)
  ...
  'metadata': {
-     'source': 'obsidian',
+     'source': args.source_label,
      ...
  }
```

Plus a README subsection documenting it.

## Usage

```bash
# default: unchanged (source = "obsidian")
python import-obsidian.py /path/to/vault

# new: stamp a specific origin
python import-obsidian.py /path/to/journal-vault --source-label apple-journal
python import-obsidian.py /path/to/dayone-vault  --source-label day-one
```

After import: `metadata->>'source' = 'apple-journal'` retrieves only Apple Journal-originated thoughts.

## Backward compatibility

100%. Default value matches the previous hardcoded constant. Anyone not passing the flag sees zero behavioral change.

## Test plan

- [x] `--help` shows the new flag
- [x] Default value is `obsidian` (preserves existing behavior)
- [x] Passing `--source-label apple-journal` sets `metadata.source` accordingly on all inserted rows
- [x] No other metadata key is affected

## Related

Complementary to #301 (preserve full frontmatter under `metadata.frontmatter`). With both merged, a single Obsidian vault can carry multi-source provenance: `metadata.source` says **where the thought came from**, and `metadata.frontmatter.*` carries the per-note original YAML.