### PR TITLE
fix(professional-crm): two deploy-blocking bugs in the Edge Function reference

### DIFF
--- a/extensions/professional-crm/index.ts
+++ b/extensions/professional-crm/index.ts
@@ -17,7 +17,21 @@ import { StreamableHTTPTransport } from "@hono/mcp";
 import { z } from "zod";
 import { createClient } from "@supabase/supabase-js";
 
+// CORS headers — Claude Desktop / claude.ai connectors send a preflight
+// OPTIONS request before opening the MCP stream; without these the
+// connector probe fails and Claude reports "Couldn't reach the MCP server"
+// or falls back to inferring an OAuth flow.
+const corsHeaders = {
+  "Access-Control-Allow-Origin": "*",
+  "Access-Control-Allow-Headers":
+    "authorization, x-client-info, apikey, content-type, x-access-key, accept, mcp-session-id",
+  "Access-Control-Allow-Methods": "GET, POST, OPTIONS, DELETE",
+};
+
 const app = new Hono();
+
+// CORS preflight
+app.options("*", (c) => c.text("ok", 200, corsHeaders));
 
 // POST /mcp - Main MCP endpoint
 app.post("*", async (c) => {
@@ -37,7 +51,7 @@ app.post("*", async (c) => {
   const key = c.req.query("key") || c.req.header("x-access-key");
   const expected = Deno.env.get("MCP_ACCESS_KEY");
   if (!key || key !== expected) {
-    return c.json({ error: "Unauthorized" }, 401);
+    return c.json({ error: "Unauthorized" }, 401, corsHeaders);
   }
 
   const supabase = createClient(
@@ -53,7 +67,7 @@ app.post("*", async (c) => {
 
   const userId = Deno.env.get("DEFAULT_USER_ID");
   if (!userId) {
-    return c.json({ error: "DEFAULT_USER_ID not configured" }, 500);
+    return c.json({ error: "DEFAULT_USER_ID not configured" }, 500, corsHeaders);
   }
 
   const server = new McpServer({ name: "professional-crm", version: "1.1.0" });
@@ -699,6 +713,6 @@ app.post("*", async (c) => {
   return transport.handleRequest(c);
 });
 
-app.get("*", (c) => c.json({ status: "ok", service: "Professional CRM", version: "1.1.0" }));
+app.get("*", (c) => c.json({ status: "ok", service: "Professional CRM", version: "1.1.0" }, 200, corsHeaders));
 
 Deno.serve(app.fetch);

--- a/extensions/professional-crm/index.ts
+++ b/extensions/professional-crm/index.ts
@@ -694,10 +694,7 @@ app.post("*", async (c) => {
     },
   );
 
-  const transport = new StreamableHTTPTransport({
-    sessionIdGenerator: undefined,
-    enableJsonResponse: true,
-  });
+  const transport = new StreamableHTTPTransport();
   await server.connect(transport);
   return transport.handleRequest(c);
 });


### PR DESCRIPTION
## Summary

Fixes two issues that prevent `extensions/professional-crm/index.ts` from being deployed as published — anyone who follows the README and runs `supabase functions deploy professional-crm-mcp` against a fresh project hits both immediately.

Discovered while deploying the extension against a real Supabase project + claude.ai connector. Each fix is isolated in its own commit so they can be reviewed (or split into separate PRs) independently.

### Bug 1 — `StreamableHTTPTransport` constructor options crash on every POST

The transport is instantiated with `{ sessionIdGenerator: undefined, enableJsonResponse: true }`. The pinned `@hono/mcp@0.1.1` (deno.json) does not accept these options on its `StreamableHTTPTransport` constructor — passing them causes the handler to fail at runtime, returning HTTP 500 on every POST. GET probes return 200 (looks healthy), but MCP traffic 100% fails.

Symptom in Claude Desktop: `"Couldn't reach the MCP server"` on first connect, then — after retry — `"Couldn't register with sign-in service. You can try again, or add an OAuth Client ID in the connector settings"` (Claude infers an OAuth flow from the 500 response).

Fix: `new StreamableHTTPTransport()` with no args, matching the pattern in OB1's working core MCP example.

### Bug 2 — Missing CORS preflight + response headers

Claude Desktop and claude.ai connectors send an OPTIONS preflight before opening the MCP stream. Without an `app.options(...)` handler, Hono returns 404 and the connector probe fails. Error responses (401, 500) also need CORS headers so the browser-based client can read the JSON body.

Fix: add `corsHeaders`, an `app.options("*", ...)` handler, and attach `corsHeaders` to existing 401/500/GET responses. The MCP success path through `transport.handleRequest(c)` is unchanged.

## Verification

After applying both commits, deployed to a Supabase Edge Function (`@hono/mcp@0.1.1`, `@modelcontextprotocol/sdk@1.24.3`, hono@4.9.2 — all per the pinned deno.json) and confirmed:

- `OPTIONS /functions/v1/professional-crm-mcp` → 200 with CORS headers
- `GET /functions/v1/professional-crm-mcp` → 200 status JSON
- `POST … {"method":"initialize"}` → 200 with proper MCP `serverInfo`
- `POST … {"method":"tools/list"}` → 200 listing all 10 `crm_*` tools
- `POST … {"method":"tools/call","params":{"name":"crm_get_follow_ups",…}}` → 200 with real data from `professional_contacts`
- Claude Desktop connector reaches green-checkmark state and all 10 tools appear in chat

## Test plan

- [ ] Maintainer can reproduce the original 500 by deploying current `main` against a clean Supabase project with the four required secrets set
- [ ] After applying these commits, the same deploy succeeds end-to-end with no client/connector retries needed
- [ ] Manual MCP `initialize` returns the expected `serverInfo` JSON
- [ ] No regression in the upstream README-documented flow

Closes #331