### PR TITLE
[recipes] Local Docker Open Brain — Postgres + pgvector + AWS Bedrock

### DIFF
--- a/recipes/local-docker/.env.example
+++ b/recipes/local-docker/.env.example
@@ -1,0 +1,28 @@
+# Copy this to .env and fill in the values
+# .env is gitignored — never commit it
+
+# Strong password for the local Postgres instance
+POSTGRES_PASSWORD=change-me
+
+# Random hex string — your MCP access key
+# Generate one with: openssl rand -hex 32
+MCP_ACCESS_KEY=change-me
+
+# Set this in your PowerShell profile or system environment to use capture.ps1
+# Must match MCP_ACCESS_KEY above
+OPEN_BRAIN_KEY=change-me
+
+# AWS credentials directory on the host — bind-mounted into the container
+# Linux/macOS: AWS_HOME=$HOME/.aws
+# Windows:     AWS_HOME=C:\Users\<your-username>\.aws
+AWS_HOME=/path/to/.aws
+
+# AWS region where your Bedrock models are enabled
+AWS_REGION=us-east-1
+
+# AWS profile to use for Bedrock (must have bedrock:InvokeModel permissions)
+AWS_PROFILE=default
+
+# Bedrock model IDs (defaults shown — override to switch models)
+EMBEDDING_MODEL=amazon.titan-embed-text-v2:0
+METADATA_MODEL=us.anthropic.claude-haiku-4-5-20251001-v1:0

--- a/recipes/local-docker/.gitignore
+++ b/recipes/local-docker/.gitignore
@@ -1,0 +1,1 @@
+scripts/

--- a/recipes/local-docker/ARCHITECTURE.md
+++ b/recipes/local-docker/ARCHITECTURE.md
@@ -1,0 +1,378 @@
+# Open Brain Local Docker — Architecture & Decision Log
+
+## What This Is
+
+A local Docker adaptation of the stock Open Brain (OB1) MCP server. The goal is a
+self-contained personal knowledge capture system with no cloud dependencies, suitable
+for work content under corporate data privacy constraints.
+
+---
+
+## What We Changed From Stock OB1 and Why
+
+### 1. No Supabase (cloud → local Postgres)
+
+**Stock OB1:** Supabase cloud hosts both the database (Postgres + pgvector) and the
+MCP server runtime (Supabase Edge Functions / Deno).
+
+**Our version:** `pgvector/pgvector:pg16` Docker container. Same schema, same SQL
+functions (`match_thoughts`, `upsert_thought`), same everything — just running locally.
+
+**Why:** Work content cannot go to arbitrary cloud services. Supabase cloud is out.
+
+---
+
+### 2. No OpenRouter / OpenAI (cloud AI → local or AWS)
+
+**Stock OB1:** OpenRouter proxies to OpenAI for:
+- Embeddings: `text-embedding-3-small` → 1536-dim vectors
+- Metadata extraction: `gpt-4o-mini`
+
+**Our version (current target):** AWS Bedrock for both:
+- Embeddings: `amazon.titan-embed-text-v2:0` → 1024-dim vectors
+- Metadata extraction: `anthropic.claude-haiku-4-5-20251001`
+
+**Why:** Same data privacy constraint. AWS Bedrock is already approved — data stays
+within the corporate AWS account. Configure your AWS profile and region in `.env`
+(see `.env.example`).
+
+**Schema impact:** Vector dimension changed from 1536 → 1024. Both `01-schema.sql`
+references updated accordingly.
+
+**We also tried:** Ollama (local, fully offline) with `nomic-embed-text` (768-dim)
+and `llama3.2` / `qwen2.5:0.5b`. This worked but was too slow on CPU (~12-16s per
+embedding, ~30s+ for metadata extraction). Bedrock is the right answer — sub-second
+latency and data stays in AWS.
+
+---
+
+### 3. MCP server runtime — Node.js (ported from Deno)
+
+**Stock OB1:** Deno running in Supabase Edge Functions. Uses `@supabase/supabase-js`
+for database access.
+
+**Our version:** Node.js 22 running in a `node:22-alpine` container. Switched database
+client from `@supabase/supabase-js` to `postgres` (postgres.js) for direct
+Postgres access.
+
+**Key fix made:** postgres.js requires `sql.json()` to pass JSONB parameters — plain
+object passing silently stores `{}`. This was the metadata storage bug.
+
+**Why we moved from Deno to Node.js:** The AWS SDK for JavaScript
+(`@aws-sdk/client-bedrock-runtime`) is a Node.js SDK. It uses Node.js's `http2`
+module which Deno does not fully implement — causing `Not implemented:
+Http2Session.settings` at runtime. Node.js is the native target for the AWS SDK:
+no shims, no workarounds, clean credential handling via `fromIni`.
+
+**Runtime is inside Docker** — no Node.js installation required on the host machine.
+The `node:22-alpine` image is pulled and built as part of `docker compose up`.
+
+**Deno-isms removed in the port:**
+- `Deno.env.get()` → `process.env`
+- `Deno.serve()` → `@hono/node-server` (`serve()`)
+- `NodeHttpHandler` shim → removed (not needed on Node.js)
+- `duplex: "half"` request workaround → removed
+- `deno.json` import map → standard `package.json`; TypeScript run via `tsx`
+
+---
+
+### 4. AWS Credential Handling
+
+The MCP server needs Bedrock access. Credentials are sourced from your host's `~/.aws/credentials` file via a read-only bind mount, then parsed on every Bedrock call. This is deliberate — the alternatives all have failure modes.
+
+**How it works:**
+- `docker-compose.yml` bind-mounts `${AWS_HOME}` → `/root/.aws` as `read_only: true`. The container can read your credentials but cannot modify them.
+- `server/index.ts:readCredentials()` parses the standard INI format manually, picks the section named by `AWS_PROFILE`, and returns `{ accessKeyId, secretAccessKey, sessionToken? }`.
+- `makeBedrock()` is called fresh per Bedrock request. No SDK credential caching, no module-level singleton. Every request reads the file again.
+
+**Why not the AWS SDK's built-in `fromIni()` / default credential chain:**
+- The SDK chain caches credentials in memory. With SSO or assume-role profiles whose tokens expire on the order of hours, that cache goes stale and you get `ExpiredTokenException` until the container is restarted.
+- Reading the file per request makes rotation transparent. Run `aws sso login` on the host and the next Bedrock call from the container picks up the new tokens automatically — no container restart needed.
+
+**What never leaves the container:**
+- Credentials go to the AWS Bedrock endpoint (HTTPS) and nowhere else.
+- They are never written to logs, captured thoughts, or the database.
+- They are never copied into the image — only mounted at runtime.
+
+**Trade-offs we rejected:**
+- *Inject `AWS_ACCESS_KEY_ID` etc. via env vars* — breaks when tokens rotate.
+- *Mount `~/.aws` writable* — unnecessary privilege; we only need to read.
+- *Bake credentials into the image* — never. The image is portable; credentials are per-user.
+
+**Operator notes:**
+- If `aws configure list --profile <your-profile>` works on the host, the container will see the same credentials.
+- Expired credentials cause the startup health check to fail fast (`process.exit(1)`) so the container won't run with broken AWS access.
+- On Windows with Git Bash, the `AWS_HOME` env var must be the Windows absolute path (e.g. `C:\Users\you\.aws`), not a translated Unix path. `MSYS_NO_PATHCONV=1` is only needed for `docker exec` commands that mention `/root/...` — the mount itself works correctly without it.
+
+---
+
+## Current Stack
+
+```
+postgres (pgvector/pgvector:pg16)
+  - Port 5432
+  - Data volume: postgres-data
+  - Init SQL: local-docker/init-db/01-schema.sql
+
+mcp-server (node:22-alpine)
+  - Port 3000
+  - Source: local-docker/server/
+  - Env: DATABASE_URL, MCP_ACCESS_KEY, AWS_REGION, AWS_PROFILE
+  - Volume: ${AWS_HOME} → /root/.aws (read-only)
+```
+
+Ollama container was removed — Bedrock replaces it entirely.
+
+---
+
+## REST API (Human Capture Clients)
+
+In addition to the MCP endpoint, the server exposes two plain REST routes for
+capture and search from non-MCP clients (browser, scripts, hotkeys). Both use the
+same `x-brain-key` authentication header and return plain JSON — no SSE, no
+JSON-RPC envelope.
+
+### `POST /capture-external`
+
+Captures a thought from any external source.
+
+**Request body:**
+```json
+{
+  "content": "The thought to capture",
+  "source": "teams|outlook|browser-selection|browser-url|clipboard|terminal|...",
+  "title": "Optional page or document title",
+  "url": "Optional source URL"
+}
+```
+
+Only `content` is required. `source`, `title`, and `url` are stored as provenance
+metadata alongside the AI-extracted fields (`type`, `topics`, `people`, etc.).
+
+**Response:**
+```json
+{ "id": "uuid", "type": "observation", "topics": ["tag1", "tag2"] }
+```
+
+### `POST /search-external`
+
+Searches thoughts semantically or browses by metadata filter.
+
+**Semantic search** (returns top N by vector similarity):
+```json
+{ "query": "what do I know about X", "limit": 10, "threshold": 0.25 }
+```
+
+**Browse by tag/type/source** (returns up to N sorted newest first, no embedding):
+```json
+{ "tag": "AWS" }
+{ "type": "idea" }
+{ "source": "teams" }
+```
+
+`tag`, `type`, and `source` can be combined. `limit` defaults to 10 for semantic
+search and 50 for browse mode.
+
+**Response:**
+```json
+{
+  "mode": "search|browse",
+  "results": [
+    {
+      "id": "uuid",
+      "content": "...",
+      "similarity": 87,
+      "type": "observation",
+      "topics": ["tag1"],
+      "source": "mcp",
+      "created_at": "2026-05-01T..."
+    }
+  ]
+}
+```
+
+`similarity` is `null` in browse mode (no ranking).
+
+---
+
+## Human Capture Clients
+
+### `bookmarklet.html`
+
+Open this file locally in Chrome and drag the button to the bookmarks bar. On any
+page, click the bookmark to capture:
+- **Selected text** → captured with `source: "browser-selection"`, plus `title` and `url`
+- **No selection** → captures the page URL with `source: "browser-url"` and `title`
+
+Shows a 3-second toast notification on success. Stores `OPEN_BRAIN_KEY` in
+`localStorage` — prompted once, never again.
+
+**Limitation:** Chrome blocks `fetch` to `http://localhost` from `https://` pages
+(mixed-content policy). Works on HTTP pages and local files. HTTPS sites (e.g.
+Confluence) require the server to be behind HTTPS (e.g. Caddy reverse proxy).
+
+### `capture.ahk`
+
+AutoHotkey v2 script providing a global system hotkey (`Ctrl+Shift+B` by default).
+On trigger:
+1. Reads the foreground window process name **before** anything steals focus
+2. Infers `source` from the active application (Teams, Outlook, Chrome, Edge, Word,
+   PowerPoint, OneNote, Windows Terminal → `"desktop"` for anything else)
+3. Sends `Ctrl+C` and reads the clipboard
+4. Reads `OPEN_BRAIN_KEY` from the environment
+5. POSTs to `/capture-external`
+6. Shows a tray toast with the result
+
+**To install:** Double-click `capture.ahk` (requires AutoHotkey v2). For startup:
+press `Win+R`, type `shell:startup`, drop a shortcut to `capture.ahk` there.
+
+**To change the hotkey:** Edit the `MyHotkey` line at the top of the script.
+
+### `capture.ps1`
+
+PowerShell script for terminal-based capture. Accepts a string argument or reads
+from the clipboard if none provided.
+
+```powershell
+.\capture.ps1 "A thought to capture"
+.\capture.ps1   # reads clipboard
+```
+
+Requires `OPEN_BRAIN_KEY` as a user/system environment variable.
+
+### `search.html`
+
+A standalone local search UI — open in Chrome directly from the filesystem. No build
+step, no dependencies.
+
+**Usage:**
+- Type a query and press Enter for semantic search (top 10 by similarity)
+- `tag:aws` — browse all thoughts tagged "aws", newest first
+- `type:idea` — browse all thoughts of type "idea", newest first
+- `source:teams` — browse all thoughts captured from Teams, newest first
+
+Results show match %, type, source, topics, and date as clickable badges. Clicking a
+topic or type badge triggers a browse search for that value. Key stored in
+`localStorage`, prompted once.
+
+---
+
+## File Map
+
+```
+local-docker/
+  docker-compose.yml       — 2-container stack (postgres + mcp-server)
+  .env                     — POSTGRES_PASSWORD, MCP_ACCESS_KEY, AWS_PROFILE, AWS_HOME
+  .env.example             — template (committed)
+  bookmarklet.html         — Chrome bookmarklet installer page
+  capture.ahk              — AutoHotkey v2 global hotkey capture script
+  capture.ps1              — PowerShell capture script (clipboard or argument)
+  search.html              — Standalone browser search UI
+  session-audit.mjs        — Utility: audit Claude Code session availability
+  timing-test.sh           — Direct HTTP benchmark script (bash timing-test.sh)
+  timing.mjs               — Node.js timing utility
+  init-db/
+    01-schema.sql          — thoughts table, indexes, match_thoughts, upsert_thought
+  server/
+    index.ts               — MCP + REST server (Node.js/Hono)
+    package.json           — npm dependencies
+    Dockerfile             — node:22-alpine base
+```
+
+---
+
+## How to Run Timing Tests
+
+Timing is measured by calling `date +%s%3N` (milliseconds since epoch) immediately
+before and after each MCP tool call, then subtracting. This is done from Claude Code
+by interleaving `Bash` tool calls with MCP tool calls in the same response.
+
+Example pattern:
+
+```
+1. Bash: date +%s%3N          → capture start timestamp
+2. MCP:  capture_thought(...)  → capture call
+3. Bash: date +%s%3N          → capture end / search start
+4. MCP:  search_thoughts(...)  → search call
+5. Bash: date +%s%3N          → search end timestamp
+```
+
+Elapsed = (end - start) / 1000 seconds.
+
+**How to run:** From Git Bash in `local-docker/`:
+
+```bash
+bash timing-test.sh
+```
+
+The script does a warmup call then 3 capture + search pairs, printing elapsed ms for
+each. This measures true server latency — not Claude Code round-trip time.
+
+**Important:** Do not use `date +%s%3N` around MCP tool calls in Claude Code to
+measure latency. That captures the full Claude Code transport round-trip and produces
+wildly inflated numbers (20-60s). Always use the timing script for benchmarks.
+
+---
+
+**Ollama results (CPU only, warm, embedding-only capture — no metadata extraction):**
+
+| Operation | Time |
+|---|---|
+| Capture (nomic-embed-text, 768-dim, no metadata) | ~12-16s |
+| Search (nomic-embed-text) | ~12-15s |
+
+No meaningful difference between Ollama in Docker vs Ollama native on Windows —
+virtualization overhead was not the bottleneck. Pure CPU compute.
+
+**Bedrock results (Node.js server, Titan V2 1024-dim + Claude Haiku metadata, warm):**
+
+| Operation | Time |
+|---|---|
+| Capture (embedding + metadata extraction in parallel) | ~4s |
+| Search (embedding only) | ~2.5s |
+
+Bedrock capture includes both Titan V2 embedding AND Claude Haiku metadata extraction
+running in parallel — yet still 3-4x faster than Ollama embedding alone on CPU.
+Search is embedding-only in both cases, so the 2.5s vs 12-15s gap is pure
+Bedrock-vs-CPU difference.
+
+**Estimated self-contained Ollama result with metadata (never fully measured):**
+Capture would have been ~40-50s (12-16s embedding + 30s metadata extraction
+sequentially). This was why metadata extraction was decoupled from capture in the
+Ollama configuration.
+
+**Note on "cold" vs "warm":** First call after container start is slow (model loading).
+Subsequent calls are the warm numbers above. Always run at least one throwaway call
+before recording benchmark numbers.
+
+---
+
+## What Works Today
+
+- Postgres + pgvector schema initializes correctly
+- MCP server starts and serves all 5 tools
+- Auth (`x-brain-key` header) works on all endpoints
+- All 5 MCP tools work correctly:
+  - `capture_thought` — stores content + metadata, updates embedding
+  - `search_thoughts` — vector similarity search with threshold
+  - `list_thoughts` — filtered recent thoughts
+  - `thought_stats` — aggregated counts
+  - `enrich_thoughts` — batch metadata extraction for untagged thoughts
+- REST endpoints work:
+  - `POST /capture-external` — plain JSON capture from any HTTP client
+  - `POST /search-external` — semantic search and metadata browse
+- Chrome bookmarklet captures selected text or page URL from any HTTP page
+- AutoHotkey global hotkey captures from any Windows application
+- PowerShell capture script works from terminal
+- Standalone search UI works from local filesystem
+- Claude Code MCP connection works (`claude mcp add --transport http --scope user`)
+- Credential file mount works (Windows path required)
+- AWS credential rotation is handled automatically — `makeBedrock()` reads fresh
+  credentials on every call; no restart required after token rotation
+
+## What Does Not Work / Known Limitations
+
+- Bookmarklet is blocked by Chrome's mixed-content policy on HTTPS pages — requires
+  HTTPS on the server side to work on sites like Confluence
+- Startup health check calls `process.exit(1)` on Bedrock failure — if the container
+  restarts during an auth outage it will not come back up until credentials are valid

--- a/recipes/local-docker/README.md
+++ b/recipes/local-docker/README.md
@@ -1,0 +1,213 @@
+# Local Docker Open Brain
+
+> A fully self-contained Open Brain deployment using Docker, local Postgres + pgvector, and AWS Bedrock — for environments where data cannot leave your infrastructure.
+
+## What It Does
+
+Deploys a complete Open Brain instance (database + MCP server + capture clients) as a Docker Compose stack on your local machine. Instead of Supabase cloud and OpenRouter, it uses local PostgreSQL with pgvector for storage and AWS Bedrock for embeddings and metadata extraction. All data stays on your machine and within your AWS account.
+
+> [!IMPORTANT]
+> This recipe uses a **local MCP server** rather than the standard remote (Supabase Edge Function) pattern. This is intentional — it exists for environments with data privacy constraints where sending knowledge to cloud-hosted databases is not permitted. If you don't have this constraint, the standard Open Brain setup with Supabase is simpler.
+
+## Prerequisites
+
+- Working knowledge of the [Open Brain concepts](../../docs/01-getting-started.md) (you don't need a Supabase instance — this replaces it)
+- [Docker Desktop](https://www.docker.com/products/docker-desktop/) installed and running
+- AWS account with Bedrock model access enabled for:
+  - `amazon.titan-embed-text-v2:0` (embeddings)
+  - `us.anthropic.claude-haiku-4-5-20251001-v1:0` (metadata extraction)
+- [AWS CLI](https://aws.amazon.com/cli/) configured with a profile that has `bedrock:InvokeModel` permissions
+- An AI client that supports HTTP-based MCP servers (Claude Code, Claude Desktop, etc.)
+
+## Credential Tracker
+
+Copy this block into a text editor and fill it in as you go.
+
+```text
+LOCAL DOCKER OPEN BRAIN -- CREDENTIAL TRACKER
+----------------------------------------------
+
+GENERATED DURING SETUP
+  Postgres password:     ____________  (Step 1 — openssl rand -hex 16)
+  MCP access key:        ____________  (Step 1 — openssl rand -hex 32)
+  AWS profile name:      ____________  (your existing AWS CLI profile)
+  AWS home path:         ____________  (e.g., C:\Users\you\.aws)
+
+----------------------------------------------
+```
+
+## Steps
+
+![Step 1](https://img.shields.io/badge/Step_1-Configure_Environment-2E7D32?style=for-the-badge)
+
+**1. Copy the environment template:**
+
+```bash
+cd recipes/local-docker
+cp .env.example .env
+```
+
+**2. Generate credentials and fill in `.env`:**
+
+```bash
+# Generate a strong Postgres password
+openssl rand -hex 16
+
+# Generate your MCP access key
+openssl rand -hex 32
+```
+
+**3. Edit `.env` with your values:**
+
+```env
+POSTGRES_PASSWORD=<paste hex from step above>
+MCP_ACCESS_KEY=<paste hex from step above>
+AWS_HOME=C:\Users\<your-username>\.aws
+AWS_REGION=us-east-1
+AWS_PROFILE=default
+```
+
+> [!TIP]
+> On Linux/macOS, use `AWS_HOME=$HOME/.aws`. On Windows, use the full path with backslashes.
+
+> [!WARNING]
+> The `AWS_PROFILE` must point to a profile with valid credentials. If you use temporary session tokens (SSO, assume-role), they must be refreshed before the container starts.
+
+`Done when:` `.env` exists with all values filled in, no `change-me` placeholders remain.
+
+---
+
+![Step 2](https://img.shields.io/badge/Step_2-Start_the_Stack-2E7D32?style=for-the-badge)
+
+```bash
+docker compose up --build -d
+```
+
+This builds the MCP server image and starts two containers:
+- **postgres** — `pgvector/pgvector:pg16` on port 5432, auto-initializes schema from `init-db/01-schema.sql`
+- **mcp-server** — Node.js 22 on port 3000, performs a Bedrock health check on startup
+
+> [!CAUTION]
+> If the health check fails (expired credentials, wrong region, model not enabled), the container will exit. Check logs with `docker compose logs mcp-server` and fix `.env` before retrying.
+
+`Done when:` `docker compose ps` shows both containers as "running" (healthy).
+
+---
+
+![Step 3](https://img.shields.io/badge/Step_3-Connect_Your_AI_Client-2E7D32?style=for-the-badge)
+
+Register the MCP server with your AI client. For Claude Code:
+
+```bash
+claude mcp add open-brain --transport http --url http://localhost:3000/mcp --header "x-brain-key: <your-MCP_ACCESS_KEY>"
+```
+
+For Claude Desktop: Settings > Connectors > Add custom connector, paste `http://localhost:3000/mcp` and add the `x-brain-key` header.
+
+`Done when:` Your AI client lists 5 tools: `capture_thought`, `search_thoughts`, `list_thoughts`, `thought_stats`, `enrich_thoughts`.
+
+---
+
+![Step 4](https://img.shields.io/badge/Step_4-Install_Capture_Clients_(Optional)-2E7D32?style=for-the-badge)
+
+The MCP tools handle capture from AI sessions. For capturing from other applications, install one or more human capture clients:
+
+![4.1](https://img.shields.io/badge/4.1-Chrome_Bookmarklet-555?style=for-the-badge&labelColor=2E7D32)
+
+Open `bookmarklet.html` in Chrome and drag the button to your bookmarks bar. On any page:
+- **Selected text** is captured with the page title and URL
+- **No selection** captures the page URL as a reference
+
+> [!NOTE]
+> Chrome blocks mixed-content requests (HTTP from HTTPS pages). The bookmarklet only works on HTTP pages and local files unless you put the server behind HTTPS (e.g., Caddy reverse proxy).
+
+![4.2](https://img.shields.io/badge/4.2-AutoHotkey_Global_Hotkey_(Windows)-555?style=for-the-badge&labelColor=2E7D32)
+
+Requires [AutoHotkey v2](https://www.autohotkey.com/).
+
+1. Set the `OPEN_BRAIN_KEY` environment variable to your MCP access key
+2. Double-click `capture.ahk` to start
+3. Press `Ctrl+Shift+B` in any application to capture the selected text
+
+The script auto-detects the source application (Teams, Outlook, Chrome, Edge, Word, etc.) and records it as provenance metadata.
+
+To auto-start: press `Win+R`, type `shell:startup`, drop a shortcut to `capture.ahk` there.
+
+![4.3](https://img.shields.io/badge/4.3-PowerShell_Script-555?style=for-the-badge&labelColor=2E7D32)
+
+```powershell
+# Set once in your PowerShell profile:
+$env:OPEN_BRAIN_KEY = "<your-MCP_ACCESS_KEY>"
+
+# Capture a thought:
+.\capture.ps1 "A thought to capture"
+
+# Or capture from clipboard:
+.\capture.ps1
+```
+
+![4.4](https://img.shields.io/badge/4.4-Search_UI-555?style=for-the-badge&labelColor=2E7D32)
+
+Open `search.html` directly in Chrome from the filesystem. No build step required.
+
+- Type a query and press Enter for semantic search
+- `tag:aws` — browse by topic
+- `type:idea` — browse by type
+- `source:teams` — browse by source
+
+`Done when:` At least one capture client is installed and you can capture and retrieve a test thought.
+
+---
+
+## Expected Outcome
+
+After completing all steps:
+
+1. `docker compose ps` shows both containers healthy
+2. Your AI client can call `capture_thought` and `search_thoughts` successfully
+3. Asking your AI "what do I know about [topic]?" retrieves semantically relevant results
+4. Capture latency is ~4s (embedding + metadata in parallel), search is ~2.5s
+
+Test it by capturing a thought and immediately searching for it:
+- Capture: "The quarterly planning meeting is moving to Thursdays starting next month"
+- Search: "when is planning?" — should return the thought above with high similarity
+
+## Troubleshooting
+
+**Issue: Container exits immediately after starting**
+
+Check `docker compose logs mcp-server`. Most common cause: expired AWS credentials. Refresh your session tokens (`aws sso login` or re-run your assume-role script), then `docker compose restart mcp-server`.
+
+**Issue: Capture/search returns "Error: No credentials found for profile"**
+
+The `AWS_PROFILE` in `.env` doesn't match any profile in your `~/.aws/credentials` file. Verify with `aws configure list --profile <your-profile>`.
+
+**Issue: "model is not accessible" error from Bedrock**
+
+You need to enable model access in the AWS console. Go to Amazon Bedrock > Model access > Request access for both `Titan Text Embeddings V2` and `Claude 3.5 Haiku`. This can take a few minutes to propagate.
+
+**Issue: Bookmarklet doesn't work on HTTPS pages**
+
+This is Chrome's mixed-content policy — it blocks HTTP requests from HTTPS origins. Options:
+1. Use the AutoHotkey or PowerShell clients instead (they call localhost directly)
+2. Put the server behind a local HTTPS reverse proxy (e.g., [Caddy](https://caddyserver.com/))
+
+**Issue: Slow first request after container start**
+
+The first Bedrock call after startup is always slower (~8-10s) due to model loading on the AWS side. Subsequent calls are warm (~2.5-4s). This is expected behavior.
+
+## Architecture
+
+For detailed design decisions, alternatives considered, and performance benchmarks, see [ARCHITECTURE.md](ARCHITECTURE.md).
+
+## Tool Surface Area
+
+This recipe exposes 5 MCP tools. As you add more Open Brain extensions, review the [MCP Tool Audit & Optimization Guide](../../docs/05-tool-audit.md) to manage your total tool surface area.
+
+| Tool | Type | Description |
+|------|------|-------------|
+| `capture_thought` | Write | Save a thought with auto-generated embedding and metadata |
+| `search_thoughts` | Read | Semantic similarity search across all thoughts |
+| `list_thoughts` | Read | Browse recent thoughts with metadata filters |
+| `thought_stats` | Read | Aggregate statistics: totals, types, top topics |
+| `enrich_thoughts` | Write | Batch metadata extraction for untagged thoughts |

--- a/recipes/local-docker/bookmarklet.html
+++ b/recipes/local-docker/bookmarklet.html
@@ -1,0 +1,59 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Open Brain Bookmarklet</title>
+  <style>
+    body { font-family: system-ui, sans-serif; max-width: 600px; margin: 60px auto; padding: 0 24px; color: #1a1a2e; }
+    h1 { font-size: 1.4rem; margin-bottom: 4px; }
+    p { color: #555; margin-top: 4px; }
+    .bookmarklet {
+      display: inline-block;
+      margin: 24px 0;
+      padding: 12px 20px;
+      background: #1a1a2e;
+      color: #fff;
+      border-radius: 8px;
+      text-decoration: none;
+      font-size: 1rem;
+      cursor: grab;
+    }
+    .bookmarklet:active { cursor: grabbing; }
+    ol { line-height: 2; color: #333; }
+    details { margin-top: 32px; }
+    summary { cursor: pointer; color: #888; font-size: 0.9rem; }
+    pre { background: #f4f4f4; padding: 16px; border-radius: 6px; font-size: 0.8rem; white-space: pre-wrap; word-break: break-all; margin-top: 8px; }
+  </style>
+</head>
+<body>
+  <h1>Open Brain — Browser Bookmarklet</h1>
+  <p>Capture selected text or the current URL to your Open Brain.</p>
+
+  <a class="bookmarklet" href="javascript:(function(){var key=localStorage.getItem('ob_key');if(!key){key=prompt('Open Brain key (stored locally, one-time):');if(!key)return;localStorage.setItem('ob_key',key);}var sel=window.getSelection().toString().trim();var content=sel||location.href;fetch('http://localhost:3000/capture-external',{method:'POST',headers:{'Content-Type':'application/json','x-brain-key':key},body:JSON.stringify({content:content,source:sel?'browser-selection':'browser-url',title:document.title,url:location.href})}).then(function(r){return r.json();}).then(function(d){if(d.error){alert('Open Brain error: '+d.error);return;}var msg=sel?'Selection captured':'URL captured';var n=document.createElement('div');n.textContent=msg+': '+(d.type||'')+(d.topics&amp;&amp;d.topics.length?' - '+d.topics.join(', '):'');n.style.cssText='position:fixed;top:16px;right:16px;z-index:999999;background:#1a1a2e;color:#fff;padding:12px 16px;border-radius:8px;font:14px/1.4 system-ui;box-shadow:0 4px 12px rgba(0,0,0,.4);max-width:320px;';document.body.appendChild(n);setTimeout(function(){n.remove();},3000);}).catch(function(e){alert('Capture failed: '+e.message);});})();">
+    Capture to Open Brain
+  </a>
+
+  <ol>
+    <li>Drag the button above to your Chrome bookmarks bar.</li>
+    <li>Navigate to any page. Select some text, or select nothing to capture the URL.</li>
+    <li>Click the bookmark. On first use it will prompt for your <code>OPEN_BRAIN_KEY</code> and store it in <code>localStorage</code>.</li>
+    <li>A confirmation toast appears for 3 seconds showing the captured type and topics.</li>
+  </ol>
+
+  <details>
+    <summary>Reset stored key</summary>
+    <p>Run this in the browser console on any page:</p>
+    <pre>localStorage.removeItem('ob_key')</pre>
+  </details>
+
+  <details>
+    <summary>Raw bookmarklet code</summary>
+    <pre id="raw"></pre>
+  </details>
+
+  <script>
+    var code = document.querySelector('.bookmarklet').getAttribute('href');
+    document.getElementById('raw').textContent = decodeURIComponent(code);
+  </script>
+</body>
+</html>

--- a/recipes/local-docker/capture.ahk
+++ b/recipes/local-docker/capture.ahk
@@ -1,0 +1,69 @@
+#Requires AutoHotkey v2.0
+#SingleInstance Force
+
+MyHotkey := "^+b"  ; Ctrl+Shift+B — change this to your preferred combo
+
+Hotkey MyHotkey, Capture
+
+Capture(*) {
+    ; Get foreground window before anything steals focus
+    hwnd := WinGetID("A")
+    procName := WinGetProcessName("A")
+
+    source := "desktop"
+    if InStr(procName, "Teams")
+        source := "teams"
+    else if InStr(procName, "OUTLOOK")
+        source := "outlook"
+    else if InStr(procName, "chrome")
+        source := "browser-selection"
+    else if InStr(procName, "msedge")
+        source := "browser-selection"
+    else if InStr(procName, "WINWORD")
+        source := "word"
+    else if InStr(procName, "POWERPNT")
+        source := "powerpoint"
+    else if InStr(procName, "ONENOTE")
+        source := "onenote"
+    else if InStr(procName, "WindowsTerminal")
+        source := "terminal"
+
+    ; Copy selection to clipboard
+    A_Clipboard := ""
+    Send "^c"
+    ClipWait 1
+    content := A_Clipboard
+
+    if (content = "") {
+        TrayTip "Open Brain", "Nothing selected to capture.", 2
+        return
+    }
+
+    ; Read key from environment
+    key := EnvGet("OPEN_BRAIN_KEY")
+    if (key = "") {
+        TrayTip "Open Brain", "OPEN_BRAIN_KEY not set.", 2
+        return
+    }
+
+    ; Build JSON body — escape content for JSON
+    content := StrReplace(content, "\", "\\")
+    content := StrReplace(content, '"', '\"')
+    content := StrReplace(content, "`n", "\n")
+    content := StrReplace(content, "`r", "")
+    body := '{"content":"' content '","source":"' source '"}'
+
+    ; POST to capture-external
+    req := ComObject("WinHttp.WinHttpRequest.5.1")
+    req.Open("POST", "http://localhost:3000/capture-external", false)
+    req.SetRequestHeader("Content-Type", "application/json")
+    req.SetRequestHeader("x-brain-key", key)
+    req.Send(body)
+
+    if (req.Status = 200) {
+        resp := req.ResponseText
+        TrayTip "Open Brain", "Captured (" source ")", 2
+    } else {
+        TrayTip "Open Brain", "Capture failed: " req.Status, 2
+    }
+}

--- a/recipes/local-docker/capture.ps1
+++ b/recipes/local-docker/capture.ps1
@@ -1,0 +1,47 @@
+# capture.ps1 — Send a thought to the local Open Brain MCP server
+#
+# Usage:
+#   .\capture.ps1 "Your thought here"
+#   .\capture.ps1                        # reads from clipboard if no argument
+#
+# Required environment variable:
+#   OPEN_BRAIN_KEY — your MCP access key (set in your PowerShell profile or system env)
+
+param(
+    [Parameter(Position=0)]
+    [string]$Content
+)
+
+$key = $env:OPEN_BRAIN_KEY
+if (-not $key) {
+    Write-Error "OPEN_BRAIN_KEY environment variable is not set."
+    exit 1
+}
+
+if (-not $Content) {
+    $Content = Get-Clipboard
+}
+
+if (-not $Content -or $Content.Trim() -eq "") {
+    Write-Error "No content to capture. Pass a string or copy something to the clipboard first."
+    exit 1
+}
+
+$body = @{
+    content = $Content.Trim()
+    source  = "clipboard"
+} | ConvertTo-Json
+
+try {
+    $response = Invoke-RestMethod `
+        -Uri "http://localhost:3000/capture-external" `
+        -Method POST `
+        -ContentType "application/json" `
+        -Headers @{ "x-brain-key" = $key } `
+        -Body $body
+
+    Write-Host "Captured: $($response.type) - $($response.topics -join ', ') (id: $($response.id))"
+} catch {
+    Write-Error "Failed to capture: $_"
+    exit 1
+}

--- a/recipes/local-docker/docker-compose.yml
+++ b/recipes/local-docker/docker-compose.yml
@@ -1,0 +1,42 @@
+services:
+  postgres:
+    image: pgvector/pgvector:pg16
+    ports:
+      - "5432:5432"
+    environment:
+      POSTGRES_DB: openbrain
+      POSTGRES_USER: openbrain
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
+    volumes:
+      - postgres-data:/var/lib/postgresql/data
+      - ./init-db:/docker-entrypoint-initdb.d
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U openbrain -d openbrain"]
+      interval: 5s
+      timeout: 5s
+      retries: 10
+
+  mcp-server:
+    build: ./server
+    ports:
+      - "3000:3000"
+    environment:
+      DATABASE_URL: postgres://openbrain:${POSTGRES_PASSWORD}@postgres:5432/openbrain
+      MCP_ACCESS_KEY: ${MCP_ACCESS_KEY}
+      PORT: 3000
+      AWS_REGION: ${AWS_REGION:-us-east-1}
+      AWS_PROFILE: ${AWS_PROFILE:-default}
+      AWS_SHARED_CREDENTIALS_FILE: /root/.aws/credentials
+      EMBEDDING_MODEL: ${EMBEDDING_MODEL:-amazon.titan-embed-text-v2:0}
+      METADATA_MODEL: ${METADATA_MODEL:-us.anthropic.claude-haiku-4-5-20251001-v1:0}
+    volumes:
+      - type: bind
+        source: ${AWS_HOME}
+        target: /root/.aws
+        read_only: true
+    depends_on:
+      postgres:
+        condition: service_healthy
+
+volumes:
+  postgres-data:

--- a/recipes/local-docker/init-db/01-schema.sql
+++ b/recipes/local-docker/init-db/01-schema.sql
@@ -1,0 +1,86 @@
+create extension if not exists vector;
+
+create table thoughts (
+  id uuid default gen_random_uuid() primary key,
+  content text not null,
+  embedding vector(1024),
+  metadata jsonb default '{}'::jsonb,
+  created_at timestamptz default now(),
+  updated_at timestamptz default now()
+);
+
+create index on thoughts using hnsw (embedding vector_cosine_ops);
+create index on thoughts using gin (metadata);
+create index on thoughts (created_at desc);
+
+create or replace function update_updated_at()
+returns trigger as $$
+begin
+  new.updated_at = now();
+  return new;
+end;
+$$ language plpgsql;
+
+create trigger thoughts_updated_at
+  before update on thoughts
+  for each row
+  execute function update_updated_at();
+
+create or replace function match_thoughts(
+  query_embedding vector(1024),
+  match_threshold float default 0.25,
+  match_count int default 10,
+  filter jsonb default '{}'::jsonb
+)
+returns table (
+  id uuid,
+  content text,
+  metadata jsonb,
+  similarity float,
+  created_at timestamptz
+)
+language plpgsql
+as $$
+begin
+  return query
+  select
+    t.id,
+    t.content,
+    t.metadata,
+    1 - (t.embedding <=> query_embedding) as similarity,
+    t.created_at
+  from thoughts t
+  where 1 - (t.embedding <=> query_embedding) > match_threshold
+    and (filter = '{}'::jsonb or t.metadata @> filter)
+  order by t.embedding <=> query_embedding
+  limit match_count;
+end;
+$$;
+
+alter table thoughts add column content_fingerprint text;
+
+create unique index idx_thoughts_fingerprint
+  on thoughts (content_fingerprint)
+  where content_fingerprint is not null;
+
+create or replace function upsert_thought(p_content text, p_payload jsonb default '{}')
+returns jsonb as $$
+declare
+  v_fingerprint text;
+  v_id uuid;
+begin
+  v_fingerprint := encode(sha256(convert_to(
+    lower(trim(regexp_replace(p_content, '\s+', ' ', 'g'))),
+    'UTF8'
+  )), 'hex');
+
+  insert into thoughts (content, content_fingerprint, metadata)
+  values (p_content, v_fingerprint, coalesce(p_payload->'metadata', '{}'::jsonb))
+  on conflict (content_fingerprint) where content_fingerprint is not null do update
+  set updated_at = now(),
+      metadata = thoughts.metadata || coalesce(excluded.metadata, '{}'::jsonb)
+  returning id into v_id;
+
+  return jsonb_build_object('id', v_id, 'fingerprint', v_fingerprint);
+end;
+$$ language plpgsql;

--- a/recipes/local-docker/metadata.json
+++ b/recipes/local-docker/metadata.json
@@ -1,0 +1,21 @@
+{
+  "name": "Local Docker Open Brain",
+  "description": "A self-contained Docker deployment of Open Brain using local Postgres + pgvector and AWS Bedrock for embeddings and metadata extraction. Designed for environments with data privacy constraints where cloud-hosted databases are not permitted.",
+  "category": "recipes",
+  "author": {
+    "name": "Tom Otvos",
+    "github": "tomotvos"
+  },
+  "version": "1.0.0",
+  "requires": {
+    "open_brain": true,
+    "services": ["AWS Bedrock"],
+    "tools": ["Docker", "Docker Compose", "AWS CLI"]
+  },
+  "requires_skills": [],
+  "tags": ["docker", "local", "privacy", "aws-bedrock", "pgvector", "self-hosted"],
+  "difficulty": "intermediate",
+  "estimated_time": "30 minutes",
+  "created": "2026-04-20",
+  "updated": "2026-05-07"
+}

--- a/recipes/local-docker/search.html
+++ b/recipes/local-docker/search.html
@@ -1,0 +1,209 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Open Brain Search</title>
+  <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>🧠</text></svg>">
+  <style>
+    * { box-sizing: border-box; margin: 0; padding: 0; }
+    body { font-family: system-ui, sans-serif; background: #f8f9fa; color: #1a1a2e; min-height: 100vh; }
+
+    .hero { display: flex; flex-direction: column; align-items: center; padding: 80px 24px 40px; }
+    .hero h1 { font-size: 2.4rem; font-weight: 800; margin-bottom: 32px; letter-spacing: -1px; font-family: Georgia, 'Times New Roman', serif; }
+
+    .search-bar { display: flex; width: 100%; max-width: 640px; border: 2px solid #1a1a2e; border-radius: 32px; overflow: hidden; background: #fff; box-shadow: 0 2px 12px rgba(0,0,0,.08); }
+    .search-bar input { flex: 1; padding: 14px 20px; font-size: 1rem; border: none; outline: none; background: transparent; }
+    .search-bar button { padding: 14px 24px; background: #1a1a2e; color: #fff; border: none; font-size: 0.95rem; cursor: pointer; }
+    .search-bar button:hover { background: #2d2d4e; }
+
+    .results-header { max-width: 900px; margin: 0 auto; padding: 24px 24px 0; font-size: 0.85rem; color: #888; }
+    .results-header strong { color: #1a1a2e; }
+
+    .results { max-width: 900px; margin: 0 auto; padding: 12px 24px 24px; }
+    .result { background: #fff; border-radius: 12px; padding: 20px; margin-bottom: 16px; box-shadow: 0 1px 4px rgba(0,0,0,.08); }
+    .result-meta { display: flex; gap: 10px; align-items: center; margin-bottom: 10px; flex-wrap: wrap; }
+    .badge { font-size: 0.75rem; padding: 3px 10px; border-radius: 20px; font-weight: 500; }
+    .badge-match { background: #e8f5e9; color: #2e7d32; }
+    .badge-type { background: #e3f2fd; color: #1565c0; cursor: pointer; }
+    .badge-type:hover { background: #bbdefb; }
+    .badge-source { background: #fff3e0; color: #e65100; }
+    .badge-topic { background: #f3e5f5; color: #6a1b9a; cursor: pointer; }
+    .badge-topic:hover { background: #e1bee7; }
+    .result-date { font-size: 0.75rem; color: #888; margin-left: auto; }
+    .result-content { font-size: 0.95rem; line-height: 1.6; color: #333; white-space: pre-wrap; }
+
+    .status { text-align: center; padding: 40px; color: #888; font-size: 0.95rem; }
+    .error { color: #c62828; }
+
+    .key-prompt { margin-top: 16px; font-size: 0.85rem; color: #888; }
+    .key-prompt a { color: #1a1a2e; cursor: pointer; text-decoration: underline; }
+
+    .filters-hint { margin-top: 12px; max-width: 640px; text-align: center; font-size: 0.8rem; color: #666; line-height: 1.8; }
+    .filters-hint code { background: #ececf2; padding: 2px 7px; border-radius: 4px; font-family: ui-monospace, SFMono-Regular, Menlo, monospace; font-size: 0.78rem; color: #1a1a2e; }
+  </style>
+</head>
+<body>
+
+<div class="hero">
+  <h1>🧠 Open Brain</h1>
+  <div class="search-bar">
+    <input type="text" id="query" placeholder="What do you know about..." autofocus>
+    <button onclick="search()">Search</button>
+  </div>
+  <p class="filters-hint">
+    Filters: <code>tag:foo</code> · <code>type:reference</code> · <code>source:mcp</code> · <code>date:today</code> · <code>date:yesterday</code> · <code>date:2026-05-13</code> · <code>since:2026-05-01</code> · <code>until:2026-05-13</code>
+  </p>
+  <p class="key-prompt" id="key-status"></p>
+</div>
+
+<div id="results-header" class="results-header"></div>
+<div class="results" id="results"></div>
+
+<script>
+  const KEY_STORAGE = 'ob_key';
+
+  function getKey() {
+    let key = localStorage.getItem(KEY_STORAGE);
+    if (!key) {
+      key = prompt('Open Brain key (stored locally, one-time):');
+      if (key) localStorage.setItem(KEY_STORAGE, key);
+    }
+    return key;
+  }
+
+  function showKeyStatus() {
+    const key = localStorage.getItem(KEY_STORAGE);
+    const el = document.getElementById('key-status');
+    el.innerHTML = key
+      ? 'Using stored key. <a onclick="resetKey()">Reset</a>'
+      : 'No key stored. You will be prompted on first search.';
+  }
+
+  function resetKey() {
+    localStorage.removeItem(KEY_STORAGE);
+    showKeyStatus();
+  }
+
+  document.getElementById('query').addEventListener('keydown', e => {
+    if (e.key === 'Enter') search();
+  });
+
+  function browseTag(tag) {
+    document.getElementById('query').value = '';
+    doSearch({ tag, limit: 50 }, `tag: ${tag}`);
+  }
+
+  function browseType(type) {
+    document.getElementById('query').value = '';
+    doSearch({ type, limit: 50 }, `type: ${type}`);
+  }
+
+  function resolveDate(input) {
+    const lower = input.toLowerCase();
+    const fmt = d => `${d.getFullYear()}-${String(d.getMonth()+1).padStart(2,'0')}-${String(d.getDate()).padStart(2,'0')}`;
+    if (lower === 'today') return fmt(new Date());
+    if (lower === 'yesterday') { const y = new Date(); y.setDate(y.getDate()-1); return fmt(y); }
+    if (/^\d{4}-\d{2}-\d{2}$/.test(input)) return input;
+    return null;
+  }
+
+  function search() {
+    const raw = document.getElementById('query').value.trim();
+    if (!raw) return;
+    const lower = raw.toLowerCase();
+    if (lower.startsWith('tag:')) {
+      const tag = raw.slice(4).trim();
+      if (tag) doSearch({ tag, limit: 50 }, `tag: ${tag}`);
+    } else if (lower.startsWith('type:')) {
+      const type = raw.slice(5).trim();
+      if (type) doSearch({ type, limit: 50 }, `type: ${type}`);
+    } else if (lower.startsWith('source:')) {
+      const source = raw.slice(7).trim();
+      if (source) doSearch({ source, limit: 50 }, `source: ${source}`);
+    } else if (lower.startsWith('date:')) {
+      const date = resolveDate(raw.slice(5).trim());
+      if (date) doSearch({ date, limit: 50 }, `date: ${date}`);
+      else document.getElementById('results').innerHTML = '<div class="status error">date must be today, yesterday, or YYYY-MM-DD</div>';
+    } else if (lower.startsWith('since:')) {
+      const since = resolveDate(raw.slice(6).trim());
+      if (since) doSearch({ since, limit: 50 }, `since: ${since}`);
+      else document.getElementById('results').innerHTML = '<div class="status error">since must be today, yesterday, or YYYY-MM-DD</div>';
+    } else if (lower.startsWith('until:')) {
+      const until = resolveDate(raw.slice(6).trim());
+      if (until) doSearch({ until, limit: 50 }, `until: ${until}`);
+      else document.getElementById('results').innerHTML = '<div class="status error">until must be today, yesterday, or YYYY-MM-DD</div>';
+    } else {
+      doSearch({ query: raw, limit: 10 }, `"${raw}"`);
+    }
+  }
+
+  async function doSearch(body, label) {
+    const key = getKey();
+    if (!key) return;
+
+    const resultsEl = document.getElementById('results');
+    const headerEl = document.getElementById('results-header');
+    resultsEl.innerHTML = '<div class="status">Searching...</div>';
+    headerEl.innerHTML = '';
+
+    try {
+      const resp = await fetch('http://localhost:3000/search-external', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', 'x-brain-key': key },
+        body: JSON.stringify(body)
+      });
+      const data = await resp.json();
+
+      if (data.error) {
+        resultsEl.innerHTML = `<div class="status error">Error: ${data.error}</div>`;
+        return;
+      }
+
+      if (!data.results.length) {
+        resultsEl.innerHTML = '<div class="status">No results found.</div>';
+        return;
+      }
+
+      const mode = data.mode === 'browse' ? 'most recent' : 'best match';
+      headerEl.innerHTML = `<strong>${data.results.length}</strong> result${data.results.length !== 1 ? 's' : ''} for ${escapeHtml(label)} &mdash; sorted by ${mode}`;
+
+      resultsEl.innerHTML = data.results.map(r => {
+        const matchBadge = r.similarity !== null
+          ? `<span class="badge badge-match">${r.similarity}%</span>` : '';
+        const typeBadge = `<span class="badge badge-type" onclick="browseType('${escapeAttr(r.type)}')" title="Browse all ${escapeHtml(r.type)}">${escapeHtml(r.type)}</span>`;
+        const sourceBadge = r.source ? `<span class="badge badge-source">${escapeHtml(r.source)}</span>` : '';
+        const topicBadges = (r.topics || []).map(t =>
+          `<span class="badge badge-topic" onclick="browseTag('${escapeAttr(t)}')" title="Browse all: ${escapeHtml(t)}">${escapeHtml(t)}</span>`
+        ).join('');
+        const date = new Date(r.created_at).toLocaleDateString();
+        return `
+          <div class="result">
+            <div class="result-meta">
+              ${matchBadge}
+              ${typeBadge}
+              ${sourceBadge}
+              ${topicBadges}
+              <span class="result-date">${date}</span>
+            </div>
+            <div class="result-content">${escapeHtml(r.content)}</div>
+          </div>`;
+      }).join('');
+
+    } catch (e) {
+      resultsEl.innerHTML = `<div class="status error">Failed: ${e.message}</div>`;
+    }
+  }
+
+  function escapeHtml(s) {
+    return String(s).replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;');
+  }
+
+  function escapeAttr(s) {
+    return String(s).replace(/'/g, "\\'");
+  }
+
+  showKeyStatus();
+</script>
+</body>
+</html>

--- a/recipes/local-docker/server/Dockerfile
+++ b/recipes/local-docker/server/Dockerfile
@@ -1,0 +1,12 @@
+FROM node:22-alpine
+
+WORKDIR /app
+
+COPY package.json .
+RUN npm install
+
+COPY index.ts .
+
+EXPOSE 3000
+
+CMD ["npm", "start"]

--- a/recipes/local-docker/server/index.ts
+++ b/recipes/local-docker/server/index.ts
@@ -1,0 +1,421 @@
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { StreamableHTTPTransport } from "@hono/mcp";
+import { serve } from "@hono/node-server";
+import { Hono } from "hono";
+import { z } from "zod";
+import postgres from "postgres";
+import { BedrockRuntimeClient, InvokeModelCommand } from "@aws-sdk/client-bedrock-runtime";
+import { readFileSync } from "fs";
+
+const DATABASE_URL = process.env.DATABASE_URL!;
+const MCP_ACCESS_KEY = process.env.MCP_ACCESS_KEY!;
+const PORT = parseInt(process.env.PORT || "3000");
+const AWS_REGION = process.env.AWS_REGION || "us-west-2";
+const AWS_PROFILE = process.env.AWS_PROFILE || "default";
+const AWS_CREDENTIALS_FILE = process.env.AWS_SHARED_CREDENTIALS_FILE || `${process.env.HOME || "/root"}/.aws/credentials`;
+const EMBEDDING_MODEL = process.env.EMBEDDING_MODEL || "amazon.titan-embed-text-v2:0";
+const METADATA_MODEL = process.env.METADATA_MODEL || "us.anthropic.claude-haiku-4-5-20251001-v1:0";
+
+const sql = postgres(DATABASE_URL);
+
+function readCredentials() {
+  const text = readFileSync(AWS_CREDENTIALS_FILE, "utf8").replace(/\r/g, "");
+  const sections: Record<string, Record<string, string>> = {};
+  let current = "";
+  for (const line of text.split("\n")) {
+    const section = line.match(/^\[(.+)\]/);
+    if (section) { current = section[1]; sections[current] = {}; continue; }
+    const kv = line.match(/^([^=]+)=(.*)$/);
+    if (kv && current) sections[current][kv[1].trim()] = kv[2].trim();
+  }
+  const profile = sections[AWS_PROFILE] || sections["default"];
+  if (!profile?.aws_access_key_id) throw new Error(`No credentials found for profile: ${AWS_PROFILE}`);
+  return {
+    accessKeyId: profile.aws_access_key_id,
+    secretAccessKey: profile.aws_secret_access_key,
+    ...(profile.aws_session_token ? { sessionToken: profile.aws_session_token } : {}),
+  };
+}
+
+function makeBedrock() {
+  return new BedrockRuntimeClient({
+    region: AWS_REGION,
+    credentials: readCredentials(),
+  });
+}
+
+function parseMeta(raw: unknown): Record<string, unknown> {
+  if (!raw) return {};
+  if (typeof raw === "string") { try { return JSON.parse(raw); } catch { return {}; } }
+  return raw as Record<string, unknown>;
+}
+
+async function getEmbedding(text: string): Promise<number[]> {
+  const cmd = new InvokeModelCommand({
+    modelId: EMBEDDING_MODEL,
+    contentType: "application/json",
+    accept: "application/json",
+    body: JSON.stringify({ inputText: text, dimensions: 1024, normalize: true }),
+  });
+  const resp = await makeBedrock().send(cmd);
+  const body = JSON.parse(new TextDecoder().decode(resp.body));
+  return body.embedding;
+}
+
+async function extractMetadata(text: string): Promise<Record<string, unknown>> {
+  const cmd = new InvokeModelCommand({
+    modelId: METADATA_MODEL,
+    contentType: "application/json",
+    accept: "application/json",
+    body: JSON.stringify({
+      anthropic_version: "bedrock-2023-05-31",
+      max_tokens: 512,
+      messages: [{
+        role: "user",
+        content: `Extract metadata from the following thought and return a JSON object with these fields:
+- "people": array of people mentioned (empty if none)
+- "action_items": array of implied to-dos (empty if none)
+- "dates_mentioned": array of dates YYYY-MM-DD (empty if none)
+- "topics": array of 1-3 short topic tags (always at least one)
+- "type": one of "observation", "task", "idea", "reference", "person_note"
+Only extract what's explicitly there. Return only the JSON object, nothing else.
+
+Thought: ${text}`,
+      }],
+    }),
+  });
+  const resp = await makeBedrock().send(cmd);
+  const body = JSON.parse(new TextDecoder().decode(resp.body));
+  try {
+    const match = body.content[0].text.match(/\{[\s\S]*\}/);
+    return match ? JSON.parse(match[0]) : { topics: ["uncategorized"], type: "observation" };
+  } catch {
+    return { topics: ["uncategorized"], type: "observation" };
+  }
+}
+
+async function captureThought(
+  content: string,
+  provenance: { source?: string; title?: string; url?: string } = {}
+): Promise<{ id: string; metadata: Record<string, unknown> }> {
+  const [embedding, metadata] = await Promise.all([getEmbedding(content), extractMetadata(content)]);
+  const fullMetadata: Record<string, unknown> = {
+    ...metadata,
+    source: provenance.source || "mcp",
+    ...(provenance.title ? { title: provenance.title } : {}),
+    ...(provenance.url ? { url: provenance.url } : {}),
+  };
+  const [{ upsert_thought: result }] = await sql<{ upsert_thought: { id: string } }[]>`
+    select upsert_thought(${content}, ${sql.json({ metadata: fullMetadata })})
+  `;
+  const vecStr = `[${embedding.join(",")}]`;
+  await sql`update thoughts set embedding = ${vecStr}::vector where id = ${result.id}::uuid`;
+  return { id: result.id, metadata: fullMetadata };
+}
+
+// --- MCP Server Setup ---
+
+const server = new McpServer({ name: "open-brain", version: "1.0.0" });
+
+server.registerTool(
+  "search_thoughts",
+  {
+    title: "Search Thoughts",
+    description: "Search captured thoughts by meaning. Use this when the user asks about a topic, person, or idea they've previously captured.",
+    annotations: { readOnlyHint: true },
+    inputSchema: {
+      query: z.string().describe("What to search for"),
+      limit: z.number().optional().default(10),
+      threshold: z.number().optional().default(0.25),
+    },
+  },
+  async ({ query, limit, threshold }) => {
+    try {
+      const qEmb = await getEmbedding(query);
+      const vecStr = `[${qEmb.join(",")}]`;
+      const rows = await sql<{ content: string; metadata: Record<string, unknown>; similarity: number; created_at: string }[]>`
+        select content, metadata, similarity, created_at
+        from match_thoughts(${vecStr}::vector, ${threshold}, ${limit}, '{}'::jsonb)
+      `;
+      if (!rows.length) return { content: [{ type: "text" as const, text: `No thoughts found matching "${query}".` }] };
+      const results = rows.map((t, i) => {
+        const m = parseMeta(t.metadata);
+        const parts = [
+          `--- Result ${i + 1} (${(t.similarity * 100).toFixed(1)}% match) ---`,
+          `Captured: ${new Date(t.created_at).toLocaleDateString()}`,
+          `Type: ${m.type || "unknown"}`,
+        ];
+        if (Array.isArray(m.topics) && m.topics.length) parts.push(`Topics: ${(m.topics as string[]).join(", ")}`);
+        if (Array.isArray(m.people) && m.people.length) parts.push(`People: ${(m.people as string[]).join(", ")}`);
+        if (Array.isArray(m.action_items) && m.action_items.length) parts.push(`Actions: ${(m.action_items as string[]).join("; ")}`);
+        parts.push(`\n${t.content}`);
+        return parts.join("\n");
+      });
+      return { content: [{ type: "text" as const, text: `Found ${rows.length} thought(s):\n\n${results.join("\n\n")}` }] };
+    } catch (err: unknown) {
+      return { content: [{ type: "text" as const, text: `Error: ${(err as Error).message}` }], isError: true };
+    }
+  }
+);
+
+server.registerTool(
+  "list_thoughts",
+  {
+    title: "List Recent Thoughts",
+    description: "List recently captured thoughts with optional filters by type, topic, person, or time range.",
+    annotations: { readOnlyHint: true },
+    inputSchema: {
+      limit: z.number().optional().default(10),
+      type: z.string().optional().describe("Filter by type: observation, task, idea, reference, person_note"),
+      topic: z.string().optional().describe("Filter by topic tag"),
+      person: z.string().optional().describe("Filter by person mentioned"),
+      days: z.number().optional().describe("Only thoughts from the last N days"),
+    },
+  },
+  async ({ limit, type, topic, person, days }) => {
+    try {
+      const rows = await sql<{ content: string; metadata: Record<string, unknown>; created_at: string }[]>`
+        select content, metadata, created_at from thoughts
+        where true
+          ${type ? sql`and metadata @> ${JSON.stringify({ type })}::jsonb` : sql``}
+          ${topic ? sql`and metadata @> ${JSON.stringify({ topics: [topic] })}::jsonb` : sql``}
+          ${person ? sql`and metadata @> ${JSON.stringify({ people: [person] })}::jsonb` : sql``}
+          ${days ? sql`and created_at >= now() - ${`${days} days`}::interval` : sql``}
+        order by created_at desc limit ${limit}
+      `;
+      if (!rows.length) return { content: [{ type: "text" as const, text: "No thoughts found." }] };
+      const results = rows.map((t, i) => {
+        const m = parseMeta(t.metadata);
+        const tags = Array.isArray(m.topics) ? (m.topics as string[]).join(", ") : "";
+        return `${i + 1}. [${new Date(t.created_at).toLocaleDateString()}] (${m.type || "??"}${tags ? " - " + tags : ""})\n   ${t.content}`;
+      });
+      return { content: [{ type: "text" as const, text: `${rows.length} recent thought(s):\n\n${results.join("\n\n")}` }] };
+    } catch (err: unknown) {
+      return { content: [{ type: "text" as const, text: `Error: ${(err as Error).message}` }], isError: true };
+    }
+  }
+);
+
+server.registerTool(
+  "thought_stats",
+  {
+    title: "Thought Statistics",
+    description: "Get a summary of all captured thoughts: totals, types, top topics, and people.",
+    annotations: { readOnlyHint: true },
+    inputSchema: {},
+  },
+  async () => {
+    try {
+      const [{ count }] = await sql<{ count: string }[]>`select count(*)::text as count from thoughts`;
+      const rows = await sql<{ metadata: Record<string, unknown>; created_at: string }[]>`
+        select metadata, created_at from thoughts order by created_at desc
+      `;
+      const types: Record<string, number> = {};
+      const topics: Record<string, number> = {};
+      const people: Record<string, number> = {};
+      for (const r of rows) {
+        const m = parseMeta(r.metadata);
+        if (m.type) types[m.type as string] = (types[m.type as string] || 0) + 1;
+        if (Array.isArray(m.topics)) for (const t of m.topics) topics[t as string] = (topics[t as string] || 0) + 1;
+        if (Array.isArray(m.people)) for (const p of m.people) people[p as string] = (people[p as string] || 0) + 1;
+      }
+      const sort = (o: Record<string, number>): [string, number][] => Object.entries(o).sort((a, b) => b[1] - a[1]).slice(0, 10);
+      const lines = [
+        `Total thoughts: ${count}`,
+        `Date range: ${rows.length ? new Date(rows[rows.length - 1].created_at).toLocaleDateString() + " → " + new Date(rows[0].created_at).toLocaleDateString() : "N/A"}`,
+        "", "Types:", ...sort(types).map(([k, v]) => `  ${k}: ${v}`),
+      ];
+      if (Object.keys(topics).length) { lines.push("", "Top topics:"); for (const [k, v] of sort(topics)) lines.push(`  ${k}: ${v}`); }
+      if (Object.keys(people).length) { lines.push("", "People mentioned:"); for (const [k, v] of sort(people)) lines.push(`  ${k}: ${v}`); }
+      return { content: [{ type: "text" as const, text: lines.join("\n") }] };
+    } catch (err: unknown) {
+      return { content: [{ type: "text" as const, text: `Error: ${(err as Error).message}` }], isError: true };
+    }
+  }
+);
+
+server.registerTool(
+  "capture_thought",
+  {
+    title: "Capture Thought",
+    description: "Save a new thought to the Open Brain. Generates an embedding and extracts metadata automatically.",
+    annotations: { readOnlyHint: false, openWorldHint: false, destructiveHint: false },
+    inputSchema: {
+      content: z.string().describe("The thought to capture — a clear, standalone statement that will make sense when retrieved later by any AI"),
+    },
+  },
+  async ({ content }) => {
+    try {
+      const { metadata } = await captureThought(content);
+      let confirmation = `Captured as ${metadata.type || "thought"}`;
+      if (Array.isArray(metadata.topics) && metadata.topics.length) confirmation += ` — ${(metadata.topics as string[]).join(", ")}`;
+      if (Array.isArray(metadata.people) && metadata.people.length) confirmation += ` | People: ${(metadata.people as string[]).join(", ")}`;
+      if (Array.isArray(metadata.action_items) && metadata.action_items.length) confirmation += ` | Actions: ${(metadata.action_items as string[]).join("; ")}`;
+      return { content: [{ type: "text" as const, text: confirmation }] };
+    } catch (err: unknown) {
+      return { content: [{ type: "text" as const, text: `Error: ${(err as Error).message}` }], isError: true };
+    }
+  }
+);
+
+server.registerTool(
+  "enrich_thoughts",
+  {
+    title: "Enrich Untagged Thoughts",
+    description: "Run metadata extraction on all thoughts that have no metadata yet.",
+    annotations: { readOnlyHint: false, openWorldHint: false, destructiveHint: false },
+    inputSchema: {
+      limit: z.number().optional().default(20).describe("Max thoughts to process in one run"),
+    },
+  },
+  async ({ limit }) => {
+    try {
+      const rows = await sql<{ id: string; content: string }[]>`
+        select id, content from thoughts
+        where metadata = '{}'::jsonb or metadata = '{"source":"mcp"}'::jsonb
+        order by created_at asc limit ${limit}
+      `;
+      if (!rows.length) return { content: [{ type: "text" as const, text: "No untagged thoughts found." }] };
+      let processed = 0;
+      for (const row of rows) {
+        const metadata = await extractMetadata(row.content);
+        await sql`update thoughts set metadata = ${sql.json({ ...metadata, source: "mcp" })} where id = ${row.id}::uuid`;
+        processed++;
+      }
+      return { content: [{ type: "text" as const, text: `Enriched ${processed} thought(s).` }] };
+    } catch (err: unknown) {
+      return { content: [{ type: "text" as const, text: `Error: ${(err as Error).message}` }], isError: true };
+    }
+  }
+);
+
+// --- Hono App with Auth + CORS ---
+
+const corsHeaders = {
+  "Access-Control-Allow-Origin": "*",
+  "Access-Control-Allow-Headers": "authorization, x-client-info, apikey, content-type, x-brain-key, accept, mcp-session-id",
+  "Access-Control-Allow-Methods": "GET, POST, OPTIONS, DELETE",
+};
+
+const app = new Hono();
+app.options("*", (c) => c.text("ok", 200, corsHeaders));
+
+app.post("/capture-external", async (c) => {
+  const provided = c.req.header("x-brain-key") || new URL(c.req.url).searchParams.get("key");
+  if (!provided || provided !== MCP_ACCESS_KEY) return c.json({ error: "Invalid or missing access key" }, 401, corsHeaders);
+  let body: { content?: string; source?: string; title?: string; url?: string };
+  try {
+    body = await c.req.json();
+  } catch {
+    return c.json({ error: "Invalid JSON body" }, 400, corsHeaders);
+  }
+  if (!body.content || body.content.trim() === "") {
+    return c.json({ error: "content is required" }, 400, corsHeaders);
+  }
+  try {
+    const { id, metadata } = await captureThought(body.content.trim(), {
+      source: body.source,
+      title: body.title,
+      url: body.url,
+    });
+    return c.json({ id, type: metadata.type, topics: metadata.topics }, 200, corsHeaders);
+  } catch (err: unknown) {
+    return c.json({ error: (err as Error).message }, 500, corsHeaders);
+  }
+});
+
+app.post("/search-external", async (c) => {
+  const provided = c.req.header("x-brain-key") || new URL(c.req.url).searchParams.get("key");
+  if (!provided || provided !== MCP_ACCESS_KEY) return c.json({ error: "Invalid or missing access key" }, 401, corsHeaders);
+  let body: { query?: string; tag?: string; type?: string; source?: string; date?: string; since?: string; until?: string; limit?: number; threshold?: number };
+  try {
+    body = await c.req.json();
+  } catch {
+    return c.json({ error: "Invalid JSON body" }, 400, corsHeaders);
+  }
+  if (!body.query && !body.tag && !body.type && !body.source && !body.date && !body.since && !body.until) {
+    return c.json({ error: "query, tag, type, source, date, since, or until is required" }, 400, corsHeaders);
+  }
+  const isDate = (s: string | undefined) => !!s && /^\d{4}-\d{2}-\d{2}$/.test(s);
+  if (body.date && !isDate(body.date)) return c.json({ error: "date must be YYYY-MM-DD" }, 400, corsHeaders);
+  if (body.since && !isDate(body.since)) return c.json({ error: "since must be YYYY-MM-DD" }, 400, corsHeaders);
+  if (body.until && !isDate(body.until)) return c.json({ error: "until must be YYYY-MM-DD" }, 400, corsHeaders);
+  try {
+    const limit = body.limit || 10;
+
+    // Browse mode — date-sorted, no embedding needed. Triggered by any non-query filter.
+    if (body.tag || body.type || body.source || body.date || body.since || body.until) {
+      const filter: Record<string, unknown> = {};
+      if (body.tag) filter.topics = [body.tag];
+      if (body.type) filter.type = body.type;
+      if (body.source) filter.source = body.source;
+      const rows = await sql<{ id: string; content: string; metadata: Record<string, unknown>; created_at: string }[]>`
+        select id, content, metadata, created_at from thoughts
+        where true
+          ${Object.keys(filter).length ? sql`and metadata @> ${sql.json(filter)}::jsonb` : sql``}
+          ${body.date ? sql`and created_at::date = ${body.date}::date` : sql``}
+          ${body.since ? sql`and created_at::date >= ${body.since}::date` : sql``}
+          ${body.until ? sql`and created_at::date <= ${body.until}::date` : sql``}
+        order by created_at desc limit ${limit}
+      `;
+      const results = rows.map(t => ({
+        id: t.id,
+        content: t.content,
+        similarity: null,
+        type: (parseMeta(t.metadata).type as string) || "unknown",
+        topics: (parseMeta(t.metadata).topics as string[]) || [],
+        source: (parseMeta(t.metadata).source as string) || null,
+        created_at: t.created_at,
+      }));
+      return c.json({ results, mode: "browse" }, 200, corsHeaders);
+    }
+
+    // Semantic search
+    const threshold = body.threshold || 0.25;
+    const qEmb = await getEmbedding(body.query!.trim());
+    const vecStr = `[${qEmb.join(",")}]`;
+    const rows = await sql<{ id: string; content: string; metadata: Record<string, unknown>; similarity: number; created_at: string }[]>`
+      select id, content, metadata, similarity, created_at
+      from match_thoughts(${vecStr}::vector, ${threshold}, ${limit}, '{}'::jsonb)
+    `;
+    const results = rows.map(t => ({
+      id: t.id,
+      content: t.content,
+      similarity: Math.round(t.similarity * 100),
+      type: (parseMeta(t.metadata).type as string) || "unknown",
+      topics: (parseMeta(t.metadata).topics as string[]) || [],
+      source: (parseMeta(t.metadata).source as string) || null,
+      created_at: t.created_at,
+    }));
+    return c.json({ results, mode: "search" }, 200, corsHeaders);
+  } catch (err: unknown) {
+    return c.json({ error: (err as Error).message }, 500, corsHeaders);
+  }
+});
+
+app.all("*", async (c) => {
+  const provided = c.req.header("x-brain-key") || new URL(c.req.url).searchParams.get("key");
+  if (!provided || provided !== MCP_ACCESS_KEY) return c.json({ error: "Invalid or missing access key" }, 401, corsHeaders);
+  const transport = new StreamableHTTPTransport();
+  await server.connect(transport);
+  return transport.handleRequest(c);
+});
+
+(async () => {
+  try {
+    const cmd = new InvokeModelCommand({
+      modelId: EMBEDDING_MODEL,
+      contentType: "application/json",
+      accept: "application/json",
+      body: JSON.stringify({ inputText: "startup health check", dimensions: 1024, normalize: true }),
+    });
+    await makeBedrock().send(cmd);
+    console.log(`AWS Bedrock health check passed (profile: ${process.env.AWS_PROFILE || "default"})`);
+  } catch (e) {
+    console.error("FATAL: Bedrock health check failed:", (e as Error).message);
+    process.exit(1);
+  }
+  serve({ fetch: app.fetch, port: PORT }, () => {
+    console.log(`Open Brain MCP server running on port ${PORT}`);
+  });
+})();

--- a/recipes/local-docker/server/package.json
+++ b/recipes/local-docker/server/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "open-brain-mcp-server",
+  "version": "1.0.0",
+  "type": "module",
+  "scripts": {
+    "start": "node --import tsx/esm index.ts"
+  },
+  "dependencies": {
+    "@aws-sdk/client-bedrock-runtime": "3.839.0",
+"@hono/mcp": "0.1.1",
+    "@hono/node-server": "1.13.7",
+    "@modelcontextprotocol/sdk": "1.24.3",
+    "hono": "4.9.2",
+    "postgres": "3.4.5",
+    "tsx": "4.19.4",
+    "zod": "4.1.13"
+  }
+}


### PR DESCRIPTION
## Contribution Type

- [x] Recipe (`/recipes`)
- [ ] Schema (`/schemas`)
- [ ] Dashboard (`/dashboards`)
- [ ] Integration (`/integrations`)
- [ ] Skill (`/skills`)
- [ ] Repo improvement (docs, CI, templates)

## What does this do?

Adds a self-contained Docker stack that runs Open Brain entirely on the user's own machine — Postgres + pgvector as the store, a Node.js MCP server in a sibling container, and AWS Bedrock for embeddings (Titan V2) and metadata extraction (Claude Haiku 4.5). Designed for environments under data-privacy constraints where cloud-hosted databases like Supabase are not permitted. Includes a Chrome bookmarklet, AutoHotkey global hotkey, PowerShell script, and standalone search UI for human capture from outside an AI session.

## Requirements

- Docker Desktop
- AWS account with Bedrock model access for `amazon.titan-embed-text-v2:0` and `us.anthropic.claude-haiku-4-5-20251001-v1:0`
- AWS CLI configured with a profile that has `bedrock:InvokeModel` permissions
- An AI client that supports HTTP-based MCP servers (Claude Code, Claude Desktop, GitHub Copilot, etc.)

The recipe README documents the credential bind-mount (read-only) and the rationale for hand-parsing `~/.aws/credentials` instead of using the AWS SDK's default credential chain — the SDK chain caches credentials in memory and fails when SSO/assume-role tokens rotate.

## Notes

A companion Qdrant-backed variant of this recipe is in a separate PR (`[recipes] Local Docker Open Brain (Qdrant)`). The two are independent and can run side-by-side on different ports.

## Checklist

- [x] I've read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] My contribution has a `README.md` with prerequisites, step-by-step instructions, and expected outcome
- [x] My `metadata.json` has all required fields
- [x] If my contribution depends on a skill or primitive, I declared it in metadata.json and linked it in the README *(no such dependency in this recipe)*
- [x] I tested this on my own Open Brain instance
- [x] No credentials, API keys, or secrets are included
