### PR TITLE
Fix OB1 Agent Memory ClawHub install metadata

### DIFF
--- a/integrations/openclaw-agent-memory/CLAW_HUB_PUBLISHING.md
+++ b/integrations/openclaw-agent-memory/CLAW_HUB_PUBLISHING.md
@@ -130,6 +130,20 @@ Prepared on 2026-05-22:
 - `clawhub package publish --dry-run --json` passed for
   `@natebjones/ob1-agent-memory` version `0.1.5`.
 
+## Prepared 0.1.6 ClawHub Install Fix
+
+Prepared on 2026-05-22:
+
+- Package version bumped to `0.1.6`.
+- `openclaw` stays in `peerDependencies` so OpenClaw can symlink the host SDK
+  during plugin install.
+- `peerDependenciesMeta.openclaw.optional` prevents npm from auto-installing a
+  real nested `node_modules/openclaw` before OpenClaw creates the host SDK
+  symlink.
+- The recommended install path is the one-line ClawHub resolver on OpenClaw
+  `2026.5.7` and newer.
+- OpenClaw `2026.5.2` should continue using the published tarball fallback.
+
 License note: the OB1 repository is `FSL-1.1-MIT`. ClawHub requires public
 skills to be `MIT-0`, so the standalone skill files in
 [../../skills/openclaw-agent-memory](../../skills/openclaw-agent-memory/) are
@@ -162,8 +176,8 @@ npx -y clawhub@0.12.2 package publish integrations/openclaw-agent-memory/plugin 
   --family code-plugin \
   --name @natebjones/ob1-agent-memory \
   --display-name "NBJ OB1 Agent Memory for OpenClaw" \
-  --version 0.1.5 \
-  --changelog "OpenClaw/Claude compatibility fix: recall and write-back now expose explicit tool parameter properties instead of patternProperties-only schemas." \
+  --version 0.1.6 \
+  --changelog "ClawHub install fix: mark the OpenClaw peer dependency optional so npm does not materialize a nested OpenClaw package before the host SDK symlink is created." \
   --tags latest,nbj,nate-jones,ob1,openbrain,agent-memory,openclaw,provenance \
   --source-repo NateBJones-Projects/OB1 \
   --source-commit "$(git rev-parse HEAD)" \
@@ -199,8 +213,8 @@ npx -y clawhub@0.12.2 package publish integrations/openclaw-agent-memory/plugin 
   --family code-plugin \
   --name @natebjones/ob1-agent-memory \
   --display-name "NBJ OB1 Agent Memory for OpenClaw" \
-  --version 0.1.5 \
-  --changelog "OpenClaw/Claude compatibility fix: recall and write-back now expose explicit tool parameter properties instead of patternProperties-only schemas." \
+  --version 0.1.6 \
+  --changelog "ClawHub install fix: mark the OpenClaw peer dependency optional so npm does not materialize a nested OpenClaw package before the host SDK symlink is created." \
   --tags latest,nbj,nate-jones,ob1,openbrain,agent-memory,openclaw,provenance \
   --source-repo NateBJones-Projects/OB1 \
   --source-commit "$(git rev-parse HEAD)" \
@@ -239,7 +253,7 @@ openclaw plugins install clawhub:@natebjones/ob1-agent-memory
 
 - Plugin manifest validates.
 - Plugin manifest declares `contracts.tools` for every `openbrain_*` tool. OpenClaw rejects tool registration without the manifest contract.
-- Plugin config accepts `endpoint`, `workspaceId`, and `accessKey`. Prefer an OpenClaw SecretRef backed by a file, env, or exec provider so the access key does not live in plaintext config.
+- Plugin config accepts `endpoint`, `workspaceId`, and `accessKey`. Prefer an OpenClaw SecretRef backed by a file or exec provider so the access key does not live in plaintext config.
 - Tool entry uses `definePluginEntry`, `typebox` parameters, `label`, `execute(_id, params)`, and returns `details`.
 - Package includes compiled runtime output at `plugin/dist/index.js`; ClawHub rejects TypeScript-only plugin entrypoints.
 - Local linked install is tested in an isolated profile with `openclaw --profile ob1-agent-memory plugins install integrations/openclaw-agent-memory/plugin --link`.
@@ -257,7 +271,7 @@ openclaw plugins install clawhub:@natebjones/ob1-agent-memory
 
 ## Release Notes
 
-See [RELEASE_NOTES_0.1.5.md](./RELEASE_NOTES_0.1.5.md).
+See [RELEASE_NOTES_0.1.6.md](./RELEASE_NOTES_0.1.6.md).
 
 Public release copy should always include a short Nate Jones CTA. Keep it useful-first, not hype-first: Nate gives away practical AI systems like this, and the next step is following or subscribing for more.
 

--- a/integrations/openclaw-agent-memory/RELEASE_NOTES_0.1.6.md
+++ b/integrations/openclaw-agent-memory/RELEASE_NOTES_0.1.6.md
@@ -1,0 +1,24 @@
+# NBJ OB1 Agent Memory for OpenClaw 0.1.6
+
+ClawHub install compatibility fix.
+
+## Changed
+
+- Marks the `openclaw` peer dependency as optional for npm install planning.
+- Keeps the OpenClaw peer declaration so the host SDK can still be symlinked by
+  OpenClaw during plugin install.
+- Updates install docs so OpenClaw `2026.5.7` and newer use the one-line
+  ClawHub install path.
+- Keeps the tarball fallback documented for OpenClaw `2026.5.2`.
+
+## Verification Target
+
+The one-line install should work from a clean profile:
+
+```bash
+openclaw --profile ob1-agent-memory plugins install clawhub:@natebjones/ob1-agent-memory
+openclaw --profile ob1-agent-memory plugins inspect nbj-ob1-agent-memory --runtime --json
+```
+
+Runtime inspect should show version `0.1.6`, all seven `openbrain_*` tools,
+and no diagnostics.

--- a/integrations/openclaw-agent-memory/plugin/README.md
+++ b/integrations/openclaw-agent-memory/plugin/README.md
@@ -6,21 +6,24 @@ Built by Nate B. Jones / OB1. Follow Nate for practical AI systems, agent workfl
 
 ## Install
 
-Current OpenClaw `2026.5.2` installs the ClawHub-hosted package cleanly from the published tarball:
-
-```bash
-curl -fsSL \
-  https://clawhub.ai/api/npm/@natebjones/ob1-agent-memory/-/natebjones-ob1-agent-memory-0.1.5.tgz \
-  -o natebjones-ob1-agent-memory-0.1.5.tgz
-
-openclaw plugins install ./natebjones-ob1-agent-memory-0.1.5.tgz
-```
-
-The package is also published on ClawHub as `@natebjones/ob1-agent-memory`. When OpenClaw's `clawhub:` resolver accepts npm-pack artifact metadata directly, this should become the normal one-line install:
+Recommended for OpenClaw `2026.5.7` and newer:
 
 ```bash
 openclaw plugins install clawhub:@natebjones/ob1-agent-memory
 ```
+
+OpenClaw `2026.5.2` predates the current ClawHub npm-pack resolver metadata
+path. Use the published tarball fallback on that host version:
+
+```bash
+curl -fsSL \
+  https://clawhub.ai/api/npm/@natebjones/ob1-agent-memory/-/natebjones-ob1-agent-memory-0.1.6.tgz \
+  -o natebjones-ob1-agent-memory-0.1.6.tgz
+
+openclaw plugins install ./natebjones-ob1-agent-memory-0.1.6.tgz
+```
+
+The package is published on ClawHub as `@natebjones/ob1-agent-memory`.
 
 For local linked development:
 

--- a/integrations/openclaw-agent-memory/plugin/package.json
+++ b/integrations/openclaw-agent-memory/plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@natebjones/ob1-agent-memory",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "description": "Governed NBJ OB1 Agent Memory tools for OpenClaw: recall before work, write back after, inspect everything.",
   "type": "module",
   "license": "MIT-0",
@@ -46,6 +46,11 @@
   },
   "peerDependencies": {
     "openclaw": ">=2026.3.24-beta.2"
+  },
+  "peerDependenciesMeta": {
+    "openclaw": {
+      "optional": true
+    }
   },
   "openclaw": {
     "extensions": [


### PR DESCRIPTION
## Summary
- bump OB1 Agent Memory OpenClaw plugin to 0.1.6
- mark the OpenClaw peer dependency optional so npm does not install a nested OpenClaw package before host SDK symlink repair
- update install docs and release notes for the ClawHub one-line path plus the 2026.5.2 tarball fallback

## Verification
- npm run schema:check
- npm run build
- npm pack --dry-run
- local 0.1.6 tarball install on OpenClaw 2026.5.2, 2026.5.7, and 2026.5.20
- published @natebjones/ob1-agent-memory@0.1.6 to ClawHub
- live clawhub install on OpenClaw 2026.5.7 and 2026.5.20
- live tarball fallback install on OpenClaw 2026.5.2
- runtime inspect shows version 0.1.6, all seven openbrain_* tools, and no diagnostics

Linear: NAT-999