### PR TITLE
Export SYNTHESIZERS catalogue and guard main() entrypoint

### DIFF
--- a/recipes/wiki-synthesis/scripts/synthesize-wiki.mjs
+++ b/recipes/wiki-synthesis/scripts/synthesize-wiki.mjs
@@ -55,7 +55,7 @@ const PAGE_SIZE = 1000;
 
 // ── Synthesizer catalogue ─────────────────────────────────────────────────
 
-const SYNTHESIZERS = {};
+export const SYNTHESIZERS = {};
 
 SYNTHESIZERS.autobiography = {
   summary: "Narrative autobiography grouped by year, from dated thoughts.",
@@ -155,7 +155,7 @@ SYNTHESIZERS.autobiography = {
 
 // ── Main ─────────────────────────────────────────────────────────────────
 
-async function main() {
+export async function main() {
   const args = parseArgs(process.argv.slice(2));
 
   if (args.help) {
@@ -387,4 +387,6 @@ function fail(msg) {
   process.exit(1);
 }
 
-await main();
+if (import.meta.url === `file://${process.argv[1]}`) {
+  await main();
+}


### PR DESCRIPTION
## Summary

`recipes/wiki-synthesis/scripts/synthesize-wiki.mjs` is structurally closed to extension: the `SYNTHESIZERS` registry is module-local, `main` is unexported, and the file ends with a top-level `await main()` that fires on any import. This PR adds three lines so the module can be imported by a sibling runner that registers additional synthesizers, without changing the CLI behaviour or the built-in `autobiography` synthesizer.

## Motivation

I want to extend the catalogue (e.g. `priority1`, `topic-narrative`) from a sibling script in my own repo without forking this one. Today that is structurally blocked:

- `const SYNTHESIZERS = {}` is module-local — no export to mutate.
- `main` is unexported — a sibling runner cannot reuse the CLI plumbing.
- `await main()` at module top-level runs immediately on `import()`, so dynamic-import-then-mutate is a non-starter.

The three-line patch turns the module into a reusable library while keeping `node synthesize-wiki.mjs ...` working exactly as today.

## Changes

1. Line 58: `const SYNTHESIZERS = {}` -> `export const SYNTHESIZERS = {}`
2. Line 158: `async function main()` -> `export async function main()`
3. Line 390: replace `await main();` with an entrypoint guard:

   ```js
   if (import.meta.url === `file://${process.argv[1]}`) {
     await main();
   }
   ```

## Compatibility

Non-breaking and additive. The entrypoint guard preserves `node synthesize-wiki.mjs --topic autobiography` behaviour because `import.meta.url` matches `file://${process.argv[1]}` when run directly. The module simply gains the ability to be imported without auto-executing.

## Test plan

- [x] `node synthesize-wiki.mjs --list` prints the built-in `autobiography` entry.
- [x] `node -e "import('./synthesize-wiki.mjs').then(m => console.log(Object.keys(m.SYNTHESIZERS)))"` prints `[ 'autobiography' ]` and does **not** trigger `main()`.
- [ ] `node synthesize-wiki.mjs --topic autobiography --dry-run` completes as before.
- [ ] A sibling script that does `import { SYNTHESIZERS, main } from './synthesize-wiki.mjs'`, mutates `SYNTHESIZERS`, then calls `main()` runs the extended synthesizer.