### PR TITLE
[schemas] Document workflow-status prerequisite for enhanced-thoughts

### DIFF
--- a/schemas/enhanced-thoughts/README.md
+++ b/schemas/enhanced-thoughts/README.md
@@ -12,8 +12,12 @@ This schema extension adds six new columns to the `thoughts` table (`type`, `sen
 
 ## Prerequisites
 
+> [!IMPORTANT]
+> **Apply the [`workflow-status`](../workflow-status/) schema first.** This migration's `upsert_thought` function writes to the `status` and `status_updated_at` columns on the `thoughts` table (see `schema.sql` lines 347-383). Those columns are created by the `workflow-status` schema. If you run this migration on a fresh install without `workflow-status` applied, the `CREATE OR REPLACE FUNCTION upsert_thought` block will fail with `column "status" of relation "thoughts" does not exist`.
+
 - Working Open Brain setup (see the getting-started guide in `docs/01-getting-started.md`)
 - Supabase project with the `thoughts` table, `match_thoughts` function, and `upsert_thought` function already created
+- [`workflow-status`](../workflow-status/) schema already applied (adds the `status` and `status_updated_at` columns this migration writes to)
 
 ## Credential Tracker
 


### PR DESCRIPTION
## Summary

The `enhanced-thoughts` schema has a hidden dependency on the `workflow-status` schema that isn't documented in the README. This PR adds a clearly placed Prerequisites callout.

## Symptom (fresh install)

Running `schemas/enhanced-thoughts/schema.sql` on a project that hasn't applied `workflow-status` first fails with:

```
ERROR:  column "status" of relation "thoughts" does not exist
```

The failure happens inside the `CREATE OR REPLACE FUNCTION public.upsert_thought` block.

## Why

`schemas/enhanced-thoughts/schema.sql` writes to two columns on the `thoughts` table that `enhanced-thoughts` does not itself create:

- **INSERT** at lines 347-370 writes to `status` and `status_updated_at`
- **ON CONFLICT UPDATE** at lines 379-383 updates those same columns

Those columns are created by `schemas/workflow-status/` (see its README and migration).

## Fix

Single doc-only change to `schemas/enhanced-thoughts/README.md`: adds an `> [!IMPORTANT]` callout at the top of the existing Prerequisites section, plus a new bullet linking to `../workflow-status/`. No SQL, code, or `metadata.json` changes.

> Note: I considered adding a `requires.schemas` array to `metadata.json` to make this machine-checkable, but `.github/metadata.schema.json` sets `additionalProperties: false` on `requires` and only allows `open_brain` / `services` / `tools` — adding a schemas dependency field would need a schema spec change first. Happy to follow up with a separate PR if you'd like that.

## File changes

- `schemas/enhanced-thoughts/README.md` (+4 lines, -0)

## Test plan

- [ ] On a fresh Open Brain Supabase project: apply `workflow-status` first, then `enhanced-thoughts` — both succeed
- [ ] On a fresh project: apply `enhanced-thoughts` directly — reproduces the `column "status" does not exist` error referenced in the README callout
- [ ] Rendered README: confirm the IMPORTANT callout displays at the top of Prerequisites and the relative link to `../workflow-status/` resolves on github.com

Caught while installing five schemas during a Brain Architecture build on 2026-05-26.

---

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>