### PR TITLE
[recipes] Degrade-loud recall

### DIFF
--- a/recipes/degrade-loud-recall/README.md
+++ b/recipes/degrade-loud-recall/README.md
@@ -1,0 +1,49 @@
+# Degrade-loud recall
+
+## What it does
+
+This recipe wraps `match_thoughts` so recall returns a source-health block with each response. It makes three states explicit:
+
+- `OK`: recall returned rows
+- `DEGRADED`: recall ran but returned no rows
+- `UNAVAILABLE`: recall could not run
+
+The goal is to prevent a recall failure from being mistaken for a confident empty result.
+
+## Prerequisites
+
+- A local OB1-shaped Postgres database
+- `pgvector` installed
+- Existing `thoughts` table
+- Existing `match_thoughts(query_embedding vector(1536), match_threshold float, match_count int, filter jsonb)`
+
+## Steps
+
+1. Apply the wrapper locally.
+
+   ```bash
+   psql "$DATABASE_URL" -v ON_ERROR_STOP=1 -f degrade_loud_recall.sql
+   ```
+
+2. Call recall through the wrapper.
+
+   ```sql
+   select public.match_thoughts_with_health(
+     '[0.1,0.2,0.3]'::vector,
+     0.0,
+     10,
+     '{}'::jsonb
+   );
+   ```
+
+3. Add the assistant wording in `assistant-fail-loud-snippet.md` to any prompt that consumes this wrapper.
+
+## Expected outcome
+
+The caller gets both `results` and `source_health`. If recall returns no rows or errors, the assistant can say that memory was degraded or unavailable instead of implying that nothing relevant exists.
+
+## Troubleshooting
+
+- If `source_health.status` is `UNAVAILABLE`, inspect `source_health.reason`.
+- If `source_health.status` is `DEGRADED`, lower the threshold or verify embeddings were generated against the same model.
+- If the assistant still speaks confidently during degraded recall, check that the prompt snippet is actually included in the consuming prompt.

--- a/recipes/degrade-loud-recall/assistant-fail-loud-snippet.md
+++ b/recipes/degrade-loud-recall/assistant-fail-loud-snippet.md
@@ -1,0 +1,11 @@
+# Assistant recall-health snippet
+
+When recall returns `source_health.status = "UNAVAILABLE"`, say:
+
+> I could not verify memory for this answer because the recall source was unavailable. I will answer from the current conversation only and will not claim memory certainty.
+
+When recall returns `source_health.status = "DEGRADED"` with zero results, say:
+
+> I could not find verified memory for this answer. That may be because recall returned no rows, so I will avoid claiming that no memory exists.
+
+When recall returns `source_health.status = "OK"`, use the returned rows normally and keep the source-health block available for logging.

--- a/recipes/degrade-loud-recall/degrade_loud_recall.sql
+++ b/recipes/degrade-loud-recall/degrade_loud_recall.sql
@@ -1,0 +1,49 @@
+create or replace function public.match_thoughts_with_health(
+  query_embedding vector(1536),
+  match_threshold float default 0.0,
+  match_count int default 10,
+  filter jsonb default '{}'::jsonb
+)
+returns jsonb
+language plpgsql
+set search_path = public
+as $$
+declare
+  results jsonb := '[]'::jsonb;
+  returned_count integer := 0;
+  status text := 'OK';
+  reason text := 'recall_source_returned_results';
+begin
+  select coalesce(jsonb_agg(to_jsonb(mt)), '[]'::jsonb)
+  into results
+  from public.match_thoughts(query_embedding, match_threshold, match_count, filter) as mt;
+
+  returned_count := jsonb_array_length(results);
+
+  if returned_count = 0 then
+    status := 'DEGRADED';
+    reason := 'recall_source_returned_no_rows';
+  end if;
+
+  return jsonb_build_object(
+    'source_health', jsonb_build_object(
+      'status', status,
+      'reason', reason,
+      'requested_count', match_count,
+      'returned_count', returned_count
+    ),
+    'results', results
+  );
+exception
+  when others then
+    return jsonb_build_object(
+      'source_health', jsonb_build_object(
+        'status', 'UNAVAILABLE',
+        'reason', SQLERRM,
+        'requested_count', match_count,
+        'returned_count', 0
+      ),
+      'results', '[]'::jsonb
+    );
+end;
+$$;

--- a/recipes/degrade-loud-recall/metadata.json
+++ b/recipes/degrade-loud-recall/metadata.json
@@ -1,0 +1,25 @@
+{
+  "name": "degrade-loud-recall",
+  "description": "A recall wrapper and assistant snippet that make recall source health explicit instead of silently treating missing recall as normal.",
+  "category": "recipes",
+  "author": {
+    "name": "Tony Finley",
+    "github": "wefilmshit"
+  },
+  "version": "0.1.0",
+  "requires": {
+    "open_brain": true,
+    "services": [],
+    "tools": [
+      "Postgres with pgvector",
+      "psql"
+    ]
+  },
+  "tags": [
+    "recall",
+    "observability",
+    "source-health"
+  ],
+  "difficulty": "beginner",
+  "estimated_time": "15 minutes"
+}


### PR DESCRIPTION
## Contribution Type

- [x] Recipe (`/recipes`)
- [ ] Schema (`/schemas`)
- [ ] Dashboard (`/dashboards`)
- [ ] Integration (`/integrations`)
- [ ] Skill (`/skills`)
- [ ] Repo improvement (docs, CI, templates)

## What does this do?

Adds a recall wrapper that returns explicit source-health status with recall results. The wrapper distinguishes successful recall, empty/degraded recall, and unavailable recall so memory failures are not silently treated as normal empty results.

## Requirements

- Local Postgres with `pgvector`
- Existing OB1-style `thoughts` table
- Existing `match_thoughts` function
- `psql`

## Testing confirmation

Tested on a local OB1-shaped fixture database with synthetic thoughts. The wrapper returned `OK` for normal recall and `DEGRADED` for an intentionally empty recall response.

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] My contribution has a `README.md` with prerequisites, step-by-step instructions, and expected outcome
- [x] My `metadata.json` has all required fields
- [x] If my contribution depends on a skill or primitive, I declared it in metadata.json and linked it in the README
- [x] I tested this on my own Open Brain instance
- [x] No credentials, API keys, or secrets are included
