### PR TITLE
[recipes] Fix CORS + JSON-RPC envelope on work-operating-model-activation

### DIFF
--- a/recipes/work-operating-model-activation/index.ts
+++ b/recipes/work-operating-model-activation/index.ts
@@ -20,6 +20,58 @@ if (!SUPABASE_URL || !SUPABASE_SERVICE_ROLE_KEY || !MCP_ACCESS_KEY || !DEFAULT_U
 const supabase = createClient(SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY);
 const app = new Hono();
 
+// CORS + JSON-RPC envelope for browser-based MCP clients (e.g. claude.ai web UI).
+// Without these the OPTIONS preflight fails and the unauthorized path returns a
+// bare error object that is not a valid JSON-RPC 2.0 response.
+const corsHeaders = {
+  "Access-Control-Allow-Origin": "*",
+  "Access-Control-Allow-Headers":
+    "authorization, x-client-info, apikey, content-type, x-brain-key, accept, mcp-session-id, mcp-protocol-version, last-event-id",
+  "Access-Control-Allow-Methods": "GET, POST, OPTIONS, DELETE",
+};
+
+const JSON_RPC_UNAUTHORIZED_CODE = -32001;
+const UNAUTHORIZED_MESSAGE = "Unauthorized: missing or invalid authentication.";
+
+async function readBodyText(req: Request): Promise<string | null> {
+  if (req.method === "GET" || req.method === "HEAD" || req.method === "DELETE") return null;
+  try {
+    return await req.text();
+  } catch {
+    return null;
+  }
+}
+
+function extractJsonRpcId(bodyText: string | null): string | number | null {
+  if (!bodyText) return null;
+  try {
+    const parsed = JSON.parse(bodyText);
+    if (parsed && typeof parsed === "object" && "id" in parsed) {
+      const id = (parsed as { id: unknown }).id;
+      if (typeof id === "string" || typeof id === "number" || id === null) return id;
+    }
+  } catch {
+    // malformed body - id stays null
+  }
+  return null;
+}
+
+function unauthorizedResponse(id: string | number | null): Response {
+  return new Response(
+    JSON.stringify({
+      jsonrpc: "2.0",
+      error: { code: JSON_RPC_UNAUTHORIZED_CODE, message: UNAUTHORIZED_MESSAGE },
+      id,
+    }),
+    {
+      status: 200,
+      headers: { "Content-Type": "application/json", ...corsHeaders },
+    },
+  );
+}
+
+app.options("*", (c) => c.text("ok", 200, corsHeaders));
+
 const LAYERS = [
   "operating_rhythms",
   "recurring_decisions",
@@ -832,6 +884,17 @@ app.get("/health", (c) =>
 );
 
 app.all("*", async (c) => {
+  const provided =
+    c.req.header("x-brain-key") ||
+    c.req.header("x-access-key") ||
+    new URL(c.req.url).searchParams.get("key");
+
+  if (!provided || provided !== MCP_ACCESS_KEY) {
+    const bodyText = await readBodyText(c.req.raw);
+    const id = extractJsonRpcId(bodyText);
+    return unauthorizedResponse(id);
+  }
+
   if (!c.req.header("accept")?.includes("text/event-stream")) {
     const headers = new Headers(c.req.raw.headers);
     headers.set("Accept", "application/json, text/event-stream");
@@ -843,15 +906,6 @@ app.all("*", async (c) => {
       duplex: "half",
     });
     Object.defineProperty(c.req, "raw", { value: patched, writable: true });
-  }
-
-  const key =
-    c.req.query("key") ||
-    c.req.header("x-brain-key") ||
-    c.req.header("x-access-key");
-
-  if (!key || key !== MCP_ACCESS_KEY) {
-    return c.json({ error: "Unauthorized" }, 401);
   }
 
   const transport = new StreamableHTTPTransport();


### PR DESCRIPTION
## Problem

The `work-operating-model-activation` recipe's MCP Edge Function is unreachable from browser-based MCP clients (Claude.ai web UI being the canonical case). Two issues compound:

1. **CORS preflight fails.** The function has no `OPTIONS` handler. Browsers reject the subsequent POST because no `Access-Control-Allow-Origin`/`Allow-Headers`/`Allow-Methods` headers come back on the preflight.
2. **Unauthorized response is not valid JSON-RPC 2.0.** When the access key check fails, the function returns a bare `{ error: "Unauthorized" }` body at HTTP 401. MCP clients that strictly validate JSON-RPC envelopes (`{ jsonrpc: "2.0", id, error: { code, message } }`) reject the response before they can surface the real auth issue to the user, and the 401 status code itself makes some browser fetch wrappers throw before the JSON is even parsed.

## Reproduction

1. Deploy the recipe as-is to a Supabase project per `recipes/work-operating-model-activation/README.md`.
2. In `claude.ai` -> Settings -> Connectors -> Add custom connector, paste the function URL with `?key=<MCP_ACCESS_KEY>`.
3. Claude.ai surfaces a generic connection error. Network panel shows the OPTIONS preflight returning no `Access-Control-Allow-Origin` header and the POST never firing.
4. Even when bypassing CORS (e.g. server-side curl with an intentionally wrong key), the body is a bare `{ "error": "Unauthorized" }` rather than a JSON-RPC error envelope.

## Fix

Minimal, localized to the Hono app setup and the `app.all("*")` catch-all. No changes to the four MCP tools, schemas, or any business logic.

- Add `app.options("*", ...)` returning standard CORS allow-list (origin, methods, and the headers MCP transports actually use: `authorization`, `x-client-info`, `apikey`, `content-type`, `x-brain-key`, `accept`, `mcp-session-id`, `mcp-protocol-version`, `last-event-id`).
- Replace the bare 401 response with `unauthorizedResponse(id)`, which returns a JSON-RPC 2.0 envelope (`{ jsonrpc: "2.0", error: { code: -32001, message }, id }`) at HTTP 200, with CORS headers attached. The inbound request id is best-effort echoed so the client can correlate.
- Move the auth gate above the accept-header patching so the unauthorized path doesn't consume the request body twice and conflict with `transport.handleRequest(c)` ownership of the stream.

The patched version of this function has been running successfully against the live Claude.ai web UI for ~24h on the contributor's deployment, completing a full five-layer operating-model session end-to-end.

## Notes

- Branch named `fix/work-operating-model-cors` per the explicit task instruction. Happy to rename to `contrib/drewyd/work-operating-model-cors-fix` per `CONTRIBUTING.md` convention if maintainers prefer - just shout.
- Marked as draft for maintainer review before flipping to ready.

---

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>