### PR TITLE
[docs] Add Mintlify documentation site

### DIFF
--- a/mintlify/README.md
+++ b/mintlify/README.md
@@ -1,0 +1,36 @@
+# Mintlify docs for Open Brain
+
+A polished documentation site for the OB1 project. The plain-markdown `docs/` folder at the repo root remains the canonical source of truth (it's linked from Executive Circle, Substack, and external posts); this folder is a presentation layer on top.
+
+## Local preview
+
+```bash
+npm i -g mint
+cd mintlify
+mint dev
+```
+
+Opens http://localhost:3000.
+
+## Validate config
+
+```bash
+mint broken-links
+```
+
+## Deploy
+
+Connect this repo + the `mintlify/` subfolder at https://dashboard.mintlify.com. Every push to `main` deploys.
+
+## Structure
+
+- `docs.json` — Mintlify config (theme, nav, footer)
+- `introduction.mdx`, `how-it-works.mdx`, `architecture.mdx` — orientation
+- `quickstart/*.mdx` — 6-page install walkthrough
+- `extend/*.mdx` — extensions, recipes, schemas, dashboards, integrations
+- `reference/*.mdx` — MCP tool signatures, `thoughts` table schema
+- `faq.mdx`, `contributing.mdx` — community pages
+
+## Editing principle
+
+Don't duplicate content the repo already owns. Most pages link out to the canonical markdown in `docs/`, `CONTRIBUTING.md`, or contribution folder READMEs. The quickstart is the one exception — it's the primary entry point, so it's a full self-contained walkthrough.

--- a/mintlify/architecture.mdx
+++ b/mintlify/architecture.mdx
@@ -1,0 +1,97 @@
+---
+title: "Architecture"
+description: "Storage, transport, and the Edge Function pattern."
+---
+
+Open Brain is three pieces stitched together. Each is replaceable; none is fancy.
+
+## The three layers
+
+```mermaid
+flowchart TB
+  subgraph CLIENTS[AI clients]
+    CD[Claude Desktop]
+    CG[ChatGPT]
+    CC[Claude Code]
+    CX[Codex / Cursor / Windsurf]
+  end
+  subgraph TRANSPORT[Transport layer]
+    MCP[Remote MCP over HTTP<br/>Supabase Edge Function]
+  end
+  subgraph STORAGE[Storage layer]
+    PG[(Postgres + pgvector<br/>thoughts table<br/>HNSW index)]
+    OR[OpenRouter<br/>embedding + metadata extraction]
+  end
+  CLIENTS -- "MCP Connection URL + key" --> MCP
+  MCP -- "service-role auth" --> PG
+  MCP -- "embed + extract" --> OR
+```
+
+## Storage: Postgres + pgvector
+
+A single project in Supabase. One required table:
+
+```sql
+create table thoughts (
+  id uuid default gen_random_uuid() primary key,
+  content text not null,
+  embedding vector(1536),
+  metadata jsonb default '{}'::jsonb,
+  created_at timestamptz default now(),
+  updated_at timestamptz default now()
+);
+
+create index on thoughts using hnsw (embedding vector_cosine_ops);
+create index on thoughts using gin (metadata);
+create index on thoughts (created_at desc);
+```
+
+Three indexes — vector for similarity, GIN for JSON metadata filters, B-tree for time-range queries. RLS is on; only the service role can read or write.
+
+A single SQL function (`match_thoughts`) handles ranked semantic search with metadata filtering in one query.
+
+<Note>
+You can add tables freely (CRM contacts, taste preferences, calendar events). You **cannot** modify or drop the core `thoughts` table — that's the upstream contract every extension assumes.
+</Note>
+
+## Transport: remote MCP via Edge Functions
+
+Open Brain ships exactly one Edge Function: `open-brain-mcp`. It's a Deno-runtime function deployed on Supabase that speaks the Model Context Protocol over HTTP.
+
+Why remote (not local)?
+
+- **No client-specific config files.** No `claude_desktop_config.json`, no per-machine setup.
+- **Works on mobile and web clients** (ChatGPT, Claude.ai web) which can't run local stdio servers.
+- **One URL, one secret** — paste it into any MCP-capable client and you're done.
+
+Auth is intentionally simple: a long random key (`MCP_ACCESS_KEY`) passed either as a query parameter (`?key=...`) for clients that don't support custom headers, or as `x-brain-key` for clients that do.
+
+## AI gateway: OpenRouter
+
+OpenRouter is a single-key proxy in front of every major model. Open Brain uses it for two things:
+
+- **Embeddings** (1536-dim) for the `embedding` column.
+- **Metadata extraction** — lightweight LLM call that reads the thought and returns structured tags (type, people, topics, action items).
+
+Why not OpenAI directly? One billing relationship, model-agnostic, swap providers without touching the function.
+
+## Cost model
+
+| Item | Cost |
+| --- | --- |
+| Supabase | Free tier covers most personal use |
+| OpenRouter embeddings | ~$0.02 per million tokens |
+| OpenRouter metadata LLM | ~$0.10/month for typical use |
+| Edge Function invocations | Free tier: 500k/month |
+
+At typical capture volume (a few hundred thoughts/month), expect **under $1/month** all-in.
+
+## What this is **not** doing
+
+- **No middleware.** Your AI talks directly to your database via MCP. No Zapier, no n8n, no relay servers.
+- **No vendor lock-in.** Switching AI providers is one OpenRouter setting change. Switching storage is harder but not impossible (the schema is portable Postgres).
+- **No "agent" framework.** Open Brain stores facts; the agent is whatever client you connect.
+
+<Card title="See it in action" icon="play" href="/quickstart/overview">
+  Build the whole stack in 45 minutes.
+</Card>

--- a/mintlify/contributing.mdx
+++ b/mintlify/contributing.mdx
@@ -1,0 +1,98 @@
+---
+title: "Contributing"
+description: "Open extends the system. Curated paths preserve the core."
+---
+
+Open Brain accepts community contributions. The full source-of-truth document is [`CONTRIBUTING.md`](https://github.com/NateBJones-Projects/OB1/blob/main/CONTRIBUTING.md) in the repo — this page is a shorter orientation.
+
+## Before you contribute
+
+You need a working Open Brain. Every contribution should be tested against your own instance — don't submit something you haven't run yourself.
+
+Start with the [Quickstart](/quickstart/overview) if you haven't built one yet.
+
+## Not a developer? You can still contribute
+
+You don't need to write code. If you have a workflow, a use case, or an idea — that counts.
+
+1. Open a [Non-Technical Contribution issue](https://github.com/NateBJones-Projects/OB1/issues/new?template=non-technical-contribution.yml). Describe your idea in plain language.
+2. A community mentor picks it up — they write the code, structure the README, fill the metadata.
+3. You get full credit. Your name goes in `metadata.json` and `CONTRIBUTORS.md`. The mentor is co-author on the PR.
+
+Or just post ideas in `#non-dev-contributions` on [Discord](https://discord.gg/Cgh9WJEkeG).
+
+## What goes where
+
+| Category | What belongs | Open or curated? |
+| --- | --- | --- |
+| `extensions/` | Progressive, ordered builds | **Curated** — discuss first |
+| `primitives/` | Reusable concept guides referenced by 2+ extensions | **Curated** |
+| `recipes/` | Step-by-step capability builds | Open |
+| `schemas/` | Database table extensions | Open |
+| `dashboards/` | Frontend templates | Open |
+| `integrations/` | MCP extensions, webhooks, capture sources | Open |
+
+If unsure where yours fits, open a discussion issue first.
+
+## Required files
+
+Every contribution lives in its own subfolder under the right category and must include:
+
+- **`README.md`** — what it does, prerequisites, step-by-step setup, expected outcome, troubleshooting
+- **`metadata.json`** — structured metadata (template in [CONTRIBUTING.md](https://github.com/NateBJones-Projects/OB1/blob/main/CONTRIBUTING.md))
+- **Your actual code** — SQL files, Edge Function code, frontend, configs
+- **No credentials, API keys, or secrets** — automated review rejects them
+
+## The review process
+
+1. You submit a PR.
+2. An automated GitHub Action runs 11+ machine-readable checks ([`.github/workflows/ob1-review.yml`](https://github.com/NateBJones-Projects/OB1/blob/main/.github/workflows/ob1-review.yml)).
+3. If automated checks pass, a human admin reviews for quality, clarity, and safety.
+4. Expect 2–5 business days for human review.
+
+### What gets rejected
+
+- Contains credentials, API keys, or secrets
+- Requires paid services with no free-tier alternative
+- Poorly documented (missing README sections, unclear instructions)
+- Duplicates an existing contribution without meaningful improvement
+- Modifies core Open Brain infrastructure (`thoughts` table, core MCP server) — that's upstream, not here
+
+## PR format
+
+**Title:** `[category] Short description`
+
+- `[recipes] Email history import via Gmail API`
+- `[schemas] CRM contacts table with interaction tracking`
+- `[extensions] Household Knowledge Base`
+
+**Description must include:**
+
+- What the contribution does
+- What it requires (services, tools)
+- Confirmation that you tested it on your own instance
+
+## Contributor ladder
+
+| Level | What it means |
+| --- | --- |
+| **Community Member** | You use Open Brain and participate in discussions |
+| **Contributor** | One or more merged contributions |
+| **Regular** | 3+ merged, or sustained help reviewing others' work |
+| **Maintainer** | Invited based on sustained, quality involvement |
+
+Non-code contributions count at every level.
+
+## The hard rules
+
+These are enforced by automated review and apply to **everything**:
+
+1. **Never modify the core `thoughts` table structure.** Adding columns is fine; altering or dropping existing ones is not.
+2. **No credentials, API keys, or secrets** in any file.
+3. **No binary blobs over 1 MB.** No `.exe`, `.dmg`, `.zip`, `.tar.gz`.
+4. **No `DROP TABLE`, `DROP DATABASE`, `TRUNCATE`, or unqualified `DELETE FROM`** in SQL files.
+5. **MCP servers must be remote** (Supabase Edge Functions), not local. No `claude_desktop_config.json`. No `StdioServerTransport`.
+
+<Card title="Full CONTRIBUTING.md" icon="github" href="https://github.com/NateBJones-Projects/OB1/blob/main/CONTRIBUTING.md">
+  The canonical, exhaustive version — metadata templates, the 11-rule checklist, README formatting standards.
+</Card>

--- a/mintlify/docs.json
+++ b/mintlify/docs.json
@@ -1,0 +1,102 @@
+{
+  "$schema": "https://mintlify.com/docs.json",
+  "theme": "mint",
+  "name": "Open Brain",
+  "description": "One database, one AI gateway, one chat channel. Any AI you use shares the same persistent memory.",
+  "colors": {
+    "primary": "#1E88E5",
+    "light": "#5C6BC0",
+    "dark": "#0D47A1"
+  },
+  "favicon": "/favicon.png",
+  "navigation": {
+    "tabs": [
+      {
+        "tab": "Docs",
+        "groups": [
+          {
+            "group": "Start Here",
+            "pages": [
+              "introduction",
+              "how-it-works",
+              "architecture"
+            ]
+          },
+          {
+            "group": "Quickstart",
+            "pages": [
+              "quickstart/overview",
+              "quickstart/supabase",
+              "quickstart/openrouter",
+              "quickstart/mcp-deploy",
+              "quickstart/connect-client",
+              "quickstart/verify"
+            ]
+          },
+          {
+            "group": "Extend",
+            "pages": [
+              "extend/extensions",
+              "extend/recipes",
+              "extend/schemas",
+              "extend/dashboards",
+              "extend/integrations"
+            ]
+          },
+          {
+            "group": "Reference",
+            "pages": [
+              "reference/mcp-tools",
+              "reference/thoughts-table",
+              "faq"
+            ]
+          },
+          {
+            "group": "Community",
+            "pages": [
+              "contributing"
+            ]
+          }
+        ]
+      }
+    ],
+    "global": {
+      "anchors": [
+        {
+          "anchor": "GitHub",
+          "href": "https://github.com/NateBJones-Projects/OB1",
+          "icon": "github"
+        },
+        {
+          "anchor": "Discord",
+          "href": "https://discord.gg/Cgh9WJEkeG",
+          "icon": "discord"
+        },
+        {
+          "anchor": "Substack",
+          "href": "https://natesnewsletter.substack.com/",
+          "icon": "newspaper"
+        }
+      ]
+    }
+  },
+  "navbar": {
+    "links": [
+      {
+        "label": "GitHub",
+        "href": "https://github.com/NateBJones-Projects/OB1"
+      }
+    ],
+    "primary": {
+      "type": "button",
+      "label": "Setup Guide",
+      "href": "/quickstart/overview"
+    }
+  },
+  "footer": {
+    "socials": {
+      "github": "https://github.com/NateBJones-Projects/OB1",
+      "discord": "https://discord.gg/Cgh9WJEkeG"
+    }
+  }
+}

--- a/mintlify/extend/dashboards.mdx
+++ b/mintlify/extend/dashboards.mdx
@@ -1,0 +1,32 @@
+---
+title: "Dashboards"
+description: "Frontend templates that read from your Supabase backend."
+---
+
+Dashboards give your Open Brain a visual face — browsing, editing, auditing. Pick the framework you prefer; both are community-built.
+
+| Dashboard | Stack | Contributor |
+| --- | --- | --- |
+| [Open Brain Dashboard](https://github.com/NateBJones-Projects/OB1/tree/main/dashboards/open-brain-dashboard) | SvelteKit + MCP proxy + Supabase auth | @headcrest |
+| [Open Brain Dashboard (Next.js)](https://github.com/NateBJones-Projects/OB1/tree/main/dashboards/open-brain-dashboard-next) | Next.js, 8 pages, dark theme, smart ingest, quality auditing | @alanshurafa |
+
+## Deployment
+
+Both target Vercel or Netlify free tiers. Point them at your existing Supabase project — no separate backend.
+
+Each dashboard's README walks through the deploy. Typical flow:
+
+1. Fork the dashboard folder into your own repo.
+2. Connect Vercel/Netlify to that repo.
+3. Set environment variables for your Supabase URL + service-role key.
+4. Deploy.
+
+<Warning>
+Dashboards run with your **service-role key** — they have full database access. Never deploy publicly without putting your own auth (Supabase Auth, Clerk, or a simple password gate) in front.
+</Warning>
+
+## Contributing
+
+A new dashboard is welcome if it offers something the existing two don't — different framework (Astro? Remix? plain HTML?), different focus (read-only browser? mobile-first capture? analytics-heavy?), or a meaningfully different design.
+
+PR title: `[dashboards] Short description`. See [contributing](/contributing).

--- a/mintlify/extend/extensions.mdx
+++ b/mintlify/extend/extensions.mdx
@@ -1,0 +1,72 @@
+---
+title: "Extensions"
+description: "Six progressive builds that turn Open Brain into a household OS."
+---
+
+Extensions are a curated, ordered learning path. Each one teaches new concepts through something you'll actually use day-to-day. By the end, your agent manages your household, schedule, meals, professional network, and job hunt — interconnected.
+
+<Note>
+Extensions are **curated**. Adding a new one requires maintainer approval. To propose: [open an extension submission issue](https://github.com/NateBJones-Projects/OB1/issues/new?template=extension-submission.yml) first.
+</Note>
+
+## The path
+
+<Steps>
+  <Step title="Household Knowledge Base (Beginner)">
+    Home facts your agent recalls instantly — Wi-Fi password, paint colors, filter sizes, appliance manuals.
+
+    [`extensions/household-knowledge/`](https://github.com/NateBJones-Projects/OB1/tree/main/extensions/household-knowledge)
+  </Step>
+  <Step title="Home Maintenance Tracker (Beginner)">
+    Scheduling and history for home upkeep. First taste of structured schemas alongside thoughts.
+
+    [`extensions/home-maintenance/`](https://github.com/NateBJones-Projects/OB1/tree/main/extensions/home-maintenance)
+  </Step>
+  <Step title="Family Calendar (Intermediate)">
+    Multi-person schedule coordination. Introduces Row Level Security for shared access.
+
+    [`extensions/family-calendar/`](https://github.com/NateBJones-Projects/OB1/tree/main/extensions/family-calendar)
+  </Step>
+  <Step title="Meal Planning (Intermediate)">
+    Recipes, weekly meal plans, shared shopping lists. Uses the shared-MCP-server primitive.
+
+    [`extensions/meal-planning/`](https://github.com/NateBJones-Projects/OB1/tree/main/extensions/meal-planning)
+  </Step>
+  <Step title="Professional CRM (Intermediate)">
+    Contact tracking wired into your thoughts. Your CRM and your memory share context.
+
+    [`extensions/professional-crm/`](https://github.com/NateBJones-Projects/OB1/tree/main/extensions/professional-crm)
+  </Step>
+  <Step title="Job Hunt Pipeline (Advanced)">
+    Application tracking and interview pipeline. Capstone — pulls every prior concept together.
+
+    [`extensions/job-hunt/`](https://github.com/NateBJones-Projects/OB1/tree/main/extensions/job-hunt)
+  </Step>
+</Steps>
+
+## Why the order matters
+
+Extensions compound. Your CRM knows about thoughts you captured. Your meal planner checks who's home this week. Your job-hunt contacts automatically join your professional network. Building in order means each one teaches concepts the next one assumes.
+
+## Primitives (shared concepts)
+
+Two patterns get extracted because multiple extensions use them:
+
+| Primitive | Used by |
+| --- | --- |
+| [Row Level Security](https://github.com/NateBJones-Projects/OB1/tree/main/primitives/rls) | Extensions 3, 4, 5, 6 |
+| [Shared MCP Server](https://github.com/NateBJones-Projects/OB1/tree/main/primitives/shared-mcp) | Extension 4 |
+
+Learn the pattern once in the primitive; reference it from each extension.
+
+## What you'll learn along the way
+
+- Designing schemas around your real workflows (not academic data modeling)
+- pgvector + structured columns in the same query
+- RLS for multi-user access without rebuilding the stack
+- Deploying multiple Edge Functions side-by-side
+- Cross-table semantic search
+
+<Card title="Tool audit" icon="list-check" href="https://github.com/NateBJones-Projects/OB1/blob/main/docs/05-tool-audit.md">
+  After 2–3 extensions you'll have ~12+ MCP tools. The audit guide explains how to keep your tool surface manageable.
+</Card>

--- a/mintlify/extend/integrations.mdx
+++ b/mintlify/extend/integrations.mdx
@@ -1,0 +1,30 @@
+---
+title: "Integrations"
+description: "MCP extensions, alternative deployment targets, and new capture sources."
+---
+
+Integrations are connections — new ways data flows in and out of Open Brain.
+
+| Integration | What it does | Contributor |
+| --- | --- | --- |
+| [Kubernetes Deployment](https://github.com/NateBJones-Projects/OB1/tree/main/integrations/kubernetes-deployment) | Fully self-hosted K8s deployment with Postgres + pgvector — no Supabase | @velo |
+| [Slack Capture](https://github.com/NateBJones-Projects/OB1/tree/main/integrations/slack-capture) | Capture thoughts via Slack messages with auto-embedding and classification | Core |
+| [Discord Capture](https://github.com/NateBJones-Projects/OB1/tree/main/integrations/discord-capture) | Discord bot mirroring the Slack pattern | Core |
+
+## Three flavors of integration
+
+- **Deployment target** — Run Open Brain somewhere other than Supabase. Kubernetes is the existing example; self-hosted Postgres + pgvector + a Deno or Node MCP server is the pattern.
+- **Capture source** — Wire a chat channel, an inbox, a browser extension, or anything else as a one-tap capture surface. Slack and Discord are the templates.
+- **MCP extension** — Add tools beyond capture/search/list/stats. Examples: webhooks, calendar sync, browser-extension bookmarklet.
+
+## The non-negotiable rule
+
+**MCP servers must be remote** (Supabase Edge Functions, or your own remote runtime). No `claude_desktop_config.json`. No local `StdioServerTransport`. No per-machine Node setup.
+
+This is enforced by automated PR review. The reason: remote means it works on mobile, on the web, on every device the user owns, with one URL to paste.
+
+## Contributing
+
+PR title: `[integrations] Short description`. See [contributing](/contributing).
+
+Every extension and integration must link to the [Tool Audit guide](https://github.com/NateBJones-Projects/OB1/blob/main/docs/05-tool-audit.md) in its README — as users add more tools, surface-area management matters.

--- a/mintlify/extend/recipes.mdx
+++ b/mintlify/extend/recipes.mdx
@@ -1,0 +1,47 @@
+---
+title: "Recipes"
+description: "Community-built capabilities. Standalone builds with no prerequisites beyond a working Open Brain."
+---
+
+Recipes are standalone — pick what's useful, skip the rest. No ordering, no prerequisites past a working Open Brain. Open for community contributions.
+
+## Import your data
+
+Pull your digital life into Open Brain. Each recipe handles a specific source — parsing, deduplication, embedding, ingestion.
+
+| Recipe | What it does | Contributor |
+| --- | --- | --- |
+| [ChatGPT Import](https://github.com/NateBJones-Projects/OB1/tree/main/recipes/chatgpt-conversation-import) | Parse ChatGPT data exports, filter trivial conversations, summarize via LLM | @matthallett1 |
+| [Perplexity Import](https://github.com/NateBJones-Projects/OB1/tree/main/recipes/perplexity-conversation-import) | Import Perplexity search history and memory entries | @demarant |
+| [Obsidian Vault Import](https://github.com/NateBJones-Projects/OB1/tree/main/recipes/obsidian-vault-import) | Parse and import Obsidian vault notes with metadata | @snapsynapse |
+| [X/Twitter Import](https://github.com/NateBJones-Projects/OB1/tree/main/recipes/x-twitter-import) | Import tweets, DMs, and Grok chats from X data exports | @alanshurafa |
+| [Instagram Import](https://github.com/NateBJones-Projects/OB1/tree/main/recipes/instagram-import) | Import DMs, comments, captions from Instagram exports | @alanshurafa |
+| [Google Activity Import](https://github.com/NateBJones-Projects/OB1/tree/main/recipes/google-activity-import) | Import Google Search, Gmail, Maps, YouTube, Chrome history from Takeout | @alanshurafa |
+| [Grok (xAI) Import](https://github.com/NateBJones-Projects/OB1/tree/main/recipes/grok-export-import) | Import Grok conversation exports | @alanshurafa |
+| [Journals/Blogger Import](https://github.com/NateBJones-Projects/OB1/tree/main/recipes/journals-blogger-import) | Import Atom XML blog archives | @alanshurafa |
+| [Email History Import](https://github.com/NateBJones-Projects/OB1/tree/main/recipes/email-history-import) | Pull Gmail archive into searchable thoughts | @matthallett1 |
+
+## Tools & workflows
+
+Standalone capabilities that make your Open Brain smarter.
+
+| Recipe | What it does | Contributor |
+| --- | --- | --- |
+| [Panning for Gold](https://github.com/NateBJones-Projects/OB1/tree/main/recipes/panning-for-gold) | Mine brain dumps and voice transcripts for actionable ideas | @jaredirish |
+| [Claudeception](https://github.com/NateBJones-Projects/OB1/tree/main/recipes/claudeception) | Self-improving system that creates new skills from work sessions | @jaredirish |
+| [Schema-Aware Routing](https://github.com/NateBJones-Projects/OB1/tree/main/recipes/schema-aware-routing) | LLM-powered routing of unstructured text across multiple tables | @claydunker-yalc |
+| [Fingerprint Dedup Backfill](https://github.com/NateBJones-Projects/OB1/tree/main/recipes/fingerprint-dedup-backfill) | Backfill content fingerprints and remove duplicate thoughts | @alanshurafa |
+| [Source Filtering](https://github.com/NateBJones-Projects/OB1/tree/main/recipes/source-filtering) | Filter thoughts by source, backfill missing metadata | @matthallett1 |
+| [Life Engine](https://github.com/NateBJones-Projects/OB1/tree/main/recipes/life-engine) | Self-improving personal assistant — calendar, habits, health, briefings via Telegram or Discord | @justfinethanku |
+| [Life Engine Video](https://github.com/NateBJones-Projects/OB1/tree/main/recipes/life-engine-video) | Render Life Engine briefings as short animated videos with voiceover | @justfinethanku |
+| [Daily Digest](https://github.com/NateBJones-Projects/OB1/tree/main/recipes/daily-digest) | Automated daily summary via email or Slack | OB1 Team |
+
+## Contributing a recipe
+
+Anything that adds a capability without modifying the core `thoughts` table or MCP server is welcome.
+
+- Read [the contribution guide](/contributing).
+- Use the template at [`recipes/_template/`](https://github.com/NateBJones-Projects/OB1/tree/main/recipes/_template).
+- Title your PR `[recipes] Short description`.
+
+Automated review checks 11 rules (folder layout, no secrets, SQL safety, README completeness, etc.) before a human admin reviews.

--- a/mintlify/extend/schemas.mdx
+++ b/mintlify/extend/schemas.mdx
@@ -1,0 +1,39 @@
+---
+title: "Schemas"
+description: "Database table extensions that live alongside the thoughts table."
+---
+
+Schemas add tables to your Open Brain — structured data that complements the unstructured `thoughts` stream. They're open for community contributions.
+
+## What schemas are for
+
+The `thoughts` table is a **stream**. Append-only, retrieval by meaning, no rigid structure. Great for ideas, decisions, observations, conversations.
+
+A **registry** is the opposite — discrete records you query, update, and browse without semantic search. Taste preferences. Recipe library. Contact lists. Reading list.
+
+Schemas are how you add registries.
+
+## Design rules
+
+1. **Never modify or drop columns on the core `thoughts` table.** Adding columns is fine; altering existing ones breaks every extension downstream. The automated PR review enforces this.
+2. **One clear purpose per table.** Don't shoehorn unrelated concepts into one schema.
+3. **Document the queries.** Schemas are useless without examples of how to read and write them.
+4. **Provide the GRANT.** Supabase no longer auto-grants CRUD on new tables — include `grant select, insert, update, delete on table public.<your_table> to service_role;`.
+
+## Where schemas live
+
+Each schema is a folder under [`schemas/`](https://github.com/NateBJones-Projects/OB1/tree/main/schemas) with:
+
+- `README.md` — what it stores, prerequisites, setup SQL, expected outcome, troubleshooting
+- `metadata.json` — name, description, author, tags, difficulty
+- The SQL files themselves
+
+## Example: Taste Preferences
+
+The community has already built a `taste_preferences` schema as an example registry. See the [Add a Taste Preferences Table to Your Open Brain](https://github.com/NateBJones-Projects/OB1/tree/main/extensions/_taste-preferences-example) guide.
+
+It illustrates the pattern: a separate table from `thoughts`, queried with normal SQL (not semantic search), updated deliberately rather than streamed.
+
+## Contributing
+
+See [the contribution guide](/contributing). Title your PR `[schemas] Short description`. The 11-rule automated review checks SQL safety, metadata validity, and that you haven't touched `thoughts`.

--- a/mintlify/faq.mdx
+++ b/mintlify/faq.mdx
@@ -1,0 +1,145 @@
+---
+title: "FAQ"
+description: "Real questions from the Open Brain community."
+---
+
+This FAQ is sourced from [`docs/03-faq.md`](https://github.com/NateBJones-Projects/OB1/blob/main/docs/03-faq.md) in the repo, where the canonical version lives. Common gotchas first, then philosophy.
+
+## Setup and connection
+
+### Claude Desktop / ChatGPT throws an auth error but Claude Code works
+
+The single most common issue. Claude Code can send custom headers; Claude Desktop and ChatGPT cannot.
+
+**Fix:** use the MCP Connection URL with the key as a **query parameter**, not a header:
+
+```text
+https://YOUR_REF.supabase.co/functions/v1/open-brain-mcp?key=YOUR_KEY
+```
+
+In Claude Desktop or ChatGPT settings, paste that full URL and set auth to "None" — the key is already in the URL.
+
+### ChatGPT disabled my memory when I added Open Brain
+
+OpenAI requirement, not a bug. Enabling Developer Mode (needed for custom MCP connectors) disables built-in Memory. Open Brain replaces it — and works across every AI, not just ChatGPT.
+
+### ChatGPT doesn't use the Open Brain tools automatically
+
+ChatGPT is less intuitive than Claude at picking the right MCP tool. Be explicit for the first few prompts: *"Use the Open Brain search_thoughts tool to find my notes on X."* It picks up the pattern within a conversation.
+
+### "I'm stuck and Claude is rewriting my Edge Function code"
+
+Pause. The problems are almost never in the code. They're in the configuration: a secret that doesn't match, a URL missing the key, a step that got skipped.
+
+Check Supabase dashboard → **Edge Functions → open-brain-mcp → Logs** first. That tells you what's actually happening.
+
+### Search isn't working but capture is
+
+Good news — your database, function, and MCP connection are fine. The issue is isolated.
+
+Most likely culprits:
+1. `vector` extension not enabled — run `create extension if not exists vector;`
+2. Embedding generation failing silently — check function logs
+3. `match_thoughts` deployed with an error — check Database → Functions
+
+## Importing data
+
+### Can I import my Gmail?
+
+Yes — see the [Email History Import recipe](https://github.com/NateBJones-Projects/OB1/tree/main/recipes/email-history-import). OAuth, filter by label and time window, strip signatures, load each email as a thought. ~30 min setup; you'll need a Google Cloud project with Gmail API enabled.
+
+### How do I import my ChatGPT conversations?
+
+Export from ChatGPT (Settings → Data controls → Export data), then use the [ChatGPT Conversation Import recipe](https://github.com/NateBJones-Projects/OB1/tree/main/recipes/chatgpt-conversation-import). Handles the full export automatically.
+
+### What other sources can I import?
+
+See the [recipes index](/extend/recipes). Active community work on Obsidian, Twitter/X, Perplexity, Google Takeout, Instagram, Blogger, Grok, and more.
+
+## How it relates to other tools
+
+### How does this work with Obsidian?
+
+Short answer: it doesn't, and it's not supposed to.
+
+Obsidian is a note-taking app. Open Brain is a database with vector search. Different categories — you don't need a middleman between your AI and your data.
+
+If you want to bring an existing Obsidian vault over, use the [Obsidian Vault Import recipe](https://github.com/NateBJones-Projects/OB1/tree/main/recipes/obsidian-vault-import). It moves content **into** Open Brain. Obsidian doesn't sit alongside or on top.
+
+### I want the visual editing experience — headings, drag, browse
+
+That's a fair ask and Open Brain doesn't offer it natively. The Supabase Table Editor is functional but it's a database view, not a writing environment.
+
+Frame it this way: Open Brain is the backend. Obsidian is a frontend. There's nothing stopping you from having both — use Open Brain for AI-accessible storage and retrieval; keep Obsidian for the visual workflow. Or build a frontend on top — see [dashboards](/extend/dashboards).
+
+## Storage and retrieval
+
+### How do I store long-form content?
+
+Two questions in one.
+
+**Can Postgres store long content?** Yes. It's a database. A 4,000-word article is just a text column.
+
+**How does retrieval handle it?** Less well, if you embed the whole article as a single vector. You're compressing dozens of ideas into one point in vector space — search quality drops.
+
+The fix: **chunking**. Break long content into sections. Embed each chunk separately. Keep metadata tying chunks back to the parent. That's a hybrid query — filter on metadata first, vector search within the filtered set.
+
+### How do I prevent memory from getting noisy?
+
+"Store more and more" isn't the right framing. Open Brain is a capture tool — what goes in is up to you.
+
+The real answer is **siloing**. Different contexts need different memory. Your coding thoughts shouldn't pollute your creative-writing context. Tag aggressively with `source`, `domain`, or `context` and filter retrieval accordingly.
+
+ChatGPT's built-in memory has this exact problem: one flat pool with no separation. That's an architecture problem, not a memory problem.
+
+### What's the right unit of embedding?
+
+One idea per entry. Zettelkasten-style atomic notes are a near-perfect fit for vector search.
+
+- Calendar events — one per event.
+- Emails — one per email or per thread.
+- Tasks — one per task.
+- Long articles — chunk into sections.
+- Health data — one per night/day, not per month.
+
+The key is metadata. Every source tags itself (`source: "garmin"`, `source: "gmail"`) so retrieval can filter by context.
+
+### Search seems sub-par — I have to coax Claude to find things
+
+Diagnose in this order:
+
+1. **Check row count.** Supabase → Table Editor → thoughts. Under 20–30 entries? Semantic search just doesn't have enough data points. It gets better with volume.
+2. **Test directly.** Ask the AI to search for something you **know** is in there using words close to your original phrasing. If that works, the system is fine — it needs more content for vague queries to land.
+3. **Check Edge Function logs.** Silent errors show up there.
+4. **Compare list vs search.** If `list_thoughts` returns it but `search_thoughts` doesn't, that's an embedding/similarity issue — usually improves with more data.
+
+## Key rotation
+
+### I rotated my OpenRouter key and now nothing works
+
+The old key is revoked immediately on rotation. Your Open Brain uses it in **multiple places**:
+
+1. **Supabase Edge Function secrets** — the most common one to miss:
+   ```bash
+   supabase secrets set OPENROUTER_API_KEY=sk-or-v1-NEW
+   ```
+2. **Local `.env` files** for recipes/integrations that run outside the Edge Function.
+3. **Any CI/CD configs** that reference it.
+
+Verify with:
+
+```bash
+curl https://openrouter.ai/api/v1/models -H "Authorization: Bearer sk-or-v1-NEW"
+```
+
+JSON response = valid. 401 = wrong or not yet active.
+
+## Before you ask for help
+
+1. **Did you follow the guide step by step?** Most issues trace back to a skipped or modified step.
+2. **Check Edge Function logs.** Supabase → Edge Functions → your function → Logs.
+3. **Is the URL format right?** `https://YOUR_REF.supabase.co/functions/v1/open-brain-mcp?key=YOUR_KEY`
+4. **Use the Supabase AI assistant** in the dashboard for Supabase-specific errors.
+5. **Don't let AI rewrite your server code** unless you understand what it's changing.
+
+Still stuck? [Open an issue](https://github.com/NateBJones-Projects/OB1/issues) or post in the [Discord](https://discord.gg/Cgh9WJEkeG) / [Substack community](https://natesnewsletter.substack.com/).

--- a/mintlify/how-it-works.mdx
+++ b/mintlify/how-it-works.mdx
@@ -1,0 +1,67 @@
+---
+title: "How it works"
+description: "The capture → embed → retrieve loop, end to end."
+---
+
+Open Brain has one loop. Everything else is layered on top of it.
+
+## The loop in one diagram
+
+```mermaid
+flowchart LR
+  U[You speak to your AI] --> C[AI calls capture_thought]
+  C --> E[Edge Function generates embedding via OpenRouter]
+  E --> D[(thoughts table<br/>pgvector + metadata)]
+  U2[Later, you ask a question] --> S[AI calls search_thoughts]
+  S --> Q[Edge Function embeds the query]
+  Q --> M[match_thoughts SQL function<br/>cosine similarity, HNSW index]
+  M --> D
+  D --> R[Top-K results returned to AI]
+  R --> A[AI answers with your context]
+```
+
+## Capture path
+
+1. You tell any connected AI: *"Remember this: Sarah mentioned she's thinking about leaving her job."*
+2. The AI recognizes the intent and calls the `capture_thought` MCP tool.
+3. The Edge Function receives the text. It calls OpenRouter to:
+   - Generate a 1536-dimension embedding for similarity search.
+   - Extract structured metadata (type, topics, people, action items).
+4. A new row lands in the `thoughts` table — content, embedding, JSONB metadata, timestamps.
+
+## Retrieval path
+
+1. You ask: *"What did Sarah tell me about her job?"*
+2. The AI calls `search_thoughts` with your query.
+3. The Edge Function embeds the query and runs `match_thoughts(query_embedding, threshold, limit, filter)`.
+4. Postgres uses the HNSW vector index to return the top-K most similar rows by cosine distance.
+5. The AI receives the results and answers using them as context — exactly as if it had remembered.
+
+<Tip>
+Vector search is **associative**, not file-system-like. You don't need to remember what folder you put it in. Ask in plain language and the math finds it.
+</Tip>
+
+## Why this beats built-in AI memory
+
+| | ChatGPT memory | Claude projects | Open Brain |
+| --- | --- | --- | --- |
+| Cross-tool | ❌ ChatGPT only | ❌ Claude only | ✅ Any MCP client |
+| You own the data | ❌ | ❌ | ✅ Your Supabase |
+| Vector search | ❌ Keyword | Partial | ✅ pgvector + HNSW |
+| Extensible schema | ❌ | ❌ | ✅ Add tables freely |
+| Cost at scale | Plan tier | Plan tier | ~$0.02 per million tokens |
+
+## Four MCP tools, one URL
+
+Every Open Brain exposes the same four tools:
+
+- **`capture_thought`** — write a new thought with auto-extracted metadata
+- **`search_thoughts`** — semantic search across everything you've captured
+- **`list_thoughts`** — browse recent thoughts, optionally filtered
+- **`thought_stats`** — high-level stats: row count, most-mentioned topics, etc.
+
+Connect once. Every AI client that supports remote MCP gets the same four tools.
+
+<Card title="See the schema" icon="table" href="/reference/thoughts-table">
+  The exact columns, indexes, and SQL for the `thoughts` table.
+</Card>

--- a/mintlify/introduction.mdx
+++ b/mintlify/introduction.mdx
@@ -1,0 +1,51 @@
+---
+title: "What is Open Brain?"
+description: "One database, one AI gateway, one chat channel. Any AI you use plugs in."
+---
+
+Open Brain is the infrastructure layer for your thinking. It's a database with vector search and an open protocol — built so that every AI tool you use shares the same persistent memory.
+
+Claude, ChatGPT, Cursor, Claude Code, whatever ships next month — **one brain, all of them**.
+
+## What this is not
+
+- **Not a notes app.** Notion, Obsidian, and Bear are documents-first. Open Brain is retrieval-first.
+- **Not a SaaS chain.** No Zapier, no middleware. Your AI talks directly to your database.
+- **Not opinionated about clients.** If a tool supports the Model Context Protocol, it works.
+
+## What it is
+
+A Supabase project running:
+
+1. **A `thoughts` table** — your text, an embedding vector, and JSON metadata.
+2. **A search function** — semantic similarity over pgvector's HNSW index.
+3. **A remote MCP server** — a Supabase Edge Function exposing capture, search, browse, and stats tools.
+
+Total cost: ~$0.10/month in embeddings on the free tier of Supabase. Setup time: ~45 minutes, zero coding required.
+
+<Card title="Start the quickstart" icon="rocket" href="/quickstart/overview">
+  Build the full system in eight steps.
+</Card>
+
+## Where to go next
+
+<CardGroup cols={2}>
+  <Card title="How it works" icon="brain" href="/how-it-works">
+    The day-to-day loop: capture → embed → retrieve.
+  </Card>
+  <Card title="Architecture" icon="diagram-project" href="/architecture">
+    Schema, MCP protocol, and the Edge Function pattern.
+  </Card>
+  <Card title="Extend it" icon="puzzle-piece" href="/extend/extensions">
+    Six progressive builds plus the community recipes catalog.
+  </Card>
+  <Card title="FAQ" icon="circle-question" href="/faq">
+    Common gotchas, key rotation, and Obsidian questions.
+  </Card>
+</CardGroup>
+
+## Credit
+
+Open Brain was created by [Nate B. Jones](https://natesnewsletter.substack.com/). Real-time help and community lives on [Discord](https://discord.gg/Cgh9WJEkeG). Source: [github.com/NateBJones-Projects/OB1](https://github.com/NateBJones-Projects/OB1).
+
+License: [FSL-1.1-MIT](https://github.com/NateBJones-Projects/OB1/blob/main/LICENSE.md).

--- a/mintlify/quickstart/connect-client.mdx
+++ b/mintlify/quickstart/connect-client.mdx
@@ -1,0 +1,119 @@
+---
+title: "Connect your AI client"
+description: "One URL per client. Same Open Brain, every tool."
+---
+
+Pick whichever clients you actually use. You can connect the same Open Brain to as many as you want — they all share the same memory.
+
+You'll need your **MCP Connection URL** (the one ending in `?key=...`) from your tracker.
+
+## Claude Desktop
+
+The simplest connection.
+
+1. Open Claude Desktop → **Settings** → **Connectors**
+2. **Add custom connector**
+3. Name: `Open Brain`
+4. Remote MCP server URL: paste your **MCP Connection URL**
+5. **Add**
+
+Start a new conversation. Enable Open Brain per-conversation via the **+** button → Connectors.
+
+## ChatGPT
+
+<Warning>
+Requires a **paid** ChatGPT plan (Plus, Pro, Business, Enterprise, or Edu). Web only — not mobile.
+</Warning>
+
+**One-time setup — enable Developer Mode:**
+
+1. [chatgpt.com](https://chatgpt.com) → profile icon → **Settings**
+2. **Apps & Connectors** → **Advanced settings**
+3. Toggle **Developer mode** ON
+
+<Note>
+Developer Mode disables ChatGPT's built-in Memory. Yes, that's ironic. Your Open Brain replaces it — and works across every AI, not just ChatGPT.
+</Note>
+
+**Add the connector:**
+
+1. **Apps & Connectors** → **Create**
+2. Name: `Open Brain`
+3. Description: anything (just for you)
+4. MCP endpoint URL: your **MCP Connection URL**
+5. Authentication: **No Authentication** (key is in the URL)
+6. **Create**
+
+<Tip>
+ChatGPT is less intuitive than Claude at picking the right MCP tool. The first few times, be explicit: *"Use the Open Brain search_thoughts tool to find my notes about X."* It catches on within a conversation.
+</Tip>
+
+## Claude Code
+
+One terminal command:
+
+```bash
+claude mcp add --transport http open-brain \
+  https://YOUR_PROJECT_REF.supabase.co/functions/v1/open-brain-mcp \
+  --header "x-brain-key: your-access-key"
+```
+
+## OpenAI Codex
+
+Codex needs `mcp-remote` to bridge to remote MCP. Add to `~/.codex/config.toml`:
+
+```toml
+[mcp_servers.open-brain]
+command = "npx"
+args = [
+  "-y",
+  "mcp-remote",
+  "https://YOUR_PROJECT_REF.supabase.co/functions/v1/open-brain-mcp?key=YOUR_ACCESS_KEY"
+]
+startup_timeout_sec = 30
+```
+
+<Warning>
+`startup_timeout_sec = 30` is **required**. Without it Codex times out after 10s (`mcp-remote` needs longer to spin up).
+</Warning>
+
+Restart Codex. The four Open Brain tools appear immediately.
+
+## Cursor, VS Code Copilot, Windsurf, other MCP clients
+
+Two options:
+
+**Option A — URL with embedded key (easiest).** If the client has a remote MCP URL field, paste the full **MCP Connection URL** including `?key=...`.
+
+**Option B — `mcp-remote` bridge (for stdio-only clients).** Requires Node.js:
+
+```json
+{
+  "mcpServers": {
+    "open-brain": {
+      "command": "npx",
+      "args": [
+        "mcp-remote",
+        "https://YOUR_PROJECT_REF.supabase.co/functions/v1/open-brain-mcp",
+        "--header",
+        "x-brain-key:${BRAIN_KEY}"
+      ],
+      "env": {
+        "BRAIN_KEY": "your-access-key"
+      }
+    }
+  }
+}
+```
+
+<Note>
+No space after the colon in `x-brain-key:${BRAIN_KEY}` — some clients mangle spaces inside args.
+</Note>
+
+<Check>
+You can start a conversation in your AI client and it has access to four tools: `search_thoughts`, `list_thoughts`, `thought_stats`, `capture_thought`.
+</Check>
+
+<Card title="Next: verify it works" icon="arrow-right" href="/quickstart/verify">
+  Capture a test thought, retrieve it.
+</Card>

--- a/mintlify/quickstart/mcp-deploy.mdx
+++ b/mintlify/quickstart/mcp-deploy.mdx
@@ -1,0 +1,136 @@
+---
+title: "Deploy the MCP server"
+description: "One Edge Function. Four MCP tools. Live in 10 minutes."
+---
+
+You're going to deploy a single Supabase Edge Function called `open-brain-mcp`. It exposes four MCP tools to any client you connect: capture, semantic search, browse, stats.
+
+<Warning>
+**Coming back from a failed attempt?** Delete any leftover `supabase/` folder in your home directory — it will silently hijack the new setup. `rm -rf ~/supabase` (Mac/Linux) or `Remove-Item -Recurse ~\supabase` (Windows).
+</Warning>
+
+## 1. Pick a project folder
+
+Make a new folder somewhere sensible (e.g. `~/Projects/open-brain`), then `cd` into it in your terminal.
+
+<CodeGroup>
+```bash Mac/Linux
+mkdir -p ~/Projects/open-brain
+cd ~/Projects/open-brain
+pwd
+```
+
+```powershell Windows
+mkdir $HOME\Projects\open-brain
+cd $HOME\Projects\open-brain
+Get-Location
+```
+</CodeGroup>
+
+<Info>
+Every following command runs from this folder. If you close the terminal and come back, `cd` here again.
+</Info>
+
+## 2. Install the Supabase CLI
+
+<CodeGroup>
+```bash Mac/Linux (Homebrew)
+brew install supabase/tap/supabase
+supabase --version
+```
+
+```bash Mac/Linux (npm)
+npm install -g supabase
+supabase --version
+```
+
+```powershell Windows (Scoop)
+Set-ExecutionPolicy -ExecutionPolicy RemoteSigned -Scope CurrentUser
+Invoke-RestMethod -Uri https://get.scoop.sh | Invoke-Expression
+scoop bucket add supabase https://github.com/supabase/scoop-bucket.git
+scoop install supabase
+supabase --version
+```
+</CodeGroup>
+
+## 3. Log in + link
+
+```bash
+supabase login
+```
+
+Browser opens — authenticate, return when it says "You are now logged in."
+
+```bash
+supabase init
+supabase link --project-ref YOUR_PROJECT_REF
+```
+
+Replace `YOUR_PROJECT_REF` with the value from your tracker.
+
+## 4. Set your secrets
+
+```bash
+supabase secrets set MCP_ACCESS_KEY=your-access-key
+supabase secrets set OPENROUTER_API_KEY=your-openrouter-key
+```
+
+<Note>
+`SUPABASE_URL` and `SUPABASE_SERVICE_ROLE_KEY` are auto-available inside Edge Functions — you don't set those.
+</Note>
+
+<Warning>
+The `MCP_ACCESS_KEY` you set here must **exactly match** the one you saved in your tracker. Mismatch = 401 errors when connecting.
+</Warning>
+
+## 5. Download the server files
+
+<CodeGroup>
+```bash Mac/Linux
+supabase functions new open-brain-mcp
+curl -o supabase/functions/open-brain-mcp/index.ts \
+  https://raw.githubusercontent.com/NateBJones-Projects/OB1/main/server/index.ts
+curl -o supabase/functions/open-brain-mcp/deno.json \
+  https://raw.githubusercontent.com/NateBJones-Projects/OB1/main/server/deno.json
+head -1 supabase/functions/open-brain-mcp/index.ts
+```
+
+```powershell Windows
+supabase functions new open-brain-mcp
+Invoke-WebRequest -Uri https://raw.githubusercontent.com/NateBJones-Projects/OB1/main/server/index.ts -OutFile supabase\functions\open-brain-mcp\index.ts
+Invoke-WebRequest -Uri https://raw.githubusercontent.com/NateBJones-Projects/OB1/main/server/deno.json -OutFile supabase\functions\open-brain-mcp\deno.json
+Get-Content supabase\functions\open-brain-mcp\index.ts -Head 1
+```
+</CodeGroup>
+
+The last command should print `import "jsr:@supabase/functions-js/edge-runtime.d.ts";` — **not** `console.log("Hello from Functions!")`. If you see the latter, the curl/Invoke-WebRequest didn't overwrite the starter; delete the folder and retry.
+
+## 6. Deploy
+
+```bash
+supabase functions deploy open-brain-mcp --no-verify-jwt
+```
+
+<Warning>
+First line of output should say `Using workdir <your project folder>`. If it shows your home directory, your Supabase project structure is in the wrong place — start over from step 1 in a clean folder.
+</Warning>
+
+Your live URLs:
+
+```text
+MCP Server URL:
+https://YOUR_PROJECT_REF.supabase.co/functions/v1/open-brain-mcp
+
+MCP Connection URL (with key embedded):
+https://YOUR_PROJECT_REF.supabase.co/functions/v1/open-brain-mcp?key=YOUR_ACCESS_KEY
+```
+
+Paste both into your tracker.
+
+<Check>
+`supabase functions list` shows `open-brain-mcp` as **ACTIVE**. Your tracker has both URLs filled in.
+</Check>
+
+<Card title="Next: connect a client" icon="arrow-right" href="/quickstart/connect-client">
+  Claude Desktop, ChatGPT, Claude Code, Codex, or anything else MCP-capable.
+</Card>

--- a/mintlify/quickstart/openrouter.mdx
+++ b/mintlify/quickstart/openrouter.mdx
@@ -1,0 +1,47 @@
+---
+title: "OpenRouter setup"
+description: "One key, every major model. About 3 minutes."
+---
+
+OpenRouter is a single-API gateway in front of every major LLM and embedding provider. Open Brain uses it for embeddings and lightweight metadata extraction.
+
+Why not OpenAI directly? One billing relationship, one key, future-proof.
+
+## 1. Sign up + fund
+
+1. Go to [openrouter.ai](https://openrouter.ai), sign up.
+2. Go to **Credits**, add **$5**. That lasts months at typical Open Brain usage.
+
+## 2. Generate the key
+
+1. Go to [openrouter.ai/keys](https://openrouter.ai/keys).
+2. **Create Key**, name it `open-brain`.
+3. **Copy it into your credential tracker immediately.** You can't view it again after closing the dialog.
+
+## 3. Generate your MCP access key
+
+This is the secret your MCP server checks on every request. Different from the OpenRouter key — it guards your endpoint.
+
+<CodeGroup>
+```bash Mac/Linux
+openssl rand -hex 32
+```
+
+```powershell Windows
+-join ((1..32) | ForEach-Object { '{0:x2}' -f (Get-Random -Maximum 256) })
+```
+</CodeGroup>
+
+Copy the 64-character output into your tracker as **MCP Access Key**.
+
+<Warning>
+This is **the** access key for all of Open Brain — every extension you add later reuses it. Don't regenerate unless you want to update every deployed function.
+</Warning>
+
+<Check>
+Tracker has **OpenRouter API key** and **MCP Access Key** filled in.
+</Check>
+
+<Card title="Next: deploy the server" icon="arrow-right" href="/quickstart/mcp-deploy">
+  Install the Supabase CLI, link, set secrets, deploy.
+</Card>

--- a/mintlify/quickstart/overview.mdx
+++ b/mintlify/quickstart/overview.mdx
@@ -1,0 +1,64 @@
+---
+title: "Quickstart overview"
+description: "Build the full Open Brain in eight steps, about 45 minutes."
+---
+
+By the end of this quickstart you'll have:
+
+- A Supabase project with a `thoughts` table and vector search
+- An OpenRouter account funded for embeddings + lightweight LLM calls
+- A remote MCP server deployed as a Supabase Edge Function
+- Your AI client connected to it, writing and reading thoughts on demand
+
+## What you need
+
+- Email + a few minutes to verify accounts (Supabase, OpenRouter)
+- About **$5 on a card** for OpenRouter credits (lasts months)
+- An MCP-capable AI client: Claude Desktop, ChatGPT (paid), Claude Code, Cursor, Codex, Windsurf
+
+No coding experience required. The whole flow is paste-the-SQL, paste-the-command, paste-the-URL.
+
+<Warning>
+**Download the [credential tracker](https://raw.githubusercontent.com/NateBJones-Projects/OB1/main/docs/open-brain-credential-tracker.xlsx) before you start.** You'll generate keys you can't retrieve later. The spreadsheet has a slot for every credential.
+</Warning>
+
+## The eight steps
+
+<Steps>
+  <Step title="Create a Supabase project">
+    See [Supabase setup](/quickstart/supabase). Sign up, create the `open-brain` project, save the project ref.
+  </Step>
+  <Step title="Set up the database">
+    Enable pgvector, create the `thoughts` table, the `match_thoughts` function, and grant service-role access. Five SQL blocks — covered in [Supabase setup](/quickstart/supabase).
+  </Step>
+  <Step title="Save your API keys">
+    Settings → API Keys → copy Project URL and Secret key into the tracker.
+  </Step>
+  <Step title="Get an OpenRouter key">
+    See [OpenRouter setup](/quickstart/openrouter). Sign up, fund $5 in credits, generate a key.
+  </Step>
+  <Step title="Generate an access key">
+    `openssl rand -hex 32` (Mac/Linux) or PowerShell one-liner (Windows). This guards your MCP server.
+  </Step>
+  <Step title="Deploy the MCP server">
+    See [MCP deploy](/quickstart/mcp-deploy). Install the Supabase CLI, link your project, set secrets, deploy the Edge Function.
+  </Step>
+  <Step title="Connect your AI client">
+    See [Connect client](/quickstart/connect-client). One URL per client.
+  </Step>
+  <Step title="Verify it works">
+    Capture a test thought, search for it. See [Verify](/quickstart/verify).
+  </Step>
+</Steps>
+
+<Info>
+**Source of truth.** This quickstart is a polished walkthrough. The canonical, maintained, fully-screenshotted version lives in the OB1 repo at [`docs/01-getting-started.md`](https://github.com/NateBJones-Projects/OB1/blob/main/docs/01-getting-started.md). If you hit something not covered here, that's where to look — plus the [FAQ](/faq).
+</Info>
+
+## Prefer video?
+
+[Open Brain Startup Guide](https://vimeo.com/1174979042/f883f6489a) — ~27 minutes, same flow.
+
+## Prefer AI-assisted?
+
+If you'd rather have Cursor, Claude Code, or another agent drive the build for you, see [`docs/04-ai-assisted-setup.md`](https://github.com/NateBJones-Projects/OB1/blob/main/docs/04-ai-assisted-setup.md) in the repo.

--- a/mintlify/quickstart/supabase.mdx
+++ b/mintlify/quickstart/supabase.mdx
@@ -1,0 +1,130 @@
+---
+title: "Supabase setup"
+description: "Create the project, enable pgvector, build the thoughts table."
+---
+
+About 15 minutes. You'll come away with a Supabase project running pgvector and a `thoughts` table indexed for fast similarity search.
+
+## 1. Create the project
+
+1. Go to [supabase.com](https://supabase.com), sign up (GitHub login is fastest).
+2. **New Project** → pick the default organization.
+3. Name: `open-brain`. Generate a strong DB password and **paste it into your credential tracker immediately**.
+4. Pick the region closest to you. Click **Create new project**, wait 1–2 minutes.
+
+<Warning>
+Grab your **Project ref** — it's the random string in `supabase.com/dashboard/project/THIS_PART`. You'll use it constantly. Paste it into the tracker.
+</Warning>
+
+## 2. Enable pgvector
+
+Left sidebar → **Database → Extensions** → search `vector` → flip **pgvector ON**.
+
+## 3. Create the thoughts table
+
+Left sidebar → **SQL Editor → New query** → paste and **Run**:
+
+```sql
+create table thoughts (
+  id uuid default gen_random_uuid() primary key,
+  content text not null,
+  embedding vector(1536),
+  metadata jsonb default '{}'::jsonb,
+  created_at timestamptz default now(),
+  updated_at timestamptz default now()
+);
+
+create index on thoughts using hnsw (embedding vector_cosine_ops);
+create index on thoughts using gin (metadata);
+create index on thoughts (created_at desc);
+
+create or replace function update_updated_at()
+returns trigger as $$
+begin
+  new.updated_at = now();
+  return new;
+end;
+$$ language plpgsql;
+
+create trigger thoughts_updated_at
+  before update on thoughts
+  for each row
+  execute function update_updated_at();
+```
+
+## 4. Create the search function
+
+New query → paste and **Run**:
+
+```sql
+create or replace function match_thoughts(
+  query_embedding vector(1536),
+  match_threshold float default 0.7,
+  match_count int default 10,
+  filter jsonb default '{}'::jsonb
+)
+returns table (
+  id uuid,
+  content text,
+  metadata jsonb,
+  similarity float,
+  created_at timestamptz
+)
+language plpgsql
+as $$
+begin
+  return query
+  select
+    t.id,
+    t.content,
+    t.metadata,
+    1 - (t.embedding <=> query_embedding) as similarity,
+    t.created_at
+  from thoughts t
+  where 1 - (t.embedding <=> query_embedding) > match_threshold
+    and (filter = '{}'::jsonb or t.metadata @> filter)
+  order by t.embedding <=> query_embedding
+  limit match_count;
+end;
+$$;
+```
+
+## 5. Lock down access
+
+```sql
+alter table thoughts enable row level security;
+
+create policy "Service role full access"
+  on thoughts
+  for all
+  using (auth.role() = 'service_role');
+```
+
+## 6. Grant table permissions
+
+```sql
+grant select, insert, update, delete on table public.thoughts to service_role;
+```
+
+<Warning>
+This step is **required** on new Supabase projects. Without it the MCP server returns `permission denied for table thoughts` when trying to capture or search.
+</Warning>
+
+## 7. Save your API credentials
+
+Settings (gear icon) → **API Keys**. On the "Publishable and secret API keys" tab:
+
+- **Project URL** — top of the page → tracker
+- **Secret key** — scroll to "Secret keys", copy the `default` value → tracker
+
+<Note>
+The "Legacy anon, service_role API keys" tab uses old-style JWT keys. Open Brain uses the **new** key format — ignore the legacy tab.
+</Note>
+
+<Check>
+Table Editor shows a `thoughts` table with columns: `id`, `content`, `embedding`, `metadata`, `created_at`, `updated_at`. Database → Functions shows `match_thoughts`. Your tracker has Project ref, DB password, Project URL, and Secret key filled in.
+</Check>
+
+<Card title="Next: OpenRouter" icon="arrow-right" href="/quickstart/openrouter">
+  Get an embedding API key.
+</Card>

--- a/mintlify/quickstart/verify.mdx
+++ b/mintlify/quickstart/verify.mdx
@@ -1,0 +1,62 @@
+---
+title: "Verify it works"
+description: "Two prompts. Two checks. You're done."
+---
+
+## 1. Capture a thought
+
+In your connected AI, say:
+
+```text
+Remember this: Sarah mentioned she's thinking about leaving her job to start a consulting business
+```
+
+Wait a few seconds. The AI should confirm the capture and show the extracted metadata (type, topics, people, action items).
+
+## 2. Confirm it landed in the database
+
+Supabase dashboard → **Table Editor → thoughts**. You should see one row with:
+
+- Your message in `content`
+- A non-null `embedding` (long array of floats)
+- JSON in `metadata`
+
+## 3. Retrieve it
+
+In the same conversation (or a fresh one — that's the point):
+
+```text
+What did Sarah tell me?
+```
+
+The AI should retrieve the thought and answer using it as context.
+
+<Check>
+Row visible in Supabase. AI retrieves it on demand. You have a working Open Brain.
+</Check>
+
+## Common prompts to try next
+
+| Prompt | Tool triggered |
+| --- | --- |
+| "Save this: shipped v2 on March 15" | `capture_thought` |
+| "What did I capture about career changes?" | `search_thoughts` |
+| "What did I write down this week?" | `list_thoughts` |
+| "How many thoughts do I have?" | `thought_stats` |
+
+## Where to go now
+
+<CardGroup cols={2}>
+  <Card title="Build extensions" icon="cubes" href="/extend/extensions">
+    Six progressive builds — household, calendar, CRM, job hunt.
+  </Card>
+  <Card title="Import your data" icon="file-import" href="/extend/recipes">
+    ChatGPT exports, Gmail, Obsidian, Twitter, Perplexity.
+  </Card>
+  <Card title="Read the FAQ" icon="circle-question" href="/faq">
+    Auth errors, key rotation, the Obsidian question.
+  </Card>
+  <Card title="MCP tool reference" icon="terminal" href="/reference/mcp-tools">
+    Exact tool signatures and parameter shapes.
+  </Card>
+</CardGroup>

--- a/mintlify/reference/mcp-tools.mdx
+++ b/mintlify/reference/mcp-tools.mdx
@@ -1,0 +1,72 @@
+---
+title: "MCP tools"
+description: "Four tools exposed by the open-brain-mcp Edge Function."
+---
+
+Every Open Brain exposes the same four tools to any connected MCP client. The actual implementations live in [`server/index.ts`](https://github.com/NateBJones-Projects/OB1/blob/main/server/index.ts) — this page is the contract.
+
+## `capture_thought`
+
+Write a new thought. The server auto-generates the embedding and extracts metadata.
+
+**Parameters**
+
+| Name | Type | Required | Notes |
+| --- | --- | --- | --- |
+| `content` | string | ✅ | The thought text. No length cap, but chunk long content for better retrieval. |
+| `metadata` | object | optional | Caller-provided metadata, merged with LLM-extracted fields. |
+
+**Returns** — the inserted row's `id`, plus the extracted metadata so the user can see what was tagged.
+
+**When the LLM picks this tool** — phrases like "remember", "save this", "make a note", "capture", "add to my brain", or any clearly-narrative statement framed as something to retain.
+
+## `search_thoughts`
+
+Semantic similarity search against your thoughts.
+
+**Parameters**
+
+| Name | Type | Required | Notes |
+| --- | --- | --- | --- |
+| `query` | string | ✅ | Natural-language query — the server embeds it. |
+| `match_threshold` | float | optional | Cosine similarity floor (default 0.7). Lower = more results, more noise. |
+| `match_count` | int | optional | Top-K limit (default 10). |
+| `filter` | object | optional | JSONB metadata filter — e.g. `{ "source": "gmail" }`. |
+
+**Returns** — rows with `id`, `content`, `metadata`, `similarity` (0–1), `created_at`. Sorted by similarity descending.
+
+**When the LLM picks this tool** — questions about what you've said, decided, learned, or captured on a topic. "What do I think about X?" "Did I save anything about Y?" "Find my notes on Z."
+
+## `list_thoughts`
+
+Browse recent thoughts, optionally filtered. No semantic matching — pure recency.
+
+**Parameters**
+
+| Name | Type | Required | Notes |
+| --- | --- | --- | --- |
+| `limit` | int | optional | How many rows (default 20). |
+| `filter` | object | optional | JSONB metadata filter. |
+| `since` | timestamp | optional | Only thoughts created after this. |
+
+**Returns** — rows sorted by `created_at` descending.
+
+**When the LLM picks this tool** — time-bound queries: "what did I capture this week", "show me my recent thoughts", "what was I thinking about Tuesday".
+
+## `thought_stats`
+
+High-level stats about your brain.
+
+**Parameters** — none.
+
+**Returns** — total thought count, most-common metadata values (top topics, top people, source breakdown), first/last capture dates.
+
+**When the LLM picks this tool** — questions about volume, patterns, or who/what shows up most.
+
+## Auth
+
+Every request includes the access key — either as `?key=...` in the URL, or as the `x-brain-key` header. Mismatch returns 401. See [the FAQ](/faq) if you're seeing auth errors despite a correct key.
+
+## Tool surface area
+
+After a few extensions, you'll have a dozen+ tools across multiple MCP servers. The clients don't filter them well by default — read the [Tool Audit guide](https://github.com/NateBJones-Projects/OB1/blob/main/docs/05-tool-audit.md) for how to keep this manageable.

--- a/mintlify/reference/thoughts-table.mdx
+++ b/mintlify/reference/thoughts-table.mdx
@@ -1,0 +1,138 @@
+---
+title: "thoughts table reference"
+description: "The single load-bearing schema in Open Brain."
+---
+
+The `thoughts` table is the core contract. Every extension, recipe, and integration assumes its shape. **You can add columns; you cannot modify or drop the existing ones.**
+
+## Definition
+
+```sql
+create table thoughts (
+  id uuid default gen_random_uuid() primary key,
+  content text not null,
+  embedding vector(1536),
+  metadata jsonb default '{}'::jsonb,
+  created_at timestamptz default now(),
+  updated_at timestamptz default now()
+);
+```
+
+| Column | Type | Notes |
+| --- | --- | --- |
+| `id` | `uuid` | Primary key. Random per row. |
+| `content` | `text` | The thought as captured. Not null. |
+| `embedding` | `vector(1536)` | OpenRouter-generated, cosine-similarity. |
+| `metadata` | `jsonb` | LLM-extracted + caller-provided tags. |
+| `created_at` | `timestamptz` | Set on insert. |
+| `updated_at` | `timestamptz` | Trigger-maintained. |
+
+## Indexes
+
+```sql
+create index on thoughts using hnsw (embedding vector_cosine_ops);
+create index on thoughts using gin (metadata);
+create index on thoughts (created_at desc);
+```
+
+- **HNSW (vector)** — sub-millisecond similarity at million-row scale.
+- **GIN (metadata)** — fast filtering on JSON fields (`metadata @> '{"source":"gmail"}'`).
+- **B-tree (created_at)** — efficient recency queries.
+
+## Trigger
+
+```sql
+create or replace function update_updated_at()
+returns trigger as $$ begin new.updated_at = now(); return new; end; $$
+language plpgsql;
+
+create trigger thoughts_updated_at
+  before update on thoughts
+  for each row
+  execute function update_updated_at();
+```
+
+## Row Level Security
+
+```sql
+alter table thoughts enable row level security;
+
+create policy "Service role full access"
+  on thoughts
+  for all
+  using (auth.role() = 'service_role');
+```
+
+Only the service role can read/write. Anon clients are blocked entirely — no public access path. Multi-user setups (Extensions 3–6) add per-user RLS policies on top.
+
+## Service-role grant
+
+Required on new Supabase projects:
+
+```sql
+grant select, insert, update, delete on table public.thoughts to service_role;
+```
+
+Without it, the MCP server returns `permission denied for table thoughts` on every call.
+
+## The search function
+
+A single SQL function handles ranked similarity search with optional metadata filtering:
+
+```sql
+create or replace function match_thoughts(
+  query_embedding vector(1536),
+  match_threshold float default 0.7,
+  match_count int default 10,
+  filter jsonb default '{}'::jsonb
+)
+returns table (
+  id uuid,
+  content text,
+  metadata jsonb,
+  similarity float,
+  created_at timestamptz
+)
+language plpgsql as $$
+begin
+  return query
+  select t.id, t.content, t.metadata,
+         1 - (t.embedding <=> query_embedding) as similarity,
+         t.created_at
+  from thoughts t
+  where 1 - (t.embedding <=> query_embedding) > match_threshold
+    and (filter = '{}'::jsonb or t.metadata @> filter)
+  order by t.embedding <=> query_embedding
+  limit match_count;
+end;
+$$;
+```
+
+The `<=>` operator is pgvector's cosine distance. `1 - distance` converts it to similarity (0–1, higher is closer).
+
+## Metadata conventions
+
+Open Brain doesn't enforce a metadata schema, but contributions follow a few conventions:
+
+```json
+{
+  "type": "decision | observation | idea | question | task | reference",
+  "topics": ["array", "of", "tags"],
+  "people": ["names mentioned"],
+  "source": "claude | chatgpt | gmail | obsidian | manual | ...",
+  "action_items": ["array", "of", "to-dos"]
+}
+```
+
+Imports stamp `source`. Extensions add their own fields (e.g., `crm_contact_id`, `recipe_id`). Filter against these via the `filter` parameter on `match_thoughts`.
+
+## Adding columns
+
+Adding columns is allowed and encouraged when an extension needs structured data on every thought:
+
+```sql
+alter table thoughts add column priority text;
+alter table thoughts add column reviewed boolean default false;
+```
+
+But **never** rename, retype, or drop the six original columns. The automated PR review enforces this.


### PR DESCRIPTION
Adds a Mintlify documentation site at mintlify/ that presents Open  as a polished public docs experience, alongside (not replacing) the plain-markdown docs/ folder which remains the canonical source linked from Executive Circle and .

What it contains (19 MDX + docs.):
- introduction, how-it-works (capture/retrieve mermaid diagram), architecture
- quickstart: 6-page install walkthrough (overview, supabase, openrouter, mcp-deploy, connect-client, verify) with CodeGroup blocks for Mac/Linux/Windows
- extend: 5 index pages (extensions, recipes, schemas, dashboards, integrations) linking to the actual contribution folders
- reference: mcp-tools (4 tool signatures) and thoughts-table (full schema)
- faq, contributing

Theme: OB1 blue (#1E88E5), top-nav anchors to /Discord/. Most pages link out to canonical content rather than duplicate it; the quickstart is the one exception since it is the primary entry point.

To preview locally: cd mintlify && npx mint dev
To deploy: connect this repo + the mintlify/ subfolder at dashboard.mintlify.com

Note: have not yet validated docs.json against the Mintlify schema or run mint dev locally; reviewer should do both before merge.

## Contribution Type

<!-- Check one -->
- [ ] Recipe (`/recipes`)
- [ ] Schema (`/schemas`)
- [ ] Dashboard (`/dashboards`)
- [ ] Integration (`/integrations`)
- [ ] Skill (`/skills`)
- [ ] Repo improvement (docs, CI, templates)

## What does this do?

<!-- 1-3 sentences describing what this contribution adds or changes -->

## Requirements

<!-- What external services, tools, or APIs does this need? (e.g.,  , Node.js 18+) -->
<!-- If this depends on a canonical skill or primitive, mention it here and declare it in metadata. -->

## Checklist

- [ ] I've read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [ ] My contribution has a `README.md` with prerequisites, step-by-step instructions, and expected outcome
- [ ] My `metadata.json` has all required fields
- [ ] If my contribution depends on a skill or primitive, I declared it in metadata.json and linked it in the README
- [ ] I tested this on my own Open  instance
- [ ] No credentials, API keys, or secrets are included
