### PR TITLE
[recipes] Local Docker Open Brain (Qdrant) — multi-tenancy-primed vector store with ACL

### DIFF
--- a/recipes/local-docker-qdrant/.env.example
+++ b/recipes/local-docker-qdrant/.env.example
@@ -1,0 +1,25 @@
+# Copy this to .env and fill in the values.
+# .env is gitignored — never commit it.
+
+# Random hex string — your MCP access key
+# Generate one with: openssl rand -hex 32
+MCP_ACCESS_KEY=change-me
+
+# Set this in your PowerShell profile or system environment to use capture.ps1
+# Must match MCP_ACCESS_KEY above
+OPEN_BRAIN_KEY=change-me
+
+# AWS credentials directory on the host — bind-mounted into the container
+# Linux/macOS: AWS_HOME=$HOME/.aws
+# Windows:     AWS_HOME=C:\Users\<your-username>\.aws
+AWS_HOME=/path/to/.aws
+
+# AWS region where your Bedrock models are enabled
+AWS_REGION=us-east-1
+
+# AWS profile to use for Bedrock (must have bedrock:InvokeModel permissions)
+AWS_PROFILE=default
+
+# Bedrock model IDs (defaults shown — override to switch models)
+EMBEDDING_MODEL=amazon.titan-embed-text-v2:0
+METADATA_MODEL=us.anthropic.claude-haiku-4-5-20251001-v1:0

--- a/recipes/local-docker-qdrant/.gitignore
+++ b/recipes/local-docker-qdrant/.gitignore
@@ -1,0 +1,4 @@
+.env
+node_modules/
+dist/
+qdrant-storage/

--- a/recipes/local-docker-qdrant/ARCHITECTURE.md
+++ b/recipes/local-docker-qdrant/ARCHITECTURE.md
@@ -1,0 +1,184 @@
+# Architecture — Local Docker Open Brain (Qdrant)
+
+## What This Is
+
+The Qdrant variant of [recipes/local-docker](../local-docker/). It replaces PostgreSQL + pgvector with a self-hosted Qdrant instance for vector storage while keeping the same AWS Bedrock integration for embeddings and metadata extraction.
+
+The design is **multi-tenancy-primed**: ACL enforcement is built into every read path now, using a trivially-passing identity in local mode. Stage 2 (hosted deployment) activates real user isolation by swapping one environment variable — no data migration, no schema changes.
+
+---
+
+## Collection Schema
+
+Qdrant collection name: `thoughts`
+
+| Field | Qdrant type | Notes |
+|---|---|---|
+| `content` | text | Raw thought text |
+| `type` | keyword | e.g. `idea`, `decision`, `reference` |
+| `topics` | keyword[] | Extracted topic tags |
+| `people` | keyword[] | Extracted person names |
+| `actions` | keyword[] | Extracted action items |
+| `source` | keyword | Originating application or surface |
+| `title` | keyword (optional) | Page or document title |
+| `url` | keyword (optional) | Source URL |
+| `owner_id` | keyword | Identity of the owner; `"local-user"` in local mode |
+| `owner_email` | keyword | Owner's email address; empty string in local mode |
+| `visibility` | keyword | `"private"` or `"shared"` |
+| `shared_with` | keyword[] | List of user IDs this thought is explicitly shared with |
+| `created_at` | datetime | ISO 8601 UTC timestamp |
+
+Vector configuration: size **1024**, distance **Cosine** (matching Amazon Titan Text Embeddings V2 output dimensions).
+
+---
+
+## Payload Indexes
+
+Eight payload fields are indexed at collection creation time:
+
+| Field | Index type | Purpose |
+|---|---|---|
+| `owner_id` | keyword | ACL filter — isolate by owner |
+| `visibility` | keyword | ACL filter — find shared thoughts |
+| `shared_with` | keyword | ACL filter — explicit sharing list |
+| `type` | keyword | `list_thoughts` type filter |
+| `source` | keyword | `list_thoughts` source filter |
+| `created_at` | datetime | `list_thoughts` date range filter |
+| `topics` | keyword | `list_thoughts` / `search_thoughts` topic filter |
+| `people` | keyword | `list_thoughts` people filter |
+
+These indexes ensure all ACL and metadata filters are resolved by Qdrant's inverted index rather than a full vector scan. This keeps read latency flat regardless of collection size.
+
+---
+
+## ACL Filter Shape
+
+Every read handler calls `buildAclFilter()` before executing a search or scroll. This is the single enforcement point for access control.
+
+```typescript
+// ACL filter composition is the single enforcement point.
+// If you add a new read handler, you MUST call buildAclFilter().
+{
+  must: [
+    ...userFilter?.must ?? [],
+    {
+      should: [
+        { key: "owner_id", match: { value: identity.owner_id } },
+        { key: "visibility", match: { value: "shared" } }
+      ]
+    }
+  ]
+}
+```
+
+In local mode (`IDENTITY_MODE=local`), `identity.owner_id` is always `"local-user"`. Since every thought is written with `owner_id: "local-user"`, the first `should` branch matches every record, and the filter trivially passes. This means local operation is functionally identical to having no ACL at all — there is zero behavioral difference for a single user.
+
+In Stage 2, when `IDENTITY_MODE=entra` is set, `identity.owner_id` is derived from the verified JWT. A user can only see their own `private` thoughts, or any thought with `visibility: "shared"`. This boundary is enforced entirely within `buildAclFilter()` — no changes to the tool handlers are needed.
+
+---
+
+## Identity Modes
+
+| Mode | Behavior | How to activate |
+|---|---|---|
+| `local` | Stamps every request with `owner_id=local-user`, `owner_email=""`. ACL filter trivially passes for all records. | Default; set `IDENTITY_MODE=local` in `.env` |
+| `entra` | Validates a Bearer token against Microsoft Entra (Azure AD). Extracts `oid` as `owner_id` and `upn` as `owner_email`. | Set `IDENTITY_MODE=entra` + Entra app config (Stage 2). Currently throws HTTP 501. |
+
+---
+
+## Why Qdrant Over pgvector
+
+| Consideration | Qdrant | pgvector |
+|---|---|---|
+| Primary purpose | Purpose-built vector database | Vector extension on top of Postgres |
+| Payload indexing | Native inverted indexes on any field | Requires separate B-tree/GIN indexes; harder to compose with vector queries |
+| ACL filter performance | ACL filter resolved by payload index, not vector scan | Full-table ACL scan unless carefully indexed; degrades at scale |
+| Multi-tenant scaling | Designed for filtered, partitioned workloads | Works well single-user; ACL overhead grows with row count |
+| HTTP API | First-class, stable REST API — no DB client library needed | Requires `pg` or compatible Postgres client |
+| Operational simplicity | Single binary, single data directory | Requires init SQL, schema migrations, connection pooling considerations |
+
+For a single-user local deployment, the difference is imperceptible. The architectural choice pays off in Stage 2, where multi-tenant isolation with thousands of thoughts per user would impose measurable overhead on a pgvector ACL scan.
+
+---
+
+## AWS Credential Handling
+
+The MCP server needs Bedrock access. Credentials are sourced from your host's `~/.aws/credentials` file via a read-only bind mount, then parsed on every Bedrock call. This is deliberate — the alternatives all have failure modes.
+
+**How it works:**
+- `docker-compose.yml` bind-mounts `${AWS_HOME}` → `/root/.aws` as `read_only: true`. The container can read your credentials but cannot modify them.
+- `server/src/bedrock.ts:readCredentials()` parses the standard INI format manually, picks the section named by `AWS_PROFILE`, and returns `{ accessKeyId, secretAccessKey, sessionToken? }`.
+- `makeBedrock()` is called fresh per Bedrock request. No SDK credential caching, no module-level singleton. Every request reads the file again.
+
+**Why not the AWS SDK's built-in `fromIni()` / default credential chain:**
+- The SDK chain caches credentials in memory. With SSO or assume-role profiles whose tokens expire on the order of hours, that cache goes stale and you get `ExpiredTokenException` until the container is restarted.
+- Reading the file per request makes rotation transparent. Run `aws sso login` on the host and the next Bedrock call from the container picks up the new tokens automatically — no container restart needed.
+
+**What never leaves the container:**
+- Credentials go to the AWS Bedrock endpoint (HTTPS) and nowhere else.
+- They are never written to logs, captured thoughts, or the Qdrant payload.
+- They are never copied into the image — only mounted at runtime.
+
+**Trade-offs we rejected:**
+- *Inject `AWS_ACCESS_KEY_ID` etc. via env vars* — breaks when tokens rotate.
+- *Mount `~/.aws` writable* — unnecessary privilege; we only need to read.
+- *Bake credentials into the image* — never. The image is portable; credentials are per-user.
+
+**Operator notes:**
+- If `aws configure list --profile <your-profile>` works on the host, the container will see the same credentials.
+- Expired credentials cause the startup health check to fail fast (`process.exit(1)`) so the container won't run with broken AWS access.
+
+---
+
+## Port Layout
+
+| Stack | Service | Port | Protocol |
+|---|---|---|---|
+| pgvector recipe | MCP server | 3000 | HTTP |
+| pgvector recipe | PostgreSQL | 5432 | TCP |
+| Qdrant recipe | MCP server | 3100 | HTTP |
+| Qdrant recipe | Qdrant (HTTP API) | 6333 | HTTP |
+| Qdrant recipe | Qdrant (gRPC API) | 6334 | gRPC |
+
+The two stacks share no ports and can run simultaneously without conflict.
+
+---
+
+## Migration Path
+
+### Stage 1 → Stage 2 (single-user local → multi-user hosted)
+
+1. Deploy the Qdrant stack to a hosted environment (ECS, Fly.io, etc.)
+2. Set `IDENTITY_MODE=entra` and configure Entra app registration env vars
+3. Done — no data migration required. The ACL fields are already present on every existing thought; they will be filtered correctly once real identities are in play.
+
+### From pgvector recipe → Qdrant recipe
+
+Use the provided migration script to copy existing thoughts from the pgvector Postgres instance into Qdrant. Both stacks must be running during migration.
+
+```bash
+# Preview without writing
+node scripts/migrate-pgvector-to-qdrant.mjs --dry-run
+
+# Execute migration
+node scripts/migrate-pgvector-to-qdrant.mjs
+```
+
+The script re-generates embeddings via Bedrock for each thought (Qdrant uses the same embedding model — Titan V2 at 1024 dimensions — so existing vectors could in principle be transferred, but regenerating ensures consistency). It stamps `owner_id=local-user` and `visibility=private` on all migrated records.
+
+---
+
+## Differences from the pgvector Recipe
+
+| Dimension | pgvector recipe | Qdrant recipe |
+|---|---|---|
+| Vector store | PostgreSQL 16 + pgvector | Qdrant v1.16.3 |
+| MCP server port | 3000 | 3100 |
+| Database port | 5432 (Postgres) | 6333/6334 (Qdrant HTTP/gRPC) |
+| MCP tools | 5 (no sharing) | 6 (adds `share_thought`) |
+| `capture_thought` | No visibility param | Adds `visibility` param (`"private"`/`"shared"`) |
+| `search_thoughts` | No scope param | Adds `scope` param (`"private"`/`"shared"`/`"all"`) |
+| ACL enforcement | None | Built into every read path via `buildAclFilter()` |
+| Thought fields | No ownership fields | Adds `owner_id`, `owner_email`, `visibility`, `shared_with` |
+| Init SQL | Required (`init-db/01-schema.sql`) | None — Qdrant collection created programmatically on startup |
+| Multi-tenant path | Not designed for it | Stage 2: swap `IDENTITY_MODE=entra` |

--- a/recipes/local-docker-qdrant/README.md
+++ b/recipes/local-docker-qdrant/README.md
@@ -1,0 +1,277 @@
+# Local Docker Open Brain (Qdrant)
+
+> A self-contained Docker deployment of Open Brain using local Qdrant for vector storage and AWS Bedrock for embeddings and metadata extraction. Multi-tenancy-primed with ACL enforcement built in — runs side-by-side with the pgvector recipe.
+
+## What It Does
+
+Deploys a complete Open Brain instance (Qdrant vector store + MCP server + capture clients) as a Docker Compose stack on your local machine. Instead of Supabase cloud and OpenRouter, it uses local [Qdrant](https://qdrant.tech/) for vector storage and AWS Bedrock for embeddings and metadata extraction. All data stays on your machine and within your AWS account.
+
+This is the Qdrant variant of [recipes/local-docker](../local-docker/). The two stacks run independently and can be active at the same time on different ports.
+
+> [!IMPORTANT]
+> This recipe uses a **local MCP server** rather than the standard remote (Supabase Edge Function) pattern. This is intentional — it exists for environments with data privacy constraints where sending knowledge to cloud-hosted databases is not permitted. If you don't have this constraint, the standard Open Brain setup with Supabase is simpler.
+
+### What sets this apart from the pgvector recipe
+
+Every thought carries `owner_id`, `visibility`, and `shared_with` fields, and every read operation enforces an ACL filter. Locally, `owner_id` is always `local-user`, so the filter trivially passes — you won't notice the difference day-to-day. The payoff comes in Stage 2, where swapping a single env var (`IDENTITY_MODE=entra`) turns on real user isolation without any data migration.
+
+There is also a sixth MCP tool — `share_thought` — that lets you flip a thought's visibility between `private` and `shared`, and `search_thoughts` gains a `scope` parameter (`"private"`, `"shared"`, or `"all"`) for filtering results by audience.
+
+### When to choose this recipe vs. the pgvector recipe
+
+| Scenario | Recommendation |
+|---|---|
+| Single-user, simplest possible setup | [recipes/local-docker](../local-docker/) (pgvector) |
+| You want ACL/sharing groundwork now | This recipe (Qdrant) |
+| You plan to scale to multi-user (Stage 2) | This recipe (Qdrant) |
+| You prefer Qdrant's native vector capabilities | This recipe (Qdrant) |
+| Already running pgvector and want to migrate | This recipe + `scripts/migrate-pgvector-to-qdrant.mjs` |
+
+## Prerequisites
+
+- Working knowledge of the [Open Brain concepts](../../docs/01-getting-started.md) (you don't need a Supabase instance — this replaces it)
+- [Docker Desktop](https://www.docker.com/products/docker-desktop/) installed and running
+- AWS account with Bedrock model access enabled for:
+  - `amazon.titan-embed-text-v2:0` (embeddings)
+  - `us.anthropic.claude-haiku-4-5-20251001-v1:0` (metadata extraction)
+- [AWS CLI](https://aws.amazon.com/cli/) configured with a profile that has `bedrock:InvokeModel` permissions
+- An AI client that supports HTTP-based MCP servers (Claude Code, Claude Desktop, etc.)
+
+## Credential Tracker
+
+Copy this block into a text editor and fill it in as you go.
+
+```text
+LOCAL DOCKER OPEN BRAIN (QDRANT) -- CREDENTIAL TRACKER
+-------------------------------------------------------
+
+GENERATED DURING SETUP
+  MCP access key:        ____________  (Step 1 — openssl rand -hex 32)
+  AWS profile name:      ____________  (your existing AWS CLI profile)
+  AWS home path:         ____________  (e.g., C:\Users\you\.aws)
+
+-------------------------------------------------------
+```
+
+## Steps
+
+![Step 1](https://img.shields.io/badge/Step_1-Configure_Environment-2E7D32?style=for-the-badge)
+
+**1. Copy the environment template:**
+
+```bash
+cd recipes/local-docker-qdrant
+cp .env.example .env
+```
+
+**2. Generate an MCP access key:**
+
+```bash
+openssl rand -hex 32
+```
+
+**3. Edit `.env` with your values:**
+
+```env
+MCP_ACCESS_KEY=<paste hex from step above>
+AWS_HOME=C:\Users\<your-username>\.aws
+AWS_REGION=us-east-1
+AWS_PROFILE=default
+```
+
+> [!TIP]
+> On Linux/macOS, use `AWS_HOME=$HOME/.aws`. On Windows, use the full path with backslashes.
+
+> [!WARNING]
+> The `AWS_PROFILE` must point to a profile with valid credentials. If you use temporary session tokens (SSO, assume-role), they must be refreshed before the container starts.
+
+`Done when:` `.env` exists with all values filled in, no `change-me` placeholders remain.
+
+---
+
+![Step 2](https://img.shields.io/badge/Step_2-Start_the_Stack-2E7D32?style=for-the-badge)
+
+Run from inside `recipes/local-docker-qdrant/`:
+
+```bash
+docker compose up --build -d
+```
+
+This builds the MCP server image and starts two containers:
+- **qdrant** — `qdrant/qdrant:v1.16.3` on ports 6333 (HTTP) and 6334 (gRPC), data persisted to a named Docker volume
+- **mcp-server** — Node.js 22 on port 3100, performs a Bedrock health check on startup
+
+> [!CAUTION]
+> If the health check fails (expired credentials, wrong region, model not enabled), the MCP server container will exit. Check logs with `docker compose logs mcp-server` and fix `.env` before retrying.
+
+`Done when:` `docker compose ps` shows both containers as "running" (healthy).
+
+---
+
+![Step 3](https://img.shields.io/badge/Step_3-Connect_Your_AI_Client-2E7D32?style=for-the-badge)
+
+Register the MCP server with your AI client. Note: this recipe uses port **3100**, not 3000.
+
+For Claude Code:
+
+```bash
+claude mcp add open-brain-qdrant --transport http --url http://localhost:3100/mcp --header "x-brain-key: <your-MCP_ACCESS_KEY>"
+```
+
+For Claude Desktop: Settings > Connectors > Add custom connector, paste `http://localhost:3100/mcp` and add the `x-brain-key` header.
+
+`Done when:` Your AI client lists 6 tools: `capture_thought`, `search_thoughts`, `list_thoughts`, `thought_stats`, `enrich_thoughts`, `share_thought`.
+
+---
+
+![Step 4](https://img.shields.io/badge/Step_4-Install_Capture_Clients_(Optional)-2E7D32?style=for-the-badge)
+
+The MCP tools handle capture from AI sessions. For capturing from other applications, install one or more human capture clients. All clients in the `clients/` folder are pre-configured for port 3100.
+
+![4.1](https://img.shields.io/badge/4.1-Chrome_Bookmarklet-555?style=for-the-badge&labelColor=2E7D32)
+
+Open `clients/bookmarklet.html` in Chrome and drag the button to your bookmarks bar. On any page:
+- **Selected text** is captured with the page title and URL
+- **No selection** captures the page URL as a reference
+
+> [!NOTE]
+> Chrome blocks mixed-content requests (HTTP from HTTPS pages). The bookmarklet only works on HTTP pages and local files unless you put the server behind HTTPS (e.g., a Caddy reverse proxy).
+
+![4.2](https://img.shields.io/badge/4.2-AutoHotkey_Global_Hotkey_(Windows)-555?style=for-the-badge&labelColor=2E7D32)
+
+Requires [AutoHotkey v2](https://www.autohotkey.com/).
+
+1. Set the `OPEN_BRAIN_KEY` environment variable to your MCP access key
+2. Double-click `clients/capture.ahk` to start
+3. Press `Ctrl+Shift+B` in any application to capture the selected text
+
+The script auto-detects the source application (Teams, Outlook, Chrome, Edge, Word, etc.) and records it as provenance metadata. POSTs to `http://localhost:3100/capture-external`.
+
+To auto-start: press `Win+R`, type `shell:startup`, drop a shortcut to `clients/capture.ahk` there.
+
+![4.3](https://img.shields.io/badge/4.3-PowerShell_Script-555?style=for-the-badge&labelColor=2E7D32)
+
+```powershell
+# Set once in your PowerShell profile:
+$env:OPEN_BRAIN_KEY = "<your-MCP_ACCESS_KEY>"
+
+# Capture a thought:
+.\clients\capture.ps1 "A thought to capture"
+
+# Or capture from clipboard:
+.\clients\capture.ps1
+```
+
+![4.4](https://img.shields.io/badge/4.4-Search_UI-555?style=for-the-badge&labelColor=2E7D32)
+
+Open `clients/search.html` directly in Chrome from the filesystem. No build step required.
+
+- Type a query and press Enter for semantic search
+- `tag:aws` — browse by topic
+- `type:idea` — browse by type
+- `source:teams` — browse by source
+
+`Done when:` At least one capture client is installed and you can capture and retrieve a test thought.
+
+---
+
+## Validating Side-by-Side Operation
+
+If you are running both the pgvector and Qdrant stacks simultaneously:
+
+- `curl http://localhost:3000/health` — hits the pgvector MCP server
+- `curl http://localhost:3100/health` — hits the Qdrant MCP server
+
+Thoughts captured to one stack are invisible to the other. This is expected — each stack maintains its own independent store. If you want to move existing pgvector data into Qdrant, use the migration script (see below).
+
+**Stopping only the Qdrant stack** leaves the pgvector stack running untouched:
+
+```bash
+docker compose -p open-brain-qdrant down
+```
+
+---
+
+## Expected Outcome
+
+After completing all steps:
+
+1. `docker compose ps` shows both containers healthy
+2. Your AI client can call `capture_thought` and `search_thoughts` successfully
+3. Asking your AI "what do I know about [topic]?" retrieves semantically relevant results
+4. Capture latency is ~4s (embedding + metadata in parallel), search is ~2.5s
+
+Test it by capturing a thought and immediately searching for it:
+- Capture: "The quarterly planning meeting is moving to Thursdays starting next month"
+- Search: "when is planning?" — should return the thought above with high similarity
+
+---
+
+## Tool Surface Area
+
+This recipe exposes 6 MCP tools. As you add more Open Brain extensions, review the [MCP Tool Audit & Optimization Guide](../../docs/05-tool-audit.md) to manage your total tool surface area.
+
+| Tool | Type | Description |
+|------|------|-------------|
+| `capture_thought` | Write | Save a thought with auto-generated embedding and metadata. Accepts an optional `visibility` parameter (`"private"` or `"shared"`, default `"private"`) |
+| `search_thoughts` | Read | Semantic similarity search. Accepts an optional `scope` parameter (`"private"`, `"shared"`, or `"all"`, default `"all"`) |
+| `list_thoughts` | Read | Browse recent thoughts with metadata filters |
+| `thought_stats` | Read | Aggregate statistics: totals, types, top topics |
+| `enrich_thoughts` | Write | Batch metadata extraction for untagged thoughts |
+| `share_thought` | Write | **NEW** — Flip the visibility of any thought you own between `"private"` and `"shared"` |
+
+---
+
+## Migration from the pgvector Recipe
+
+If you have an existing pgvector deployment and want to move your data into Qdrant, a migration script is provided:
+
+```bash
+# Dry run — shows what would be migrated without writing anything
+node scripts/migrate-pgvector-to-qdrant.mjs --dry-run
+
+# Live run
+node scripts/migrate-pgvector-to-qdrant.mjs
+```
+
+The script reads from the pgvector Postgres instance (must be running) and writes into the Qdrant instance (must be running). Both stacks must be up simultaneously during migration.
+
+---
+
+## Troubleshooting
+
+**Issue: MCP server container exits immediately after starting**
+
+Check `docker compose logs mcp-server`. Most common cause: expired AWS credentials. Refresh your session tokens (`aws sso login` or re-run your assume-role script), then `docker compose restart mcp-server`.
+
+**Issue: Capture/search returns "Error: No credentials found for profile"**
+
+The `AWS_PROFILE` in `.env` doesn't match any profile in your `~/.aws/credentials` file. Verify with `aws configure list --profile <your-profile>`.
+
+**Issue: "model is not accessible" error from Bedrock**
+
+You need to enable model access in the AWS console. Go to Amazon Bedrock > Model access > Request access for both `Titan Text Embeddings V2` and `Claude 3.5 Haiku`. This can take a few minutes to propagate.
+
+**Issue: Qdrant container is unhealthy**
+
+Qdrant's readiness is determined by its `/readyz` endpoint. If the container stays unhealthy, check `docker compose logs qdrant`. Common causes: port 6333 already in use (another Qdrant instance?), or insufficient disk space for the data volume.
+
+**Issue: Bookmarklet doesn't work on HTTPS pages**
+
+This is Chrome's mixed-content policy — it blocks HTTP requests from HTTPS origins. Options:
+1. Use the AutoHotkey or PowerShell client instead (they call localhost directly)
+2. Put the server behind a local HTTPS reverse proxy (e.g., [Caddy](https://caddyserver.com/))
+
+**Issue: Slow first request after container start**
+
+The first Bedrock call after startup is always slower (~8-10s) due to model loading on the AWS side. Subsequent calls are warm (~2.5-4s). This is expected behavior.
+
+**Issue: Both stacks running but searches return no results from the Qdrant stack**
+
+Check that your AI client connector is pointing to port **3100**, not 3000. The `claude mcp list` command shows the registered URL.
+
+---
+
+## Architecture
+
+For design decisions, collection schema, ACL filter design, payload indexes, and the multi-tenancy roadmap, see [ARCHITECTURE.md](ARCHITECTURE.md).

--- a/recipes/local-docker-qdrant/clients/bookmarklet.html
+++ b/recipes/local-docker-qdrant/clients/bookmarklet.html
@@ -1,0 +1,59 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Open Brain Bookmarklet (Qdrant)</title>
+  <style>
+    body { font-family: system-ui, sans-serif; max-width: 600px; margin: 60px auto; padding: 0 24px; color: #1a1a2e; }
+    h1 { font-size: 1.4rem; margin-bottom: 4px; }
+    p { color: #555; margin-top: 4px; }
+    .bookmarklet {
+      display: inline-block;
+      margin: 24px 0;
+      padding: 12px 20px;
+      background: #1a1a2e;
+      color: #fff;
+      border-radius: 8px;
+      text-decoration: none;
+      font-size: 1rem;
+      cursor: grab;
+    }
+    .bookmarklet:active { cursor: grabbing; }
+    ol { line-height: 2; color: #333; }
+    details { margin-top: 32px; }
+    summary { cursor: pointer; color: #888; font-size: 0.9rem; }
+    pre { background: #f4f4f4; padding: 16px; border-radius: 6px; font-size: 0.8rem; white-space: pre-wrap; word-break: break-all; margin-top: 8px; }
+  </style>
+</head>
+<body>
+  <h1>Open Brain — Browser Bookmarklet (Qdrant Stack)</h1>
+  <p>Capture selected text or the current URL to your Open Brain.</p>
+
+  <a class="bookmarklet" href="javascript:(function(){var key=localStorage.getItem('ob_qdrant_key');if(!key){key=prompt('Open Brain Qdrant key (stored locally, one-time):');if(!key)return;localStorage.setItem('ob_qdrant_key',key);}var sel=window.getSelection().toString().trim();var content=sel||location.href;fetch('http://localhost:3100/capture-external',{method:'POST',headers:{'Content-Type':'application/json','x-brain-key':key},body:JSON.stringify({content:content,source:sel?'browser-selection':'browser-url',title:document.title,url:location.href})}).then(function(r){return r.json();}).then(function(d){if(d.error){alert('Open Brain error: '+d.error);return;}var msg=sel?'Selection captured':'URL captured';var n=document.createElement('div');n.textContent=msg+': '+(d.type||'')+(d.topics&amp;&amp;d.topics.length?' - '+d.topics.join(', '):'');n.style.cssText='position:fixed;top:16px;right:16px;z-index:999999;background:#1a1a2e;color:#fff;padding:12px 16px;border-radius:8px;font:14px/1.4 system-ui;box-shadow:0 4px 12px rgba(0,0,0,.4);max-width:320px;';document.body.appendChild(n);setTimeout(function(){n.remove();},3000);}).catch(function(e){alert('Capture failed: '+e.message);});})();">
+    Capture to Open Brain (Qdrant)
+  </a>
+
+  <ol>
+    <li>Drag the button above to your Chrome bookmarks bar.</li>
+    <li>Navigate to any page. Select some text, or select nothing to capture the URL.</li>
+    <li>Click the bookmark. On first use it will prompt for your <code>OPEN_BRAIN_KEY</code> and store it in <code>localStorage</code>.</li>
+    <li>A confirmation toast appears for 3 seconds showing the captured type and topics.</li>
+  </ol>
+
+  <details>
+    <summary>Reset stored key</summary>
+    <p>Run this in the browser console on any page:</p>
+    <pre>localStorage.removeItem('ob_qdrant_key')</pre>
+  </details>
+
+  <details>
+    <summary>Raw bookmarklet code</summary>
+    <pre id="raw"></pre>
+  </details>
+
+  <script>
+    var code = document.querySelector('.bookmarklet').getAttribute('href');
+    document.getElementById('raw').textContent = decodeURIComponent(code);
+  </script>
+</body>
+</html>

--- a/recipes/local-docker-qdrant/clients/capture.ahk
+++ b/recipes/local-docker-qdrant/clients/capture.ahk
@@ -1,0 +1,69 @@
+#Requires AutoHotkey v2.0
+#SingleInstance Force
+
+MyHotkey := "^+b"  ; Ctrl+Shift+B — change this to your preferred combo
+
+Hotkey MyHotkey, Capture
+
+Capture(*) {
+    ; Get foreground window before anything steals focus
+    hwnd := WinGetID("A")
+    procName := WinGetProcessName("A")
+
+    source := "desktop"
+    if InStr(procName, "Teams")
+        source := "teams"
+    else if InStr(procName, "OUTLOOK")
+        source := "outlook"
+    else if InStr(procName, "chrome")
+        source := "browser-selection"
+    else if InStr(procName, "msedge")
+        source := "browser-selection"
+    else if InStr(procName, "WINWORD")
+        source := "word"
+    else if InStr(procName, "POWERPNT")
+        source := "powerpoint"
+    else if InStr(procName, "ONENOTE")
+        source := "onenote"
+    else if InStr(procName, "WindowsTerminal")
+        source := "terminal"
+
+    ; Copy selection to clipboard
+    A_Clipboard := ""
+    Send "^c"
+    ClipWait 1
+    content := A_Clipboard
+
+    if (content = "") {
+        TrayTip "Open Brain", "Nothing selected to capture.", 2
+        return
+    }
+
+    ; Read key from environment
+    key := EnvGet("OPEN_BRAIN_KEY")
+    if (key = "") {
+        TrayTip "Open Brain", "OPEN_BRAIN_KEY not set.", 2
+        return
+    }
+
+    ; Build JSON body — escape content for JSON
+    content := StrReplace(content, "\", "\\")
+    content := StrReplace(content, '"', '\"')
+    content := StrReplace(content, "`n", "\n")
+    content := StrReplace(content, "`r", "")
+    body := '{"content":"' content '","source":"' source '"}'
+
+    ; POST to capture-external
+    req := ComObject("WinHttp.WinHttpRequest.5.1")
+    req.Open("POST", "http://localhost:3100/capture-external", false)
+    req.SetRequestHeader("Content-Type", "application/json")
+    req.SetRequestHeader("x-brain-key", key)
+    req.Send(body)
+
+    if (req.Status = 200) {
+        resp := req.ResponseText
+        TrayTip "Open Brain", "Captured (" source ")", 2
+    } else {
+        TrayTip "Open Brain", "Capture failed: " req.Status, 2
+    }
+}

--- a/recipes/local-docker-qdrant/clients/capture.ps1
+++ b/recipes/local-docker-qdrant/clients/capture.ps1
@@ -1,0 +1,50 @@
+# capture.ps1 — Send a thought to the local Open Brain Qdrant stack (port 3100)
+#
+# Usage:
+#   .\capture.ps1 "Your thought here"
+#   .\capture.ps1                        # reads from clipboard if no argument
+#
+# Required environment variable:
+#   OPEN_BRAIN_KEY — your MCP access key (set in your PowerShell profile or system env)
+#
+# Note: This script targets the Qdrant stack on port 3100.
+#       For the pgvector stack (port 3000), use recipes/local-docker/capture.ps1 instead.
+
+param(
+    [Parameter(Position=0)]
+    [string]$Content
+)
+
+$key = $env:OPEN_BRAIN_KEY
+if (-not $key) {
+    Write-Error "OPEN_BRAIN_KEY environment variable is not set."
+    exit 1
+}
+
+if (-not $Content) {
+    $Content = Get-Clipboard
+}
+
+if (-not $Content -or $Content.Trim() -eq "") {
+    Write-Error "No content to capture. Pass a string or copy something to the clipboard first."
+    exit 1
+}
+
+$body = @{
+    content = $Content.Trim()
+    source  = "clipboard"
+} | ConvertTo-Json
+
+try {
+    $response = Invoke-RestMethod `
+        -Uri "http://localhost:3100/capture-external" `
+        -Method POST `
+        -ContentType "application/json" `
+        -Headers @{ "x-brain-key" = $key } `
+        -Body $body
+
+    Write-Host "Captured: $($response.type) - $($response.topics -join ', ') (id: $($response.id))"
+} catch {
+    Write-Error "Failed to capture: $_"
+    exit 1
+}

--- a/recipes/local-docker-qdrant/clients/search.html
+++ b/recipes/local-docker-qdrant/clients/search.html
@@ -1,0 +1,209 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Open Brain Search (Qdrant)</title>
+  <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>🧠</text></svg>">
+  <style>
+    * { box-sizing: border-box; margin: 0; padding: 0; }
+    body { font-family: system-ui, sans-serif; background: #f8f9fa; color: #1a1a2e; min-height: 100vh; }
+
+    .hero { display: flex; flex-direction: column; align-items: center; padding: 80px 24px 40px; }
+    .hero h1 { font-size: 2.4rem; font-weight: 800; margin-bottom: 32px; letter-spacing: -1px; font-family: Georgia, 'Times New Roman', serif; }
+
+    .search-bar { display: flex; width: 100%; max-width: 640px; border: 2px solid #1a1a2e; border-radius: 32px; overflow: hidden; background: #fff; box-shadow: 0 2px 12px rgba(0,0,0,.08); }
+    .search-bar input { flex: 1; padding: 14px 20px; font-size: 1rem; border: none; outline: none; background: transparent; }
+    .search-bar button { padding: 14px 24px; background: #1a1a2e; color: #fff; border: none; font-size: 0.95rem; cursor: pointer; }
+    .search-bar button:hover { background: #2d2d4e; }
+
+    .results-header { max-width: 900px; margin: 0 auto; padding: 24px 24px 0; font-size: 0.85rem; color: #888; }
+    .results-header strong { color: #1a1a2e; }
+
+    .results { max-width: 900px; margin: 0 auto; padding: 12px 24px 24px; }
+    .result { background: #fff; border-radius: 12px; padding: 20px; margin-bottom: 16px; box-shadow: 0 1px 4px rgba(0,0,0,.08); }
+    .result-meta { display: flex; gap: 10px; align-items: center; margin-bottom: 10px; flex-wrap: wrap; }
+    .badge { font-size: 0.75rem; padding: 3px 10px; border-radius: 20px; font-weight: 500; }
+    .badge-match { background: #e8f5e9; color: #2e7d32; }
+    .badge-type { background: #e3f2fd; color: #1565c0; cursor: pointer; }
+    .badge-type:hover { background: #bbdefb; }
+    .badge-source { background: #fff3e0; color: #e65100; }
+    .badge-topic { background: #f3e5f5; color: #6a1b9a; cursor: pointer; }
+    .badge-topic:hover { background: #e1bee7; }
+    .result-date { font-size: 0.75rem; color: #888; margin-left: auto; }
+    .result-content { font-size: 0.95rem; line-height: 1.6; color: #333; white-space: pre-wrap; }
+
+    .status { text-align: center; padding: 40px; color: #888; font-size: 0.95rem; }
+    .error { color: #c62828; }
+
+    .key-prompt { margin-top: 16px; font-size: 0.85rem; color: #888; }
+    .key-prompt a { color: #1a1a2e; cursor: pointer; text-decoration: underline; }
+
+    .filters-hint { margin-top: 12px; max-width: 640px; text-align: center; font-size: 0.8rem; color: #666; line-height: 1.8; }
+    .filters-hint code { background: #ececf2; padding: 2px 7px; border-radius: 4px; font-family: ui-monospace, SFMono-Regular, Menlo, monospace; font-size: 0.78rem; color: #1a1a2e; }
+  </style>
+</head>
+<body>
+
+<div class="hero">
+  <h1>🧠 Open Brain (Qdrant)</h1>
+  <div class="search-bar">
+    <input type="text" id="query" placeholder="What do you know about..." autofocus>
+    <button onclick="search()">Search</button>
+  </div>
+  <p class="filters-hint">
+    Filters: <code>tag:foo</code> · <code>type:reference</code> · <code>source:mcp</code> · <code>date:today</code> · <code>date:yesterday</code> · <code>date:2026-05-13</code> · <code>since:2026-05-01</code> · <code>until:2026-05-13</code>
+  </p>
+  <p class="key-prompt" id="key-status"></p>
+</div>
+
+<div id="results-header" class="results-header"></div>
+<div class="results" id="results"></div>
+
+<script>
+  const KEY_STORAGE = 'ob_qdrant_key';
+
+  function getKey() {
+    let key = localStorage.getItem('ob_qdrant_key');
+    if (!key) {
+      key = prompt('Open Brain Qdrant key (stored locally, one-time):');
+      if (key) localStorage.setItem('ob_qdrant_key', key);
+    }
+    return key;
+  }
+
+  function showKeyStatus() {
+    const key = localStorage.getItem('ob_qdrant_key');
+    const el = document.getElementById('key-status');
+    el.innerHTML = key
+      ? 'Using stored key. <a onclick="resetKey()">Reset</a>'
+      : 'No key stored. You will be prompted on first search.';
+  }
+
+  function resetKey() {
+    localStorage.removeItem('ob_qdrant_key');
+    showKeyStatus();
+  }
+
+  document.getElementById('query').addEventListener('keydown', e => {
+    if (e.key === 'Enter') search();
+  });
+
+  function browseTag(tag) {
+    document.getElementById('query').value = '';
+    doSearch({ tag, limit: 50 }, `tag: ${tag}`);
+  }
+
+  function browseType(type) {
+    document.getElementById('query').value = '';
+    doSearch({ type, limit: 50 }, `type: ${type}`);
+  }
+
+  function resolveDate(input) {
+    const lower = input.toLowerCase();
+    const fmt = d => `${d.getFullYear()}-${String(d.getMonth()+1).padStart(2,'0')}-${String(d.getDate()).padStart(2,'0')}`;
+    if (lower === 'today') return fmt(new Date());
+    if (lower === 'yesterday') { const y = new Date(); y.setDate(y.getDate()-1); return fmt(y); }
+    if (/^\d{4}-\d{2}-\d{2}$/.test(input)) return input;
+    return null;
+  }
+
+  function search() {
+    const raw = document.getElementById('query').value.trim();
+    if (!raw) return;
+    const lower = raw.toLowerCase();
+    if (lower.startsWith('tag:')) {
+      const tag = raw.slice(4).trim();
+      if (tag) doSearch({ tag, limit: 50 }, `tag: ${tag}`);
+    } else if (lower.startsWith('type:')) {
+      const type = raw.slice(5).trim();
+      if (type) doSearch({ type, limit: 50 }, `type: ${type}`);
+    } else if (lower.startsWith('source:')) {
+      const source = raw.slice(7).trim();
+      if (source) doSearch({ source, limit: 50 }, `source: ${source}`);
+    } else if (lower.startsWith('date:')) {
+      const date = resolveDate(raw.slice(5).trim());
+      if (date) doSearch({ date, limit: 50 }, `date: ${date}`);
+      else document.getElementById('results').innerHTML = '<div class="status error">date must be today, yesterday, or YYYY-MM-DD</div>';
+    } else if (lower.startsWith('since:')) {
+      const since = resolveDate(raw.slice(6).trim());
+      if (since) doSearch({ since, limit: 50 }, `since: ${since}`);
+      else document.getElementById('results').innerHTML = '<div class="status error">since must be today, yesterday, or YYYY-MM-DD</div>';
+    } else if (lower.startsWith('until:')) {
+      const until = resolveDate(raw.slice(6).trim());
+      if (until) doSearch({ until, limit: 50 }, `until: ${until}`);
+      else document.getElementById('results').innerHTML = '<div class="status error">until must be today, yesterday, or YYYY-MM-DD</div>';
+    } else {
+      doSearch({ query: raw, limit: 10 }, `"${raw}"`);
+    }
+  }
+
+  async function doSearch(body, label) {
+    const key = getKey();
+    if (!key) return;
+
+    const resultsEl = document.getElementById('results');
+    const headerEl = document.getElementById('results-header');
+    resultsEl.innerHTML = '<div class="status">Searching...</div>';
+    headerEl.innerHTML = '';
+
+    try {
+      const resp = await fetch('http://localhost:3100/search-external', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', 'x-brain-key': key },
+        body: JSON.stringify(body)
+      });
+      const data = await resp.json();
+
+      if (data.error) {
+        resultsEl.innerHTML = `<div class="status error">Error: ${data.error}</div>`;
+        return;
+      }
+
+      if (!data.results.length) {
+        resultsEl.innerHTML = '<div class="status">No results found.</div>';
+        return;
+      }
+
+      const mode = data.mode === 'browse' ? 'most recent' : 'best match';
+      headerEl.innerHTML = `<strong>${data.results.length}</strong> result${data.results.length !== 1 ? 's' : ''} for ${escapeHtml(label)} &mdash; sorted by ${mode}`;
+
+      resultsEl.innerHTML = data.results.map(r => {
+        const matchBadge = r.similarity !== null
+          ? `<span class="badge badge-match">${r.similarity}%</span>` : '';
+        const typeBadge = `<span class="badge badge-type" onclick="browseType('${escapeAttr(r.type)}')" title="Browse all ${escapeHtml(r.type)}">${escapeHtml(r.type)}</span>`;
+        const sourceBadge = r.source ? `<span class="badge badge-source">${escapeHtml(r.source)}</span>` : '';
+        const topicBadges = (r.topics || []).map(t =>
+          `<span class="badge badge-topic" onclick="browseTag('${escapeAttr(t)}')" title="Browse all: ${escapeHtml(t)}">${escapeHtml(t)}</span>`
+        ).join('');
+        const date = new Date(r.created_at).toLocaleDateString();
+        return `
+          <div class="result">
+            <div class="result-meta">
+              ${matchBadge}
+              ${typeBadge}
+              ${sourceBadge}
+              ${topicBadges}
+              <span class="result-date">${date}</span>
+            </div>
+            <div class="result-content">${escapeHtml(r.content)}</div>
+          </div>`;
+      }).join('');
+
+    } catch (e) {
+      resultsEl.innerHTML = `<div class="status error">Failed: ${e.message}</div>`;
+    }
+  }
+
+  function escapeHtml(s) {
+    return String(s).replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;');
+  }
+
+  function escapeAttr(s) {
+    return String(s).replace(/'/g, "\\'");
+  }
+
+  showKeyStatus();
+</script>
+</body>
+</html>

--- a/recipes/local-docker-qdrant/docker-compose.yml
+++ b/recipes/local-docker-qdrant/docker-compose.yml
@@ -1,0 +1,42 @@
+name: open-brain-qdrant
+
+services:
+  qdrant:
+    image: qdrant/qdrant:v1.16.3
+    ports:
+      - "6333:6333"
+      - "6334:6334"
+    volumes:
+      - qdrant-storage:/qdrant/storage
+    healthcheck:
+      test: ["CMD-SHELL", "bash -c '</dev/tcp/localhost/6333' || exit 1"]
+      interval: 5s
+      timeout: 5s
+      retries: 10
+
+  mcp-server:
+    build: ./server
+    ports:
+      - "3100:3100"
+    environment:
+      QDRANT_URL: http://qdrant:6333
+      MCP_ACCESS_KEY: ${MCP_ACCESS_KEY}
+      PORT: 3100
+      IDENTITY_MODE: local
+      LOCAL_OWNER_ID: local-user
+      AWS_REGION: ${AWS_REGION:-us-east-1}
+      AWS_PROFILE: ${AWS_PROFILE:-default}
+      AWS_SHARED_CREDENTIALS_FILE: /root/.aws/credentials
+      EMBEDDING_MODEL: ${EMBEDDING_MODEL:-amazon.titan-embed-text-v2:0}
+      METADATA_MODEL: ${METADATA_MODEL:-us.anthropic.claude-haiku-4-5-20251001-v1:0}
+    volumes:
+      - type: bind
+        source: ${AWS_HOME}
+        target: /root/.aws
+        read_only: true
+    depends_on:
+      qdrant:
+        condition: service_healthy
+
+volumes:
+  qdrant-storage:

--- a/recipes/local-docker-qdrant/metadata.json
+++ b/recipes/local-docker-qdrant/metadata.json
@@ -1,0 +1,21 @@
+{
+  "name": "Local Docker Open Brain (Qdrant)",
+  "description": "A self-contained Docker deployment of Open Brain using local Qdrant for vector storage and AWS Bedrock for embeddings and metadata extraction. Multi-tenancy-primed with ACL enforcement — runs side-by-side with the pgvector recipe.",
+  "category": "recipes",
+  "author": {
+    "name": "Tom Otvos",
+    "github": "tomotvos"
+  },
+  "version": "1.0.0",
+  "requires": {
+    "open_brain": true,
+    "services": ["AWS Bedrock"],
+    "tools": ["Docker", "Docker Compose", "AWS CLI"]
+  },
+  "requires_skills": [],
+  "tags": ["qdrant", "vector-store", "mcp", "multi-tenant-primed", "docker", "local", "privacy", "aws-bedrock", "self-hosted"],
+  "difficulty": "intermediate",
+  "estimated_time": "30 minutes",
+  "created": "2026-05-20",
+  "updated": "2026-05-20"
+}

--- a/recipes/local-docker-qdrant/scripts/migrate-pgvector-to-qdrant.mjs
+++ b/recipes/local-docker-qdrant/scripts/migrate-pgvector-to-qdrant.mjs
@@ -1,0 +1,259 @@
+#!/usr/bin/env node
+// migrate-pgvector-to-qdrant.mjs
+// Migrates thoughts from local pgvector (Open Brain local-docker recipe) to Qdrant (this recipe).
+//
+// Prerequisites: Node 18+, access to both stacks.
+// Install postgres package first: npm install postgres
+//
+// Usage:
+//   node migrate-pgvector-to-qdrant.mjs \
+//     --pg-url postgres://openbrain:password@localhost:5432/openbrain \
+//     --qdrant-url http://localhost:6333 \
+//     --dry-run
+//
+// Use --dry-run first to verify counts without writing anything.
+// The script is idempotent: re-running it upserts existing points by UUID.
+
+// Run: npm install postgres  (one-time, in the scripts/ directory or anywhere on the path)
+
+import postgres from "postgres";
+
+// ---------------------------------------------------------------------------
+// Arg parsing
+// ---------------------------------------------------------------------------
+
+function parseArgs(argv) {
+  const args = argv.slice(2);
+  const result = {
+    pgUrl: null,
+    qdrantUrl: "http://localhost:6333",
+    ownerId: "local-user",
+    visibility: "private",
+    dryRun: false,
+    batchSize: 100,
+  };
+
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i];
+    const next = args[i + 1];
+
+    switch (arg) {
+      case "--pg-url":
+        result.pgUrl = next;
+        i++;
+        break;
+      case "--qdrant-url":
+        result.qdrantUrl = next;
+        i++;
+        break;
+      case "--owner-id":
+        result.ownerId = next;
+        i++;
+        break;
+      case "--visibility":
+        result.visibility = next;
+        i++;
+        break;
+      case "--dry-run":
+        result.dryRun = true;
+        break;
+      case "--batch-size":
+        result.batchSize = parseInt(next, 10);
+        i++;
+        break;
+      default:
+        if (arg.startsWith("--")) {
+          console.warn(`Warning: unknown argument "${arg}"`);
+        }
+    }
+  }
+
+  return result;
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+
+async function main() {
+  const config = parseArgs(process.argv);
+
+  if (!config.pgUrl) {
+    console.error("Error: --pg-url is required.");
+    console.error(
+      "Example: node migrate-pgvector-to-qdrant.mjs --pg-url postgres://openbrain:password@localhost:5432/openbrain"
+    );
+    process.exit(1);
+  }
+
+  if (isNaN(config.batchSize) || config.batchSize < 1) {
+    console.error("Error: --batch-size must be a positive integer.");
+    process.exit(1);
+  }
+
+  // Print configuration summary
+  console.log("=== pgvector → Qdrant Migration ===");
+  console.log(`  pg-url:     ${config.pgUrl.replace(/:\/\/[^@]+@/, "://<redacted>@")}`);
+  console.log(`  qdrant-url: ${config.qdrantUrl}`);
+  console.log(`  owner-id:   ${config.ownerId}`);
+  console.log(`  visibility: ${config.visibility}`);
+  console.log(`  batch-size: ${config.batchSize}`);
+  console.log(`  dry-run:    ${config.dryRun}`);
+  console.log("");
+
+  // ---------------------------------------------------------------------------
+  // Connect to pgvector
+  // ---------------------------------------------------------------------------
+  const sql = postgres(config.pgUrl, { max: 1 });
+
+  let totalCount;
+  try {
+    const [row] = await sql`SELECT COUNT(*) AS count FROM thoughts WHERE embedding IS NOT NULL`;
+    totalCount = parseInt(row.count, 10);
+  } catch (err) {
+    console.error("Failed to connect to pgvector or query thoughts table:", err.message);
+    await sql.end();
+    process.exit(1);
+  }
+
+  console.log(`Found ${totalCount} thoughts with embeddings to migrate.`);
+
+  if (totalCount === 0) {
+    console.log("Nothing to migrate. Exiting.");
+    await sql.end();
+    process.exit(0);
+  }
+
+  const totalBatches = Math.ceil(totalCount / config.batchSize);
+
+  let written = 0;
+  let errors = 0;
+  let offset = 0;
+  let batchIndex = 0;
+
+  // ---------------------------------------------------------------------------
+  // Batch scroll + upsert
+  // ---------------------------------------------------------------------------
+  while (offset < totalCount) {
+    batchIndex++;
+
+    const rows = await sql`
+      SELECT id, content, metadata, embedding::text AS embedding, created_at
+      FROM thoughts
+      WHERE embedding IS NOT NULL
+      ORDER BY created_at ASC
+      LIMIT ${config.batchSize} OFFSET ${offset}
+    `;
+
+    if (rows.length === 0) {
+      break;
+    }
+
+    if (config.dryRun) {
+      // Print first 3, then count the rest
+      const preview = rows.slice(0, 3);
+      for (const row of preview) {
+        const snippet = row.content.substring(0, 60).replace(/\n/g, " ");
+        console.log(`  Would migrate: ${row.id} — ${snippet}`);
+      }
+      if (rows.length > 3) {
+        console.log(`  ... and ${rows.length - 3} more in this batch.`);
+      }
+      written += rows.length;
+    } else {
+      // Build Qdrant points
+      const batchPoints = rows.map((row) => {
+        const meta = row.metadata ?? {};
+
+        // Parse embedding from pgvector text representation "[0.1,0.2,...]"
+        let vector;
+        try {
+          vector = JSON.parse(row.embedding);
+        } catch (parseErr) {
+          throw new Error(`Failed to parse embedding for row ${row.id}: ${parseErr.message}`);
+        }
+
+        const payload = {
+          content: row.content,
+          type: meta.type ?? "observation",
+          topics: meta.topics ?? [],
+          people: meta.people ?? [],
+          actions: meta.action_items ?? [],
+          source: meta.source ?? "migration",
+          owner_id: config.ownerId,
+          owner_email: "local@localhost",
+          visibility: config.visibility,
+          shared_with: [],
+          created_at: row.created_at instanceof Date
+            ? row.created_at.toISOString()
+            : String(row.created_at),
+        };
+
+        // Optional fields — only include if present in metadata
+        if (meta.title !== undefined) payload.title = meta.title;
+        if (meta.url !== undefined) payload.url = meta.url;
+
+        return { id: row.id, vector, payload };
+      });
+
+      // Upsert to Qdrant
+      try {
+        const resp = await fetch(
+          `${config.qdrantUrl}/collections/thoughts/points?wait=true`,
+          {
+            method: "PUT",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ points: batchPoints }),
+          }
+        );
+
+        if (!resp.ok) {
+          const body = await resp.text();
+          throw new Error(`HTTP ${resp.status}: ${body}`);
+        }
+
+        written += batchPoints.length;
+      } catch (err) {
+        console.error(
+          `  ERROR on batch ${batchIndex}/${totalBatches}: ${err.message}`
+        );
+        errors += rows.length;
+      }
+    }
+
+    console.log(
+      `Batch ${batchIndex}/${totalBatches}: migrated ${written} / ${totalCount} (errors: ${errors})`
+    );
+
+    offset += rows.length;
+  }
+
+  // ---------------------------------------------------------------------------
+  // Cleanup
+  // ---------------------------------------------------------------------------
+  await sql.end();
+
+  const skipped = totalCount - written - errors;
+
+  if (config.dryRun) {
+    console.log("");
+    console.log(
+      `Dry-run complete: ${written} thoughts would be written (${errors} errors, ${skipped} skipped).`
+    );
+    console.log("Re-run without --dry-run to perform the actual migration.");
+  } else {
+    console.log("");
+    console.log(
+      `Migration complete: ${written} written, ${errors} errors, ${skipped} skipped (no embedding).`
+    );
+  }
+
+  if (errors > 0) {
+    process.exit(1);
+  }
+}
+
+main().catch((err) => {
+  console.error("Unexpected error:", err);
+  process.exit(1);
+});

--- a/recipes/local-docker-qdrant/scripts/smoke-test.sh
+++ b/recipes/local-docker-qdrant/scripts/smoke-test.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+# smoke-test.sh — Integration smoke test for the local-docker-qdrant recipe.
+# Usage: bash scripts/smoke-test.sh
+# Assumes the stack is running: docker compose up --build -d
+# Requires: curl, jq, OPEN_BRAIN_KEY environment variable
+set -euo pipefail
+
+# --- Guard: require jq ---
+if ! command -v jq &>/dev/null; then
+  echo "ERROR: jq is required but not found on PATH."
+  echo "  Windows: winget install jqlang.jq"
+  echo "  Or download jq.exe from https://jqlang.org/download/ and place it in a directory on your PATH."
+  exit 1
+fi
+
+# --- Guard: require OPEN_BRAIN_KEY ---
+if [[ -z "${OPEN_BRAIN_KEY:-}" ]]; then
+  echo "ERROR: OPEN_BRAIN_KEY environment variable is not set."
+  echo "  Export it before running: export OPEN_BRAIN_KEY=<your-key>"
+  exit 1
+fi
+
+echo "Starting smoke tests for local-docker-qdrant..."
+echo "  MCP server : http://localhost:3100"
+echo "  Qdrant     : http://localhost:6333"
+echo ""
+
+# --- Step 1: Qdrant collection check ---
+echo "Step 1: Qdrant collection check..."
+COLLECTION=$(curl -s http://localhost:6333/collections/thoughts)
+VECTOR_SIZE=$(echo "$COLLECTION" | jq -r '.result.config.params.vectors.size')
+DISTANCE=$(echo "$COLLECTION" | jq -r '.result.config.params.vectors.distance')
+if [[ "$VECTOR_SIZE" == "1024" && "$DISTANCE" == "Cosine" ]]; then
+  echo "  PASS: collection exists, vector size=1024, distance=Cosine"
+else
+  echo "  FAIL: unexpected collection config: size=$VECTOR_SIZE distance=$DISTANCE"
+  exit 1
+fi
+
+# --- Step 2: Capture a test thought (private by default) ---
+echo "Step 2: Capture test thought..."
+CAPTURE_RESP=$(curl -s -X POST http://localhost:3100/capture-external \
+  -H "Content-Type: application/json" \
+  -H "x-brain-key: $OPEN_BRAIN_KEY" \
+  -d '{"content":"Smoke test thought: Open Brain Qdrant stack is working correctly","source":"smoke-test"}')
+CAPTURED_ID=$(echo "$CAPTURE_RESP" | jq -r '.id')
+if [[ -z "$CAPTURED_ID" || "$CAPTURED_ID" == "null" ]]; then
+  echo "  FAIL: capture returned no id. Response: $CAPTURE_RESP"
+  exit 1
+fi
+echo "  PASS: captured id=$CAPTURED_ID"
+
+# --- Step 3: Search and verify the captured thought appears ---
+echo "Step 3: Search for captured thought..."
+sleep 1  # Allow Qdrant to index the point
+SEARCH_RESP=$(curl -s -X POST http://localhost:3100/search-external \
+  -H "Content-Type: application/json" \
+  -H "x-brain-key: $OPEN_BRAIN_KEY" \
+  -d '{"query":"Open Brain Qdrant stack smoke test","limit":5,"threshold":0.1}')
+FOUND=$(echo "$SEARCH_RESP" | jq -r --arg id "$CAPTURED_ID" '.results[]? | select(.id == $id) | .id')
+if [[ "$FOUND" == "$CAPTURED_ID" ]]; then
+  echo "  PASS: captured thought found in search results"
+else
+  echo "  FAIL: captured thought not found in results. Response: $SEARCH_RESP"
+  exit 1
+fi
+
+# --- Step 4: Capture a shared thought ---
+echo "Step 4: Capture shared thought..."
+SHARED_RESP=$(curl -s -X POST http://localhost:3100/capture-external \
+  -H "Content-Type: application/json" \
+  -H "x-brain-key: $OPEN_BRAIN_KEY" \
+  -d '{"content":"Smoke test shared thought: visible to all users","source":"smoke-test","visibility":"shared"}')
+SHARED_ID=$(echo "$SHARED_RESP" | jq -r '.id')
+if [[ -z "$SHARED_ID" || "$SHARED_ID" == "null" ]]; then
+  echo "  FAIL: shared capture returned no id. Response: $SHARED_RESP"
+  exit 1
+fi
+echo "  PASS: shared thought captured id=$SHARED_ID"
+
+# --- Step 5: Browse mode — verify results returned ---
+echo "Step 5: Browse mode (tag filter)..."
+BROWSE_RESP=$(curl -s -X POST http://localhost:3100/search-external \
+  -H "Content-Type: application/json" \
+  -H "x-brain-key: $OPEN_BRAIN_KEY" \
+  -d '{"source":"smoke-test","limit":10}')
+BROWSE_COUNT=$(echo "$BROWSE_RESP" | jq '.results | length')
+BROWSE_MODE=$(echo "$BROWSE_RESP" | jq -r '.mode')
+if [[ "$BROWSE_MODE" == "browse" && "$BROWSE_COUNT" -ge 1 ]]; then
+  echo "  PASS: browse mode returned $BROWSE_COUNT result(s)"
+else
+  echo "  FAIL: browse mode failed. mode=$BROWSE_MODE count=$BROWSE_COUNT"
+  exit 1
+fi
+
+echo ""
+echo "All smoke tests PASSED."
+echo "Stack is healthy at http://localhost:3100"
+echo "Qdrant collection: http://localhost:6333/collections/thoughts"

--- a/recipes/local-docker-qdrant/server/Dockerfile
+++ b/recipes/local-docker-qdrant/server/Dockerfile
@@ -1,0 +1,7 @@
+FROM node:22-alpine
+WORKDIR /app
+COPY package.json .
+RUN npm install
+COPY src/ ./src/
+EXPOSE 3100
+CMD ["node", "--import", "tsx/esm", "src/index.ts"]

--- a/recipes/local-docker-qdrant/server/package.json
+++ b/recipes/local-docker-qdrant/server/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "open-brain-qdrant-mcp-server",
+  "version": "1.0.0",
+  "type": "module",
+  "dependencies": {
+    "@aws-sdk/client-bedrock-runtime": "3.839.0",
+    "@hono/mcp": "0.1.1",
+    "@hono/node-server": "1.13.7",
+    "@modelcontextprotocol/sdk": "1.24.3",
+    "hono": "4.9.2",
+    "tsx": "4.19.4",
+    "uuid": "9.0.1",
+    "zod": "4.1.13"
+  },
+  "devDependencies": {
+    "typescript": "5.8.3"
+  }
+}

--- a/recipes/local-docker-qdrant/server/src/acl.ts
+++ b/recipes/local-docker-qdrant/server/src/acl.ts
@@ -1,0 +1,27 @@
+import type { QdrantFilter } from "./qdrant.js";
+import type { Identity } from "./identity.js";
+
+// ACL filter composition is the single enforcement point.
+// If you add a new read handler, you MUST call buildAclFilter().
+export function buildAclFilter(
+  identity: Identity,
+  userFilter?: QdrantFilter
+): QdrantFilter {
+  return {
+    must: [
+      ...(userFilter?.must ?? []),
+      {
+        should: [
+          { key: "owner_id", match: { value: identity.owner_id } },
+          { key: "visibility", match: { value: "shared" } },
+        ],
+      },
+    ],
+  };
+}
+
+export function buildOwnerOnlyFilter(identity: Identity): QdrantFilter {
+  return {
+    must: [{ key: "owner_id", match: { value: identity.owner_id } }],
+  };
+}

--- a/recipes/local-docker-qdrant/server/src/bedrock.ts
+++ b/recipes/local-docker-qdrant/server/src/bedrock.ts
@@ -1,0 +1,86 @@
+import { BedrockRuntimeClient, InvokeModelCommand } from "@aws-sdk/client-bedrock-runtime";
+import { readFileSync } from "fs";
+import {
+  AWS_REGION,
+  AWS_PROFILE,
+  AWS_CREDENTIALS_FILE,
+  EMBEDDING_MODEL,
+  METADATA_MODEL,
+} from "./config.js";
+
+export function readCredentials() {
+  const text = readFileSync(AWS_CREDENTIALS_FILE, "utf8").replace(/\r/g, "");
+  const sections: Record<string, Record<string, string>> = {};
+  let current = "";
+  for (const line of text.split("\n")) {
+    const section = line.match(/^\[(.+)\]/);
+    if (section) { current = section[1]; sections[current] = {}; continue; }
+    const kv = line.match(/^([^=]+)=(.*)$/);
+    if (kv && current) sections[current][kv[1].trim()] = kv[2].trim();
+  }
+  const profile = sections[AWS_PROFILE] || sections["default"];
+  if (!profile?.aws_access_key_id) throw new Error(`No credentials found for profile: ${AWS_PROFILE}`);
+  return {
+    accessKeyId: profile.aws_access_key_id,
+    secretAccessKey: profile.aws_secret_access_key,
+    ...(profile.aws_session_token ? { sessionToken: profile.aws_session_token } : {}),
+  };
+}
+
+// Called per-request so rotating session tokens are always picked up from the live credentials file.
+export function makeBedrock() {
+  return new BedrockRuntimeClient({
+    region: AWS_REGION,
+    credentials: readCredentials(),
+  });
+}
+
+export async function getEmbedding(text: string): Promise<number[]> {
+  const cmd = new InvokeModelCommand({
+    modelId: EMBEDDING_MODEL,
+    contentType: "application/json",
+    accept: "application/json",
+    body: JSON.stringify({ inputText: text, dimensions: 1024, normalize: true }),
+  });
+  const resp = await makeBedrock().send(cmd);
+  const body = JSON.parse(new TextDecoder().decode(resp.body));
+  return body.embedding;
+}
+
+export async function extractMetadata(text: string): Promise<{
+  type: string;
+  topics: string[];
+  people: string[];
+  action_items: string[];
+  dates_mentioned?: string[];
+}> {
+  const cmd = new InvokeModelCommand({
+    modelId: METADATA_MODEL,
+    contentType: "application/json",
+    accept: "application/json",
+    body: JSON.stringify({
+      anthropic_version: "bedrock-2023-05-31",
+      max_tokens: 512,
+      messages: [{
+        role: "user",
+        content: `Extract metadata from the following thought and return a JSON object with these fields:
+- "people": array of people mentioned (empty if none)
+- "action_items": array of implied to-dos (empty if none)
+- "dates_mentioned": array of dates YYYY-MM-DD (empty if none)
+- "topics": array of 1-3 short topic tags (always at least one)
+- "type": one of "observation", "task", "idea", "reference", "person_note"
+Only extract what's explicitly there. Return only the JSON object, nothing else.
+
+Thought: ${text}`,
+      }],
+    }),
+  });
+  const resp = await makeBedrock().send(cmd);
+  const body = JSON.parse(new TextDecoder().decode(resp.body));
+  try {
+    const match = body.content[0].text.match(/\{[\s\S]*\}/);
+    return match ? JSON.parse(match[0]) : { topics: ["uncategorized"], type: "observation", people: [], action_items: [] };
+  } catch {
+    return { topics: ["uncategorized"], type: "observation", people: [], action_items: [] };
+  }
+}

--- a/recipes/local-docker-qdrant/server/src/config.ts
+++ b/recipes/local-docker-qdrant/server/src/config.ts
@@ -1,0 +1,29 @@
+function require(name: string): string {
+  const value = process.env[name];
+  if (!value) throw new Error(`Missing required environment variable: ${name}`);
+  return value;
+}
+
+function optional(name: string, defaultValue: string): string {
+  return process.env[name] || defaultValue;
+}
+
+export const MCP_ACCESS_KEY: string = require("MCP_ACCESS_KEY");
+export const QDRANT_URL: string = require("QDRANT_URL");
+
+export const PORT: number = parseInt(optional("PORT", "3100"));
+export const AWS_REGION: string = optional("AWS_REGION", "us-east-1");
+export const AWS_PROFILE: string = optional("AWS_PROFILE", "default");
+export const AWS_CREDENTIALS_FILE: string =
+  process.env.AWS_SHARED_CREDENTIALS_FILE ||
+  `${process.env.HOME || "/root"}/.aws/credentials`;
+export const EMBEDDING_MODEL: string = optional(
+  "EMBEDDING_MODEL",
+  "amazon.titan-embed-text-v2:0"
+);
+export const METADATA_MODEL: string = optional(
+  "METADATA_MODEL",
+  "us.anthropic.claude-haiku-4-5-20251001-v1:0"
+);
+export const IDENTITY_MODE: string = optional("IDENTITY_MODE", "local");
+export const LOCAL_OWNER_ID: string = optional("LOCAL_OWNER_ID", "local-user");

--- a/recipes/local-docker-qdrant/server/src/handlers/capture.ts
+++ b/recipes/local-docker-qdrant/server/src/handlers/capture.ts
@@ -1,0 +1,95 @@
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+import { getEmbedding, extractMetadata } from "../bedrock.js";
+import * as qdrant from "../qdrant.js";
+import type { Identity } from "../identity.js";
+
+export async function captureThought(
+  content: string,
+  identity: Identity,
+  options: {
+    source?: string;
+    title?: string;
+    url?: string;
+    visibility?: "private" | "shared";
+  } = {}
+): Promise<{ id: string; type: string; topics: string[] }> {
+  const [embedding, meta] = await Promise.all([
+    getEmbedding(content),
+    extractMetadata(content),
+  ]);
+
+  const id = crypto.randomUUID();
+
+  await qdrant.upsertPoint({
+    id,
+    vector: embedding,
+    payload: {
+      content,
+      type: meta.type,
+      topics: meta.topics,
+      people: meta.people,
+      actions: meta.action_items,
+      source: options.source ?? "mcp",
+      ...(options.title ? { title: options.title } : {}),
+      ...(options.url ? { url: options.url } : {}),
+      owner_id: identity.owner_id,
+      owner_email: identity.owner_email,
+      visibility: options.visibility ?? "private",
+      shared_with: [],
+      created_at: new Date().toISOString(),
+    },
+  });
+
+  return { id, type: meta.type, topics: meta.topics };
+}
+
+export function registerCaptureHandler(server: McpServer, identity: Identity): void {
+  server.registerTool(
+    "capture_thought",
+    {
+      title: "Capture Thought",
+      description:
+        "Save a new thought to the Open Brain. Generates an embedding and extracts metadata automatically.",
+      annotations: {
+        readOnlyHint: false,
+        openWorldHint: false,
+        destructiveHint: false,
+      },
+      inputSchema: {
+        content: z
+          .string()
+          .describe(
+            "The thought to capture — a clear, standalone statement that will make sense when retrieved later"
+          ),
+        visibility: z
+          .enum(["private", "shared"])
+          .default("private")
+          .describe("Who can see this thought"),
+      },
+    },
+    async ({ content, visibility }) => {
+      try {
+        const result = await captureThought(content, identity, { visibility });
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: `Captured as ${result.type} — ${result.topics.join(", ")}`,
+            },
+          ],
+        };
+      } catch (err) {
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: `Error: ${(err as Error).message}`,
+            },
+          ],
+          isError: true,
+        };
+      }
+    }
+  );
+}

--- a/recipes/local-docker-qdrant/server/src/handlers/enrich.ts
+++ b/recipes/local-docker-qdrant/server/src/handlers/enrich.ts
@@ -1,0 +1,124 @@
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+import { extractMetadata } from "../bedrock.js";
+import { scrollPoints, setPayload } from "../qdrant.js";
+import { buildOwnerOnlyFilter } from "../acl.js";
+import type { Identity } from "../identity.js";
+
+export function registerEnrichHandler(server: McpServer, identity: Identity): void {
+  server.registerTool(
+    "enrich_thoughts",
+    {
+      title: "Enrich Untagged Thoughts",
+      description: "Run metadata extraction on thoughts that have missing or minimal metadata.",
+      annotations: { readOnlyHint: false, openWorldHint: false, destructiveHint: false },
+      inputSchema: {
+        limit: z.number().optional().default(20).describe("Max thoughts to process in one run"),
+        ids: z.array(z.string().uuid()).optional().describe(
+          "Specific thought IDs to enrich (if omitted, finds minimally-tagged thoughts)"
+        ),
+      },
+    },
+    async ({ limit, ids }) => {
+      try {
+        let processed = 0;
+        let skipped = 0;
+
+        const ownerFilter = buildOwnerOnlyFilter(identity);
+
+        if (ids && ids.length > 0) {
+          // Fetch all owned thoughts up to a generous limit so we can match against the supplied ids
+          const fetchLimit = Math.max(ids.length * 2, 200);
+          const points = await scrollPoints({ filter: ownerFilter, limit: fetchLimit });
+
+          // Build lookup map from the scrolled results
+          const pointMap = new Map(points.map((p) => [p.id, p]));
+
+          for (const id of ids) {
+            const point = pointMap.get(id);
+
+            if (!point) {
+              console.warn(`enrich: id ${id} not found or not owned by ${identity.owner_id} — skipping`);
+              skipped++;
+              continue;
+            }
+
+            // Double-check owner_id on the payload
+            if (point.payload.owner_id !== identity.owner_id) {
+              console.warn(
+                `enrich: id ${id} has owner_id ${String(point.payload.owner_id)}, expected ${identity.owner_id} — skipping`
+              );
+              skipped++;
+              continue;
+            }
+
+            const content = point.payload.content as string | undefined;
+            if (!content) {
+              console.warn(`enrich: id ${id} has no content — skipping`);
+              skipped++;
+              continue;
+            }
+
+            const meta = await extractMetadata(content);
+            await setPayload(point.id, {
+              type: meta.type,
+              topics: meta.topics,
+              people: meta.people,
+              actions: meta.action_items,
+            });
+            processed++;
+          }
+        } else {
+          // Find minimally-tagged thoughts owned by this user
+          const points = await scrollPoints({ filter: ownerFilter, limit });
+
+          const candidates = points.filter((p) => {
+            const topics = p.payload.topics;
+            const type = p.payload.type;
+            const hasTopics =
+              Array.isArray(topics) && (topics as unknown[]).length > 0;
+            const hasType = typeof type === "string" && type.length > 0;
+            return !hasTopics || !hasType;
+          });
+
+          for (const point of candidates) {
+            // Verify owner_id before any write
+            if (point.payload.owner_id !== identity.owner_id) {
+              console.warn(
+                `enrich: point ${point.id} has unexpected owner_id ${String(point.payload.owner_id)} — skipping`
+              );
+              skipped++;
+              continue;
+            }
+
+            const content = point.payload.content as string | undefined;
+            if (!content) {
+              console.warn(`enrich: point ${point.id} has no content — skipping`);
+              skipped++;
+              continue;
+            }
+
+            const meta = await extractMetadata(content);
+            await setPayload(point.id, {
+              type: meta.type,
+              topics: meta.topics,
+              people: meta.people,
+              actions: meta.action_items,
+            });
+            processed++;
+          }
+        }
+
+        const skippedNote = skipped > 0 ? `, skipped ${skipped}` : "";
+        return {
+          content: [{ type: "text", text: `Enriched ${processed} thought(s)${skippedNote}.` }],
+        };
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        return {
+          content: [{ type: "text", text: `Error during enrichment: ${message}` }],
+        };
+      }
+    }
+  );
+}

--- a/recipes/local-docker-qdrant/server/src/handlers/list.ts
+++ b/recipes/local-docker-qdrant/server/src/handlers/list.ts
@@ -1,0 +1,88 @@
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+import { scrollPoints } from "../qdrant.js";
+import type { QdrantFilter } from "../qdrant.js";
+import { buildAclFilter } from "../acl.js";
+import type { Identity } from "../identity.js";
+
+export function registerListHandler(server: McpServer, identity: Identity): void {
+  server.registerTool(
+    "list_thoughts",
+    {
+      title: "List Recent Thoughts",
+      description:
+        "List recently captured thoughts with optional filters by type, topic, person, or time range.",
+      annotations: { readOnlyHint: true },
+      inputSchema: {
+        limit: z.number().optional().default(10),
+        type: z
+          .string()
+          .optional()
+          .describe("Filter by type: observation, task, idea, reference, person_note"),
+        topic: z.string().optional().describe("Filter by topic tag"),
+        person: z.string().optional().describe("Filter by person mentioned"),
+        days: z.number().optional().describe("Only thoughts from the last N days"),
+      },
+    },
+    async ({ limit, type, topic, person, days }) => {
+      try {
+        const conditions: unknown[] = [];
+
+        if (type) {
+          conditions.push({ key: "type", match: { value: type } });
+        }
+        if (topic) {
+          // topics is a keyword-indexed array; match targets individual elements
+          conditions.push({ key: "topics", match: { value: topic } });
+        }
+        if (person) {
+          conditions.push({ key: "people", match: { value: person } });
+        }
+        if (days) {
+          const since = new Date(Date.now() - days * 86400000).toISOString();
+          conditions.push({ key: "created_at", range: { gte: since } });
+        }
+
+        const userFilter: QdrantFilter | undefined = conditions.length
+          ? { must: conditions }
+          : undefined;
+
+        // ACL is the single enforcement point — always called, never skipped
+        const filter = buildAclFilter(identity, userFilter);
+
+        const points = await scrollPoints({
+          filter,
+          limit: limit ?? 10,
+          order_by: { key: "created_at", direction: "desc" },
+        });
+
+        if (points.length === 0) {
+          return { content: [{ type: "text", text: "No thoughts found." }] };
+        }
+
+        const lines = points.map((point, i) => {
+          const p = point.payload;
+          const date =
+            typeof p.created_at === "string"
+              ? p.created_at.slice(0, 10)
+              : String(p.created_at ?? "");
+          const pointType = typeof p.type === "string" ? p.type : "";
+          const topics = Array.isArray(p.topics)
+            ? (p.topics as string[]).filter((t) => typeof t === "string")
+            : [];
+          const content = typeof p.content === "string" ? p.content : String(p.content ?? "");
+          const topicSuffix = topics.length ? " - " + topics.join(", ") : "";
+          return `${i + 1}. [${date}] (${pointType}${topicSuffix})\n   ${content}`;
+        });
+
+        return { content: [{ type: "text", text: lines.join("\n\n") }] };
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        return {
+          content: [{ type: "text", text: `Error listing thoughts: ${message}` }],
+          isError: true,
+        };
+      }
+    }
+  );
+}

--- a/recipes/local-docker-qdrant/server/src/handlers/search.ts
+++ b/recipes/local-docker-qdrant/server/src/handlers/search.ts
@@ -1,0 +1,126 @@
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+import { getEmbedding } from "../bedrock.js";
+import { searchPoints } from "../qdrant.js";
+import type { QdrantFilter } from "../qdrant.js";
+import { buildAclFilter } from "../acl.js";
+import type { Identity } from "../identity.js";
+
+export function registerSearchHandler(server: McpServer, identity: Identity): void {
+  server.registerTool(
+    "search_thoughts",
+    {
+      title: "Search Thoughts",
+      description:
+        "Search captured thoughts by meaning. Use this when the user asks about a topic, person, or idea they've previously captured.",
+      annotations: { readOnlyHint: true },
+      inputSchema: {
+        query: z.string().describe("What to search for"),
+        limit: z.number().optional().default(10),
+        threshold: z.number().optional().default(0.25),
+        scope: z
+          .enum(["private", "shared", "all"])
+          .optional()
+          .default("all")
+          .describe(
+            "Filter by visibility: 'private' (mine only), 'shared' (shared thoughts only), 'all' (both)"
+          ),
+      },
+    },
+    async ({ query, limit, threshold, scope }) => {
+      try {
+        const vector = await getEmbedding(query);
+
+        let filter: QdrantFilter;
+
+        if (scope === "private") {
+          filter = buildAclFilter(identity, {
+            must: [
+              { key: "visibility", match: { value: "private" } },
+              { key: "owner_id", match: { value: identity.owner_id } },
+            ],
+          });
+        } else if (scope === "shared") {
+          filter = buildAclFilter(identity, {
+            must: [{ key: "visibility", match: { value: "shared" } }],
+          });
+        } else {
+          // scope === "all"
+          filter = buildAclFilter(identity);
+        }
+
+        const hits = await searchPoints({
+          vector,
+          filter,
+          limit: limit ?? 10,
+          score_threshold: threshold ?? 0.25,
+        });
+
+        if (hits.length === 0) {
+          return {
+            content: [
+              {
+                type: "text",
+                text: `No thoughts found matching "${query}".`,
+              },
+            ],
+          };
+        }
+
+        const formatted = hits.map((hit, index) => {
+          const p = hit.payload;
+          const date = p["captured_at"]
+            ? new Date(p["captured_at"] as string).toLocaleDateString()
+            : "Unknown";
+          const type = (p["type"] as string) ?? "unknown";
+          const topics = Array.isArray(p["topics"])
+            ? (p["topics"] as string[]).join(", ")
+            : (p["topics"] as string) ?? "";
+          const people = Array.isArray(p["people"])
+            ? (p["people"] as string[]).join(", ")
+            : typeof p["people"] === "string"
+            ? p["people"]
+            : null;
+          const actions = Array.isArray(p["actions"])
+            ? (p["actions"] as string[]).join(", ")
+            : typeof p["actions"] === "string"
+            ? p["actions"]
+            : null;
+          const content = (p["content"] as string) ?? "";
+          const scorePercent = (hit.score * 100).toFixed(1);
+
+          const lines = [
+            `--- Result ${index + 1} (${scorePercent}% match) ---`,
+            `Captured: ${date}`,
+            `Type: ${type}`,
+            `Topics: ${topics}`,
+          ];
+          if (people) lines.push(`People: ${people}`);
+          if (actions) lines.push(`Actions: ${actions}`);
+          lines.push("", content);
+
+          return lines.join("\n");
+        });
+
+        return {
+          content: [
+            {
+              type: "text",
+              text: `Found ${hits.length} thought(s):\n\n${formatted.join("\n\n")}`,
+            },
+          ],
+        };
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        return {
+          content: [
+            {
+              type: "text",
+              text: `Search failed: ${message}`,
+            },
+          ],
+        };
+      }
+    }
+  );
+}

--- a/recipes/local-docker-qdrant/server/src/handlers/share.ts
+++ b/recipes/local-docker-qdrant/server/src/handlers/share.ts
@@ -1,0 +1,61 @@
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+import { getPoint, setPayload } from "../qdrant.js";
+import type { Identity } from "../identity.js";
+
+export function registerShareHandler(server: McpServer, identity: Identity): void {
+  server.registerTool(
+    "share_thought",
+    {
+      title: "Share Thought",
+      description:
+        "Change the visibility of a thought you own. Set to 'shared' to make it visible to all users, or 'private' to restrict it to yourself.",
+      annotations: { readOnlyHint: false, openWorldHint: false, destructiveHint: false },
+      inputSchema: {
+        thought_id: z.string().uuid().describe("UUID of the thought to update"),
+        visibility: z.enum(["private", "shared"]).describe("New visibility setting"),
+      },
+    },
+    async ({ thought_id, visibility }) => {
+      try {
+        const point = await getPoint(thought_id);
+
+        if (point === null) {
+          return {
+            content: [{ type: "text", text: "Thought not found." }],
+            isError: true,
+          };
+        }
+
+        if (point.payload.owner_id !== identity.owner_id) {
+          return {
+            content: [
+              {
+                type: "text",
+                text: "Permission denied: you do not own this thought.",
+              },
+            ],
+            isError: true,
+          };
+        }
+
+        await setPayload(thought_id, { visibility });
+
+        return {
+          content: [
+            {
+              type: "text",
+              text: `Visibility updated to "${visibility}" for thought ${thought_id}.`,
+            },
+          ],
+        };
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        return {
+          content: [{ type: "text", text: `Error updating visibility: ${message}` }],
+          isError: true,
+        };
+      }
+    }
+  );
+}

--- a/recipes/local-docker-qdrant/server/src/handlers/stats.ts
+++ b/recipes/local-docker-qdrant/server/src/handlers/stats.ts
@@ -1,0 +1,135 @@
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+import { countPoints, scrollPoints } from "../qdrant.js";
+import type { QdrantFilter } from "../qdrant.js";
+import { buildAclFilter } from "../acl.js";
+import type { Identity } from "../identity.js";
+
+export function registerStatsHandler(server: McpServer, identity: Identity): void {
+  server.registerTool(
+    "thought_stats",
+    {
+      title: "Thought Statistics",
+      description:
+        "Get a summary of all captured thoughts: totals, types, top topics, and people.",
+      annotations: { readOnlyHint: true },
+      inputSchema: {},
+    },
+    async () => {
+      try {
+        const baseFilter = buildAclFilter(identity);
+
+        // Total count
+        const total = await countPoints(baseFilter);
+
+        // Count by type — run in parallel
+        const typeNames = [
+          "observation",
+          "task",
+          "idea",
+          "reference",
+          "person_note",
+        ] as const;
+
+        const typeCounts = await Promise.all(
+          typeNames.map((typeName) =>
+            countPoints(
+              buildAclFilter(identity, {
+                must: [{ key: "type", match: { value: typeName } }],
+              })
+            )
+          )
+        );
+
+        // Scroll up to 1000 points for client-side topic/people aggregation
+        // Note: topic/people aggregation is client-side; accurate up to 1000 most recent thoughts
+        const sample = await scrollPoints({
+          filter: baseFilter,
+          limit: 1000,
+        });
+
+        // Aggregate topics
+        const topicFreq: Record<string, number> = {};
+        for (const point of sample) {
+          const topics = point.payload.topics;
+          if (Array.isArray(topics)) {
+            for (const topic of topics) {
+              if (typeof topic === "string") {
+                topicFreq[topic] = (topicFreq[topic] ?? 0) + 1;
+              }
+            }
+          }
+        }
+
+        // Aggregate people
+        const peopleFreq: Record<string, number> = {};
+        for (const point of sample) {
+          const people = point.payload.people;
+          if (Array.isArray(people)) {
+            for (const person of people) {
+              if (typeof person === "string") {
+                peopleFreq[person] = (peopleFreq[person] ?? 0) + 1;
+              }
+            }
+          }
+        }
+
+        // Date range — oldest is last element of sample, newest is first
+        const newestDate =
+          sample.length > 0
+            ? String(sample[0].payload.created_at ?? "unknown")
+            : "unknown";
+        const oldestDate =
+          sample.length > 0
+            ? String(sample[sample.length - 1].payload.created_at ?? "unknown")
+            : "unknown";
+
+        // Sort topics and people by frequency descending, take top 10
+        const topTopics = Object.entries(topicFreq)
+          .sort((a, b) => b[1] - a[1])
+          .slice(0, 10);
+
+        const topPeople = Object.entries(peopleFreq)
+          .sort((a, b) => b[1] - a[1])
+          .slice(0, 10);
+
+        // Build output
+        const lines: string[] = [];
+
+        lines.push(`Total thoughts: ${total}`);
+        lines.push(`Date range: ${oldestDate} → ${newestDate}`);
+        lines.push("");
+        lines.push("Types:");
+        for (let i = 0; i < typeNames.length; i++) {
+          lines.push(`  ${typeNames[i]}: ${typeCounts[i]}`);
+        }
+
+        if (topTopics.length > 0) {
+          lines.push("");
+          lines.push("Top topics:");
+          for (const [topic, count] of topTopics) {
+            lines.push(`  ${topic}: ${count}`);
+          }
+        }
+
+        if (topPeople.length > 0) {
+          lines.push("");
+          lines.push("People mentioned:");
+          for (const [person, count] of topPeople) {
+            lines.push(`  ${person}: ${count}`);
+          }
+        }
+
+        return {
+          content: [{ type: "text", text: lines.join("\n") }],
+        };
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        return {
+          content: [{ type: "text", text: `Error retrieving stats: ${message}` }],
+          isError: true,
+        };
+      }
+    }
+  );
+}

--- a/recipes/local-docker-qdrant/server/src/identity.ts
+++ b/recipes/local-docker-qdrant/server/src/identity.ts
@@ -1,0 +1,38 @@
+import type { Context, MiddlewareHandler } from "hono";
+import { MCP_ACCESS_KEY, IDENTITY_MODE, LOCAL_OWNER_ID } from "./config.js";
+
+export interface Identity {
+  owner_id: string;
+  owner_email: string;
+}
+
+export const identityMiddleware: MiddlewareHandler = async (c, next) => {
+  const key = c.req.header("x-brain-key") ?? c.req.query("key");
+
+  if (!key || key !== MCP_ACCESS_KEY) {
+    return c.json({ error: "Invalid or missing access key" }, 401);
+  }
+
+  if (IDENTITY_MODE === "local") {
+    c.set("owner_id", LOCAL_OWNER_ID);
+    c.set("owner_email", "local@localhost");
+  } else if (IDENTITY_MODE === "entra") {
+    // TODO: Stage 2 — implement Entra OIDC token validation and owner_id extraction
+    return c.json({ error: "Entra identity mode not yet implemented" }, 501);
+  }
+
+  await next();
+};
+
+export function getIdentity(c: Context): Identity {
+  const owner_id = c.get("owner_id") as string | undefined;
+  const owner_email = c.get("owner_email") as string | undefined;
+
+  if (!owner_id || !owner_email) {
+    throw new Error(
+      "[identity] owner_id or owner_email missing from context — identityMiddleware was not applied to this route"
+    );
+  }
+
+  return { owner_id, owner_email };
+}

--- a/recipes/local-docker-qdrant/server/src/index.ts
+++ b/recipes/local-docker-qdrant/server/src/index.ts
@@ -1,0 +1,83 @@
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { StreamableHTTPTransport } from "@hono/mcp";
+import { serve } from "@hono/node-server";
+import { Hono } from "hono";
+import { InvokeModelCommand } from "@aws-sdk/client-bedrock-runtime";
+import { PORT, MCP_ACCESS_KEY, EMBEDDING_MODEL } from "./config.js";
+import { makeBedrock } from "./bedrock.js";
+import * as qdrantClient from "./qdrant.js";
+import { identityMiddleware, getIdentity } from "./identity.js";
+import { registerCaptureHandler } from "./handlers/capture.js";
+import { registerSearchHandler } from "./handlers/search.js";
+import { registerListHandler } from "./handlers/list.js";
+import { registerStatsHandler } from "./handlers/stats.js";
+import { registerEnrichHandler } from "./handlers/enrich.js";
+import { registerShareHandler } from "./handlers/share.js";
+import { mountCaptureExternal } from "./rest/capture-external.js";
+import { mountSearchExternal } from "./rest/search-external.js";
+
+(async () => {
+  // 1. Qdrant collection setup
+  const t0 = Date.now();
+  await qdrantClient.ensureCollection();
+  console.log(`[qdrant] collection ready (${Date.now() - t0}ms)`);
+
+  const t1 = Date.now();
+  await qdrantClient.ensurePayloadIndexes();
+  console.log(`[qdrant] payload indexes ready (${Date.now() - t1}ms)`);
+
+  // 2. Bedrock health check — exit 1 on failure
+  try {
+    const cmd = new InvokeModelCommand({
+      modelId: EMBEDDING_MODEL,
+      contentType: "application/json",
+      accept: "application/json",
+      body: JSON.stringify({ inputText: "startup health check", dimensions: 1024, normalize: true }),
+    });
+    await makeBedrock().send(cmd);
+    console.log(`[bedrock] health check passed (profile: ${process.env.AWS_PROFILE || "default"})`);
+  } catch (e) {
+    console.error("FATAL: Bedrock health check failed:", (e as Error).message);
+    process.exit(1);
+  }
+
+  // 3. Build Hono app
+  const corsHeaders = {
+    "Access-Control-Allow-Origin": "*",
+    "Access-Control-Allow-Headers": "authorization, x-client-info, apikey, content-type, x-brain-key, accept, mcp-session-id",
+    "Access-Control-Allow-Methods": "GET, POST, OPTIONS, DELETE",
+  };
+
+  const app = new Hono();
+  app.options("*", (c) => c.text("ok", 200, corsHeaders));
+
+  // 4. Mount identity middleware globally (validates x-brain-key on all routes)
+  app.use("*", identityMiddleware);
+
+  // 5. Mount REST sidecars BEFORE the MCP catch-all
+  mountCaptureExternal(app);
+  mountSearchExternal(app);
+
+  // 6. MCP catch-all — per-request McpServer with identity in closures
+  app.all("*", async (c) => {
+    const identity = getIdentity(c);
+
+    const server = new McpServer({ name: "open-brain-qdrant", version: "1.0.0" });
+
+    registerCaptureHandler(server, identity);
+    registerSearchHandler(server, identity);
+    registerListHandler(server, identity);
+    registerStatsHandler(server, identity);
+    registerEnrichHandler(server, identity);
+    registerShareHandler(server, identity);
+
+    const transport = new StreamableHTTPTransport();
+    await server.connect(transport);
+    return transport.handleRequest(c);
+  });
+
+  // 7. Start server
+  serve({ fetch: app.fetch, port: PORT }, () => {
+    console.log(`Open Brain Qdrant MCP server running on port ${PORT}`);
+  });
+})();

--- a/recipes/local-docker-qdrant/server/src/qdrant.ts
+++ b/recipes/local-docker-qdrant/server/src/qdrant.ts
@@ -1,0 +1,237 @@
+import { QDRANT_URL } from "./config.js";
+
+export interface QdrantFilter {
+  must?: unknown[];
+  should?: unknown[];
+  must_not?: unknown[];
+}
+
+export interface QdrantPoint {
+  id: string;
+  vector: number[];
+  payload: Record<string, unknown>;
+}
+
+// ---------------------------------------------------------------------------
+// Internal helper
+// ---------------------------------------------------------------------------
+
+async function fetchWithRetry(
+  url: string,
+  options: RequestInit
+): Promise<Response> {
+  let lastError: unknown;
+  for (let attempt = 0; attempt < 2; attempt++) {
+    try {
+      const res = await fetch(url, options);
+      return res;
+    } catch (err) {
+      lastError = err;
+      // Only retry on network / connection errors (fetch throws), not HTTP errors.
+      if (attempt === 0) {
+        console.warn(`[qdrant] Network error on attempt ${attempt + 1}, retrying…`, err);
+        continue;
+      }
+    }
+  }
+  throw lastError;
+}
+
+async function qdrantRequest(
+  method: string,
+  path: string,
+  body?: unknown
+): Promise<unknown> {
+  const url = `${QDRANT_URL}${path}`;
+  const options: RequestInit = {
+    method,
+    headers: { "Content-Type": "application/json" },
+    ...(body !== undefined ? { body: JSON.stringify(body) } : {}),
+  };
+
+  const res = await fetchWithRetry(url, options);
+
+  if (!res.ok) {
+    const text = await res.text();
+    console.error(`[qdrant] ${method} ${url} -> ${res.status}: ${text}`);
+    return { __status: res.status, __body: text };
+  }
+
+  return res.json();
+}
+
+function isAlreadyExists(result: unknown): boolean {
+  if (
+    typeof result === "object" &&
+    result !== null &&
+    "__status" in result &&
+    "__body" in result
+  ) {
+    const r = result as { __status: number; __body: string };
+    return (r.__status === 400 || r.__status === 409) && r.__body.includes("already exists");
+  }
+  return false;
+}
+
+function assertSuccess(result: unknown, method: string, path: string): void {
+  if (
+    typeof result === "object" &&
+    result !== null &&
+    "__status" in result
+  ) {
+    throw new Error(
+      `[qdrant] ${method} ${path} failed with status ${(result as { __status: number }).__status}`
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+export async function ensureCollection(): Promise<void> {
+  const result = await qdrantRequest("PUT", "/collections/thoughts", {
+    vectors: { size: 1024, distance: "Cosine" },
+  });
+
+  if (isAlreadyExists(result)) return;
+  assertSuccess(result, "PUT", "/collections/thoughts");
+}
+
+export async function ensurePayloadIndexes(): Promise<void> {
+  const indexes: Array<{ field_name: string; field_schema: string }> = [
+    { field_name: "owner_id", field_schema: "keyword" },
+    { field_name: "visibility", field_schema: "keyword" },
+    { field_name: "shared_with", field_schema: "keyword" },
+    { field_name: "type", field_schema: "keyword" },
+    { field_name: "source", field_schema: "keyword" },
+    { field_name: "created_at", field_schema: "datetime" },
+    { field_name: "topics", field_schema: "keyword" },
+    { field_name: "people", field_schema: "keyword" },
+  ];
+
+  for (const index of indexes) {
+    const result = await qdrantRequest(
+      "PUT",
+      "/collections/thoughts/index",
+      index
+    );
+    if (isAlreadyExists(result)) continue;
+    assertSuccess(result, "PUT", "/collections/thoughts/index");
+  }
+}
+
+export async function upsertPoint(point: QdrantPoint): Promise<void> {
+  const result = await qdrantRequest(
+    "PUT",
+    "/collections/thoughts/points?wait=true",
+    {
+      points: [
+        {
+          id: point.id,
+          vector: point.vector,
+          payload: point.payload,
+        },
+      ],
+    }
+  );
+  assertSuccess(result, "PUT", "/collections/thoughts/points");
+}
+
+export async function searchPoints(params: {
+  vector: number[];
+  filter: QdrantFilter;
+  limit: number;
+  score_threshold: number;
+}): Promise<Array<{ id: string; score: number; payload: Record<string, unknown> }>> {
+  const result = await qdrantRequest(
+    "POST",
+    "/collections/thoughts/points/search",
+    {
+      vector: params.vector,
+      filter: params.filter,
+      limit: params.limit,
+      score_threshold: params.score_threshold,
+      with_payload: true,
+    }
+  ) as { result: Array<{ id: string; score: number; payload: Record<string, unknown> }> };
+
+  assertSuccess(result, "POST", "/collections/thoughts/points/search");
+  return result.result;
+}
+
+export async function scrollPoints(params: {
+  filter: QdrantFilter;
+  limit: number;
+  order_by?: { key: string; direction: string };
+  offset?: string | null;
+}): Promise<Array<{ id: string; payload: Record<string, unknown> }>> {
+  const body: Record<string, unknown> = {
+    filter: params.filter,
+    limit: params.limit,
+    order_by: params.order_by ?? { key: "created_at", direction: "desc" },
+    with_payload: true,
+    ...(params.offset ? { offset: params.offset } : {}),
+  };
+
+  const result = await qdrantRequest(
+    "POST",
+    "/collections/thoughts/points/scroll",
+    body
+  ) as { result: { points: Array<{ id: string; payload: Record<string, unknown> }> } };
+
+  assertSuccess(result, "POST", "/collections/thoughts/points/scroll");
+  return result.result.points;
+}
+
+export async function countPoints(filter: QdrantFilter): Promise<number> {
+  const result = await qdrantRequest(
+    "POST",
+    "/collections/thoughts/points/count",
+    {
+      filter,
+      exact: true,
+    }
+  ) as { result: { count: number } };
+
+  assertSuccess(result, "POST", "/collections/thoughts/points/count");
+  return result.result.count;
+}
+
+export async function setPayload(
+  id: string,
+  payload: Record<string, unknown>
+): Promise<void> {
+  const result = await qdrantRequest(
+    "POST",
+    "/collections/thoughts/points/payload?wait=true",
+    {
+      payload,
+      points: [id],
+    }
+  );
+  assertSuccess(result, "POST", "/collections/thoughts/points/payload");
+}
+
+export async function getPoint(
+  id: string
+): Promise<{ id: string; payload: Record<string, unknown> } | null> {
+  const url = `${QDRANT_URL}/collections/thoughts/points/${id}`;
+  const options: RequestInit = {
+    method: "GET",
+    headers: { "Content-Type": "application/json" },
+  };
+
+  const res = await fetchWithRetry(url, options);
+
+  if (res.status === 404) return null;
+
+  if (!res.ok) {
+    const text = await res.text();
+    console.error(`[qdrant] GET ${url} -> ${res.status}: ${text}`);
+    throw new Error(`[qdrant] GET /collections/thoughts/points/${id} failed with status ${res.status}`);
+  }
+
+  const data = await res.json() as { result: { id: string; payload: Record<string, unknown> } };
+  return { id: data.result.id, payload: data.result.payload };
+}

--- a/recipes/local-docker-qdrant/server/src/rest/capture-external.ts
+++ b/recipes/local-docker-qdrant/server/src/rest/capture-external.ts
@@ -1,0 +1,51 @@
+import type { Hono } from "hono";
+import type { Context } from "hono";
+import { getIdentity } from "../identity.js";
+import { captureThought } from "../handlers/capture.js";
+
+const corsHeaders = {
+  "Access-Control-Allow-Origin": "*",
+  "Access-Control-Allow-Headers":
+    "authorization, x-client-info, apikey, content-type, x-brain-key, accept, mcp-session-id",
+  "Access-Control-Allow-Methods": "GET, POST, OPTIONS, DELETE",
+};
+
+export function mountCaptureExternal(app: Hono): void {
+  app.post("/capture-external", async (c: Context) => {
+    const identity = getIdentity(c);
+
+    let body: {
+      content?: string;
+      source?: string;
+      title?: string;
+      url?: string;
+      visibility?: "private" | "shared";
+    };
+
+    try {
+      body = await c.req.json();
+    } catch {
+      return c.json({ error: "Invalid JSON body" }, 400, corsHeaders);
+    }
+
+    if (!body.content || body.content.trim() === "") {
+      return c.json({ error: "content is required" }, 400, corsHeaders);
+    }
+
+    try {
+      const { id, type, topics } = await captureThought(
+        body.content.trim(),
+        identity,
+        {
+          source: body.source,
+          title: body.title,
+          url: body.url,
+          visibility: body.visibility,
+        }
+      );
+      return c.json({ id, type, topics }, 200, corsHeaders);
+    } catch (err) {
+      return c.json({ error: (err as Error).message }, 500, corsHeaders);
+    }
+  });
+}

--- a/recipes/local-docker-qdrant/server/src/rest/search-external.ts
+++ b/recipes/local-docker-qdrant/server/src/rest/search-external.ts
@@ -1,0 +1,174 @@
+import type { Hono, Context } from "hono";
+import { getEmbedding } from "../bedrock.js";
+import { searchPoints, scrollPoints } from "../qdrant.js";
+import type { QdrantFilter } from "../qdrant.js";
+import { buildAclFilter } from "../acl.js";
+import { getIdentity } from "../identity.js";
+
+const corsHeaders = {
+  "Access-Control-Allow-Origin": "*",
+  "Access-Control-Allow-Headers":
+    "authorization, x-client-info, apikey, content-type, x-brain-key, accept, mcp-session-id",
+  "Access-Control-Allow-Methods": "GET, POST, OPTIONS, DELETE",
+};
+
+const DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
+
+function isValidDate(value: string): boolean {
+  if (!DATE_RE.test(value)) return false;
+  const d = new Date(value);
+  return !isNaN(d.getTime());
+}
+
+export function mountSearchExternal(app: Hono): void {
+  app.post("/search-external", async (c: Context) => {
+    try {
+      const identity = getIdentity(c);
+
+      let body: {
+        query?: string;
+        tag?: string;
+        type?: string;
+        source?: string;
+        date?: string;
+        since?: string;
+        until?: string;
+        limit?: number;
+        threshold?: number;
+      };
+
+      try {
+        body = await c.req.json();
+      } catch {
+        return c.json({ error: "Invalid JSON body" }, 400, corsHeaders);
+      }
+
+      // At least one filter field required
+      if (
+        !body.query &&
+        !body.tag &&
+        !body.type &&
+        !body.source &&
+        !body.date &&
+        !body.since &&
+        !body.until
+      ) {
+        return c.json(
+          {
+            error:
+              "query, tag, type, source, date, since, or until is required",
+          },
+          400,
+          corsHeaders,
+        );
+      }
+
+      // Validate date fields
+      if (body.date && !isValidDate(body.date)) {
+        return c.json(
+          { error: "date must be in YYYY-MM-DD format" },
+          400,
+          corsHeaders,
+        );
+      }
+      if (body.since && !isValidDate(body.since)) {
+        return c.json(
+          { error: "since must be in YYYY-MM-DD format" },
+          400,
+          corsHeaders,
+        );
+      }
+      if (body.until && !isValidDate(body.until)) {
+        return c.json(
+          { error: "until must be in YYYY-MM-DD format" },
+          400,
+          corsHeaders,
+        );
+      }
+
+      // Browse mode — triggered by any non-query filter
+      if (body.tag || body.type || body.source || body.date || body.since || body.until) {
+        const conditions: unknown[] = [];
+
+        if (body.tag) {
+          conditions.push({ key: "topics", match: { value: body.tag } });
+        }
+        if (body.type) {
+          conditions.push({ key: "type", match: { value: body.type } });
+        }
+        if (body.source) {
+          conditions.push({ key: "source", match: { value: body.source } });
+        }
+        if (body.date) {
+          conditions.push({
+            key: "created_at",
+            range: {
+              gte: `${body.date}T00:00:00Z`,
+              lte: `${body.date}T23:59:59Z`,
+            },
+          });
+        } else {
+          if (body.since) {
+            conditions.push({
+              key: "created_at",
+              range: { gte: `${body.since}T00:00:00Z` },
+            });
+          }
+          if (body.until) {
+            conditions.push({
+              key: "created_at",
+              range: { lte: `${body.until}T23:59:59Z` },
+            });
+          }
+        }
+
+        const userFilter: QdrantFilter = { must: conditions };
+        const filter = buildAclFilter(identity, userFilter);
+
+        const hits = await scrollPoints({
+          filter,
+          limit: body.limit ?? 50,
+          order_by: { key: "created_at", direction: "desc" },
+        });
+
+        const results = hits.map((hit) => ({
+          id: hit.id,
+          content: (hit.payload.content as string) ?? "",
+          similarity: null,
+          type: (hit.payload.type as string) ?? "",
+          topics: (hit.payload.topics as string[]) ?? [],
+          source: (hit.payload.source as string | null) ?? null,
+          created_at: (hit.payload.created_at as string) ?? "",
+        }));
+
+        return c.json({ results, mode: "browse" }, 200, corsHeaders);
+      }
+
+      // Semantic search mode
+      const vector = await getEmbedding(body.query!.trim());
+      const filter = buildAclFilter(identity);
+
+      const hits = await searchPoints({
+        vector,
+        filter,
+        limit: body.limit ?? 10,
+        score_threshold: body.threshold ?? 0.25,
+      });
+
+      const results = hits.map((hit) => ({
+        id: hit.id,
+        content: (hit.payload.content as string) ?? "",
+        similarity: Math.round(hit.score * 100),
+        type: (hit.payload.type as string) ?? "",
+        topics: (hit.payload.topics as string[]) ?? [],
+        source: (hit.payload.source as string | null) ?? null,
+        created_at: (hit.payload.created_at as string) ?? "",
+      }));
+
+      return c.json({ results, mode: "search" }, 200, corsHeaders);
+    } catch (err) {
+      console.error("[search-external] error:", err);
+      return c.json({ error: "Internal server error" }, 500, corsHeaders);
+    }
+  });
+}

--- a/recipes/local-docker-qdrant/server/tsconfig.json
+++ b/recipes/local-docker-qdrant/server/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "outDir": "dist"
+  },
+  "include": ["src/**/*"]
+}


### PR DESCRIPTION
## Contribution Type

- [x] Recipe (`/recipes`)
- [ ] Schema (`/schemas`)
- [ ] Dashboard (`/dashboards`)
- [ ] Integration (`/integrations`)
- [ ] Skill (`/skills`)
- [ ] Repo improvement (docs, CI, templates)

## What does this do?

Adds a Qdrant-backed variant of the local-docker recipe that builds the groundwork for an eventual multi-user deployment without sacrificing the single-user local experience.

**Why the extra machinery?** A single-user pgvector recipe works fine for one person, but as soon as you want to share an Open Brain with teammates — or deploy it as a hosted service — you need user isolation and sharing semantics baked into the data model. Retrofitting that later means a painful data migration. By introducing `owner_id`, `visibility`, and `shared_with` fields on every thought now, and routing every read through a single `buildAclFilter()` enforcement point, the same code path that runs trivially in local mode (where `owner_id` is always `local-user`) is ready to enforce real user isolation when `IDENTITY_MODE` flips from `local` to `entra` (Entra OIDC) in Stage 2 of the multi-tenant roadmap. No data migration is needed at that point — the ACL fields are already on every thought.

**What's new compared to the pgvector recipe?**

- 6th MCP tool: `share_thought` — flips a thought's visibility between `private` and `shared`
- `search_thoughts` gains a `scope` parameter (`private` / `shared` / `all`)
- `capture_thought` gains a `visibility` parameter
- Runs side-by-side with the pgvector stack on different ports (3100 vs 3000) — no conflict
- A standalone migration script (`scripts/migrate-pgvector-to-qdrant.mjs`) copies existing pgvector thoughts into Qdrant without re-embedding (same Titan V2 model, vectors are directly portable)

## Requirements

- Docker Desktop
- AWS account with Bedrock model access for `amazon.titan-embed-text-v2:0` and `us.anthropic.claude-haiku-4-5-20251001-v1:0`
- AWS CLI configured with a profile that has `bedrock:InvokeModel` permissions
- An AI client that supports HTTP-based MCP servers
- For the migration script only: `npm install postgres` in the script's directory (the dependency is not in the server's `package.json` since the server itself never talks to Postgres)

The recipe `ARCHITECTURE.md` documents the AWS credential handling, ACL filter design, identity modes (local vs entra stub), Qdrant collection schema and payload indexes, and the Stage 1 → Stage 2 migration path.

## Notes

Companion to `[recipes] Local Docker Open Brain` (separate PR). The two recipes are independent — you can run either, neither, or both. The Qdrant recipe does not modify any file in the pgvector recipe.

## Checklist

- [x] I've read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] My contribution has a `README.md` with prerequisites, step-by-step instructions, and expected outcome
- [x] My `metadata.json` has all required fields
- [x] If my contribution depends on a skill or primitive, I declared it in metadata.json and linked it in the README *(no such dependency in this recipe)*
- [x] I tested this on my own Open Brain instance
- [x] No credentials, API keys, or secrets are included
