### PR TITLE
[codex] Add MCP-backed graph dashboard auth flow

### DIFF
--- a/dashboards/open-brain-dashboard-next/README.md
+++ b/dashboards/open-brain-dashboard-next/README.md
@@ -1,210 +1,215 @@
 # Open Brain Dashboard (Next.js)
 
-<div align="center">
+A web dashboard for Open Brain with dashboard stats, search, workflow, thought browsing, and a visual graph view.
 
-![Community Contribution](https://img.shields.io/badge/OB1_COMMUNITY-Approved_Contribution-2ea44f?style=for-the-badge&logo=github)
+This version is built for the **MCP-backed Open Brain setup** and uses **Supabase Auth** for login.
 
-**Created by [@alanshurafa](https://github.com/alanshurafa)**
+## What this dashboard does
 
-*Reviewed and merged by the Open Brain maintainer team — thank you for building the future of AI memory!*
+- shows dashboard stats and recent activity
+- lets users browse recent thoughts
+- supports semantic search
+- includes a workflow board for task-style thoughts
+- includes a graph explorer for connected thoughts
+- supports quick capture / add-to-brain flows
+- uses email/password, GitHub, or Google sign-in
 
-</div>
+## Important architecture note
 
-A full-featured web dashboard for your Open Brain second brain. Browse, search, capture, and manage thoughts through a modern dark-themed UI. Built with Next.js, React, TypeScript, and Tailwind CSS. Deploy to Vercel or any Node.js host.
+This dashboard no longer assumes a deployed `open-brain-rest` backend.
 
-## What It Does
+It is wired to the Open Brain backend pieces that are actually deployed in this project:
 
-Provides 9 pages for managing your thoughts:
+- `open-brain-mcp`
+- `mcp-server`
 
-| Page | Description |
-|------|-------------|
-| **Dashboard** | Stats overview (total thoughts, type distribution, top topics), recent activity, quick capture, workflow summary widget |
-| **Workflow** | Kanban board for tasks and ideas with drag-and-drop status management (New → Planning → Active → Review → Done → Archived) |
-| **Browse** | Paginated thought table with filters for type, source, and importance |
-| **Detail** | Full thought view with inline editing, delete, linked reflections, and related connections |
-| **Search** | Semantic (vector similarity) and full-text search with match scores and pagination |
-| **Add to Brain** | Smart ingest with auto-routing — short text goes to single capture, long text to extraction with dry-run preview |
-| **Audit** | Quality review for low-score thoughts with bulk delete |
-| **Duplicates** | Semantic similarity detection with keep/delete/keep-both resolution |
-| **Login** | API key authentication via encrypted session cookie |
+That means the dashboard is primarily **MCP-backed**.
 
 ## Prerequisites
 
-- A working Open Brain setup with the **REST API gateway** (`open-brain-rest`) deployed
-- **Node.js 18+** installed
-- A **Vercel account** (free tier works) or any Node.js hosting
+- a working Supabase project for Open Brain
+- `open-brain-mcp` deployed
+- `mcp-server` deployed
+- Node.js 18+
+- a Supabase Auth setup
 
-### Credential Tracker
+## Environment variables
 
-| Credential | Where to get it | Where it goes |
-|------------|----------------|---------------|
-| `NEXT_PUBLIC_API_URL` | Your Supabase project URL + `/functions/v1/open-brain-rest` | `.env` or hosting env vars |
-| `SESSION_SECRET` | Generate: `openssl rand -hex 32` | `.env` or hosting env vars |
-| `RESTRICTED_PASSPHRASE_HASH` | Optional. Generate: `echo -n "passphrase" \| shasum -a 256` | `.env` or hosting env vars |
+Create `.env.local` and set:
 
-## Steps
-
-### Step 1: Clone the dashboard
-
-```bash
-# From the OB1 repo
-cd dashboards/open-brain-dashboard
-```
-
-Or copy the folder to your own project directory.
-
-### Step 2: Install dependencies
-
-```bash
-npm install
-```
-
-### Step 3: Configure environment
-
-```bash
-cp .env.example .env
-```
-
-Edit `.env` and set your values:
-
-```
-NEXT_PUBLIC_API_URL=https://YOUR-PROJECT-REF.supabase.co/functions/v1/open-brain-rest
+```env
+NEXT_PUBLIC_SUPABASE_URL=https://YOUR-PROJECT-REF.supabase.co
+NEXT_PUBLIC_SUPABASE_ANON_KEY=sb_publishable_xxx
+OPEN_BRAIN_MCP_URL=https://YOUR-PROJECT-REF.supabase.co/functions/v1/open-brain-mcp
+OPEN_BRAIN_MCP_ACCESS_KEY=your-mcp-access-key
+NEXT_PUBLIC_APP_URL=http://127.0.0.1:3001
 SESSION_SECRET=your-32-char-secret-here
 ```
 
-### Step 4: Run locally
+Optional:
+
+```env
+RESTRICTED_PASSPHRASE_HASH=optional-hash
+```
+
+## Local setup
 
 ```bash
+npm install
 npm run dev
 ```
 
-Open [http://localhost:3000](http://localhost:3000). You should see the login page.
+Open the local URL shown by Next.js. In this project it has commonly been:
 
-Enter your Open Brain API key (the `MCP_ACCESS_KEY` from your Supabase Edge Function secrets). After login, the dashboard loads with your stats and recent thoughts.
+`http://127.0.0.1:3001`
 
-### Step 5: Deploy to Vercel (optional)
+## Login flow
+
+Login uses **Supabase Auth**.
+
+Supported sign-in methods:
+
+- email/password
+- GitHub
+- Google
+
+The dashboard keeps `OPEN_BRAIN_MCP_ACCESS_KEY` on the server. End users do **not** paste the MCP key into the login form.
+
+## Supabase Auth setup
+
+### URL Configuration
+
+In Supabase:
+
+`Authentication -> URL Configuration`
+
+Set:
+
+- `Site URL`
+  `https://open-brain-dashboard-next-eight.vercel.app`
+
+- `Redirect URLs`
+  `https://open-brain-dashboard-next-eight.vercel.app/auth/callback`
+  `http://127.0.0.1:3001/auth/callback`
+
+### GitHub provider
+
+In Supabase:
+
+`Authentication -> Sign In / Providers -> GitHub`
+
+Use a real GitHub OAuth app.
+
+GitHub OAuth app settings:
+
+- Homepage URL:
+  `https://open-brain-dashboard-next-eight.vercel.app`
+- Authorization callback URL:
+  `https://mnihakzwdnhnxkinpuhy.supabase.co/auth/v1/callback`
+
+Paste the GitHub-issued:
+
+- `Client ID`
+- `Client Secret`
+
+into the Supabase GitHub provider settings.
+
+### Google provider
+
+In Supabase:
+
+`Authentication -> Sign In / Providers -> Google`
+
+Use a real Google OAuth client.
+
+Google OAuth settings should include:
+
+- redirect URI:
+  `https://mnihakzwdnhnxkinpuhy.supabase.co/auth/v1/callback`
+- origins:
+  `https://open-brain-dashboard-next-eight.vercel.app`
+  `http://127.0.0.1:3001`
+
+Paste the Google-issued:
+
+- `Client ID`
+- `Client Secret`
+
+into the Supabase Google provider settings.
+
+## Current behavior
+
+Working well now:
+
+- GitHub sign-in
+- dashboard stats
+- recent thoughts
+- graph page
+- MCP-backed thought loading
+- workflow summary
+
+## Validation
+
+These checks pass:
+
+```bash
+npm run lint
+npx tsc --noEmit
+```
+
+## Main files
+
+- `app/login/page.tsx`
+- `app/login/LoginForm.tsx`
+- `app/auth/callback/route.ts`
+- `lib/supabaseAuth.ts`
+- `lib/supabaseServerAuth.ts`
+- `lib/openBrainMcp.ts`
+- `components/GraphExplorer.tsx`
+- `app/api/graph/route.ts`
+- `app/api/graph-search/route.ts`
+
+## Troubleshooting
+
+### `Authentication callback failed`
+
+Check:
+
+- Supabase `Site URL`
+- Supabase redirect URLs
+- GitHub / Google provider credentials
+- production deploy contains the latest callback code
+
+### GitHub or Google button opens provider but never signs in
+
+Usually means one of these is wrong:
+
+- provider `Client ID`
+- provider `Client Secret`
+- Supabase callback URL
+- Supabase redirect URL allow-list
+
+### `SESSION_SECRET env var is required`
+
+Set a 32+ character `SESSION_SECRET`.
+
+### Search returns no results
+
+Make sure thoughts have embeddings populated.
+
+## Deployment
+
+Deploy with Vercel:
 
 ```bash
 npx vercel --prod
 ```
 
-Or connect the folder to Vercel via the dashboard. Set the environment variables (`NEXT_PUBLIC_API_URL`, `SESSION_SECRET`) in your Vercel project settings.
+Make sure production env vars match your local `.env.local` values, especially:
 
-> [!TIP]
-> The free Vercel tier is sufficient. The dashboard makes server-side API calls to your Open Brain REST endpoint — there's no heavy compute.
-
-## Expected Outcome
-
-When working correctly:
-
-- **Login page** accepts your Open Brain API key and redirects to the dashboard
-- **Dashboard** shows thought count, type distribution chart, top topics, and recent thoughts
-- **Browse** displays a paginated table of all thoughts with working type/source/importance filters
-- **Search** returns results with similarity scores (semantic mode) or rank scores (full-text mode)
-- **Add to Brain** auto-routes short text (< 500 chars, single paragraph) to single capture, and long/structured text to extraction with dry-run preview
-- **Detail page** shows full thought content with metadata, inline edit for content/type/importance, and linked reflections
-
-## Workflow Board
-
-The Workflow page adds a visual kanban board for managing `task` and `idea` thoughts through status stages.
-
-### Features
-
-- **Drag-and-drop** between status columns using @dnd-kit (touch-friendly with 200ms hold delay)
-- **Collapsible columns** — click the arrow to collapse any column to a slim vertical bar (persisted in localStorage)
-- **Auto-adjusting widths** — expanded columns share available space equally, no horizontal scrollbar
-- **Inline editing** — tap a card to open the edit modal (status, priority, type, content)
-- **Priority dots** — click to change priority (Critical/High/Medium/Low mapped from importance 0-100)
-- **Dashboard widget** — summary of active workflow items on the main dashboard
-- **Mobile-first** — responsive layout, pinch-to-zoom enabled, full-screen edit modal on small screens
-
-### Status Flow
-
-```
-New → Planning → Active → Review → Done → (Archived)
-```
-
-Cards auto-archive from Done after 30 days. Archived cards are hidden by default (toggle with "Show archived").
-
-### Database Requirements
-
-The Workflow board requires two additional columns on the `thoughts` table. See the [workflow-status schema](../../schemas/workflow-status/) for the migration SQL.
-
-### MCP Integration
-
-The `progress_task` tool in the Open Brain MCP server allows AI assistants to update task status and priority conversationally:
-
-```
-"Move the API redesign task to active"
-"Set priority on thought 42 to high"
-```
-
-When a new task or idea is captured, the MCP server auto-assigns `status: "new"`.
-
-## REST API Endpoints Required
-
-The dashboard calls these endpoints on your Open Brain REST API:
-
-| Endpoint | Method | Used By |
-|----------|--------|---------|
-| `/health` | GET | Login validation |
-| `/thoughts` | GET | Browse page (paginated, filtered) |
-| `/thought/:id` | GET | Detail page |
-| `/thought/:id` | PUT | Inline edit (content, type, importance) |
-| `/thought/:id` | DELETE | Delete button |
-| `/search` | POST | Search page (semantic + full-text) |
-| `/stats` | GET | Dashboard stats widget |
-| `/capture` | POST | Quick capture (single thought) |
-| `/thought/:id/reflection` | GET | Detail page (linked reflections) |
-| `/ingest` | POST | Smart ingest (extraction) |
-| `/ingestion-jobs` | GET | Ingest page (job history) |
-| `/duplicates` | GET | Duplicates page |
-| `/thoughts?type=task` | GET | Workflow board (filtered by type) |
-| `/thought/:id` | PUT | Workflow board (status/priority updates) |
-
-> [!NOTE]
-> If your Open Brain instance doesn't have all these endpoints (e.g., no smart-ingest or duplicates), those pages will show errors but the core pages (dashboard, browse, search, detail) will still work.
-
-## Optional: Restricted Content
-
-If you've applied the [sensitivity-tiers](https://github.com/NateBJones-Projects/OB1/pull/110) primitive and want to control access to sensitive thoughts:
-
-1. Set `RESTRICTED_PASSPHRASE_HASH` in your environment
-2. A lock/unlock toggle appears in the sidebar
-3. When locked (default), restricted thoughts are filtered from all views
-4. Enter your passphrase to temporarily unlock restricted content for the session
-
-If `RESTRICTED_PASSPHRASE_HASH` is not set, the toggle is hidden — no action needed.
-
-## Authentication
-
-The dashboard uses **iron-session** for encrypted HTTP-only session cookies:
-
-1. User enters their Open Brain API key once at login
-2. Key is validated against the `/health` endpoint
-3. Key is stored in an encrypted session cookie (not in client-side JS or localStorage)
-4. All server-side API calls use the key from the session
-5. Sessions expire after 24 hours
-
-No API key is stored in environment variables or exposed to the browser.
-
-## Tech Stack
-
-- **Next.js 16** (App Router)
-- **React 19** with TypeScript
-- **Tailwind CSS 4** (dark theme)
-- **iron-session 8** (encrypted cookies)
-- **@dnd-kit** (drag-and-drop for workflow board)
-- Zero external runtime dependencies beyond these
-
-## Troubleshooting
-
-1. **"Could not reach API" on login** — Verify `NEXT_PUBLIC_API_URL` is correct and your REST API gateway (`open-brain-rest`) is deployed. Test with: `curl https://YOUR-REF.supabase.co/functions/v1/open-brain-rest/health -H "x-brain-key: YOUR_KEY"`.
-
-2. **"SESSION_SECRET env var is required"** — The app requires a 32+ character secret for cookie encryption. Generate one with `openssl rand -hex 32`.
-
-3. **Build fails with SWC error** — This happens when `node_modules` was installed on a different platform (e.g., Windows modules on Linux). Delete `node_modules` and `package-lock.json`, then run `npm install` on your target platform.
-
-4. **Search returns no results** — Ensure your thoughts have embeddings. Semantic search requires the `embedding` column to be populated. Run an embedding backfill if needed.
-
-5. **Ingest page shows "extracting" forever** — Check that the `smart-ingest` Edge Function is deployed. The ingest feature depends on a separate Edge Function for document extraction.
+- `NEXT_PUBLIC_SUPABASE_URL`
+- `NEXT_PUBLIC_SUPABASE_ANON_KEY`
+- `OPEN_BRAIN_MCP_URL`
+- `OPEN_BRAIN_MCP_ACCESS_KEY`
+- `NEXT_PUBLIC_APP_URL`
+- `SESSION_SECRET`

--- a/dashboards/open-brain-dashboard-next/app/api/graph-search/route.ts
+++ b/dashboards/open-brain-dashboard-next/app/api/graph-search/route.ts
@@ -1,0 +1,45 @@
+import { NextRequest, NextResponse } from "next/server";
+import { requireSession, AuthError } from "@/lib/auth";
+import { mcpSearchThoughts } from "@/lib/openBrainMcp";
+
+export async function GET(request: NextRequest) {
+  let apiKey: string;
+  try {
+    ({ apiKey } = await requireSession());
+  } catch (err) {
+    if (err instanceof AuthError) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+    throw err;
+  }
+
+  const q = request.nextUrl.searchParams.get("q");
+  if (!q?.trim()) {
+    return NextResponse.json({ error: "Query required" }, { status: 400 });
+  }
+
+  try {
+    const documents = await mcpSearchThoughts(apiKey, q.trim());
+    const results = documents.map((doc) => {
+      const metadata = doc.metadata || {};
+      return {
+        id: doc.id,
+        content: doc.text,
+        type:
+          typeof metadata.type === "string" ? metadata.type : "reference",
+        created_at:
+          typeof metadata.created_at === "string"
+            ? metadata.created_at
+            : new Date().toISOString(),
+        metadata,
+      };
+    });
+
+    return NextResponse.json({ results });
+  } catch (err) {
+    return NextResponse.json(
+      { error: err instanceof Error ? err.message : "Search failed" },
+      { status: 500 }
+    );
+  }
+}

--- a/dashboards/open-brain-dashboard-next/app/api/graph/route.ts
+++ b/dashboards/open-brain-dashboard-next/app/api/graph/route.ts
@@ -1,0 +1,208 @@
+import { NextRequest, NextResponse } from "next/server";
+import { requireSession, AuthError } from "@/lib/auth";
+import { mcpFetchThought, mcpSearchThoughts, type McpThoughtDocument } from "@/lib/openBrainMcp";
+import type { GraphEdge, GraphNode } from "@/lib/types";
+
+const MAX_FIRST_RING = 10;
+const MAX_GRAPH_NODES = 24;
+
+type Meta = {
+  type?: string;
+  topics?: string[];
+  people?: string[];
+  created_at?: string;
+};
+
+function clampDepth(value: number): 1 | 2 {
+  return value >= 2 ? 2 : 1;
+}
+
+function normalizeMeta(document: McpThoughtDocument): Meta {
+  const metadata = document.metadata || {};
+  return {
+    type: typeof metadata.type === "string" ? metadata.type : "reference",
+    topics: Array.isArray(metadata.topics) ? metadata.topics.filter((v): v is string => typeof v === "string") : [],
+    people: Array.isArray(metadata.people) ? metadata.people.filter((v): v is string => typeof v === "string") : [],
+    created_at:
+      typeof metadata.created_at === "string"
+        ? metadata.created_at
+        : undefined,
+  };
+}
+
+function toGraphNode(
+  document: McpThoughtDocument,
+  ring: 0 | 1 | 2
+): GraphNode {
+  const meta = normalizeMeta(document);
+  return {
+    id: document.id,
+    type: meta.type || "reference",
+    importance: 0,
+    content: document.text,
+    preview:
+      document.text.length > 180
+        ? `${document.text.slice(0, 180)}...`
+        : document.text,
+    created_at: meta.created_at || new Date().toISOString(),
+    metadata: {
+      topics: meta.topics,
+      people: meta.people,
+    },
+    ring,
+  };
+}
+
+function overlap(a: string[], b: string[]) {
+  const right = new Set(b);
+  return a.filter((item) => right.has(item));
+}
+
+function buildEdge(
+  source: McpThoughtDocument,
+  target: McpThoughtDocument
+): GraphEdge {
+  const sourceMeta = normalizeMeta(source);
+  const targetMeta = normalizeMeta(target);
+  const sharedTopics = overlap(sourceMeta.topics || [], targetMeta.topics || []);
+  const sharedPeople = overlap(sourceMeta.people || [], targetMeta.people || []);
+
+  return {
+    source: source.id,
+    target: target.id,
+    overlap_count: sharedTopics.length + sharedPeople.length,
+    shared_topics: sharedTopics,
+    shared_people: sharedPeople,
+  };
+}
+
+function buildQueries(document: McpThoughtDocument) {
+  const meta = normalizeMeta(document);
+  const queries = [
+    ...(meta.topics || []).slice(0, 3),
+    ...(meta.people || []).slice(0, 3),
+  ];
+
+  if (queries.length === 0) {
+    const fallback = document.text
+      .replace(/\s+/g, " ")
+      .trim()
+      .split(" ")
+      .slice(0, 8)
+      .join(" ");
+    if (fallback) queries.push(fallback);
+  }
+
+  return Array.from(new Set(queries));
+}
+
+async function collectNeighbors(
+  apiKey: string,
+  seed: McpThoughtDocument,
+  excludeIds: Set<string>,
+  maxNeighbors: number
+) {
+  const queries = buildQueries(seed);
+  const candidates = new Map<string, McpThoughtDocument>();
+
+  for (const query of queries) {
+    const results = await mcpSearchThoughts(apiKey, query).catch(() => []);
+    for (const result of results) {
+      if (excludeIds.has(result.id) || result.id === seed.id) continue;
+      candidates.set(result.id, result);
+    }
+  }
+
+  return Array.from(candidates.values())
+    .map((candidate) => ({
+      document: candidate,
+      edge: buildEdge(seed, candidate),
+    }))
+    .filter((entry) => (entry.edge.overlap_count || 0) > 0 || queries.length === 1)
+    .sort((a, b) => (b.edge.overlap_count || 0) - (a.edge.overlap_count || 0))
+    .slice(0, maxNeighbors);
+}
+
+export async function GET(request: NextRequest) {
+  let apiKey: string;
+  try {
+    ({ apiKey } = await requireSession());
+  } catch (err) {
+    if (err instanceof AuthError) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+    throw err;
+  }
+
+  const thoughtId = request.nextUrl.searchParams.get("thought_id");
+  const depth = clampDepth(
+    Number(request.nextUrl.searchParams.get("depth") || "1")
+  );
+
+  if (!thoughtId?.trim()) {
+    return NextResponse.json(
+      { error: "Valid thought_id is required" },
+      { status: 400 }
+    );
+  }
+
+  try {
+    const centerThought = await mcpFetchThought(apiKey, thoughtId.trim());
+    const nodes = new Map<string, GraphNode>();
+    const edges = new Map<string, GraphEdge>();
+    let truncated = false;
+
+    nodes.set(centerThought.id, toGraphNode(centerThought, 0));
+
+    const firstRing = await collectNeighbors(
+      apiKey,
+      centerThought,
+      new Set([centerThought.id]),
+      MAX_FIRST_RING
+    );
+
+    for (const entry of firstRing) {
+      nodes.set(entry.document.id, toGraphNode(entry.document, 1));
+      edges.set(`${centerThought.id}->${entry.document.id}`, entry.edge);
+    }
+
+    if (depth === 2) {
+      for (const entry of firstRing) {
+        const usedIds = new Set(nodes.keys());
+        const secondRing = await collectNeighbors(
+          apiKey,
+          entry.document,
+          usedIds,
+          3
+        );
+
+        for (const second of secondRing) {
+          if (!nodes.has(second.document.id)) {
+            if (nodes.size >= MAX_GRAPH_NODES) {
+              truncated = true;
+              continue;
+            }
+            nodes.set(second.document.id, toGraphNode(second.document, 2));
+          }
+
+          edges.set(`${entry.document.id}->${second.document.id}`, second.edge);
+        }
+      }
+    }
+
+    return NextResponse.json({
+      centerId: centerThought.id,
+      depth,
+      truncated,
+      nodes: Array.from(nodes.values()).sort((a, b) =>
+        a.ring === b.ring ? a.content.localeCompare(b.content) : a.ring - b.ring
+      ),
+      edges: Array.from(edges.values()),
+    });
+  } catch (err) {
+    return NextResponse.json(
+      { error: err instanceof Error ? err.message : "Failed to build graph" },
+      { status: 500 }
+    );
+  }
+}

--- a/dashboards/open-brain-dashboard-next/app/audit/page.tsx
+++ b/dashboards/open-brain-dashboard-next/app/audit/page.tsx
@@ -47,7 +47,7 @@ export default function AuditPage() {
     if (selected.size === data.data.length) {
       setSelected(new Set());
     } else {
-      setSelected(new Set(data.data.map((t) => t.id)));
+      setSelected(new Set(data.data.map((t) => Number(t.id))));
     }
   };
 
@@ -131,8 +131,8 @@ export default function AuditPage() {
                   <td className="px-4 py-3">
                     <input
                       type="checkbox"
-                      checked={selected.has(t.id)}
-                      onChange={() => toggleSelect(t.id)}
+                      checked={selected.has(Number(t.id))}
+                      onChange={() => toggleSelect(Number(t.id))}
                       className="accent-violet"
                     />
                   </td>

--- a/dashboards/open-brain-dashboard-next/app/auth/callback/route.ts
+++ b/dashboards/open-brain-dashboard-next/app/auth/callback/route.ts
@@ -1,0 +1,42 @@
+import { redirect } from "next/navigation";
+import type { EmailOtpType } from "@supabase/supabase-js";
+import { getSession } from "@/lib/auth";
+import { exchangeAuthCodeForUser, verifyMagicLink } from "@/lib/supabaseAuth";
+
+function sanitizeNext(next: string | null) {
+  if (!next || !next.startsWith("/")) {
+    return "/";
+  }
+  return next;
+}
+
+export async function GET(request: Request) {
+  const { searchParams } = new URL(request.url);
+  const code = searchParams.get("code");
+  const tokenHash = searchParams.get("token_hash");
+  const type = searchParams.get("type") as EmailOtpType | null;
+  const next = sanitizeNext(searchParams.get("next"));
+
+  try {
+    const user = code
+      ? await exchangeAuthCodeForUser(code)
+      : tokenHash && type
+        ? await verifyMagicLink(tokenHash, type)
+        : null;
+
+    if (!user) {
+      redirect("/login?error=Invalid%20or%20expired%20sign-in%20link");
+    }
+
+    const session = await getSession();
+    session.userId = user.id;
+    session.email = user.email ?? "";
+    session.loggedIn = true;
+    session.restrictedUnlocked = false;
+    await session.save();
+  } catch {
+    redirect("/login?error=Authentication%20callback%20failed");
+  }
+
+  redirect(next);
+}

--- a/dashboards/open-brain-dashboard-next/app/graph/page.tsx
+++ b/dashboards/open-brain-dashboard-next/app/graph/page.tsx
@@ -1,0 +1,29 @@
+import { requireSessionOrRedirect } from "@/lib/auth";
+import { GraphExplorer } from "@/components/GraphExplorer";
+
+export const dynamic = "force-dynamic";
+
+function parseThoughtId(value: string | undefined) {
+  const trimmed = value?.trim();
+  return trimmed ? trimmed : undefined;
+}
+
+function parseDepth(value: string | undefined): 1 | 2 {
+  return value === "2" ? 2 : 1;
+}
+
+export default async function GraphPage({
+  searchParams,
+}: {
+  searchParams: Promise<Record<string, string | undefined>>;
+}) {
+  await requireSessionOrRedirect();
+  const params = await searchParams;
+
+  return (
+    <GraphExplorer
+      initialThoughtId={parseThoughtId(params.thought)}
+      initialDepth={parseDepth(params.depth)}
+    />
+  );
+}

--- a/dashboards/open-brain-dashboard-next/app/login/LoginForm.tsx
+++ b/dashboards/open-brain-dashboard-next/app/login/LoginForm.tsx
@@ -2,49 +2,125 @@
 
 import { useActionState } from "react";
 
+type FormState = {
+  error?: string;
+  success?: string;
+};
+
 export function LoginForm({
-  action,
+  credentialAction,
+  githubAction,
+  googleAction,
 }: {
-  action: (formData: FormData) => Promise<{ error: string } | undefined>;
+  credentialAction: (formData: FormData) => Promise<FormState | undefined>;
+  githubAction: () => Promise<void>;
+  googleAction: () => Promise<void>;
 }) {
-  const [state, formAction, pending] = useActionState(
-    async (_prev: { error: string } | undefined, formData: FormData) => {
-      return await action(formData);
-    },
-    undefined
-  );
+  const [credentialState, credentialFormAction, credentialPending] =
+    useActionState(
+      async (_prev: FormState | undefined, formData: FormData) => {
+        return credentialAction(formData);
+      },
+      undefined
+    );
 
   return (
-    <form action={formAction} className="space-y-4">
-      <div>
-        <label
-          htmlFor="apiKey"
-          className="block text-sm font-medium text-text-secondary mb-1.5"
-        >
-          MCP Access Key
-        </label>
-        <input
-          id="apiKey"
-          name="apiKey"
-          type="password"
-          required
-          autoFocus
-          placeholder="your-api-key"
-          className="w-full px-4 py-2.5 bg-bg-surface border border-border rounded-lg text-text-primary placeholder-text-muted focus:outline-none focus:border-violet focus:ring-1 focus:ring-violet/30 transition"
-        />
+    <div className="space-y-6">
+      <form action={credentialFormAction} className="space-y-4">
+        <div>
+          <label
+            htmlFor="email"
+            className="block text-sm font-medium text-text-secondary mb-1.5"
+          >
+            Google / Gmail email
+          </label>
+          <input
+            id="email"
+            name="email"
+            type="email"
+            required
+            autoFocus
+            placeholder="you@gmail.com"
+            className="w-full px-4 py-2.5 bg-bg-surface border border-border rounded-lg text-text-primary placeholder-text-muted focus:outline-none focus:border-violet focus:ring-1 focus:ring-violet/30 transition"
+          />
+        </div>
+
+        <div>
+          <label
+            htmlFor="password"
+            className="block text-sm font-medium text-text-secondary mb-1.5"
+          >
+            Password
+          </label>
+          <input
+            id="password"
+            name="password"
+            type="password"
+            required
+            placeholder="Your password"
+            className="w-full px-4 py-2.5 bg-bg-surface border border-border rounded-lg text-text-primary placeholder-text-muted focus:outline-none focus:border-violet focus:ring-1 focus:ring-violet/30 transition"
+          />
+        </div>
+
+        {credentialState?.error && (
+          <p className="text-danger text-sm">{credentialState.error}</p>
+        )}
+        {credentialState?.success && (
+          <p className="text-emerald-400 text-sm">{credentialState.success}</p>
+        )}
+
+        <div className="grid grid-cols-2 gap-3">
+          <button
+            type="submit"
+            name="intent"
+            value="sign-in"
+            disabled={credentialPending}
+            className="w-full py-2.5 bg-violet hover:bg-violet-dim text-white font-medium rounded-lg transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+          >
+            {credentialPending ? "Working..." : "Sign in"}
+          </button>
+          <button
+            type="submit"
+            name="intent"
+            value="sign-up"
+            disabled={credentialPending}
+            className="w-full py-2.5 bg-bg-elevated border border-border text-text-primary font-medium rounded-lg transition-colors hover:bg-bg-hover disabled:opacity-50 disabled:cursor-not-allowed"
+          >
+            {credentialPending ? "Working..." : "Create account"}
+          </button>
+        </div>
+      </form>
+
+        <div className="relative">
+          <div className="absolute inset-0 flex items-center">
+            <div className="w-full border-t border-border" />
+          </div>
+          <div className="relative flex justify-center">
+            <span className="bg-bg-primary px-3 text-xs text-text-muted">
+              Or continue with Google or GitHub
+            </span>
+          </div>
+        </div>
+
+      <div className="grid grid-cols-2 gap-3">
+        <form action={googleAction}>
+          <button
+            type="submit"
+            className="w-full py-2.5 bg-bg-elevated border border-border text-text-primary font-medium rounded-lg transition-colors hover:bg-bg-hover disabled:opacity-50 disabled:cursor-not-allowed"
+          >
+            Continue with Google
+          </button>
+        </form>
+
+        <form action={githubAction}>
+          <button
+            type="submit"
+            className="w-full py-2.5 bg-bg-elevated border border-border text-text-primary font-medium rounded-lg transition-colors hover:bg-bg-hover disabled:opacity-50 disabled:cursor-not-allowed"
+          >
+            Continue with GitHub
+          </button>
+        </form>
       </div>
-
-      {state?.error && (
-        <p className="text-danger text-sm">{state.error}</p>
-      )}
-
-      <button
-        type="submit"
-        disabled={pending}
-        className="w-full py-2.5 bg-violet hover:bg-violet-dim text-white font-medium rounded-lg transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
-      >
-        {pending ? "Verifying..." : "Sign in"}
-      </button>
-    </form>
+    </div>
   );
 }

--- a/dashboards/open-brain-dashboard-next/app/login/page.tsx
+++ b/dashboards/open-brain-dashboard-next/app/login/page.tsx
@@ -1,41 +1,106 @@
 import { redirect } from "next/navigation";
 import { getSession } from "@/lib/auth";
+import {
+  getGithubSignInUrl,
+  getGoogleSignInUrl,
+  signInWithPassword,
+  signUpWithPassword,
+} from "@/lib/supabaseAuth";
 import { LoginForm } from "./LoginForm";
 
-async function loginAction(formData: FormData) {
-  "use server";
+type LoginState = {
+  error?: string;
+  success?: string;
+};
 
-  const apiKey = formData.get("apiKey") as string;
-  if (!apiKey?.trim()) {
-    return { error: "API key is required" };
-  }
-
-  // Validate key against health endpoint
-  const apiUrl = process.env.NEXT_PUBLIC_API_URL;
-  try {
-    const res = await fetch(`${apiUrl}/health`, {
-      headers: { "x-brain-key": apiKey },
-    });
-    if (!res.ok) {
-      return { error: "Invalid API key or service unavailable" };
-    }
-  } catch {
-    return { error: "Could not reach API. Check your connection." };
-  }
-
-  const session = await getSession();
-  session.apiKey = apiKey;
-  session.loggedIn = true;
-  await session.save();
-
-  redirect("/");
+function normalizeEmail(value: FormDataEntryValue | null) {
+  return typeof value === "string" ? value.trim().toLowerCase() : "";
 }
 
-export default async function LoginPage() {
+function validatePassword(value: FormDataEntryValue | null) {
+  return typeof value === "string" ? value : "";
+}
+
+async function credentialAction(formData: FormData): Promise<LoginState | undefined> {
+  "use server";
+
+  const intent = formData.get("intent");
+  const email = normalizeEmail(formData.get("email"));
+  const password = validatePassword(formData.get("password"));
+
+  if (!email) {
+    return { error: "Email is required" };
+  }
+
+  if (!password) {
+    return { error: "Password is required" };
+  }
+
+  try {
+    if (intent === "sign-up") {
+      const data = await signUpWithPassword(email, password);
+
+      if (data.user && data.session) {
+        const session = await getSession();
+        session.userId = data.user.id;
+        session.email = data.user.email ?? email;
+        session.loggedIn = true;
+        session.restrictedUnlocked = false;
+        await session.save();
+        redirect("/");
+      }
+
+      return {
+        success:
+          "Account created. Check your email to confirm your address before signing in.",
+      };
+    }
+
+    const user = await signInWithPassword(email, password);
+    const session = await getSession();
+    session.userId = user.id;
+    session.email = user.email ?? email;
+    session.loggedIn = true;
+    session.restrictedUnlocked = false;
+    await session.save();
+
+    redirect("/");
+  } catch (error) {
+    return {
+      error:
+        error instanceof Error
+          ? error.message
+          : "Authentication failed",
+    };
+  }
+}
+
+async function githubAction() {
+  "use server";
+
+  const url = await getGithubSignInUrl("/");
+  redirect(url);
+}
+
+async function googleAction() {
+  "use server";
+
+  const url = await getGoogleSignInUrl("/");
+  redirect(url);
+}
+
+export default async function LoginPage({
+  searchParams,
+}: {
+  searchParams: Promise<Record<string, string | undefined>>;
+}) {
   const session = await getSession();
-  if (session.loggedIn && session.apiKey) {
+  if (session.loggedIn && session.userId) {
     redirect("/");
   }
+
+  const params = await searchParams;
+  const callbackError = params.error;
 
   return (
     <div className="min-h-screen flex items-center justify-center bg-bg-primary ml-0">
@@ -48,11 +113,19 @@ export default async function LoginPage() {
             Open Brain
           </h1>
           <p className="text-text-secondary text-sm mt-1">
-            Enter your API key to continue
+            Sign in with GitHub, Google, or your Google / Gmail email
           </p>
         </div>
 
-        <LoginForm action={loginAction} />
+        {callbackError && (
+          <p className="text-danger text-sm mb-4 text-center">{callbackError}</p>
+        )}
+
+        <LoginForm
+          credentialAction={credentialAction}
+          githubAction={githubAction}
+          googleAction={googleAction}
+        />
       </div>
     </div>
   );

--- a/dashboards/open-brain-dashboard-next/app/thoughts/[id]/page.tsx
+++ b/dashboards/open-brain-dashboard-next/app/thoughts/[id]/page.tsx
@@ -16,6 +16,7 @@ import { FormattedDate } from "@/components/FormattedDate";
 import Link from "next/link";
 
 export const dynamic = "force-dynamic";
+const MCP_MODE = Boolean(process.env.OPEN_BRAIN_MCP_URL);
 
 export default async function ThoughtDetailPage({
   params,
@@ -26,8 +27,7 @@ export default async function ThoughtDetailPage({
   const session = await getSession();
   const excludeRestricted = !session.restrictedUnlocked;
   const { id } = await params;
-  const thoughtId = parseInt(id, 10);
-  if (isNaN(thoughtId)) notFound();
+  const thoughtId = id;
 
   let thought;
   try {
@@ -55,7 +55,7 @@ export default async function ThoughtDetailPage({
 
   let reflections: Awaited<ReturnType<typeof fetchReflections>> = [];
   try {
-    reflections = await fetchReflections(apiKey, thoughtId);
+    reflections = await fetchReflections(apiKey, Number(thoughtId));
   } catch {
     reflections = [];
   }
@@ -66,24 +66,27 @@ export default async function ThoughtDetailPage({
 
   async function editAction(formData: FormData) {
     "use server";
+    if (MCP_MODE) return;
     const { apiKey } = await requireSessionOrRedirect();
     const content = formData.get("content") as string;
     const type = formData.get("type") as string;
     const importance = parseInt(formData.get("importance") as string, 10);
-    await updateThought(apiKey, thoughtId, { content, type, importance });
+    await updateThought(apiKey, Number(thoughtId), { content, type, importance });
   }
 
   async function deleteAction() {
     "use server";
+    if (MCP_MODE) return;
     const { apiKey } = await requireSessionOrRedirect();
-    await deleteThought(apiKey, thoughtId);
+    await deleteThought(apiKey, Number(thoughtId));
+
     redirect("/thoughts");
   }
 
   return (
     <div className="space-y-6">
       {/* Header */}
-      <div className="flex items-start justify-between">
+      <div className="flex items-start justify-between gap-4">
         <div>
           <div className="flex items-center gap-3 mb-2 flex-wrap">
             <TypeBadge type={thought.type} />
@@ -117,11 +120,25 @@ export default async function ThoughtDetailPage({
               ` | Sensitivity: ${thought.sensitivity_tier}`}
           </p>
         </div>
-        <ThoughtDeleteButton deleteAction={deleteAction} />
+        <div className="flex items-center gap-3">
+          <Link
+            href={`/graph?thought=${thought.id}`}
+            className="px-3 py-2 rounded-lg border border-border bg-bg-surface text-sm text-text-secondary hover:text-text-primary hover:border-violet/30 transition-colors whitespace-nowrap"
+          >
+            View graph
+          </Link>
+          {!MCP_MODE && <ThoughtDeleteButton deleteAction={deleteAction} />}
+        </div>
       </div>
 
+      {MCP_MODE && (
+        <div className="rounded-lg border border-violet/20 bg-violet/5 px-4 py-3 text-sm text-text-secondary">
+          This thought is being shown in MCP read-only mode. Editing, deleting, reflections, and legacy REST-based connections are still being migrated.
+        </div>
+      )}
+
       {/* Content + Edit */}
-      <ThoughtEditor thought={thought} editAction={editAction} />
+      <ThoughtEditor thought={thought} editAction={editAction} readOnly={MCP_MODE} />
 
       {/* Metadata panel */}
       {(topics.length > 0 ||
@@ -173,13 +190,15 @@ export default async function ThoughtDetailPage({
       )}
 
       {/* Connections */}
-      <ConnectionsPanel
-        thoughtId={thought.id}
-        hasMetadata={
-          topics.length > 0 ||
-          ((meta.people as string[]) || []).length > 0
-        }
-      />
+      {!MCP_MODE && (
+        <ConnectionsPanel
+          thoughtId={thought.id}
+          hasMetadata={
+            topics.length > 0 ||
+            ((meta.people as string[]) || []).length > 0
+          }
+        />
+      )}
 
       {/* Reflections */}
       {reflections.length > 0 && (
@@ -211,7 +230,9 @@ export default async function ThoughtDetailPage({
         </div>
       )}
 
-      <ReflectionComposer thoughtId={thought.id} />
+      {!MCP_MODE && typeof thought.id === "number" && (
+        <ReflectionComposer thoughtId={thought.id} />
+      )}
     </div>
   );
 }

--- a/dashboards/open-brain-dashboard-next/components/ConnectionsPanel.tsx
+++ b/dashboards/open-brain-dashboard-next/components/ConnectionsPanel.tsx
@@ -6,7 +6,7 @@ import { TypeBadge } from "./ThoughtCard";
 import { FormattedDate } from "./FormattedDate";
 
 interface Connection {
-  id: number;
+  id: string | number;
   type: string;
   importance: number;
   preview: string;
@@ -23,23 +23,40 @@ export function ConnectionsPanel({
   thoughtId,
   hasMetadata,
 }: {
-  thoughtId: number;
+  thoughtId: string | number;
   hasMetadata: boolean;
 }) {
   const [connections, setConnections] = useState<Connection[]>([]);
-  const [loading, setLoading] = useState(true);
+  const [loading, setLoading] = useState(hasMetadata);
 
   useEffect(() => {
     if (!hasMetadata) {
-      setLoading(false);
       return;
     }
 
+    let cancelled = false;
+
     fetch(`/api/thoughts/${thoughtId}/connections`)
       .then((res) => res.json())
-      .then((data) => setConnections(data.connections ?? []))
-      .catch(() => setConnections([]))
-      .finally(() => setLoading(false));
+      .then((data) => {
+        if (!cancelled) {
+          setConnections(data.connections ?? []);
+        }
+      })
+      .catch(() => {
+        if (!cancelled) {
+          setConnections([]);
+        }
+      })
+      .finally(() => {
+        if (!cancelled) {
+          setLoading(false);
+        }
+      });
+
+    return () => {
+      cancelled = true;
+    };
   }, [thoughtId, hasMetadata]);
 
   if (!hasMetadata || (!loading && connections.length === 0)) return null;

--- a/dashboards/open-brain-dashboard-next/components/GraphExplorer.tsx
+++ b/dashboards/open-brain-dashboard-next/components/GraphExplorer.tsx
@@ -1,0 +1,508 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useRouter } from "next/navigation";
+import { FormattedDate } from "@/components/FormattedDate";
+import { SearchBar } from "@/components/SearchBar";
+import { TypeBadge } from "@/components/ThoughtCard";
+import type { GraphNode, GraphResponse } from "@/lib/types";
+
+type SearchResult = {
+  id: string;
+  content: string;
+  type: string;
+  created_at: string;
+  metadata?: {
+    topics?: string[];
+    people?: string[];
+  };
+};
+
+const CANVAS_WIDTH = 1120;
+const CANVAS_HEIGHT = 680;
+const CENTER_X = CANVAS_WIDTH / 2;
+const CENTER_Y = CANVAS_HEIGHT / 2;
+
+const NODE_COLORS: Record<
+  string,
+  { fill: string; stroke: string; text: string }
+> = {
+  idea: { fill: "rgba(251, 191, 36, 0.18)", stroke: "#fbbf24", text: "#fde68a" },
+  task: { fill: "rgba(96, 165, 250, 0.18)", stroke: "#60a5fa", text: "#bfdbfe" },
+  person_note: { fill: "rgba(52, 211, 153, 0.18)", stroke: "#34d399", text: "#a7f3d0" },
+  reference: { fill: "rgba(148, 163, 184, 0.18)", stroke: "#94a3b8", text: "#cbd5e1" },
+  decision: { fill: "rgba(139, 92, 246, 0.18)", stroke: "#8b5cf6", text: "#ddd6fe" },
+  lesson: { fill: "rgba(251, 146, 60, 0.18)", stroke: "#fb923c", text: "#fdba74" },
+  meeting: { fill: "rgba(34, 211, 238, 0.18)", stroke: "#22d3ee", text: "#a5f3fc" },
+  journal: { fill: "rgba(244, 114, 182, 0.18)", stroke: "#f472b6", text: "#fbcfe8" },
+};
+
+function clampDepth(value: number): 1 | 2 {
+  return value >= 2 ? 2 : 1;
+}
+
+function getNodeColors(type: string) {
+  return NODE_COLORS[type] ?? NODE_COLORS.reference;
+}
+
+function truncateLabel(value: string, max = 22) {
+  const compact = value.replace(/\s+/g, " ").trim();
+  if (compact.length <= max) return compact;
+  return `${compact.slice(0, max - 1)}...`;
+}
+
+function polarPosition(
+  index: number,
+  total: number,
+  radiusX: number,
+  radiusY: number
+) {
+  const angle = (-Math.PI / 2) + (index / Math.max(total, 1)) * Math.PI * 2;
+  return {
+    x: CENTER_X + Math.cos(angle) * radiusX,
+    y: CENTER_Y + Math.sin(angle) * radiusY,
+  };
+}
+
+function buildNodePositions(graph: GraphResponse) {
+  const positions = new Map<string, { x: number; y: number }>();
+  positions.set(graph.centerId, { x: CENTER_X, y: CENTER_Y });
+
+  const ringOne = graph.nodes.filter((node) => node.ring === 1);
+  const ringTwo = graph.nodes.filter((node) => node.ring === 2);
+
+  ringOne.forEach((node, index) => {
+    positions.set(node.id, polarPosition(index, ringOne.length, 250, 180));
+  });
+
+  ringTwo.forEach((node, index) => {
+    positions.set(node.id, polarPosition(index, ringTwo.length, 430, 300));
+  });
+
+  return positions;
+}
+
+function graphNodeSize(node: GraphNode) {
+  const base = node.ring === 0 ? 24 : node.ring === 1 ? 18 : 14;
+  const importanceBoost = Math.min(Math.max(node.importance, 0), 100) / 25;
+  return base + importanceBoost;
+}
+
+function GraphCanvas({
+  graph,
+  selectedNodeId,
+  onSelectNode,
+}: {
+  graph: GraphResponse;
+  selectedNodeId: string;
+  onSelectNode: (nodeId: string) => void;
+}) {
+  const positions = buildNodePositions(graph);
+
+  return (
+    <div className="bg-[radial-gradient(circle_at_top,_rgba(139,92,246,0.16),_transparent_35%),linear-gradient(180deg,_rgba(17,17,24,0.98),_rgba(10,10,15,1))] border border-border rounded-2xl overflow-hidden">
+      <svg
+        viewBox={`0 0 ${CANVAS_WIDTH} ${CANVAS_HEIGHT}`}
+        className="w-full h-[520px] md:h-[620px]"
+        role="img"
+        aria-label="Thought graph"
+      >
+        <defs>
+          <filter id="node-glow" x="-50%" y="-50%" width="200%" height="200%">
+            <feGaussianBlur stdDeviation="8" result="blur" />
+            <feMerge>
+              <feMergeNode in="blur" />
+              <feMergeNode in="SourceGraphic" />
+            </feMerge>
+          </filter>
+        </defs>
+
+        {graph.edges.map((edge) => {
+          const source = positions.get(edge.source);
+          const target = positions.get(edge.target);
+          if (!source || !target) return null;
+          const isSelected =
+            edge.source === selectedNodeId || edge.target === selectedNodeId;
+
+          return (
+            <g key={`${edge.source}-${edge.target}`}>
+              <line
+                x1={source.x}
+                y1={source.y}
+                x2={target.x}
+                y2={target.y}
+                stroke={isSelected ? "#8b5cf6" : "rgba(139, 92, 246, 0.22)"}
+                strokeWidth={isSelected ? 2.5 : 1.2}
+              />
+            </g>
+          );
+        })}
+
+        {graph.nodes.map((node) => {
+          const position = positions.get(node.id);
+          if (!position) return null;
+          const colors = getNodeColors(node.type);
+          const isCenter = node.id === graph.centerId;
+          const isSelected = node.id === selectedNodeId;
+          const radius = graphNodeSize(node);
+
+          return (
+            <g
+              key={node.id}
+              onClick={() => onSelectNode(node.id)}
+              className="cursor-pointer"
+            >
+              <circle
+                cx={position.x}
+                cy={position.y}
+                r={radius + (isSelected ? 5 : 0)}
+                fill={isSelected ? "rgba(139, 92, 246, 0.16)" : "transparent"}
+              />
+              <circle
+                cx={position.x}
+                cy={position.y}
+                r={radius}
+                fill={colors.fill}
+                stroke={isCenter ? "#ffffff" : colors.stroke}
+                strokeWidth={isSelected ? 3 : isCenter ? 2.5 : 1.5}
+                filter={isSelected ? "url(#node-glow)" : undefined}
+              />
+              {isCenter && (
+                <circle
+                  cx={position.x}
+                  cy={position.y}
+                  r={4}
+                  fill="#ffffff"
+                />
+              )}
+              <text
+                x={position.x}
+                y={position.y + radius + 18}
+                textAnchor="middle"
+                fill={colors.text}
+                fontSize={12}
+                fontWeight={isSelected ? 700 : 500}
+              >
+                {truncateLabel(node.content)}
+              </text>
+            </g>
+          );
+        })}
+      </svg>
+    </div>
+  );
+}
+
+export function GraphExplorer({
+  initialThoughtId,
+  initialDepth = 1,
+}: {
+  initialThoughtId?: string;
+  initialDepth?: 1 | 2;
+}) {
+  const router = useRouter();
+  const [graph, setGraph] = useState<GraphResponse | null>(null);
+  const [searchResults, setSearchResults] = useState<SearchResult[]>([]);
+  const [selectedNodeId, setSelectedNodeId] = useState<string | null>(
+    initialThoughtId ?? null
+  );
+  const [depth, setDepth] = useState<1 | 2>(clampDepth(initialDepth));
+  const [searchError, setSearchError] = useState<string | null>(null);
+  const [graphError, setGraphError] = useState<string | null>(null);
+  const [searching, setSearching] = useState(false);
+  const [loadingGraph, setLoadingGraph] = useState(false);
+
+  async function loadGraph(thoughtId: string, nextDepth = depth) {
+    setLoadingGraph(true);
+    setGraphError(null);
+
+    try {
+      const response = await fetch(
+        `/api/graph?thought_id=${encodeURIComponent(thoughtId)}&depth=${nextDepth}`
+      );
+      const data = (await response.json()) as GraphResponse & {
+        error?: string;
+      };
+
+      if (!response.ok) {
+        throw new Error(data.error || "Failed to load graph");
+      }
+
+      setGraph(data);
+      setSelectedNodeId(thoughtId);
+      router.replace(`/graph?thought=${encodeURIComponent(thoughtId)}&depth=${nextDepth}`, {
+        scroll: false,
+      });
+    } catch (error) {
+      setGraphError(
+        error instanceof Error ? error.message : "Failed to load graph"
+      );
+    } finally {
+      setLoadingGraph(false);
+    }
+  }
+
+  async function handleSearch(query: string, mode: "semantic" | "text") {
+    setSearching(true);
+    setSearchError(null);
+
+    try {
+      const response = await fetch(
+        `/api/graph-search?q=${encodeURIComponent(query)}&mode=${mode}&page=1`
+      );
+      const data = (await response.json()) as {
+        results?: SearchResult[];
+        error?: string;
+      };
+
+      if (!response.ok) {
+        throw new Error(data.error || "Search failed");
+      }
+
+      setSearchResults((data.results ?? []).slice(0, 8));
+    } catch (error) {
+      setSearchResults([]);
+      setSearchError(
+        error instanceof Error ? error.message : "Search failed"
+      );
+    } finally {
+      setSearching(false);
+    }
+  }
+
+  useEffect(() => {
+    if (initialThoughtId) {
+      void loadGraph(initialThoughtId, clampDepth(initialDepth));
+    }
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [initialThoughtId, initialDepth]);
+
+  const selectedNode =
+    graph?.nodes.find((node) => node.id === selectedNodeId) ?? null;
+  const selectedConnections =
+    graph?.edges.filter(
+      (edge) => edge.source === selectedNodeId || edge.target === selectedNodeId
+    ).length ?? 0;
+
+  return (
+    <div className="space-y-6">
+      <div className="flex flex-col gap-3 lg:flex-row lg:items-end lg:justify-between">
+        <div>
+          <h1 className="text-2xl font-semibold mb-1">Graph</h1>
+          <p className="text-text-secondary text-sm max-w-2xl">
+            Explore a local thought graph around any note in your brain. Start
+            with search, then pivot node by node the way you would in an
+            Obsidian local graph.
+          </p>
+        </div>
+
+        <div className="flex items-center gap-2">
+          <span className="text-xs uppercase tracking-[0.2em] text-text-muted">
+            Depth
+          </span>
+          {[1, 2].map((value) => {
+            const active = depth === value;
+            return (
+              <button
+                key={value}
+                type="button"
+                onClick={() => {
+                  const nextDepth = clampDepth(value);
+                  setDepth(nextDepth);
+                  if (graph) {
+                    void loadGraph(graph.centerId, nextDepth);
+                  }
+                }}
+                className={`px-3 py-1.5 rounded-lg border text-sm transition-colors ${
+                  active
+                    ? "bg-violet-surface border-violet/30 text-violet"
+                    : "bg-bg-surface border-border text-text-secondary hover:text-text-primary"
+                }`}
+              >
+                {value} hop{value > 1 ? "s" : ""}
+              </button>
+            );
+          })}
+        </div>
+      </div>
+
+      <SearchBar
+        onSearch={handleSearch}
+        initialMode="semantic"
+        placeholder="Search for a thought to center the graph..."
+      />
+
+      {(searching || searchError || searchResults.length > 0) && (
+        <div className="bg-bg-surface border border-border rounded-xl p-4 space-y-3">
+          <div className="flex items-center justify-between">
+            <h2 className="text-sm font-medium text-text-primary">
+              Search Results
+            </h2>
+            {searching && (
+              <span className="text-xs text-text-muted">Searching...</span>
+            )}
+          </div>
+
+          {searchError && <p className="text-sm text-danger">{searchError}</p>}
+
+          <div className="space-y-2">
+            {searchResults.map((result) => (
+              <button
+                key={result.id}
+                type="button"
+                onClick={() => void loadGraph(result.id, depth)}
+                className="w-full text-left p-3 rounded-lg border border-border hover:border-violet/30 hover:bg-bg-hover transition-colors"
+              >
+                <div className="flex items-center gap-2 mb-1 flex-wrap">
+                  <TypeBadge type={result.type} />
+                  <span className="text-xs text-text-muted ml-auto">
+                    <FormattedDate date={result.created_at} />
+                  </span>
+                </div>
+                <p className="text-sm text-text-secondary">
+                  {truncateLabel(result.content, 140)}
+                </p>
+              </button>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {graphError && (
+        <div className="bg-danger/10 border border-danger/30 rounded-lg p-4 text-sm text-danger">
+          {graphError}
+        </div>
+      )}
+
+      {!graph && !loadingGraph && (
+        <div className="bg-bg-surface border border-dashed border-border rounded-2xl p-10 text-center">
+          <p className="text-text-primary font-medium mb-2">
+            Pick a thought to generate its local graph
+          </p>
+          <p className="text-sm text-text-secondary max-w-xl mx-auto">
+            This first pass uses the project&apos;s existing connection signals,
+            so we can visualize relationship neighborhoods immediately without
+            adding a separate graph service.
+          </p>
+        </div>
+      )}
+
+      {loadingGraph && (
+        <div className="flex items-center gap-2 text-text-muted text-sm">
+          <div className="w-4 h-4 border-2 border-violet/30 border-t-violet rounded-full animate-spin" />
+          Building graph...
+        </div>
+      )}
+
+      {graph && (
+        <div className="grid gap-6 xl:grid-cols-[minmax(0,1fr)_320px]">
+          <GraphCanvas
+            graph={graph}
+            selectedNodeId={selectedNodeId ?? graph.centerId}
+            onSelectNode={setSelectedNodeId}
+          />
+
+          <aside className="space-y-4">
+            <div className="bg-bg-surface border border-border rounded-xl p-4">
+              <div className="flex items-center justify-between gap-3 mb-3">
+                <h2 className="text-sm font-medium text-text-primary">
+                  Selection
+                </h2>
+                {graph.truncated && (
+                  <span className="text-[11px] text-warning">
+                    Graph trimmed for clarity
+                  </span>
+                )}
+              </div>
+
+              {selectedNode ? (
+                <div className="space-y-3">
+                  <div className="flex items-center gap-2 flex-wrap">
+                    <TypeBadge type={selectedNode.type} />
+                    {selectedNode.id === graph.centerId && (
+                      <span className="text-xs text-violet">center</span>
+                    )}
+                  </div>
+
+                  <p className="text-sm text-text-primary leading-relaxed">
+                    {selectedNode.preview}
+                  </p>
+
+                  <div className="text-xs text-text-muted space-y-1">
+                    <p>ID: {selectedNode.id}</p>
+                    <p>Connections shown: {selectedConnections}</p>
+                    <p>
+                      Created <FormattedDate date={selectedNode.created_at} />
+                    </p>
+                  </div>
+
+                  {selectedNode.metadata.topics &&
+                    selectedNode.metadata.topics.length > 0 && (
+                      <div>
+                        <p className="text-xs text-text-muted mb-1">Topics</p>
+                        <div className="flex flex-wrap gap-1">
+                          {selectedNode.metadata.topics.map((topic) => (
+                            <span
+                              key={topic}
+                              className="px-2 py-0.5 rounded bg-violet-surface text-violet text-xs"
+                            >
+                              {topic}
+                            </span>
+                          ))}
+                        </div>
+                      </div>
+                    )}
+
+                  {selectedNode.metadata.people &&
+                    selectedNode.metadata.people.length > 0 && (
+                      <div>
+                        <p className="text-xs text-text-muted mb-1">People</p>
+                        <div className="flex flex-wrap gap-1">
+                          {selectedNode.metadata.people.map((person) => (
+                            <span
+                              key={person}
+                              className="px-2 py-0.5 rounded bg-bg-elevated text-text-secondary text-xs"
+                            >
+                              {person}
+                            </span>
+                          ))}
+                        </div>
+                      </div>
+                    )}
+
+                  <div className="flex flex-wrap gap-2 pt-1">
+                    {selectedNode.id !== graph.centerId && (
+                      <button
+                        type="button"
+                        onClick={() => void loadGraph(selectedNode.id, depth)}
+                        className="px-3 py-1.5 rounded-lg bg-violet hover:bg-violet-dim text-white text-sm transition-colors"
+                      >
+                        Center here
+                      </button>
+                    )}
+                  </div>
+                </div>
+              ) : (
+                <p className="text-sm text-text-muted">
+                  Select a node to inspect it.
+                </p>
+              )}
+            </div>
+
+            <div className="bg-bg-surface border border-border rounded-xl p-4">
+              <h2 className="text-sm font-medium text-text-primary mb-2">
+                What You&apos;re Seeing
+              </h2>
+              <p className="text-sm text-text-secondary leading-relaxed">
+                The center node is the active thought. In MCP mode, nearby nodes
+                are inferred from shared people and topic metadata returned by
+                your deployed Open Brain tools, then expanded outward in two-hop
+                mode for local exploration.
+              </p>
+            </div>
+          </aside>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/dashboards/open-brain-dashboard-next/components/KanbanCard.tsx
+++ b/dashboards/open-brain-dashboard-next/components/KanbanCard.tsx
@@ -68,7 +68,7 @@ export function KanbanCard({
       <div className="flex items-start justify-between gap-2 mb-1.5">
         <PriorityDot
           importance={thought.importance}
-          onPriorityChange={(val) => onPriorityChange(thought.id, val)}
+          onPriorityChange={(val) => onPriorityChange(Number(thought.id), val)}
         />
         <TypeBadge type={thought.type} />
       </div>
@@ -97,7 +97,7 @@ export function KanbanCard({
               type="button"
               onClick={(e) => {
                 e.stopPropagation();
-                onArchive(thought.id);
+                onArchive(Number(thought.id));
               }}
               className="text-[10px] text-text-muted hover:text-text-secondary transition-colors"
               title="Archive"

--- a/dashboards/open-brain-dashboard-next/components/KanbanCardModal.tsx
+++ b/dashboards/open-brain-dashboard-next/components/KanbanCardModal.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect, useRef } from "react";
+import { useState, useEffect, useRef, useCallback } from "react";
 import { createPortal } from "react-dom";
 import type { Thought, KanbanStatus } from "@/lib/types";
 import { KANBAN_STATUSES, KANBAN_LABELS, PRIORITY_LEVELS, getPriorityLevel, THOUGHT_TYPES, KANBAN_TYPES } from "@/lib/types";
@@ -27,20 +27,24 @@ export function KanbanCardModal({
   const [status, setStatus] = useState(thought.status ?? "new");
   const [importance, setImportance] = useState(thought.importance);
   const [type, setType] = useState(thought.type);
-  const [hasChanges, setHasChanges] = useState(false);
   const [showDiscardConfirm, setShowDiscardConfirm] = useState(false);
   const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
   const backdropRef = useRef<HTMLDivElement>(null);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
 
-  useEffect(() => {
-    const isChanged =
-      content !== thought.content ||
-      status !== (thought.status ?? "new") ||
-      importance !== thought.importance ||
-      type !== thought.type;
-    setHasChanges(isChanged);
-  }, [content, status, importance, type, thought]);
+  const hasChanges =
+    content !== thought.content ||
+    status !== (thought.status ?? "new") ||
+    importance !== thought.importance ||
+    type !== thought.type;
+
+  const tryClose = useCallback(() => {
+    if (hasChanges) {
+      setShowDiscardConfirm(true);
+    } else {
+      onClose();
+    }
+  }, [hasChanges, onClose]);
 
   useEffect(() => {
     function handleEscape(e: KeyboardEvent) {
@@ -50,7 +54,7 @@ export function KanbanCardModal({
     }
     document.addEventListener("keydown", handleEscape);
     return () => document.removeEventListener("keydown", handleEscape);
-  }, [hasChanges]);
+  }, [tryClose]);
 
   // Lock body scroll
   useEffect(() => {
@@ -69,14 +73,6 @@ export function KanbanCardModal({
       textareaRef.current.style.height = textareaRef.current.scrollHeight + "px";
     }
   }, [content]);
-
-  function tryClose() {
-    if (hasChanges) {
-      setShowDiscardConfirm(true);
-    } else {
-      onClose();
-    }
-  }
 
   function handleBackdropClick(e: React.MouseEvent) {
     if (e.target === backdropRef.current) {
@@ -98,7 +94,7 @@ export function KanbanCardModal({
     }
 
     if (Object.keys(updates).length > 0) {
-      onSave(thought.id, updates);
+      onSave(Number(thought.id), updates);
     }
     onClose();
   }
@@ -249,7 +245,7 @@ export function KanbanCardModal({
               <button
                 type="button"
                 onClick={() => {
-                  onArchive(thought.id);
+                  onArchive(Number(thought.id));
                   onClose();
                 }}
                 className="text-sm text-text-muted hover:text-amber-400 transition-colors"
@@ -319,7 +315,7 @@ export function KanbanCardModal({
           <button
             type="button"
             onClick={() => {
-              onDelete(thought.id);
+              onDelete(Number(thought.id));
               onClose();
             }}
             className="px-4 py-1.5 text-sm rounded-lg bg-danger text-white hover:bg-danger/80 transition-colors"

--- a/dashboards/open-brain-dashboard-next/components/KanbanColumn.tsx
+++ b/dashboards/open-brain-dashboard-next/components/KanbanColumn.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect } from "react";
+import { useState } from "react";
 import { useDroppable } from "@dnd-kit/core";
 import { SortableContext, verticalListSortingStrategy } from "@dnd-kit/sortable";
 import type { Thought, KanbanStatus } from "@/lib/types";
@@ -35,13 +35,10 @@ export function KanbanColumn({
   onPriorityChange,
   onArchive,
 }: KanbanColumnProps) {
-  const [isCollapsed, setIsCollapsed] = useState(false);
-
-  // Load collapse state from localStorage
-  useEffect(() => {
-    const stored = localStorage.getItem(collapseKey(status));
-    if (stored === "true") setIsCollapsed(true);
-  }, [status]);
+  const [isCollapsed, setIsCollapsed] = useState(() => {
+    if (typeof window === "undefined") return false;
+    return localStorage.getItem(collapseKey(status)) === "true";
+  });
 
   function toggleCollapse() {
     const nextState = !isCollapsed;

--- a/dashboards/open-brain-dashboard-next/components/ReflectionComposer.tsx
+++ b/dashboards/open-brain-dashboard-next/components/ReflectionComposer.tsx
@@ -4,7 +4,6 @@ import { useState } from "react";
 import { useRouter } from "next/navigation";
 import type {
   ReflectionInput,
-  ReflectionOption,
   ReflectionFactor,
 } from "@/lib/types";
 

--- a/dashboards/open-brain-dashboard-next/components/RestrictedToggle.tsx
+++ b/dashboards/open-brain-dashboard-next/components/RestrictedToggle.tsx
@@ -21,9 +21,6 @@ export function RestrictedToggle() {
       .catch(() => {});
   }, []);
 
-  // Don't render if restricted content feature is not configured
-  if (!configured) return null;
-
   const handleUnlock = useCallback(async () => {
     if (!passphrase.trim()) return;
     setLoading(true);
@@ -61,6 +58,9 @@ export function RestrictedToggle() {
       // ignore
     }
   }, []);
+
+  // Don't render if restricted content feature is not configured
+  if (!configured) return null;
 
   return (
     <>

--- a/dashboards/open-brain-dashboard-next/components/Sidebar.tsx
+++ b/dashboards/open-brain-dashboard-next/components/Sidebar.tsx
@@ -9,6 +9,7 @@ const nav = [
   { href: "/thoughts", label: "Thoughts", icon: ThoughtsIcon },
   { href: "/kanban", label: "Workflow", icon: KanbanIcon },
   { href: "/search", label: "Search", icon: SearchIcon },
+  { href: "/graph", label: "Graph", icon: GraphIcon },
   { href: "/audit", label: "Audit", icon: AuditIcon },
   { href: "/duplicates", label: "Duplicates", icon: DuplicatesIcon },
   { href: "/ingest", label: "Add", icon: AddIcon },
@@ -103,6 +104,17 @@ function SearchIcon({ active }: { active: boolean }) {
     <svg width="18" height="18" viewBox="0 0 18 18" fill="none" className={active ? "text-violet" : "text-text-muted"}>
       <circle cx="7.5" cy="7.5" r="5" stroke="currentColor" strokeWidth="1.5" />
       <path d="M11.5 11.5L16 16" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" />
+    </svg>
+  );
+}
+
+function GraphIcon({ active }: { active: boolean }) {
+  return (
+    <svg width="18" height="18" viewBox="0 0 18 18" fill="none" className={active ? "text-violet" : "text-text-muted"}>
+      <circle cx="4" cy="4" r="2" stroke="currentColor" strokeWidth="1.5" />
+      <circle cx="14" cy="5" r="2" stroke="currentColor" strokeWidth="1.5" />
+      <circle cx="9" cy="14" r="2" stroke="currentColor" strokeWidth="1.5" />
+      <path d="M5.7 5.1L8 12.1M12.3 6.2L9.9 12" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" />
     </svg>
   );
 }

--- a/dashboards/open-brain-dashboard-next/components/ThoughtEditor.tsx
+++ b/dashboards/open-brain-dashboard-next/components/ThoughtEditor.tsx
@@ -20,12 +20,30 @@ const IMPORTANCE_OPTIONS = [1, 2, 3, 4, 5];
 export function ThoughtEditor({
   thought,
   editAction,
+  readOnly = false,
 }: {
   thought: Thought;
   editAction: (formData: FormData) => Promise<void>;
+  readOnly?: boolean;
 }) {
   const [editing, setEditing] = useState(false);
   const router = useRouter();
+
+  if (readOnly) {
+    return (
+      <div className="bg-bg-surface border border-border rounded-lg p-5">
+        <div className="flex justify-between items-start mb-3">
+          <h2 className="text-sm font-medium text-text-muted uppercase tracking-wider">
+            Content
+          </h2>
+          <span className="text-xs text-text-muted">Read only</span>
+        </div>
+        <p className="text-text-primary whitespace-pre-wrap leading-relaxed">
+          {thought.content}
+        </p>
+      </div>
+    );
+  }
 
   if (!editing) {
     return (

--- a/dashboards/open-brain-dashboard-next/lib/api.ts
+++ b/dashboards/open-brain-dashboard-next/lib/api.ts
@@ -6,8 +6,12 @@ import type {
   Reflection,
   IngestionJob,
 } from "./types";
+import { KANBAN_TYPES } from "./types";
+import { mcpFetchThought, mcpThoughtStats } from "./openBrainMcp";
 
 const API_URL = process.env.NEXT_PUBLIC_API_URL!;
+const MCP_URL = process.env.OPEN_BRAIN_MCP_URL;
+const LEGACY_MCP_SERVER_URL = MCP_URL?.replace(/open-brain-mcp\/?$/, "mcp-server");
 
 export class ApiError extends Error {
   constructor(message: string, public status: number) {
@@ -21,6 +25,151 @@ function headers(apiKey: string): HeadersInit {
     "x-brain-key": apiKey,
     "Content-Type": "application/json",
   };
+}
+
+type LegacyThoughtRecord = {
+  id: string;
+  content: string;
+  metadata?: Record<string, unknown>;
+  created_at: string;
+  updated_at: string;
+};
+
+function normalizeThoughtType(metadata: Record<string, unknown> | undefined): string {
+  const type = metadata?.type;
+  return typeof type === "string" && type.length > 0 ? type : "reference";
+}
+
+function normalizeImportance(metadata: Record<string, unknown> | undefined): number {
+  const raw = metadata?.importance;
+  if (typeof raw === "number") {
+    return Math.min(Math.max(Math.round(raw), 1), 5);
+  }
+  return 0;
+}
+
+function toThought(record: LegacyThoughtRecord): Thought {
+  const metadata = record.metadata ?? {};
+  const sensitivityTier = metadata.sensitivity_tier;
+  const status = metadata.status;
+  const sourceType = metadata.source;
+
+  return {
+    id: record.id,
+    content: record.content,
+    type: normalizeThoughtType(metadata),
+    source_type: typeof sourceType === "string" ? sourceType : "",
+    importance: normalizeImportance(metadata),
+    quality_score: 0,
+    sensitivity_tier:
+      typeof sensitivityTier === "string" ? sensitivityTier : "standard",
+    metadata,
+    created_at: record.created_at,
+    updated_at: record.updated_at,
+    status: typeof status === "string" ? status : null,
+    status_updated_at: null,
+  };
+}
+
+function summarizeThoughts(thoughts: Thought[]): StatsResponse {
+  const types: Record<string, number> = {};
+  const topics: Record<string, number> = {};
+
+  for (const thought of thoughts) {
+    types[thought.type] = (types[thought.type] ?? 0) + 1;
+
+    const thoughtTopics = thought.metadata.topics;
+    if (Array.isArray(thoughtTopics)) {
+      for (const topic of thoughtTopics) {
+        if (typeof topic === "string" && topic.trim()) {
+          topics[topic] = (topics[topic] ?? 0) + 1;
+        }
+      }
+    }
+  }
+
+  return {
+    total_thoughts: thoughts.length,
+    window_days: "all",
+    types,
+    top_topics: Object.entries(topics)
+      .sort((a, b) => b[1] - a[1])
+      .slice(0, 10)
+      .map(([topic, count]) => ({ topic, count })),
+  };
+}
+
+function parseMcpStatsReport(report: string): StatsResponse {
+  const lines = report.split(/\r?\n/);
+  const stats: StatsResponse = {
+    total_thoughts: 0,
+    window_days: "all",
+    types: {},
+    top_topics: [],
+  };
+
+  let section: "types" | "topics" | "people" | null = null;
+  for (const rawLine of lines) {
+    const line = rawLine.trim();
+    if (!line) continue;
+
+    const totalMatch = line.match(/^Total thoughts:\s*(\d+)/i);
+    if (totalMatch) {
+      stats.total_thoughts = Number(totalMatch[1]);
+      continue;
+    }
+
+    if (/^Types:/i.test(line)) {
+      section = "types";
+      continue;
+    }
+    if (/^Top topics:/i.test(line)) {
+      section = "topics";
+      continue;
+    }
+    if (/^People mentioned:/i.test(line)) {
+      section = "people";
+      continue;
+    }
+
+    const entryMatch = line.match(/^(.+):\s*(\d+)$/);
+    if (!entryMatch) continue;
+
+    const label = entryMatch[1].trim();
+    const count = Number(entryMatch[2]);
+    if (section === "types") {
+      stats.types[label] = count;
+    }
+    if (section === "topics") {
+      stats.top_topics.push({ topic: label, count });
+    }
+  }
+
+  return stats;
+}
+
+async function fetchLegacyRecentThoughts(apiKey: string): Promise<Thought[]> {
+  if (!LEGACY_MCP_SERVER_URL) {
+    throw new ApiError("Legacy MCP browse endpoint is not configured", 500);
+  }
+
+  const url = new URL(LEGACY_MCP_SERVER_URL);
+  url.searchParams.set("key", apiKey);
+
+  const res = await fetch(url.toString(), {
+    headers: {
+      Accept: "application/json",
+    },
+    cache: "no-store",
+  });
+
+  if (!res.ok) {
+    const text = await res.text().catch(() => "");
+    throw new ApiError(`API ${res.status}: ${text || res.statusText}`, res.status);
+  }
+
+  const data = (await res.json()) as LegacyThoughtRecord[];
+  return data.map(toThought);
 }
 
 async function apiFetch<T>(
@@ -54,6 +203,33 @@ export async function fetchThoughts(
     exclude_restricted?: boolean;
   }
 ): Promise<BrowseResponse> {
+  if (MCP_URL) {
+    const recent = await fetchLegacyRecentThoughts(apiKey);
+    const filtered = recent.filter((thought) => {
+      if (params?.type && thought.type !== params.type) return false;
+      if (params?.source_type && thought.source_type !== params.source_type) return false;
+      if (
+        params?.importance_min !== undefined &&
+        thought.importance < params.importance_min
+      ) {
+        return false;
+      }
+      return true;
+    });
+
+    const page = params?.page ?? 1;
+    const perPage = params?.per_page ?? 25;
+    const start = (page - 1) * perPage;
+    const data = filtered.slice(start, start + perPage);
+
+    return {
+      data,
+      total: filtered.length,
+      page,
+      per_page: perPage,
+    };
+  }
+
   const sp = new URLSearchParams();
   if (params?.page) sp.set("page", String(params.page));
   if (params?.per_page) sp.set("per_page", String(params.per_page));
@@ -73,9 +249,21 @@ export async function fetchThoughts(
 
 export async function fetchThought(
   apiKey: string,
-  id: number,
+  id: string | number,
   excludeRestricted: boolean = true
 ): Promise<Thought> {
+  if (MCP_URL) {
+    const thought = await mcpFetchThought(apiKey, String(id));
+    return toThought({
+      id: thought.id,
+      content: thought.text,
+      metadata: thought.metadata,
+      created_at: thought.metadata.created_at ?? new Date().toISOString(),
+      updated_at:
+        thought.metadata.updated_at ?? thought.metadata.created_at ?? new Date().toISOString(),
+    });
+  }
+
   const qs = excludeRestricted ? "" : "?exclude_restricted=false";
   return apiFetch<Thought>(apiKey, `/thought/${id}${qs}`);
 }
@@ -102,6 +290,20 @@ export async function fetchKanbanThoughts(
     exclude_restricted?: boolean;
   }
 ): Promise<Thought[]> {
+  if (MCP_URL) {
+    const allowedStatuses = new Set(
+      params?.status?.split(",").map((status) => status.trim()).filter(Boolean)
+    );
+    const recent = await fetchLegacyRecentThoughts(apiKey);
+    return recent
+      .filter((thought) => KANBAN_TYPES.includes(thought.type))
+      .filter((thought) => {
+        if (allowedStatuses.size === 0) return true;
+        return allowedStatuses.has(thought.status ?? "new");
+      })
+      .sort((a, b) => b.importance - a.importance);
+  }
+
   // Fetch tasks and ideas separately (API only supports single type filter)
   const results: Thought[] = [];
   for (const thoughtType of ["task", "idea"]) {
@@ -178,6 +380,14 @@ export async function fetchStats(
   days?: number,
   excludeRestricted: boolean = true
 ): Promise<StatsResponse> {
+  if (MCP_URL) {
+    try {
+      return parseMcpStatsReport(await mcpThoughtStats(apiKey));
+    } catch {
+      return summarizeThoughts(await fetchLegacyRecentThoughts(apiKey));
+    }
+  }
+
   const sp = new URLSearchParams();
   if (days) sp.set("days", String(days));
   if (!excludeRestricted) sp.set("exclude_restricted", "false");

--- a/dashboards/open-brain-dashboard-next/lib/auth.ts
+++ b/dashboards/open-brain-dashboard-next/lib/auth.ts
@@ -3,7 +3,8 @@ import { cookies } from "next/headers";
 import { redirect } from "next/navigation";
 
 export interface SessionData {
-  apiKey?: string;
+  userId?: string;
+  email?: string;
   loggedIn?: boolean;
   restrictedUnlocked?: boolean;
 }
@@ -45,11 +46,17 @@ export async function getSession() {
  * Call BEFORE parsing request body so unauthed requests get 401, not 400.
  */
 export async function requireSession(): Promise<{ apiKey: string }> {
+  const apiKey =
+    process.env.OPEN_BRAIN_MCP_ACCESS_KEY || process.env.MCP_ACCESS_KEY;
+  if (!apiKey) {
+    throw new Error("OPEN_BRAIN_MCP_ACCESS_KEY env var is required");
+  }
+
   const session = await getSession();
-  if (!session.loggedIn || !session.apiKey) {
+  if (!session.loggedIn || !session.userId) {
     throw new AuthError();
   }
-  return { apiKey: session.apiKey };
+  return { apiKey };
 }
 
 /**
@@ -58,9 +65,15 @@ export async function requireSession(): Promise<{ apiKey: string }> {
 export async function requireSessionOrRedirect(): Promise<{
   apiKey: string;
 }> {
+  const apiKey =
+    process.env.OPEN_BRAIN_MCP_ACCESS_KEY || process.env.MCP_ACCESS_KEY;
+  if (!apiKey) {
+    throw new Error("OPEN_BRAIN_MCP_ACCESS_KEY env var is required");
+  }
+
   const session = await getSession();
-  if (!session.loggedIn || !session.apiKey) {
+  if (!session.loggedIn || !session.userId) {
     redirect("/login");
   }
-  return { apiKey: session.apiKey };
+  return { apiKey };
 }

--- a/dashboards/open-brain-dashboard-next/lib/openBrainMcp.ts
+++ b/dashboards/open-brain-dashboard-next/lib/openBrainMcp.ts
@@ -1,0 +1,183 @@
+import "server-only";
+
+type JsonRpcSuccess<T> = {
+  jsonrpc: "2.0";
+  id?: string | number | null;
+  result: T;
+};
+
+type JsonRpcError = {
+  jsonrpc: "2.0";
+  id?: string | number | null;
+  error: {
+    code: number;
+    message: string;
+    data?: unknown;
+  };
+};
+
+type JsonRpcEnvelope<T> = JsonRpcSuccess<T> | JsonRpcError;
+
+type ToolCallResult = {
+  content?: Array<{
+    type: string;
+    text?: string;
+  }>;
+  isError?: boolean;
+};
+
+type SearchHit = {
+  id: string;
+  title: string;
+  url?: string;
+};
+
+export type McpThoughtDocument = {
+  id: string;
+  title: string;
+  text: string;
+  url?: string;
+  metadata: Record<string, unknown> & {
+    created_at?: string;
+    updated_at?: string | null;
+  };
+};
+
+const MCP_URL = process.env.OPEN_BRAIN_MCP_URL;
+
+function requireMcpUrl() {
+  if (!MCP_URL) {
+    throw new Error("OPEN_BRAIN_MCP_URL is not configured");
+  }
+  return MCP_URL;
+}
+
+function buildHeaders(apiKey: string): HeadersInit {
+  return {
+    Accept: "application/json, text/event-stream",
+    "Content-Type": "application/json",
+    "x-brain-key": apiKey,
+  };
+}
+
+function parseEventStreamPayload<T>(body: string): JsonRpcEnvelope<T> {
+  const dataLines = body
+    .split(/\r?\n/)
+    .filter((line) => line.startsWith("data:"))
+    .map((line) => line.slice(5).trim())
+    .filter(Boolean);
+
+  if (dataLines.length === 0) {
+    throw new Error("MCP event stream returned no data payload");
+  }
+
+  return JSON.parse(dataLines.join("\n")) as JsonRpcEnvelope<T>;
+}
+
+async function parseJsonRpc<T>(response: Response): Promise<T> {
+  const contentType = response.headers.get("content-type") ?? "";
+  const raw = await response.text();
+
+  const payload = contentType.includes("text/event-stream")
+    ? parseEventStreamPayload<T>(raw)
+    : (JSON.parse(raw) as JsonRpcEnvelope<T>);
+
+  if ("error" in payload) {
+    throw new Error(payload.error.message);
+  }
+
+  return payload.result;
+}
+
+async function mcpPost<T>({
+  apiKey,
+  body,
+}: {
+  apiKey: string;
+  body: Record<string, unknown>;
+}): Promise<T> {
+  const response = await fetch(requireMcpUrl(), {
+    method: "POST",
+    headers: buildHeaders(apiKey),
+    body: JSON.stringify(body),
+    cache: "no-store",
+  });
+
+  if (!response.ok) {
+    const text = await response.text().catch(() => "");
+    throw new Error(text || `MCP request failed (${response.status})`);
+  }
+
+  return parseJsonRpc<T>(response);
+}
+
+function extractToolText(result: ToolCallResult): string {
+  const firstText = result.content?.find((item) => item.type === "text")?.text;
+  if (!firstText) {
+    throw new Error("MCP tool returned no text payload");
+  }
+  if (result.isError) {
+    throw new Error(firstText);
+  }
+  return firstText;
+}
+
+async function callToolText(
+  apiKey: string,
+  name: string,
+  args: Record<string, unknown>
+): Promise<string> {
+  const result = await mcpPost<ToolCallResult>({
+    apiKey,
+    body: {
+      jsonrpc: "2.0",
+      id: crypto.randomUUID(),
+      method: "tools/call",
+      params: {
+        name,
+        arguments: args,
+      },
+    },
+  });
+
+  return extractToolText(result);
+}
+
+async function callTool<T>(
+  apiKey: string,
+  name: string,
+  args: Record<string, unknown>
+): Promise<T> {
+  return JSON.parse(await callToolText(apiKey, name, args)) as T;
+}
+
+export async function validateMcpKey(apiKey: string): Promise<void> {
+  await callTool<{ results: SearchHit[] }>(apiKey, "search", {
+    query: "test",
+  });
+}
+
+export async function mcpSearchThoughts(
+  apiKey: string,
+  query: string
+): Promise<McpThoughtDocument[]> {
+  const search = await callTool<{ results: SearchHit[] }>(apiKey, "search", {
+    query,
+  });
+
+  const hits = search.results ?? [];
+  return Promise.all(
+    hits.slice(0, 10).map((hit) => callTool<McpThoughtDocument>(apiKey, "fetch", { id: hit.id }))
+  );
+}
+
+export async function mcpFetchThought(
+  apiKey: string,
+  id: string
+): Promise<McpThoughtDocument> {
+  return callTool<McpThoughtDocument>(apiKey, "fetch", { id });
+}
+
+export async function mcpThoughtStats(apiKey: string): Promise<string> {
+  return callToolText(apiKey, "thought_stats", {});
+}

--- a/dashboards/open-brain-dashboard-next/lib/supabaseAuth.ts
+++ b/dashboards/open-brain-dashboard-next/lib/supabaseAuth.ts
@@ -6,6 +6,7 @@ import {
   type Provider,
   type User,
 } from "@supabase/supabase-js";
+import { createSupabaseServerAuthClient } from "@/lib/supabaseServerAuth";
 
 function requireEnv(name: string): string {
   const value = process.env[name];
@@ -15,13 +16,28 @@ function requireEnv(name: string): string {
   return value;
 }
 
+function normalizeBaseUrl(value: string) {
+  const trimmed = value.trim().replace(/\/$/, "");
+  if (/^https?:\/\//i.test(trimmed)) {
+    return trimmed;
+  }
+  if (
+    trimmed.startsWith("localhost") ||
+    trimmed.startsWith("127.0.0.1") ||
+    trimmed.startsWith("[::1]")
+  ) {
+    return `http://${trimmed}`;
+  }
+  return `https://${trimmed}`;
+}
+
 function getBaseUrl() {
-  return (
+  return normalizeBaseUrl(
     process.env.NEXT_PUBLIC_APP_URL ||
     process.env.VERCEL_PROJECT_PRODUCTION_URL ||
     process.env.VERCEL_URL ||
     "http://127.0.0.1:3001"
-  ).replace(/\/$/, "");
+  );
 }
 
 function createSupabaseAuthClient() {
@@ -42,7 +58,7 @@ export function getMagicLinkRedirectUrl(next = "/") {
 }
 
 async function getOAuthSignInUrl(provider: Provider, next = "/") {
-  const supabase = createSupabaseAuthClient();
+  const supabase = await createSupabaseServerAuthClient();
   const { data, error } = await supabase.auth.signInWithOAuth({
     provider,
     options: {
@@ -126,7 +142,7 @@ export async function verifyMagicLink(
 }
 
 export async function exchangeAuthCodeForUser(code: string): Promise<User> {
-  const supabase = createSupabaseAuthClient();
+  const supabase = await createSupabaseServerAuthClient();
   const { data, error } = await supabase.auth.exchangeCodeForSession(code);
 
   if (error) {

--- a/dashboards/open-brain-dashboard-next/lib/supabaseAuth.ts
+++ b/dashboards/open-brain-dashboard-next/lib/supabaseAuth.ts
@@ -1,0 +1,141 @@
+import "server-only";
+
+import {
+  createClient,
+  type EmailOtpType,
+  type Provider,
+  type User,
+} from "@supabase/supabase-js";
+
+function requireEnv(name: string): string {
+  const value = process.env[name];
+  if (!value) {
+    throw new Error(`${name} env var is required`);
+  }
+  return value;
+}
+
+function getBaseUrl() {
+  return (
+    process.env.NEXT_PUBLIC_APP_URL ||
+    process.env.VERCEL_PROJECT_PRODUCTION_URL ||
+    process.env.VERCEL_URL ||
+    "http://127.0.0.1:3001"
+  ).replace(/\/$/, "");
+}
+
+function createSupabaseAuthClient() {
+  return createClient(
+    requireEnv("NEXT_PUBLIC_SUPABASE_URL"),
+    requireEnv("NEXT_PUBLIC_SUPABASE_ANON_KEY"),
+    {
+      auth: {
+        autoRefreshToken: false,
+        persistSession: false,
+      },
+    }
+  );
+}
+
+export function getMagicLinkRedirectUrl(next = "/") {
+  return `${getBaseUrl()}/auth/callback?next=${encodeURIComponent(next)}`;
+}
+
+async function getOAuthSignInUrl(provider: Provider, next = "/") {
+  const supabase = createSupabaseAuthClient();
+  const { data, error } = await supabase.auth.signInWithOAuth({
+    provider,
+    options: {
+      redirectTo: getMagicLinkRedirectUrl(next),
+    },
+  });
+
+  if (error) {
+    throw error;
+  }
+
+  if (!data.url) {
+    throw new Error(`No ${provider} sign-in URL returned from Supabase Auth`);
+  }
+
+  return data.url;
+}
+
+export async function getGithubSignInUrl(next = "/") {
+  return getOAuthSignInUrl("github", next);
+}
+
+export async function getGoogleSignInUrl(next = "/") {
+  return getOAuthSignInUrl("google", next);
+}
+
+export async function signInWithPassword(email: string, password: string) {
+  const supabase = createSupabaseAuthClient();
+  const { data, error } = await supabase.auth.signInWithPassword({
+    email,
+    password,
+  });
+
+  if (error) {
+    throw error;
+  }
+
+  if (!data.user) {
+    throw new Error("No user returned from Supabase Auth");
+  }
+
+  return data.user;
+}
+
+export async function signUpWithPassword(email: string, password: string) {
+  const supabase = createSupabaseAuthClient();
+  const { data, error } = await supabase.auth.signUp({
+    email,
+    password,
+    options: {
+      emailRedirectTo: getMagicLinkRedirectUrl("/"),
+    },
+  });
+
+  if (error) {
+    throw error;
+  }
+
+  return data;
+}
+
+export async function verifyMagicLink(
+  tokenHash: string,
+  type: EmailOtpType
+): Promise<User> {
+  const supabase = createSupabaseAuthClient();
+  const { data, error } = await supabase.auth.verifyOtp({
+    token_hash: tokenHash,
+    type,
+  });
+
+  if (error) {
+    throw error;
+  }
+
+  if (!data.user) {
+    throw new Error("No user returned from Supabase Auth");
+  }
+
+  return data.user;
+}
+
+export async function exchangeAuthCodeForUser(code: string): Promise<User> {
+  const supabase = createSupabaseAuthClient();
+  const { data, error } = await supabase.auth.exchangeCodeForSession(code);
+
+  if (error) {
+    throw error;
+  }
+
+  if (!data.user) {
+    throw new Error("No user returned from Supabase Auth");
+  }
+
+  return data.user;
+}

--- a/dashboards/open-brain-dashboard-next/lib/supabaseServerAuth.ts
+++ b/dashboards/open-brain-dashboard-next/lib/supabaseServerAuth.ts
@@ -1,0 +1,33 @@
+import "server-only";
+
+import { createServerClient } from "@supabase/ssr";
+import { cookies } from "next/headers";
+
+function requireEnv(name: string): string {
+  const value = process.env[name];
+  if (!value) {
+    throw new Error(`${name} env var is required`);
+  }
+  return value;
+}
+
+export async function createSupabaseServerAuthClient() {
+  const cookieStore = await cookies();
+
+  return createServerClient(
+    requireEnv("NEXT_PUBLIC_SUPABASE_URL"),
+    requireEnv("NEXT_PUBLIC_SUPABASE_ANON_KEY"),
+    {
+      cookies: {
+        getAll() {
+          return cookieStore.getAll();
+        },
+        setAll(cookiesToSet) {
+          for (const { name, value, options } of cookiesToSet) {
+            cookieStore.set(name, value, options);
+          }
+        },
+      },
+    }
+  );
+}

--- a/dashboards/open-brain-dashboard-next/lib/types.ts
+++ b/dashboards/open-brain-dashboard-next/lib/types.ts
@@ -1,5 +1,5 @@
 export interface Thought {
-  id: number;
+  id: string | number;
   uuid?: string;
   content: string;
   type: string;
@@ -169,4 +169,37 @@ export interface AddToBrainResult {
   status?: string;
   extracted_count?: number | null;
   message: string;
+}
+
+export interface GraphNode {
+  id: string;
+  type: string;
+  importance: number;
+  content: string;
+  preview: string;
+  created_at: string;
+  metadata: {
+    topics?: string[];
+    people?: string[];
+  };
+  ring: 0 | 1 | 2;
+  similarity?: number;
+  overlap_count?: number;
+}
+
+export interface GraphEdge {
+  source: string;
+  target: string;
+  similarity?: number;
+  overlap_count?: number;
+  shared_topics?: string[];
+  shared_people?: string[];
+}
+
+export interface GraphResponse {
+  centerId: string;
+  depth: 1 | 2;
+  truncated: boolean;
+  nodes: GraphNode[];
+  edges: GraphEdge[];
 }

--- a/dashboards/open-brain-dashboard-next/middleware.ts
+++ b/dashboards/open-brain-dashboard-next/middleware.ts
@@ -6,6 +6,7 @@ export function middleware(request: NextRequest) {
   // Allow login page, API routes, and static assets
   if (
     pathname === "/login" ||
+    pathname.startsWith("/auth") ||
     pathname.startsWith("/api") ||
     pathname.startsWith("/_next") ||
     pathname.startsWith("/favicon")

--- a/dashboards/open-brain-dashboard-next/package-lock.json
+++ b/dashboards/open-brain-dashboard-next/package-lock.json
@@ -11,6 +11,7 @@
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/sortable": "^10.0.0",
         "@dnd-kit/utilities": "^3.2.2",
+        "@supabase/supabase-js": "^2.105.4",
         "iron-session": "^8.0.4",
         "next": "16.2.1",
         "react": "19.2.4",
@@ -1290,6 +1291,90 @@
       "integrity": "sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@supabase/auth-js": {
+      "version": "2.105.4",
+      "resolved": "https://registry.npmjs.org/@supabase/auth-js/-/auth-js-2.105.4.tgz",
+      "integrity": "sha512-Ejfa37M5xoIwoxVebxRahnwubPo8g22qkXQ4p50+N9MIvU9UZoN+A8dwVPtczzGf8oV/YXN80ZPxK4aWXuSN/A==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@supabase/functions-js": {
+      "version": "2.105.4",
+      "resolved": "https://registry.npmjs.org/@supabase/functions-js/-/functions-js-2.105.4.tgz",
+      "integrity": "sha512-JVNKbBft3Qkja+WlGaE026AJ2AH9K0UTsxsfvEIHgd4zFrBor4BYRCrYFrv9IDsvVqkF72wKDsODJl5GY/C4tA==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@supabase/phoenix": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/@supabase/phoenix/-/phoenix-0.4.2.tgz",
+      "integrity": "sha512-YSAGnmDAfuleFCVt3CeurQZAhxRfXWeZIIkwp7NhYzQ1UwW6ePSnzsFAiUm/mbCkfoCf70QQHKW/K6RKh52a4A==",
+      "license": "MIT"
+    },
+    "node_modules/@supabase/postgrest-js": {
+      "version": "2.105.4",
+      "resolved": "https://registry.npmjs.org/@supabase/postgrest-js/-/postgrest-js-2.105.4.tgz",
+      "integrity": "sha512-SppIyLo/kTwIlz1qpv2HN1EQqBg0GVktrDDFsXygYROha3MgVn4rT7p5EjFHFqXQm2rdRGb/BI7bc+jr10m91w==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@supabase/realtime-js": {
+      "version": "2.105.4",
+      "resolved": "https://registry.npmjs.org/@supabase/realtime-js/-/realtime-js-2.105.4.tgz",
+      "integrity": "sha512-6ov6c59+8D9h7q4M4Gy/uDJlC0Akxl9/714Y+6vJ+Sijuc16TS/p5DwhfRCLNcIhNiej1gEt+CQUwsjiPt4PxQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/phoenix": "^0.4.2",
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@supabase/storage-js": {
+      "version": "2.105.4",
+      "resolved": "https://registry.npmjs.org/@supabase/storage-js/-/storage-js-2.105.4.tgz",
+      "integrity": "sha512-Jx+pzMP1Whjof2PWHoVBUA75/p7PQE9CqKBzn1oXVyJDOggMLSH2OzVWwsXYaxEpdC1K/KltwmOX44nL3LHl9g==",
+      "license": "MIT",
+      "dependencies": {
+        "iceberg-js": "^0.8.1",
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@supabase/supabase-js": {
+      "version": "2.105.4",
+      "resolved": "https://registry.npmjs.org/@supabase/supabase-js/-/supabase-js-2.105.4.tgz",
+      "integrity": "sha512-cEnx+k49knU+qdIP7rXwR6fqEXPHZs+74xFK1R0S8MgQ7v9tbePVdGxvO03n3bPympMdJWVLadARBfU4TgNHCQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/auth-js": "2.105.4",
+        "@supabase/functions-js": "2.105.4",
+        "@supabase/postgrest-js": "2.105.4",
+        "@supabase/realtime-js": "2.105.4",
+        "@supabase/storage-js": "2.105.4"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
     },
     "node_modules/@swc/helpers": {
       "version": "0.5.15",
@@ -3991,6 +4076,15 @@
       "license": "MIT",
       "dependencies": {
         "hermes-estree": "0.25.1"
+      }
+    },
+    "node_modules/iceberg-js": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/iceberg-js/-/iceberg-js-0.8.1.tgz",
+      "integrity": "sha512-1dhVQZXhcHje7798IVM+xoo/1ZdVfzOMIc8/rgVSijRK38EDqOJoGula9N/8ZI5RD8QTxNQtK/Gozpr+qUqRRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.0.0"
       }
     },
     "node_modules/ignore": {

--- a/dashboards/open-brain-dashboard-next/package-lock.json
+++ b/dashboards/open-brain-dashboard-next/package-lock.json
@@ -11,6 +11,7 @@
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/sortable": "^10.0.0",
         "@dnd-kit/utilities": "^3.2.2",
+        "@supabase/ssr": "^0.10.3",
         "@supabase/supabase-js": "^2.105.4",
         "iron-session": "^8.0.4",
         "next": "16.2.1",
@@ -1345,6 +1346,31 @@
       },
       "engines": {
         "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@supabase/ssr": {
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/@supabase/ssr/-/ssr-0.10.3.tgz",
+      "integrity": "sha512-ux2CJgX89h0Fz2lY7ZNafNG2SkXpyRc5dz77K9eKeBLPdtywQixKwIuetDeIViAJBp/buOUVmgj8PVesOklNpw==",
+      "license": "MIT",
+      "dependencies": {
+        "cookie": "^1.0.2"
+      },
+      "peerDependencies": {
+        "@supabase/supabase-js": "^2.105.3"
+      }
+    },
+    "node_modules/@supabase/ssr/node_modules/cookie": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
+      "integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/@supabase/storage-js": {

--- a/dashboards/open-brain-dashboard-next/package.json
+++ b/dashboards/open-brain-dashboard-next/package.json
@@ -12,6 +12,7 @@
     "@dnd-kit/core": "^6.3.1",
     "@dnd-kit/sortable": "^10.0.0",
     "@dnd-kit/utilities": "^3.2.2",
+    "@supabase/ssr": "^0.10.3",
     "@supabase/supabase-js": "^2.105.4",
     "iron-session": "^8.0.4",
     "next": "16.2.1",

--- a/dashboards/open-brain-dashboard-next/package.json
+++ b/dashboards/open-brain-dashboard-next/package.json
@@ -12,6 +12,7 @@
     "@dnd-kit/core": "^6.3.1",
     "@dnd-kit/sortable": "^10.0.0",
     "@dnd-kit/utilities": "^3.2.2",
+    "@supabase/supabase-js": "^2.105.4",
     "iron-session": "^8.0.4",
     "next": "16.2.1",
     "react": "19.2.4",


### PR DESCRIPTION
## What changed
- added an MCP-backed graph experience to the Next dashboard, including graph routes, search, and the Graph explorer UI
- rewired dashboard data access away from the missing `open-brain-rest` function and onto the deployed MCP-backed endpoints
- replaced direct MCP-key login with Supabase Auth plumbing, including email/password plus Google and GitHub OAuth entry points and the auth callback flow
- updated dashboard pages that depended on the old REST API so thoughts and related views work in MCP mode

## Why
The deployed project does not expose the REST function this dashboard was originally built against, which caused 404 failures across login, dashboard, and thoughts flows. This PR moves the dashboard onto the backend that actually exists and adds the graph view the project wanted.

## Impact
- dashboard and thoughts load against the live MCP-backed backend instead of failing on missing REST endpoints
- graph view is available in the sidebar and thought flow
- login UI supports Supabase Auth-based sign-in flows instead of asking end users for the MCP access key

## Validation
- `npm run lint`
- `npx tsc --noEmit`
- verified local and deployed dashboard routes during implementation

## Notes
- GitHub and Google OAuth still require those providers to be enabled in the Supabase project before the social buttons can complete sign-in
