### PR TITLE
[recipes] obsidian-vault-import: --default-type to set metadata.type

### DIFF
--- a/recipes/obsidian-vault-import/README.md
+++ b/recipes/obsidian-vault-import/README.md
@@ -118,6 +118,8 @@ FILE LOCATION
 | `--no-secret-scan` | Disable secret detection (not recommended) |
 | `--verbose` | Show detailed progress for each note |
 | `--report` | Generate an `import-report.md` summary file |
+| `--source-label X` | Stamp `metadata.source = X` (default: `obsidian`) |
+| `--default-type X` | Fallback `metadata.type` when a note has no frontmatter `type:` (default: none) |
 
 ## What Gets Filtered
 
@@ -243,6 +245,27 @@ python import-obsidian.py /path/to/dayone-vault   --source-label day-one
 
 After this, your metadata filter becomes `{"source": "apple-journal"}` to
 retrieve only Apple Journal entries, etc.
+
+### Customizing the thought type
+
+By default the importer writes no `metadata.type` — thoughts inherit whatever
+default your downstream tooling applies. Two ways to set a type at import time:
+
+1. **Per note** — add a `type:` field to a note's YAML frontmatter. This always
+   wins, so a mixed vault can carry `type: decision`, `type: meeting`, etc.
+2. **Vault-wide fallback** — pass `--default-type` for any note that doesn't
+   declare its own. Ideal for single-purpose vaults:
+
+```bash
+python import-obsidian.py /path/to/journal-vault --default-type journal
+python import-obsidian.py /path/to/meeting-notes --default-type meeting
+```
+
+Precedence is: frontmatter `type:` → `--default-type` → omitted. After import,
+`{"type": "journal"}` filters to just those thoughts, and OB1's
+`enhanced-thoughts` schema promotes `metadata.type` into the indexed `type`
+column. Pairs naturally with `--source-label` — e.g. an Apple Journal export
+becomes `--source-label apple-journal --default-type journal`.
 
 ## Troubleshooting
 

--- a/recipes/obsidian-vault-import/import-obsidian.py
+++ b/recipes/obsidian-vault-import/import-obsidian.py
@@ -214,6 +214,18 @@ def extract_date(meta: dict, path: Path) -> str:
         return datetime.now(tz=timezone.utc).strftime('%Y-%m-%d')
 
 
+def resolve_type(meta: dict, default_type: str) -> str:
+    """Resolve a thought's type. Frontmatter 'type:' wins; else default_type.
+
+    Returns '' when neither is set, so the caller can omit metadata.type
+    entirely and preserve the prior (no-type) behavior for plain vaults.
+    """
+    val = meta.get('type')
+    if isinstance(val, str) and val.strip():
+        return val.strip()
+    return (default_type or '').strip()
+
+
 def word_count(text: str) -> int:
     return len(text.split())
 
@@ -512,6 +524,15 @@ def main():
                              "upstream tools and you want to filter by origin "
                              "in OB1 — e.g. 'apple-journal', 'day-one', "
                              "'roam-export'.")
+    parser.add_argument("--default-type", type=str, default="",
+                        help="Fallback value for metadata.type when a note's "
+                             "frontmatter doesn't declare a 'type:'. Empty by "
+                             "default (no type key written), preserving prior "
+                             "behavior. A note's own frontmatter 'type:' always "
+                             "takes precedence. Useful for single-purpose vaults "
+                             "— e.g. '--default-type journal' for a journal "
+                             "export so every entry is typed without per-note "
+                             "frontmatter.")
     args = parser.parse_args()
 
     vault_root = Path(args.vault_path).expanduser().resolve()
@@ -710,6 +731,7 @@ def main():
     for i, note in enumerate(filtered):
         chunks = chunk_note(note, use_llm, openrouter_key, verbose=args.verbose)
         note_date = extract_date(note['meta'], note['full_path'])
+        note_type = resolve_type(note['meta'], args.default_type)
 
         for chunk in chunks:
             # Format content with context prefix
@@ -738,6 +760,10 @@ def main():
             }
             if chunk['section']:
                 thought['metadata']['section'] = chunk['section']
+            # Stamp type only when resolved, so plain vaults keep prior
+            # (no-type) behavior and downstream defaults still apply.
+            if note_type:
+                thought['metadata']['type'] = note_type
 
             all_thoughts.append(thought)
 
@@ -773,7 +799,8 @@ def main():
             print("\nSample thoughts:")
             for t in all_thoughts[:5]:
                 preview = t['content'][:120] + "..." if len(t['content']) > 120 else t['content']
-                print(f"  [{t['metadata']['folder']}] {preview}")
+                type_part = f" | type={t['metadata']['type']}" if t['metadata'].get('type') else ""
+                print(f"  [{t['metadata']['folder']}{type_part}] {preview}")
         if args.report:
             _write_report(all_thoughts, filtered, vault_root, args, skip_reasons, dry_run=True)
         return


### PR DESCRIPTION
## Summary

Follow-up to #302 (`--source-label`). The obsidian importer stamps `source`, `title`, `folder`, `tags`, `date`, and full `frontmatter`, but never a **`type`**. Imported thoughts land with no `metadata.type`, so they read as "unknown" in clients that surface type and stay unpromoted by the `enhanced-thoughts` `type` column. The only way to type imported content was to edit it after the fact.

This adds `--default-type` with sensible precedence:

```
frontmatter `type:`  →  --default-type  →  omitted
```

- **Default is `""`** — no `type` key written, so existing imports are byte-for-byte unchanged unless you opt in.
- A note's own frontmatter `type:` always wins, so **mixed vaults** can carry per-note `type: decision` / `meeting` / `lesson`.
- A **single-purpose vault** types everything in one flag — pairs naturally with `--source-label`:

```bash
python import-obsidian.py /path/to/journal-vault \
    --source-label apple-journal --default-type journal
```

After import, `{"type": "journal"}` filters those thoughts, and the `enhanced-thoughts` schema promotes `metadata.type` into the indexed `type` column.

## Changes

- `import-obsidian.py`: new `resolve_type()` helper (frontmatter > flag > omit), `--default-type` arg, conditional `metadata.type` write, and resolved-type shown in verbose dry-run output.
- `README.md`: Options-table rows for `--source-label` / `--default-type` + a "Customizing the thought type" subsection.

## Test plan

- [x] `py_compile` clean
- [x] Dry-run on a 2-note temp vault — note with `type: lesson` frontmatter → `lesson`; note without → `journal` under `--default-type journal`, and **no type** when the flag is omitted (prior behavior preserved)
- [x] No behavior change unless `--default-type` is passed or a note declares its own frontmatter `type:`