### PR TITLE
[codex] Fix OB1 gate empty workflow runs

### DIFF
--- a/.github/workflows/ob1-gate.yml
+++ b/.github/workflows/ob1-gate.yml
@@ -7,16 +7,47 @@ name: OB1 PR Gate
 # This means: automated agent passes → human admin approves → merge allowed
 
 on:
-  pull_request:
-    types: [opened, synchronize, reopened]
+  pull_request_target:
+    types:
+      - assigned
+      - unassigned
+      - labeled
+      - unlabeled
+      - opened
+      - edited
+      - closed
+      - reopened
+      - synchronize
+      - converted_to_draft
+      - locked
+      - unlocked
+      - ready_for_review
+      - review_requested
+      - review_request_removed
+      - auto_merge_enabled
+      - auto_merge_disabled
     branches: [main]
+  push:
+    branches: [main]
+  workflow_dispatch:
 
 permissions:
   contents: read
 
 jobs:
+  event_guard:
+    name: OB1 Gate Event Guard
+    if: (github.event_name != 'pull_request' && github.event_name != 'pull_request_target') || github.event.action == 'closed'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Explain non-review gate run
+        run: |
+          echo "OB1 PR Gate received a ${GITHUB_EVENT_NAME} event."
+          echo "The contribution review only runs for active PR review events."
+
   review:
     name: OB1 Review
+    if: (github.event_name == 'pull_request' || github.event_name == 'pull_request_target') && github.event.action != 'closed'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout PR head safely
@@ -26,7 +57,9 @@ jobs:
           fetch-depth: 0
 
       - name: Fetch base branch
-        run: git fetch origin "${{ github.event.pull_request.base.ref }}" --depth=1
+        run: |
+          git fetch origin "${{ github.event.pull_request.base.ref }}:refs/remotes/origin/${{ github.event.pull_request.base.ref }}" --depth=1
+          git show "origin/${{ github.event.pull_request.base.ref }}:.github/metadata.schema.json" > /tmp/ob1-metadata.schema.json
 
       - name: Install metadata schema validator
         run: python3 -m pip install check-jsonschema
@@ -49,11 +82,11 @@ jobs:
 
       - name: Run review checks
         id: review
+        env:
+          CHANGED_FILES: ${{ steps.changed.outputs.files }}
+          CONTRIB_DIRS: ${{ steps.changed.outputs.contrib_dirs }}
+          PR_TITLE: ${{ github.event.pull_request.title }}
         run: |
-          CHANGED_FILES="${{ steps.changed.outputs.files }}"
-          CONTRIB_DIRS="${{ steps.changed.outputs.contrib_dirs }}"
-          PR_TITLE="${{ github.event.pull_request.title }}"
-
           pass_count=0
           fail_count=0
           results=""
@@ -140,7 +173,7 @@ jobs:
               continue
             fi
 
-            if ! schema_output=$(check-jsonschema --schemafile .github/metadata.schema.json "$dir/metadata.json" 2>&1); then
+            if ! schema_output=$(check-jsonschema --schemafile /tmp/ob1-metadata.schema.json "$dir/metadata.json" 2>&1); then
               indented_output=$(printf '%s\n' "$schema_output" | sed 's/^/      /')
               rule3_detail="${rule3_detail}  - \`$dir/metadata.json\` failed schema validation\n${indented_output}\n"
               rule3_pass=false
@@ -624,6 +657,13 @@ jobs:
           REVIEW_COMMENT: ${{ steps.review.outputs.comment }}
           REVIEW_FAILED: ${{ steps.review.outputs.failed }}
           SECRET_BLOCKED: ${{ steps.review.outputs.secret_blocked }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          PR_AUTHOR_LOGIN: ${{ github.event.pull_request.user.login }}
+          PR_AUTHOR_ASSOCIATION: ${{ github.event.pull_request.author_association }}
+          PR_DRAFT: ${{ github.event.pull_request.draft }}
         run: |
           set -euo pipefail
 
@@ -635,13 +675,13 @@ jobs:
           printf '%s\n' "${{ steps.changed.outputs.contrib_dirs }}" > gate-artifact/contribution-dirs.txt
 
           jq -n \
-            --argjson pr_number "${{ github.event.pull_request.number }}" \
-            --arg pr_url "${{ github.event.pull_request.html_url }}" \
-            --arg title "${{ github.event.pull_request.title }}" \
-            --arg head_sha "${{ github.event.pull_request.head.sha }}" \
-            --arg author_login "${{ github.event.pull_request.user.login }}" \
-            --arg author_association "${{ github.event.pull_request.author_association }}" \
-            --arg is_draft "${{ github.event.pull_request.draft }}" \
+            --argjson pr_number "$PR_NUMBER" \
+            --arg pr_url "$PR_URL" \
+            --arg title "$PR_TITLE" \
+            --arg head_sha "$PR_HEAD_SHA" \
+            --arg author_login "$PR_AUTHOR_LOGIN" \
+            --arg author_association "$PR_AUTHOR_ASSOCIATION" \
+            --arg is_draft "$PR_DRAFT" \
             --arg failed "$REVIEW_FAILED" \
             --arg secret_blocked "$SECRET_BLOCKED" \
             '{

--- a/.github/workflows/ob1-pr-followups.yml
+++ b/.github/workflows/ob1-pr-followups.yml
@@ -15,8 +15,18 @@ permissions:
   id-token: write
 
 jobs:
+  ignore_non_pr_gate:
+    name: Ignore Non-PR Gate Run
+    if: github.event.workflow_run.event != 'pull_request' && github.event.workflow_run.event != 'pull_request_target'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Explain skipped follow-up
+        run: |
+          echo "OB1 PR Follow-Ups only acts on pull_request gate runs."
+          echo "Received upstream event: ${{ github.event.workflow_run.event }}"
+
   followups:
-    if: github.event.workflow_run.event == 'pull_request'
+    if: github.event.workflow_run.event == 'pull_request' || github.event.workflow_run.event == 'pull_request_target'
     runs-on: ubuntu-latest
     concurrency:
       group: ob1-pr-followups-${{ github.event.workflow_run.pull_requests[0].number || github.event.workflow_run.id }}


### PR DESCRIPTION
## Summary
- switch the OB1 gate to `pull_request_target` so conflicted PRs can still produce real gate results instead of zero-job failures
- add explicit push/main and workflow_dispatch handling with a guard job so merge pushes do not create empty workflow failures
- add a non-PR guard to the follow-up workflow so push-triggered gate runs do not cascade into another zero-job workflow
- keep `pull_request_target` safer by using read-only permissions and validating metadata against the base-branch schema

## Root Cause
GitHub was creating `.github/workflows/ob1-gate.yml` runs with zero jobs. Recent evidence showed push events on `main` plus PR force-push/conflict cleanup. GitHub documents that `pull_request` workflows do not run when a PR has merge conflicts, which matches the noisy PR examples.

## Validation
- `ruby -e 'require "yaml"; ARGV.each { |f| YAML.load_file(f); puts "parsed #{f}" }' .github/workflows/ob1-gate.yml .github/workflows/ob1-pr-followups.yml`\n- `git diff --check`\n- `npx --yes node-actionlint .github/workflows/ob1-gate.yml .github/workflows/ob1-pr-followups.yml`\n- live manual run on this branch: https://github.com/NateBJones-Projects/OB1/actions/runs/26184769762 (`OB1 Gate Event Guard` ran successfully; `OB1 Review` skipped as intended for `workflow_dispatch`)\n\n## Note\nThe changed `pull_request_target` workflow will only become active for PR events after this lands on `main`, because GitHub evaluates `pull_request_target` workflows from the default branch.