### PR TITLE
[dashboards] Add deploy-pages workflow for openbrain.fyi

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -1,0 +1,33 @@
+name: Deploy landing page
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'dashboards/ob1-canonical-landing/**'
+      - '.github/workflows/deploy-pages.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/configure-pages@v5
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: dashboards/ob1-canonical-landing/
+      - uses: actions/deploy-pages@v4
+        id: deployment


### PR DESCRIPTION
## Contribution Type

- [x] Repo improvement (CI workflow)

## What does this do?

Follow-up to #258 (canonical landing page, merged). Adds `.github/workflows/deploy-pages.yml` so the page at `dashboards/ob1-canonical-landing/` actually publishes to GitHub Pages and serves at `openbrain.fyi`.

**Why a workflow is required:** GitHub Pages "Deploy from a branch" can only serve `/` or `/docs` — not arbitrary subfolders like `dashboards/ob1-canonical-landing/`. The only way to publish from that path is via an Actions workflow that uploads the folder as a Pages artifact. This is the exact workflow documented in the landing page's `README.md` Step 2.

## After merge — three switches to flip

These require admin access; I can't do them from a PR:

1. **Settings → Actions → General** → "Workflow permissions" → **Read and write permissions** → Save
2. **Settings → Pages** → "Source" → select **GitHub Actions** (dropdown — not "Deploy from a branch")
3. **Settings → Pages** → "Custom domain" → enter `openbrain.fyi` → Save. DNS already points correctly, so a green check should appear within a minute.

Then either push any change under `dashboards/ob1-canonical-landing/` or go to Actions → "Deploy landing page" → Run workflow on `main`. When the job succeeds, `https://openbrain.fyi/` serves the page. After 5–30 min, **Enforce HTTPS** becomes tickable.

The `CNAME` file (`openbrain.fyi`) is already in `dashboards/ob1-canonical-landing/CNAME` from #258, so the workflow uploads it with the rest of the site — no manual CNAME entry needed beyond the custom-domain field in step 3.

## Checklist

- [x] I've read CONTRIBUTING.md
- [x] No credentials, API keys, or secrets are included
- [x] Workflow scoped to `dashboards/ob1-canonical-landing/**` and the workflow file itself — won't run on unrelated pushes