### PR TITLE
[recipes] Add local-brain-no-mcp recipe + ob1-local-http skill

### DIFF
--- a/recipes/local-brain-no-mcp/.env.example
+++ b/recipes/local-brain-no-mcp/.env.example
@@ -1,0 +1,38 @@
+# local-brain-no-mcp -- environment overlay
+#
+# This file is the source of truth for the brain stack. After running setup.sh,
+# a fully-populated .env (with generated secrets) is written to
+# supabase-docker/docker/.env -- that's where docker compose reads from.
+#
+# Edit the values below BEFORE running setup.sh if you want non-defaults.
+# Once the stack has booted with a given EMBED_DIM, the value is baked into
+# the thoughts table and cannot be changed without wiping the Postgres volume.
+
+# ---------- embedding ----------
+# The Ollama model used to embed thought text. Server-side only -- dev hosts
+# never need Ollama. See README "Embedding model is a one-way door" for the
+# rules around switching models later.
+EMBED_MODEL=nomic-embed-text
+EMBED_DIM=768
+
+# Where the capture / search Edge Functions reach Ollama from inside the
+# Docker network. Don't change unless you also change the Ollama service name
+# in docker-compose.yml.
+OLLAMA_URL=http://ollama:11434
+
+# Host port to expose Ollama on (handy for `ollama pull` from the brain host
+# shell). The Edge Functions reach Ollama over the internal Docker network,
+# not this port.
+OLLAMA_PORT=11434
+
+# ---------- networking ----------
+# Hostname or IP that dev hosts use to reach the brain. Used only by
+# setup.sh when it prints the "skill install" snippet at the end. The
+# Supabase Kong gateway listens on KONG_HTTP_PORT (default 8000).
+BRAIN_HOST=brain.local
+KONG_HTTP_PORT=8000
+
+# Everything else (POSTGRES_PASSWORD, JWT_SECRET, ANON_KEY, SERVICE_ROLE_KEY,
+# DASHBOARD_USERNAME, DASHBOARD_PASSWORD, etc.) is generated for you by
+# setup.sh into supabase-docker/docker/.env -- do NOT put real secrets in
+# THIS file.

--- a/recipes/local-brain-no-mcp/README.md
+++ b/recipes/local-brain-no-mcp/README.md
@@ -1,0 +1,147 @@
+# Local Brain (No MCP)
+
+Self-hosted Open Brain on a single LAN host: the official Supabase docker-compose stack plus an Ollama sidecar for local embeddings and two Edge Functions (`capture`, `search`) wired up for OB1's `thoughts` schema. Reached from each dev host through `curl`, via the companion [`ob1-local-http`](../../skills/ob1-local-http/) skill -- no MCP transport involved.
+
+## Why this exists (deliberate exception to canonical OB1)
+
+The canonical OB1 architecture assumes (a) Claude Code can call a remote Supabase MCP server and (b) Supabase Cloud is reachable. This recipe is intentionally for environments where neither is true:
+
+- **No third-party cloud reachable** -- the host can only talk to other LAN hosts. Supabase Cloud is off the table; everything runs on a single Linux box in the office.
+- **MCP feature disabled in Claude Code** -- corporate policy or a locked-down build blocks Claude Code from speaking MCP at all (stdio or remote). The canonical capture/search tools therefore can't run.
+
+So this recipe diverges from `CLAUDE.md`'s rule "MCP servers must be remote Supabase Edge Functions." It still uses Edge Functions, but exposes them as plain HTTPS endpoints -- not as MCP -- because the network won't let MCP through. The skill on each dev host calls those endpoints with `curl`. Cloud-shaped OB1 recipes that target PostgREST/Edge Functions still work locally with a base-URL swap; only the MCP transport is gone.
+
+If your environment does NOT have these constraints, use the canonical cloud OB1 instead -- this recipe trades roughly 30 minutes of setup, ~3 GB RAM, and operational complexity for the air-gapped/no-MCP property.
+
+## What you get
+
+After setup, on one office Linux host:
+
+- Postgres 15 with `pgvector` (HNSW index on a configurable embedding dim, default 768)
+- The full Supabase stack (Kong gateway, PostgREST, GoTrue, Realtime, Storage, Studio, Edge Functions runtime, Logflare) -- canonical, unmodified, just self-hosted
+- An `ollama` sidecar that the Edge Functions call for embedding generation -- dev hosts never need Ollama
+- A `thoughts` table that mirrors the canonical OB1 schema exactly, plus `match_thoughts(...)` and `upsert_thought(...)` RPCs with the same signatures as cloud
+- Three Edge Functions reachable through Kong:
+  - `POST /functions/v1/capture` -- embed and store
+  - `POST /functions/v1/search` -- embed query and run match_thoughts
+  - `GET  /functions/v1/list` -- recent thoughts for browsing or downstream digest skills
+- Supabase Studio at `http://<brain-host>:3000` -- your day-one read-only dashboard, free
+- A `BRAIN_URL` + `BRAIN_ANON_KEY` pair that you paste into each dev host's environment for the [`ob1-local-http`](../../skills/ob1-local-http/) skill
+
+## Prerequisites
+
+On the **brain host** (one Linux box on the office network):
+
+- Docker 24+ with Compose v2.20+ (`include:` directive required)
+- `git`, `openssl`, `python3` (stdlib only -- no `pip install`)
+- ~8 GB RAM available, ~5 GB disk for images and the embedding model
+- Outbound HTTPS to GitHub and to the configured Docker registry, *one-time*, for the clone and image pulls
+- A stable hostname or IP reachable from every dev host (e.g., `brain.local`)
+
+On each **dev host**:
+
+- `curl`
+- Claude Code (or any skill-aware AI tool that reads `~/.claude/skills/`)
+
+## Setup
+
+> Run all of these on the **brain host**, from this directory (`recipes/local-brain-no-mcp/`).
+
+1. Copy `.env.example` to `.env` and edit the overlay values if you want non-defaults. The important one is `EMBED_DIM` -- see the one-way door warning below before you change it.
+
+   ```sh
+   cp .env.example .env
+   $EDITOR .env
+   ```
+
+2. Run the one-time setup. It clones `supabase/supabase`, generates secrets (POSTGRES_PASSWORD, JWT_SECRET, ANON_KEY, SERVICE_ROLE_KEY, dashboard password, vault key, logflare tokens), writes them to `supabase-docker/docker/.env`, symlinks the Edge Functions into the supabase volume, and installs the SQL init scripts.
+
+   ```sh
+   ./setup.sh
+   ```
+
+   `setup.sh` is idempotent. Re-running preserves an existing `.env` so already-captured data stays accessible.
+
+3. Bring up the stack.
+
+   ```sh
+   docker compose up -d
+   docker compose ps
+   ```
+
+   First boot pulls ~3 GB of images and runs the Postgres init scripts (creating the `thoughts` table, indexes, RPCs).
+
+4. Pull the embedding model into Ollama (one-time, model size depends on choice):
+
+   ```sh
+   docker compose exec ollama ollama pull "$(grep ^EMBED_MODEL supabase-docker/docker/.env | cut -d= -f2-)"
+   ```
+
+5. Verify reachability from the brain host itself:
+
+   ```sh
+   ANON_KEY="$(grep ^ANON_KEY supabase-docker/docker/.env | cut -d= -f2-)"
+   curl -fsS -X POST "http://localhost:8000/functions/v1/capture" \
+     -H "apikey: $ANON_KEY" \
+     -H "Authorization: Bearer $ANON_KEY" \
+     -H "Content-Type: application/json" \
+     -d '{"content":"first thought from setup.sh smoke test","metadata":{"source":"smoke-test"}}'
+   ```
+
+   Expected: HTTP 200 with `{"ok":true,"id":"...","fingerprint":"..."}`.
+
+6. On each dev host, install [`ob1-local-http`](../../skills/ob1-local-http/) and export the two env vars `setup.sh` printed at the end. The skill takes over from there.
+
+## Expected outcome
+
+- Claude Code on any dev host can capture and search thoughts by asking in natural language ("remember X", "what did I note about Y") and the skill translates that into `curl` against the brain.
+- The brain accumulates thoughts in `public.thoughts`, vector-indexed for similarity search.
+- Supabase Studio at `http://<brain-host>:3000` lets you browse, edit, or delete rows manually.
+- Nothing leaves the LAN.
+
+## The embedding model is a one-way door
+
+The `EMBED_DIM` env var is baked into the `embedding vector(N)` column when the Postgres volume is initialized. pgvector enforces this at insert time -- once the volume exists, **you cannot change `EMBED_DIM` without wiping the volume and losing all captured thoughts.**
+
+What this means in practice:
+
+- Pick `EMBED_MODEL` / `EMBED_DIM` once before first boot.
+- If you must change them later:
+  1. `docker compose down`
+  2. Back up first (see below) if you want to migrate data
+  3. `docker volume rm` the Postgres data volume (find it with `docker volume ls | grep db`)
+  4. Edit `supabase-docker/docker/.env` to the new dim
+  5. `docker compose up -d` -- Postgres re-runs the init scripts with the new dim
+  6. Re-embed your backed-up content via the new model
+
+The `embed.ts` helper does a dim check on every call and returns a clear error (`embedding-dim mismatch...`) if the model and the column disagree.
+
+## Backup and restore
+
+Stop the stack first, then snapshot the data volumes:
+
+```sh
+docker compose stop db
+docker run --rm \
+  -v "$(docker volume ls -q | grep _db-config):/from" \
+  -v "$(pwd)/backups:/to" \
+  alpine tar czf "/to/db-$(date +%F).tar.gz" -C /from .
+docker compose start db
+```
+
+To restore: `docker compose down`, `docker volume rm` the db volume, recreate empty, untar into it, `docker compose up -d`.
+
+## Troubleshooting
+
+- **`docker compose` fails with `unknown field "include"`**: you're on Compose < 2.20. Upgrade Docker Desktop or install a current `docker compose` plugin.
+- **`functions` service exits with module-resolution errors against `_shared/*.ts`**: the symlinks didn't take. Check `ls -la supabase-docker/docker/volumes/functions/` -- you should see `capture`, `search`, `list`, `_shared` as symlinks pointing back at this recipe. Re-run `./setup.sh`.
+- **`embed.ts: did you 'ollama pull <model>'?`**: you skipped step 4. Run the `ollama pull` line.
+- **`embed.ts: embedding-dim mismatch`**: someone changed `EMBED_DIM` in `.env` after the volume was initialized. Either revert the env or follow the one-way-door procedure above.
+- **HTTP 401 from Kong**: `ANON_KEY` in `.env` and the one your dev host is using are out of sync. Re-export from `supabase-docker/docker/.env`.
+- **Dev host can't reach `http://<brain-host>:8000`**: confirm the brain host's firewall allows `KONG_HTTP_PORT` inbound on the office network and that the hostname resolves.
+
+## Related
+
+- [`skills/ob1-local-http`](../../skills/ob1-local-http/) -- the companion skill pack that runs on each dev host
+- [`docs/drafts/agent-memory-staging-base.sql`](../../docs/drafts/agent-memory-staging-base.sql) -- the canonical thoughts schema this recipe mirrors
+- [`server/index.ts`](../../server/index.ts) -- the canonical MCP server this recipe deliberately does NOT use as a transport

--- a/recipes/local-brain-no-mcp/docker-compose.yml
+++ b/recipes/local-brain-no-mcp/docker-compose.yml
@@ -1,0 +1,49 @@
+# local-brain-no-mcp -- docker compose overlay
+#
+# This file merges the official supabase/supabase docker-compose stack with
+# our additions (Ollama + EMBED_* env vars). Run from this directory:
+#
+#     ./setup.sh             # one-time
+#     docker compose up -d   # bring up the brain
+#
+# `include:` resolves paths relative to the parent compose file, so
+# supabase-docker/ must be a sibling directory (setup.sh handles this).
+# Requires Docker Compose v2.20 or newer.
+
+include:
+  - path: supabase-docker/docker/docker-compose.yml
+    env_file: supabase-docker/docker/.env
+
+services:
+  ollama:
+    image: ollama/ollama:0.6.5
+    container_name: ob1-ollama
+    restart: unless-stopped
+    networks:
+      - default
+    ports:
+      - "${OLLAMA_PORT:-11434}:11434"
+    volumes:
+      - ollama_data:/root/.ollama
+    healthcheck:
+      test: ["CMD-SHELL", "ollama list >/dev/null 2>&1"]
+      interval: 30s
+      timeout: 10s
+      retries: 5
+      start_period: 60s
+
+  # Extend supabase's Edge Functions service so our handlers can find Ollama
+  # and know which model/dim to use. The functions volume mount comes from
+  # supabase's compose (./volumes/functions) -- setup.sh symlinks our handler
+  # dirs into there.
+  functions:
+    environment:
+      OLLAMA_URL: ${OLLAMA_URL:-http://ollama:11434}
+      EMBED_MODEL: ${EMBED_MODEL:-nomic-embed-text}
+      EMBED_DIM: ${EMBED_DIM:-768}
+    depends_on:
+      ollama:
+        condition: service_healthy
+
+volumes:
+  ollama_data:

--- a/recipes/local-brain-no-mcp/functions/_shared/cors.ts
+++ b/recipes/local-brain-no-mcp/functions/_shared/cors.ts
@@ -1,0 +1,21 @@
+export const corsHeaders = {
+  "Access-Control-Allow-Origin": "*",
+  "Access-Control-Allow-Headers":
+    "authorization, x-client-info, apikey, content-type",
+  "Access-Control-Allow-Methods": "POST, GET, OPTIONS",
+};
+
+export function jsonResponse(
+  body: unknown,
+  status = 200,
+  extraHeaders: Record<string, string> = {},
+): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: {
+      "Content-Type": "application/json",
+      ...corsHeaders,
+      ...extraHeaders,
+    },
+  });
+}

--- a/recipes/local-brain-no-mcp/functions/_shared/db.ts
+++ b/recipes/local-brain-no-mcp/functions/_shared/db.ts
@@ -1,0 +1,14 @@
+import { createClient, type SupabaseClient } from "jsr:@supabase/supabase-js@2";
+
+const SUPABASE_URL = Deno.env.get("SUPABASE_URL");
+const SERVICE_ROLE_KEY = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY");
+
+if (!SUPABASE_URL || !SERVICE_ROLE_KEY) {
+  throw new Error(
+    "SUPABASE_URL and SUPABASE_SERVICE_ROLE_KEY must be set by the Edge Functions runtime",
+  );
+}
+
+export const db: SupabaseClient = createClient(SUPABASE_URL, SERVICE_ROLE_KEY, {
+  auth: { autoRefreshToken: false, persistSession: false },
+});

--- a/recipes/local-brain-no-mcp/functions/_shared/embed.ts
+++ b/recipes/local-brain-no-mcp/functions/_shared/embed.ts
@@ -1,0 +1,56 @@
+// Server-side embedding via a local Ollama sidecar. Dev hosts never need
+// Ollama -- the capture and search Edge Functions both call this helper.
+
+const OLLAMA_URL = Deno.env.get("OLLAMA_URL") ?? "http://ollama:11434";
+const EMBED_MODEL = Deno.env.get("EMBED_MODEL") ?? "nomic-embed-text";
+const EMBED_DIM = Number(Deno.env.get("EMBED_DIM") ?? "768");
+
+export class EmbedError extends Error {
+  constructor(message: string, public readonly cause?: unknown) {
+    super(message);
+    this.name = "EmbedError";
+  }
+}
+
+export async function embed(text: string): Promise<number[]> {
+  const trimmed = text?.trim();
+  if (!trimmed) throw new EmbedError("empty text");
+
+  let r: Response;
+  try {
+    r = await fetch(`${OLLAMA_URL}/api/embeddings`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ model: EMBED_MODEL, prompt: trimmed }),
+    });
+  } catch (e) {
+    throw new EmbedError(
+      `unable to reach Ollama at ${OLLAMA_URL} -- is the ollama container running?`,
+      e,
+    );
+  }
+
+  if (!r.ok) {
+    const body = await r.text().catch(() => "");
+    throw new EmbedError(
+      `Ollama embedding failed: HTTP ${r.status} ${r.statusText} -- ${body.slice(0, 200)}`,
+    );
+  }
+
+  const data = await r.json();
+  const v = data?.embedding;
+  if (!Array.isArray(v) || v.length === 0) {
+    throw new EmbedError(
+      `Ollama returned no embedding -- did you 'ollama pull ${EMBED_MODEL}'?`,
+    );
+  }
+  if (v.length !== EMBED_DIM) {
+    throw new EmbedError(
+      `embedding-dim mismatch: env EMBED_DIM=${EMBED_DIM} but Ollama returned ${v.length}. ` +
+        `Either change EMBED_MODEL to one that produces ${EMBED_DIM} dims, or wipe the Postgres volume and re-bootstrap with the new dim.`,
+    );
+  }
+  return v;
+}
+
+export const config = { EMBED_MODEL, EMBED_DIM, OLLAMA_URL };

--- a/recipes/local-brain-no-mcp/functions/capture/index.ts
+++ b/recipes/local-brain-no-mcp/functions/capture/index.ts
@@ -1,0 +1,67 @@
+// POST /functions/v1/capture
+//
+// Body:
+//   { content: string, metadata?: object }
+//
+// Embeds `content` via the local Ollama sidecar and INSERTs via the
+// upsert_thought() RPC (which dedupes by sha256(normalized content)).
+//
+// Auth: Kong gateway verifies the anon-or-service-role JWT before this
+// function runs. We do not re-check.
+
+import { corsHeaders, jsonResponse } from "../_shared/cors.ts";
+import { embed, EmbedError } from "../_shared/embed.ts";
+import { db } from "../_shared/db.ts";
+
+interface CaptureBody {
+  content?: unknown;
+  metadata?: unknown;
+}
+
+Deno.serve(async (req: Request) => {
+  if (req.method === "OPTIONS") {
+    return new Response(null, { status: 204, headers: corsHeaders });
+  }
+  if (req.method !== "POST") {
+    return jsonResponse({ error: "method not allowed" }, 405);
+  }
+
+  let body: CaptureBody;
+  try {
+    body = await req.json();
+  } catch {
+    return jsonResponse({ error: "body must be valid JSON" }, 400);
+  }
+
+  const content = typeof body.content === "string" ? body.content.trim() : "";
+  if (!content) {
+    return jsonResponse({ error: "content is required (non-empty string)" }, 400);
+  }
+  const metadata =
+    body.metadata && typeof body.metadata === "object" && !Array.isArray(body.metadata)
+      ? body.metadata
+      : {};
+
+  let vec: number[];
+  try {
+    vec = await embed(content);
+  } catch (e) {
+    if (e instanceof EmbedError) return jsonResponse({ error: e.message }, 502);
+    throw e;
+  }
+
+  const { data, error } = await db.rpc("upsert_thought", {
+    p_content: content,
+    p_embedding: vec,
+    p_metadata: metadata,
+  });
+
+  if (error) {
+    return jsonResponse(
+      { error: `upsert_thought failed: ${error.message}`, details: error.details ?? null },
+      500,
+    );
+  }
+
+  return jsonResponse({ ok: true, ...data }, 200);
+});

--- a/recipes/local-brain-no-mcp/functions/list/index.ts
+++ b/recipes/local-brain-no-mcp/functions/list/index.ts
@@ -1,0 +1,35 @@
+// GET /functions/v1/list?limit=20&offset=0
+//
+// Returns most-recent thoughts (id, content, metadata, created_at) for
+// browsing and for follow-on skills like ob1-digest. No embedding involved.
+
+import { corsHeaders, jsonResponse } from "../_shared/cors.ts";
+import { db } from "../_shared/db.ts";
+
+Deno.serve(async (req: Request) => {
+  if (req.method === "OPTIONS") {
+    return new Response(null, { status: 204, headers: corsHeaders });
+  }
+  if (req.method !== "GET") {
+    return jsonResponse({ error: "method not allowed" }, 405);
+  }
+
+  const url = new URL(req.url);
+  const limit = Math.min(Math.max(1, Number(url.searchParams.get("limit") ?? 20) | 0), 200);
+  const offset = Math.max(0, Number(url.searchParams.get("offset") ?? 0) | 0);
+
+  const { data, error, count } = await db
+    .from("thoughts")
+    .select("id, content, metadata, created_at", { count: "exact" })
+    .order("created_at", { ascending: false })
+    .range(offset, offset + limit - 1);
+
+  if (error) {
+    return jsonResponse({ error: `list failed: ${error.message}` }, 500);
+  }
+
+  return jsonResponse(
+    { ok: true, limit, offset, total: count ?? null, results: data ?? [] },
+    200,
+  );
+});

--- a/recipes/local-brain-no-mcp/functions/search/index.ts
+++ b/recipes/local-brain-no-mcp/functions/search/index.ts
@@ -1,0 +1,74 @@
+// POST /functions/v1/search
+//
+// Body:
+//   { query: string, match_threshold?: number, match_count?: number, filter?: object }
+//
+// Embeds the query server-side, then calls match_thoughts() over the
+// thoughts table. Returns rows ordered by descending cosine similarity.
+//
+// Defaults mirror the canonical match_thoughts(): threshold 0.7, count 10.
+
+import { corsHeaders, jsonResponse } from "../_shared/cors.ts";
+import { embed, EmbedError } from "../_shared/embed.ts";
+import { db } from "../_shared/db.ts";
+
+interface SearchBody {
+  query?: unknown;
+  match_threshold?: unknown;
+  match_count?: unknown;
+  filter?: unknown;
+}
+
+Deno.serve(async (req: Request) => {
+  if (req.method === "OPTIONS") {
+    return new Response(null, { status: 204, headers: corsHeaders });
+  }
+  if (req.method !== "POST") {
+    return jsonResponse({ error: "method not allowed" }, 405);
+  }
+
+  let body: SearchBody;
+  try {
+    body = await req.json();
+  } catch {
+    return jsonResponse({ error: "body must be valid JSON" }, 400);
+  }
+
+  const query = typeof body.query === "string" ? body.query.trim() : "";
+  if (!query) {
+    return jsonResponse({ error: "query is required (non-empty string)" }, 400);
+  }
+
+  const match_threshold =
+    typeof body.match_threshold === "number" ? body.match_threshold : 0.7;
+  const match_count =
+    typeof body.match_count === "number" ? Math.min(Math.max(1, body.match_count | 0), 100) : 10;
+  const filter =
+    body.filter && typeof body.filter === "object" && !Array.isArray(body.filter)
+      ? body.filter
+      : {};
+
+  let vec: number[];
+  try {
+    vec = await embed(query);
+  } catch (e) {
+    if (e instanceof EmbedError) return jsonResponse({ error: e.message }, 502);
+    throw e;
+  }
+
+  const { data, error } = await db.rpc("match_thoughts", {
+    query_embedding: vec,
+    match_threshold,
+    match_count,
+    filter,
+  });
+
+  if (error) {
+    return jsonResponse(
+      { error: `match_thoughts failed: ${error.message}`, details: error.details ?? null },
+      500,
+    );
+  }
+
+  return jsonResponse({ ok: true, query, count: (data ?? []).length, results: data ?? [] }, 200);
+});

--- a/recipes/local-brain-no-mcp/metadata.json
+++ b/recipes/local-brain-no-mcp/metadata.json
@@ -1,0 +1,35 @@
+{
+  "name": "Local Brain (No MCP)",
+  "description": "Self-hosted Open Brain on a single LAN host: official Supabase docker stack + Ollama for local embeddings + two Edge Functions (capture, search). Designed for office networks that block third-party cloud and disable Claude Code's MCP feature. Accessed via plain HTTPS from each dev host through the companion ob1-local-http skill.",
+  "category": "recipes",
+  "author": {
+    "name": "dhanjit",
+    "github": "dhanjit"
+  },
+  "version": "0.1.0",
+  "requires": {
+    "open_brain": true,
+    "services": [],
+    "tools": [
+      "Docker 24+ with Compose v2.20+",
+      "git",
+      "openssl",
+      "python3"
+    ]
+  },
+  "requires_skills": ["ob1-local-http"],
+  "tags": [
+    "self-hosted",
+    "local",
+    "supabase",
+    "pgvector",
+    "ollama",
+    "no-mcp",
+    "air-gapped",
+    "lan"
+  ],
+  "difficulty": "advanced",
+  "estimated_time": "45 minutes",
+  "created": "2026-05-13",
+  "updated": "2026-05-13"
+}

--- a/recipes/local-brain-no-mcp/setup.sh
+++ b/recipes/local-brain-no-mcp/setup.sh
@@ -1,0 +1,235 @@
+#!/usr/bin/env bash
+# local-brain-no-mcp -- one-time setup
+#
+# What this does:
+#   1. Verifies host prereqs (docker, compose >= 2.20, git, openssl, python3)
+#   2. Clones supabase/supabase to ./supabase-docker (if missing)
+#   3. Writes supabase-docker/docker/.env with freshly generated secrets
+#      (POSTGRES_PASSWORD, JWT_SECRET, ANON_KEY, SERVICE_ROLE_KEY, dashboard
+#      creds, vault key, logflare tokens) and appends our embedding/Ollama vars
+#   4. Symlinks recipes/local-brain-no-mcp/functions/{capture,search,_shared}
+#      into supabase-docker/docker/volumes/functions/
+#   5. Copies the thoughts schema init scripts into
+#      supabase-docker/docker/volumes/db/init/
+#
+# Idempotent: re-running will not overwrite an existing .env (and therefore
+# will not invalidate keys for already-captured data).
+
+set -euo pipefail
+
+# ---------- locations ----------
+RECIPE_DIR="$(cd "$(dirname "$0")" && pwd)"
+SUPABASE_DIR="${RECIPE_DIR}/supabase-docker"
+DOCKER_DIR="${SUPABASE_DIR}/docker"
+ENV_FILE="${DOCKER_DIR}/.env"
+INIT_DIR="${DOCKER_DIR}/volumes/db/init"
+FN_DIR="${DOCKER_DIR}/volumes/functions"
+
+log() { printf '  \033[36m==>\033[0m %s\n' "$*"; }
+warn() { printf '  \033[33m!!!\033[0m %s\n' "$*" >&2; }
+die() { printf '  \033[31mxxx\033[0m %s\n' "$*" >&2; exit 1; }
+
+# ---------- prereqs ----------
+check_prereqs() {
+  command -v docker >/dev/null || die "docker not found"
+  command -v git    >/dev/null || die "git not found"
+  command -v openssl>/dev/null || die "openssl not found"
+  command -v python3>/dev/null || die "python3 not found"
+
+  local v
+  v="$(docker compose version --short 2>/dev/null || true)"
+  [ -n "$v" ] || die "docker compose v2 not found"
+  # crude semver compare: require >= 2.20
+  local major minor
+  major="${v%%.*}"; minor="${v#*.}"; minor="${minor%%.*}"
+  if [ "$major" -lt 2 ] || { [ "$major" -eq 2 ] && [ "$minor" -lt 20 ]; }; then
+    die "docker compose >= 2.20 required (you have $v) -- 'include:' directive needed"
+  fi
+  log "prereqs ok (docker compose $v)"
+}
+
+# ---------- clone supabase ----------
+clone_supabase() {
+  if [ -d "$SUPABASE_DIR/.git" ]; then
+    log "supabase-docker already cloned -- skipping"
+    return
+  fi
+  log "cloning supabase/supabase (shallow)..."
+  git clone --depth 1 https://github.com/supabase/supabase "$SUPABASE_DIR"
+  [ -f "${DOCKER_DIR}/docker-compose.yml" ] || die "cloned supabase but docker/docker-compose.yml not present -- repo layout may have changed"
+}
+
+# ---------- secrets ----------
+gen_secret_hex() { openssl rand -hex "${1:-32}"; }
+
+gen_jwts() {
+  # writes ANON_KEY and SERVICE_ROLE_KEY to stdout as two lines
+  local jwt_secret="$1"
+  python3 - "$jwt_secret" <<'PY'
+import sys, json, hmac, hashlib, base64, time
+secret = sys.argv[1].encode()
+
+def b64u(b):
+    return base64.urlsafe_b64encode(b).rstrip(b"=").decode()
+
+def sign(payload):
+    header = {"alg": "HS256", "typ": "JWT"}
+    h = b64u(json.dumps(header,    separators=(",", ":")).encode())
+    p = b64u(json.dumps(payload,   separators=(",", ":")).encode())
+    sig = hmac.new(secret, f"{h}.{p}".encode(), hashlib.sha256).digest()
+    return f"{h}.{p}.{b64u(sig)}"
+
+now = int(time.time())
+exp = now + 10 * 365 * 24 * 3600  # 10 years
+print(sign({"iss": "supabase", "role": "anon",         "iat": now, "exp": exp}))
+print(sign({"iss": "supabase", "role": "service_role", "iat": now, "exp": exp}))
+PY
+}
+
+write_env() {
+  if [ -f "$ENV_FILE" ]; then
+    warn ".env already exists at $ENV_FILE -- preserving existing secrets"
+    return
+  fi
+
+  local example="${DOCKER_DIR}/.env.example"
+  [ -f "$example" ] || die "$example not found in cloned supabase repo"
+
+  log "generating secrets..."
+  local pg_pass jwt_secret anon srk dash_pass vault_key
+  pg_pass="$(gen_secret_hex 24)"
+  jwt_secret="$(gen_secret_hex 32)"
+  dash_pass="$(gen_secret_hex 16)"
+  vault_key="$(gen_secret_hex 16)"  # 32 hex chars = 16 bytes
+
+  local jwts
+  jwts="$(gen_jwts "$jwt_secret")"
+  anon="$(printf '%s\n' "$jwts" | sed -n 1p)"
+  srk="$( printf '%s\n' "$jwts" | sed -n 2p)"
+
+  log "writing $ENV_FILE..."
+  # Start from upstream example, replace the placeholder values. Supabase's
+  # example uses recognizable defaults like "your-super-secret-..." so we
+  # target those.
+  cp "$example" "$ENV_FILE"
+
+  # Replace the documented placeholder values. We do this with python so we
+  # don't have to worry about sed escaping characters in the generated
+  # secrets.
+  python3 - "$ENV_FILE" "$pg_pass" "$jwt_secret" "$anon" "$srk" "$dash_pass" "$vault_key" <<'PY'
+import sys, re, pathlib
+path = pathlib.Path(sys.argv[1])
+pg_pass, jwt_secret, anon, srk, dash_pass, vault_key = sys.argv[2:8]
+
+txt = path.read_text()
+
+def setvar(name, value):
+    global txt
+    pattern = re.compile(rf"^{re.escape(name)}=.*$", re.MULTILINE)
+    if pattern.search(txt):
+        txt = pattern.sub(f"{name}={value}", txt)
+    else:
+        txt += f"\n{name}={value}\n"
+
+setvar("POSTGRES_PASSWORD",   pg_pass)
+setvar("JWT_SECRET",          jwt_secret)
+setvar("ANON_KEY",            anon)
+setvar("SERVICE_ROLE_KEY",    srk)
+setvar("DASHBOARD_USERNAME",  "supabase")
+setvar("DASHBOARD_PASSWORD",  dash_pass)
+setvar("VAULT_ENC_KEY",       vault_key)
+# logflare tokens are required by the analytics service; use random hex.
+import secrets
+setvar("LOGFLARE_PUBLIC_ACCESS_TOKEN",  secrets.token_hex(32))
+setvar("LOGFLARE_PRIVATE_ACCESS_TOKEN", secrets.token_hex(32))
+
+path.write_text(txt)
+PY
+
+  # Append our overlay vars (EMBED_*, OLLAMA_*) sourced from .env.example.
+  log "appending overlay vars from $(basename "$RECIPE_DIR/.env.example")..."
+  {
+    printf '\n# ---------- local-brain-no-mcp overlay ----------\n'
+    grep -E '^(EMBED_|OLLAMA_|BRAIN_HOST)' "$RECIPE_DIR/.env.example" || true
+  } >> "$ENV_FILE"
+
+  chmod 600 "$ENV_FILE"
+}
+
+# ---------- functions symlinks ----------
+link_functions() {
+  mkdir -p "$FN_DIR"
+  local f
+  for f in capture search list _shared; do
+    local target="$FN_DIR/$f"
+    if [ -L "$target" ] || [ -e "$target" ]; then
+      rm -rf "$target"
+    fi
+    ln -s "${RECIPE_DIR}/functions/$f" "$target"
+    log "linked functions/$f"
+  done
+}
+
+# ---------- db init scripts ----------
+copy_init_scripts() {
+  mkdir -p "$INIT_DIR"
+  local f
+  for f in "$RECIPE_DIR"/volumes/db/init/*.sh "$RECIPE_DIR"/volumes/db/init/*.sql; do
+    [ -e "$f" ] || continue
+    cp "$f" "$INIT_DIR/"
+    chmod +x "$INIT_DIR/$(basename "$f")" 2>/dev/null || true
+    log "installed init/$(basename "$f")"
+  done
+}
+
+# ---------- pull the embed model ----------
+print_next_steps() {
+  local kong_port brain_host anon_key
+  kong_port="$(grep -E '^KONG_HTTP_PORT=' "$ENV_FILE" | cut -d= -f2-)"
+  brain_host="$(grep -E '^BRAIN_HOST='     "$ENV_FILE" | cut -d= -f2-)"
+  anon_key="$(  grep -E '^ANON_KEY='       "$ENV_FILE" | cut -d= -f2-)"
+  kong_port="${kong_port:-8000}"
+  brain_host="${brain_host:-$(hostname)}"
+
+  cat <<EOF
+
+  ${0##*/} done.
+
+  Next:
+
+    1. Bring up the stack (from this directory):
+
+         docker compose up -d
+
+    2. Pull the embedding model into Ollama (one-time, ~270 MB):
+
+         docker compose exec ollama ollama pull "\${EMBED_MODEL:-nomic-embed-text}"
+
+    3. Check Studio at:
+
+         http://${brain_host}:3000
+         user: supabase  pass: (see DASHBOARD_PASSWORD in $ENV_FILE)
+
+    4. Install the ob1-local-http skill on each dev host. Tell Claude Code:
+
+         export BRAIN_URL="http://${brain_host}:${kong_port}"
+         export BRAIN_ANON_KEY="${anon_key}"
+
+       Then 'cp -r skills/ob1-local-http ~/.claude/skills/' (or your client's
+       skill dir).
+
+  See README.md for backup, dim coherence, and the no-MCP design notes.
+
+EOF
+}
+
+main() {
+  check_prereqs
+  clone_supabase
+  write_env
+  link_functions
+  copy_init_scripts
+  print_next_steps
+}
+
+main "$@"

--- a/recipes/local-brain-no-mcp/volumes/db/init/01-thoughts-schema.sh
+++ b/recipes/local-brain-no-mcp/volumes/db/init/01-thoughts-schema.sh
@@ -1,0 +1,82 @@
+#!/bin/bash
+# local-brain-no-mcp -- thoughts schema init (idempotent)
+#
+# Runs once on first boot of the Postgres container (Docker entrypoint).
+# Substitutes ${EMBED_DIM} from the container environment into the vector
+# column dimension. Once the table exists with a given dim, the dim is fixed
+# until the Postgres volume is wiped -- pgvector will reject inserts of a
+# different-sized vector.
+#
+# This mirrors docs/drafts/agent-memory-staging-base.sql (the canonical OB1
+# thoughts schema) so that cloud-shaped recipes work against this local stack
+# with a base-URL swap. The only deviation is the parameterized embedding
+# dimension.
+
+set -e
+
+: "${EMBED_DIM:?EMBED_DIM not set -- check supabase-docker/docker/.env}"
+: "${POSTGRES_USER:?POSTGRES_USER not set by entrypoint}"
+: "${POSTGRES_DB:?POSTGRES_DB not set by entrypoint}"
+
+echo "  [init/01] creating thoughts schema with embedding vector(${EMBED_DIM})..."
+
+psql -v ON_ERROR_STOP=1 \
+     -v embed_dim="${EMBED_DIM}" \
+     --username "$POSTGRES_USER" \
+     --dbname   "$POSTGRES_DB" <<'EOSQL'
+
+CREATE EXTENSION IF NOT EXISTS vector;
+CREATE EXTENSION IF NOT EXISTS pgcrypto;
+
+CREATE TABLE IF NOT EXISTS public.thoughts (
+  id UUID DEFAULT gen_random_uuid() PRIMARY KEY,
+  content TEXT NOT NULL,
+  embedding vector(:embed_dim),
+  metadata JSONB DEFAULT '{}'::jsonb,
+  created_at TIMESTAMPTZ DEFAULT now(),
+  updated_at TIMESTAMPTZ DEFAULT now(),
+  content_fingerprint TEXT
+);
+
+CREATE INDEX IF NOT EXISTS thoughts_embedding_hnsw_idx
+  ON public.thoughts
+  USING hnsw (embedding vector_cosine_ops);
+
+CREATE INDEX IF NOT EXISTS thoughts_metadata_gin_idx
+  ON public.thoughts USING gin (metadata);
+
+CREATE INDEX IF NOT EXISTS thoughts_created_at_desc_idx
+  ON public.thoughts (created_at DESC);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_thoughts_fingerprint
+  ON public.thoughts (content_fingerprint)
+  WHERE content_fingerprint IS NOT NULL;
+
+CREATE OR REPLACE FUNCTION public.update_updated_at()
+RETURNS TRIGGER AS $$
+BEGIN
+  NEW.updated_at = now();
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS thoughts_updated_at ON public.thoughts;
+CREATE TRIGGER thoughts_updated_at
+  BEFORE UPDATE ON public.thoughts
+  FOR EACH ROW
+  EXECUTE FUNCTION public.update_updated_at();
+
+ALTER TABLE public.thoughts ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS "Service role full access" ON public.thoughts;
+CREATE POLICY "Service role full access"
+  ON public.thoughts
+  FOR ALL
+  USING (auth.role() = 'service_role')
+  WITH CHECK (auth.role() = 'service_role');
+
+GRANT SELECT, INSERT, UPDATE, DELETE ON TABLE public.thoughts TO service_role;
+
+EOSQL
+
+echo "  [init/01] done."

--- a/recipes/local-brain-no-mcp/volumes/db/init/02-match-thoughts-fn.sh
+++ b/recipes/local-brain-no-mcp/volumes/db/init/02-match-thoughts-fn.sh
@@ -1,0 +1,89 @@
+#!/bin/bash
+# local-brain-no-mcp -- match_thoughts RPC (idempotent)
+#
+# Mirrors the canonical match_thoughts signature so PostgREST exposes
+# `/rest/v1/rpc/match_thoughts` with the same shape as cloud OB1. The Edge
+# Functions in this recipe DON'T call this directly via PostgREST -- they
+# invoke it as a plain plpgsql function from inside a service-role
+# connection -- but exposing it via PostgREST means cloud-shaped clients
+# can use it too if you ever drop RLS.
+
+set -e
+
+: "${EMBED_DIM:?EMBED_DIM not set}"
+: "${POSTGRES_USER:?POSTGRES_USER not set}"
+: "${POSTGRES_DB:?POSTGRES_DB not set}"
+
+echo "  [init/02] creating match_thoughts(vector(${EMBED_DIM}), ...) ..."
+
+psql -v ON_ERROR_STOP=1 \
+     -v embed_dim="${EMBED_DIM}" \
+     --username "$POSTGRES_USER" \
+     --dbname   "$POSTGRES_DB" <<'EOSQL'
+
+CREATE OR REPLACE FUNCTION public.match_thoughts(
+  query_embedding vector(:embed_dim),
+  match_threshold FLOAT DEFAULT 0.7,
+  match_count INT DEFAULT 10,
+  filter JSONB DEFAULT '{}'::jsonb
+)
+RETURNS TABLE (
+  id UUID,
+  content TEXT,
+  metadata JSONB,
+  similarity FLOAT,
+  created_at TIMESTAMPTZ
+)
+LANGUAGE plpgsql
+AS $$
+BEGIN
+  RETURN QUERY
+  SELECT
+    t.id,
+    t.content,
+    t.metadata,
+    1 - (t.embedding <=> query_embedding) AS similarity,
+    t.created_at
+  FROM public.thoughts t
+  WHERE 1 - (t.embedding <=> query_embedding) > match_threshold
+    AND (filter = '{}'::jsonb OR t.metadata @> filter)
+  ORDER BY t.embedding <=> query_embedding
+  LIMIT match_count;
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION public.match_thoughts(vector, FLOAT, INT, JSONB) TO service_role;
+
+CREATE OR REPLACE FUNCTION public.upsert_thought(
+  p_content TEXT,
+  p_embedding vector(:embed_dim),
+  p_metadata JSONB DEFAULT '{}'::jsonb
+)
+RETURNS JSONB AS $$
+DECLARE
+  v_fingerprint TEXT;
+  v_id UUID;
+BEGIN
+  v_fingerprint := encode(sha256(convert_to(
+    lower(trim(regexp_replace(p_content, '\s+', ' ', 'g'))),
+    'UTF8'
+  )), 'hex');
+
+  INSERT INTO public.thoughts (content, embedding, content_fingerprint, metadata)
+  VALUES (p_content, p_embedding, v_fingerprint, p_metadata)
+  ON CONFLICT (content_fingerprint) WHERE content_fingerprint IS NOT NULL DO UPDATE
+    SET updated_at = now(),
+        metadata   = public.thoughts.metadata || EXCLUDED.metadata
+  RETURNING id INTO v_id;
+
+  RETURN jsonb_build_object('id', v_id, 'fingerprint', v_fingerprint);
+END;
+$$ LANGUAGE plpgsql;
+
+GRANT EXECUTE ON FUNCTION public.upsert_thought(TEXT, vector, JSONB) TO service_role;
+
+NOTIFY pgrst, 'reload schema';
+
+EOSQL
+
+echo "  [init/02] done."

--- a/skills/ob1-local-http/README.md
+++ b/skills/ob1-local-http/README.md
@@ -1,0 +1,65 @@
+# OB1 Local HTTP
+
+Skill pack that lets Claude Code (or any skill-aware AI coding tool) capture and search thoughts against a self-hosted Open Brain over plain HTTPS, with no MCP transport involved. Pairs with the [`local-brain-no-mcp`](../../recipes/local-brain-no-mcp/) recipe.
+
+## What it does
+
+Tells the AI coding tool, in `SKILL.md`, how to:
+
+1. Recognize when the user wants to capture, search, or browse thoughts.
+2. Translate those intents into authenticated HTTP calls (`curl`) against the LAN-resident Open Brain stack.
+3. Surface results, score-ordered for searches, time-ordered for browses, and confirmation-ids for captures.
+
+No MCP server is started, registered, or referenced. The skill is pure bash-via-curl.
+
+## Prerequisites
+
+- The [`local-brain-no-mcp`](../../recipes/local-brain-no-mcp/) recipe deployed on a host reachable from this dev host on the local network.
+- Claude Code (or a compatible skill-aware AI tool) installed on this dev host.
+- `curl` installed (default on every Linux and macOS).
+
+## Setup
+
+1. Get the brain host's URL and anon key. After the brain admin runs `setup.sh`, the values are printed at the bottom of that script's output -- and are also stored in `supabase-docker/docker/.env` on the brain host as `ANON_KEY` and the printed `BRAIN_HOST` + `KONG_HTTP_PORT`.
+
+2. On this dev host, export both as environment variables (add them to your shell rc file so they persist):
+
+   ```sh
+   export BRAIN_URL="http://brain.local:8000"
+   export BRAIN_ANON_KEY="eyJhbGciOi..."
+   ```
+
+3. Install the skill into your AI tool's skills directory. For Claude Code:
+
+   ```sh
+   mkdir -p ~/.claude/skills
+   cp -r skills/ob1-local-http ~/.claude/skills/
+   ```
+
+   For other tools, copy the directory into wherever they read skills from.
+
+4. Verify reachability:
+
+   ```sh
+   curl -fsS "$BRAIN_URL/functions/v1/list?limit=1" \
+     -H "apikey: $BRAIN_ANON_KEY" \
+     -H "Authorization: Bearer $BRAIN_ANON_KEY"
+   ```
+
+   Expected: HTTP 200 with `{"ok":true,"limit":1,"offset":0,"total":N,"results":[...]}`.
+
+## Expected outcome
+
+When asking Claude Code things like "remember that the Q3 sales review is on the 14th" or "what did I note about the Apex deal", the tool calls the brain over curl and confirms or returns matches, without ever invoking an MCP feature.
+
+## Troubleshooting
+
+- **Skill not picked up**: confirm Claude Code's skills directory and that `SKILL.md` is at `<skills-dir>/ob1-local-http/SKILL.md`.
+- **`BRAIN_URL` or `BRAIN_ANON_KEY` not set**: re-source your shell rc or export them in the current shell.
+- **HTTP 401/403**: the anon key is wrong or the brain host has been re-bootstrapped (which rotates keys). Re-export the new `ANON_KEY` from `supabase-docker/docker/.env`.
+- **HTTP 502 with embedding errors**: see the failure modes section in `SKILL.md` -- usually an Ollama issue on the brain host, not on this dev host.
+- **Network unreachable**: ping `<brain-host>` and check the brain host's firewall is open on `KONG_HTTP_PORT`.
+
+## Why no MCP
+
+This skill exists because some environments disable Claude Code's MCP feature entirely (corporate policy, locked-down build, restricted network). When MCP is unavailable, the canonical OB1 capture/search tools don't work. This skill is the documented HTTP-only fallback. See the recipe's README for the architectural rationale.

--- a/skills/ob1-local-http/SKILL.md
+++ b/skills/ob1-local-http/SKILL.md
@@ -1,0 +1,127 @@
+---
+name: ob1-local-http
+description: |
+  Capture and search thoughts against a self-hosted Open Brain over plain
+  HTTPS, with no MCP transport involved. Use this skill in environments
+  where Claude Code's MCP feature is disabled or the network blocks remote
+  MCP endpoints, but the brain stack from the companion `local-brain-no-mcp`
+  recipe is reachable on the local network. Triggers: prompts like
+  "remember this", "save that for later", "what did I note about X",
+  "search my brain for Y", "what thoughts touched on Z", or any explicit
+  request to record or recall personal memory.
+author: dhanjit
+version: 0.1.0
+---
+
+# OB1 Local HTTP
+
+## Problem
+
+The canonical Open Brain stack assumes Claude Code can talk to a remote
+Supabase MCP server. In environments that disable MCP entirely -- corporate
+networks, air-gapped offices, restricted Claude Code builds -- that path is
+not available. This skill replaces it with `curl` calls to a LAN-resident
+Open Brain (see the `local-brain-no-mcp` recipe), keeping the same
+capture-and-recall behavior without any MCP protocol involvement.
+
+## When to Use
+
+- The user wants to remember, record, save, capture, or note something.
+- The user wants to search, recall, retrieve, find, or look up something
+  they previously captured.
+- The user wants to see recent thoughts (e.g. "what have I been thinking
+  about", "show me today's notes").
+
+## When Not to Use
+
+- The environment has a working remote Open Brain MCP connection -- prefer
+  the canonical MCP-based capture/search tools.
+- The required environment variables `BRAIN_URL` and `BRAIN_ANON_KEY` are
+  not set on the dev host -- this skill cannot function without them; ask
+  the user to follow `local-brain-no-mcp`'s install instructions first.
+
+## Required Environment
+
+On each dev host that will use this skill, the user must export:
+
+```sh
+export BRAIN_URL="http://<brain-host>:8000"   # Supabase Kong gateway
+export BRAIN_ANON_KEY="eyJhbGciOi..."          # written by setup.sh
+```
+
+If either is missing, stop and tell the user. Do not guess values.
+
+## Process
+
+### Capture
+
+When the user says something like "remember X" or "save this thought":
+
+```sh
+curl -fsS -X POST "$BRAIN_URL/functions/v1/capture" \
+  -H "apikey: $BRAIN_ANON_KEY" \
+  -H "Authorization: Bearer $BRAIN_ANON_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"content":"<the thought>","metadata":{"source":"claude-code"}}'
+```
+
+Optional `metadata` fields: `source`, `tags` (array of strings),
+`thread_id`, anything else useful. The server fingerprints content and
+de-duplicates -- re-capturing identical text returns the existing id.
+
+### Search
+
+When the user wants to recall:
+
+```sh
+curl -fsS -X POST "$BRAIN_URL/functions/v1/search" \
+  -H "apikey: $BRAIN_ANON_KEY" \
+  -H "Authorization: Bearer $BRAIN_ANON_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"query":"<what to find>","match_count":10,"match_threshold":0.65}'
+```
+
+`match_threshold` defaults to 0.7. Lower it to 0.5-0.65 for broader recall;
+raise to 0.8+ for precision. Cap `match_count` at 100.
+
+### Browse recent
+
+When the user asks "what have I been thinking about" or wants a list rather
+than a similarity search:
+
+```sh
+curl -fsS "$BRAIN_URL/functions/v1/list?limit=20" \
+  -H "apikey: $BRAIN_ANON_KEY" \
+  -H "Authorization: Bearer $BRAIN_ANON_KEY"
+```
+
+## Output
+
+- For captures: confirm the id and the de-dupe fingerprint to the user in
+  one sentence. Don't paraphrase the captured content back at them.
+- For searches: surface the top results with similarity scores and
+  created_at timestamps. Order by similarity descending. If no results
+  cross the threshold, say so plainly and suggest lowering it.
+- For browse: a compact bullet list with truncated content (first ~120
+  chars) and timestamps.
+
+## Failure Modes
+
+- HTTP 502 with "unable to reach Ollama": the brain host's Ollama service
+  is down. Tell the user to `docker compose ps` on the brain host.
+- HTTP 502 with "did you 'ollama pull...'": the embedding model isn't
+  loaded. Tell the user to run the documented `ollama pull` step.
+- HTTP 502 with "embedding-dim mismatch": the brain's `EMBED_DIM` env was
+  changed after the volume was initialized. Tell the user to read the
+  "one-way door" section of `local-brain-no-mcp`'s README.
+- HTTP 401 or 403: `BRAIN_ANON_KEY` is wrong or expired. Tell the user to
+  check `supabase-docker/docker/.env` on the brain host.
+- Network timeout: the brain host is unreachable. Tell the user to ping
+  the brain host from this dev host.
+
+## Notes
+
+- Never log or echo `BRAIN_ANON_KEY` -- it's a long-lived JWT.
+- This skill never installs or invokes any MCP server, by design.
+- The brain host generates embeddings itself; this dev host doesn't need
+  Ollama or any model files.

--- a/skills/ob1-local-http/metadata.json
+++ b/skills/ob1-local-http/metadata.json
@@ -1,0 +1,30 @@
+{
+  "name": "OB1 Local HTTP",
+  "description": "Skill pack that lets Claude Code (or any AI coding tool that supports skills) capture and search thoughts against a self-hosted Open Brain over plain HTTPS, without using MCP. Pairs with the local-brain-no-mcp recipe.",
+  "category": "skills",
+  "author": {
+    "name": "dhanjit",
+    "github": "dhanjit"
+  },
+  "version": "0.1.0",
+  "requires": {
+    "open_brain": true,
+    "services": [],
+    "tools": [
+      "Claude Code (or compatible skill-aware AI tool)",
+      "curl"
+    ]
+  },
+  "tags": [
+    "skill",
+    "local",
+    "no-mcp",
+    "curl",
+    "capture",
+    "search"
+  ],
+  "difficulty": "beginner",
+  "estimated_time": "5 minutes",
+  "created": "2026-05-13",
+  "updated": "2026-05-13"
+}


### PR DESCRIPTION
## Summary

Adds a new recipe, **local-brain-no-mcp**, and its companion skill **ob1-local-http** — a self-hosted Open Brain for environments that can't use the canonical cloud + MCP setup.

All 16 files land under **new paths only** (`recipes/local-brain-no-mcp/`, `skills/ob1-local-http/`). No existing OB1 file is touched — zero risk to current functionality.

## What it is

A single-LAN-host Open Brain:

- Official Supabase docker-compose stack (Kong, PostgREST, GoTrue, Realtime, Storage, Studio, Edge runtime), unmodified
- An **Ollama** sidecar for local embedding generation — dev hosts never need Ollama installed
- Postgres 15 + `pgvector` with a `thoughts` table that mirrors the canonical OB1 schema exactly, plus `match_thoughts()` / `upsert_thought()` RPCs with the same signatures as cloud
- Three Edge Functions through Kong: `POST /capture`, `POST /search`, `GET /list`
- The companion `ob1-local-http` skill, which lets Claude Code (or any skill-aware tool) capture/search against the local brain over plain HTTPS with `curl`

## Why — and a deliberate divergence to flag for review

This recipe is **intentionally for constrained environments**:

- **No third-party cloud reachable** — the host can only talk to LAN hosts; Supabase Cloud is off the table.
- **MCP disabled in Claude Code** — corporate policy / locked-down builds block MCP entirely, so the canonical MCP-based capture/search tools can't run.

Because of constraint #2, the recipe **deliberately diverges from `CLAUDE.md`'s rule that "MCP servers must be remote Supabase Edge Functions"**: it still uses Edge Functions, but exposes them as plain HTTPS endpoints rather than over MCP, since the network won't pass MCP. The recipe's README calls this out explicitly and tells users with no such constraints to use canonical cloud OB1 instead. Flagging it here so the divergence is a conscious review decision, not a surprise.

## Scope

- 16 new files, 1164 insertions, all additive
- Recipe: `metadata.json` v0.1.0, difficulty `advanced`, ~45 min setup
- Skill: `metadata.json` v0.1.0, difficulty `beginner`, ~5 min
- No secrets; `.env.example` provided; setup generates keys locally via `openssl`

## Test plan

- [ ] On a Linux host: `recipes/local-brain-no-mcp/setup.sh` brings up the stack (Docker 24+ / Compose v2.20+)
- [ ] `POST /functions/v1/capture` stores a thought; `POST /functions/v1/search` returns it by similarity; `GET /functions/v1/list` shows recents
- [ ] Supabase Studio reachable at `http://<brain-host>:3000`
- [ ] From a dev host: `ob1-local-http` skill captures + searches via `curl` against `BRAIN_URL`

## Notes

Submitted as v0.1.0 — happy to iterate on placement, naming, or the MCP-divergence framing per maintainer preference.