### PR TITLE
[schemas] Recall quarantine hard drop

### DIFF
--- a/schemas/recall-quarantine-hard-drop/README.md
+++ b/schemas/recall-quarantine-hard-drop/README.md
@@ -1,0 +1,73 @@
+# Recall quarantine wrapper
+
+## What it does
+
+This schema package adds a read-side quarantine layer for recall. It keeps the base `thoughts` table untouched and adds:
+
+- `recall_quarantine` for entries that should not be returned by recall
+- `recall_filter_audit` for query-time exclusion evidence
+- `match_thoughts_filtered`, a wrapper around `match_thoughts`
+
+The wrapper asks the existing recall function for a larger candidate set (one underlying call per query), removes quarantined entries, writes an audit row when a query label is supplied, and returns the filtered result set.
+
+Both new tables ship with row level security enabled. On Supabase-style setups (where a `service_role` role exists) a service-role-only policy and grant are added automatically, so a public client key can never add or remove quarantine entries. Quarantine controls what recall returns; treat write access to it like write access to memory itself.
+
+## Prerequisites
+
+- A local OB1-shaped Postgres database
+- `pgvector` installed
+- Existing `thoughts` table
+- Existing `match_thoughts(query_embedding vector(1536), match_threshold float, match_count int, filter jsonb)`
+
+## Steps
+
+1. Apply the schema locally.
+
+   ```bash
+   psql "$DATABASE_URL" -v ON_ERROR_STOP=1 -f recall_quarantine.sql
+   ```
+
+2. Add one thought to quarantine.
+
+   ```sql
+   insert into public.recall_quarantine (thought_id, reason, created_by)
+   values ('00000000-0000-0000-0000-000000000001', 'review_required', 'local-test')
+   on conflict (thought_id) do update
+   set reason = excluded.reason,
+       created_by = excluded.created_by,
+       created_at = now();
+   ```
+
+3. Query through the wrapper.
+
+   ```sql
+   select *
+   from public.match_thoughts_filtered(
+     '[0.1,0.2,0.3]'::vector,
+     0.0,
+     10,
+     '{}'::jsonb,
+     'local-test-query'
+   );
+   ```
+
+4. Inspect audit evidence.
+
+   ```sql
+   select query_label, excluded_count, excluded_thought_ids, created_at
+   from public.recall_filter_audit
+   order by created_at desc
+   limit 5;
+   ```
+
+## Expected outcome
+
+Quarantined thoughts are not returned by `match_thoughts_filtered`, even when the underlying `match_thoughts` function would return them. Audit rows record how many candidates were excluded.
+
+## Troubleshooting
+
+- If `vector` is unknown, install and enable `pgvector`.
+- If `match_thoughts` is missing, apply the base recall schema first.
+- If no audit rows appear, pass a non-empty `audit_query_label` argument.
+- If fewer rows than expected return, increase `extra_candidate_count`.
+- On plain Postgres (no `service_role` role) the policy/grant block is skipped by design; the table owner bypasses row level security. Add your own policies if other roles need access.

--- a/schemas/recall-quarantine-hard-drop/metadata.json
+++ b/schemas/recall-quarantine-hard-drop/metadata.json
@@ -1,0 +1,25 @@
+{
+  "name": "recall-quarantine-hard-drop",
+  "description": "A read-side quarantine wrapper that excludes selected thoughts from recall without altering the core thoughts table.",
+  "category": "schemas",
+  "author": {
+    "name": "Tony Finley",
+    "github": "wefilmshit"
+  },
+  "version": "0.1.0",
+  "requires": {
+    "open_brain": true,
+    "services": [],
+    "tools": [
+      "Postgres with pgvector",
+      "psql"
+    ]
+  },
+  "tags": [
+    "recall",
+    "quarantine",
+    "safety"
+  ],
+  "difficulty": "intermediate",
+  "estimated_time": "20 minutes"
+}

--- a/schemas/recall-quarantine-hard-drop/recall_quarantine.sql
+++ b/schemas/recall-quarantine-hard-drop/recall_quarantine.sql
@@ -1,0 +1,128 @@
+create table if not exists public.recall_quarantine (
+  thought_id uuid primary key references public.thoughts(id) on delete cascade,
+  reason text not null default 'review_required',
+  created_by text not null default current_user,
+  created_at timestamptz not null default now()
+);
+
+create table if not exists public.recall_filter_audit (
+  id bigserial primary key,
+  query_label text,
+  excluded_thought_ids uuid[] not null default '{}',
+  excluded_count integer not null default 0,
+  returned_count integer not null default 0,
+  created_at timestamptz not null default now()
+);
+
+-- Lock both tables down to match the base recall posture. Quarantine controls what
+-- recall returns, so it must never be writable with a public client key: row level
+-- security is enabled unconditionally, and on Supabase-style setups (where the
+-- service_role role exists) a service-role-only policy plus grant is added. On plain
+-- Postgres there is no service_role; the table owner bypasses RLS, which is what the
+-- local fixture and self-hosted setups use.
+alter table public.recall_quarantine enable row level security;
+alter table public.recall_filter_audit enable row level security;
+
+do $$
+begin
+  if exists (select 1 from pg_roles where rolname = 'service_role') then
+    if not exists (
+      select 1 from pg_policies
+      where schemaname = 'public' and tablename = 'recall_quarantine'
+        and policyname = 'Service role only'
+    ) then
+      execute 'create policy "Service role only" on public.recall_quarantine'
+        || ' as permissive for all to service_role using (true) with check (true)';
+    end if;
+    if not exists (
+      select 1 from pg_policies
+      where schemaname = 'public' and tablename = 'recall_filter_audit'
+        and policyname = 'Service role only'
+    ) then
+      execute 'create policy "Service role only" on public.recall_filter_audit'
+        || ' as permissive for all to service_role using (true) with check (true)';
+    end if;
+    execute 'grant all on table public.recall_quarantine to service_role';
+    execute 'grant all on table public.recall_filter_audit to service_role';
+    execute 'grant usage, select on sequence public.recall_filter_audit_id_seq to service_role';
+  end if;
+end
+$$;
+
+-- Single-pass wrapper: the underlying match_thoughts runs exactly once per call
+-- (a multi-statement version would re-run it per step and could disagree with
+-- itself under concurrent writes). Runs with the caller's rights (no security
+-- definer): callers that may read recall results may also be audited.
+create or replace function public.match_thoughts_filtered(
+  query_embedding vector(1536),
+  match_threshold float default 0.0,
+  match_count int default 10,
+  filter jsonb default '{}'::jsonb,
+  audit_query_label text default null,
+  extra_candidate_count int default 25
+)
+returns table (
+  id uuid,
+  content text,
+  metadata jsonb,
+  similarity float,
+  recall_filter jsonb
+)
+language sql
+volatile
+set search_path = public
+as $$
+  with raw as (
+    select mt.id, mt.content, mt.metadata, mt.similarity,
+           row_number() over () as rn,
+           exists (
+             select 1 from public.recall_quarantine rq where rq.thought_id = mt.id
+           ) as is_quarantined
+    from public.match_thoughts(
+      query_embedding,
+      match_threshold,
+      match_count + greatest(extra_candidate_count, 0),
+      filter
+    ) as mt
+  ),
+  excluded as (
+    select coalesce(array_agg(raw.id order by raw.rn), '{}'::uuid[]) as ids
+    from raw
+    where raw.is_quarantined
+  ),
+  filtered as (
+    select raw.id, raw.content, raw.metadata, raw.similarity, raw.rn
+    from raw
+    where not raw.is_quarantined
+    order by raw.rn
+    limit match_count
+  ),
+  returned as (
+    select coalesce(array_agg(filtered.id order by filtered.rn), '{}'::uuid[]) as ids,
+           count(*)::int as n
+    from filtered
+  ),
+  audit as (
+    insert into public.recall_filter_audit
+      (query_label, excluded_thought_ids, excluded_count, returned_count)
+    select audit_query_label,
+           excluded.ids,
+           coalesce(array_length(excluded.ids, 1), 0),
+           returned.n
+    from excluded, returned
+    where audit_query_label is not null and audit_query_label <> ''
+    returning recall_filter_audit.id
+  )
+  select filtered.id,
+         filtered.content,
+         filtered.metadata,
+         filtered.similarity,
+         jsonb_build_object(
+           'status', 'OK',
+           'excluded_count', coalesce(array_length(excluded.ids, 1), 0),
+           'excluded_ids', excluded.ids,
+           'audit_id', (select audit.id from audit limit 1)
+         ) as recall_filter
+  from filtered, excluded
+  order by filtered.rn;
+$$;


### PR DESCRIPTION
## Contribution Type

- [ ] Recipe (`/recipes`)
- [x] Schema (`/schemas`)
- [ ] Dashboard (`/dashboards`)
- [ ] Integration (`/integrations`)
- [ ] Skill (`/skills`)
- [ ] Repo improvement (docs, CI, templates)

## What does this do?

Adds a read-side recall quarantine layer without changing the core `thoughts` table or replacing the existing `match_thoughts` function. The new wrapper excludes quarantined thoughts from recall and records exclusion evidence.

## Requirements

- Local Postgres with `pgvector`
- Existing OB1-style `thoughts` table
- Existing `match_thoughts` function
- `psql`

## Testing confirmation

Tested on a local OB1-shaped fixture database with synthetic thoughts. A known top result was quarantined, the filtered wrapper excluded it, and an audit row recorded the exclusion count.

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] My contribution has a `README.md` with prerequisites, step-by-step instructions, and expected outcome
- [x] My `metadata.json` has all required fields
- [x] If my contribution depends on a skill or primitive, I declared it in metadata.json and linked it in the README
- [x] I tested this on my own Open Brain instance
- [x] No credentials, API keys, or secrets are included
