### PR TITLE
fix(brain-smoke-test): handle Streamable HTTP (SSE) + JSON-RPC auth errors

### DIFF
--- a/recipes/brain-smoke-test/smoke-all.js
+++ b/recipes/brain-smoke-test/smoke-all.js
@@ -184,6 +184,26 @@ async function runCheck(fn, { timeout = 10_000 } = {}) {
   }
 }
 
+// open-brain-mcp uses the MCP Streamable HTTP transport, which may answer a
+// POST with either a plain JSON body or a text/event-stream frame
+// ("event: message\ndata: {...}"). Parse both so the MCP checks below don't
+// choke on SSE with "Unexpected token 'e', \"event: mes\"...".
+function parseJsonOrSse(text) {
+  try {
+    return JSON.parse(text);
+  } catch (_) {
+    const dataLines = String(text)
+      .split(/\r?\n/)
+      .filter((line) => line.startsWith("data:"))
+      .map((line) => line.slice("data:".length).trim())
+      .filter((line) => line && line !== "[DONE]");
+    for (const line of dataLines) {
+      try { return JSON.parse(line); } catch (_) { /* skip non-payload events */ }
+    }
+    throw new Error(`unparseable MCP response: ${String(text).slice(0, 120)}`);
+  }
+}
+
 async function fetchJson(url, init, signal) {
   const res = await fetch(url, { ...init, signal });
   const text = await res.text();
@@ -193,7 +213,24 @@ async function fetchJson(url, init, signal) {
     e.status = res.status;
     throw e;
   }
-  return text ? JSON.parse(text) : null;
+  return text ? parseJsonOrSse(text) : null;
+}
+
+// A correct MCP auth rejection is either an HTTP 401/403, OR -- because
+// MCP-over-HTTP favours JSON-RPC error semantics over HTTP status -- an HTTP
+// 200 carrying a JSON-RPC error and NO tools/result. Returning tools without a
+// valid key is a real security failure, so only that case fails the check.
+async function assertMcpRejected(res) {
+  if (res.status === 401 || res.status === 403) return `HTTP ${res.status} (rejected)`;
+  const text = await res.text();
+  let parsed = null;
+  try { parsed = text ? parseJsonOrSse(text) : null; } catch (_) { /* leave null */ }
+  const hasTools = Array.isArray(parsed?.result?.tools);
+  if (res.status === 200 && parsed?.error && !hasTools) {
+    return `HTTP 200 + JSON-RPC ${parsed.error.code ?? "error"} (rejected, no data leaked)`;
+  }
+  if (hasTools) throw new Error("server returned tools without a valid key");
+  throw new Error(`expected 401/403 or JSON-RPC error, got HTTP ${res.status}`);
 }
 
 async function tableCount(table, signal, extraQuery = "") {
@@ -495,8 +532,7 @@ const authChecks = [
         body: JSON.stringify({ jsonrpc: "2.0", id: 1, method: "tools/list" }),
         signal: s,
       });
-      if (res.status === 401 || res.status === 403) return `HTTP ${res.status} (rejected)`;
-      throw new Error(`expected 401/403, got ${res.status}`);
+      return assertMcpRejected(res);
     },
   },
   {
@@ -508,8 +544,7 @@ const authChecks = [
         body: JSON.stringify({ jsonrpc: "2.0", id: 1, method: "tools/list" }),
         signal: s,
       });
-      if (res.status === 401 || res.status === 403) return `HTTP ${res.status} (rejected)`;
-      throw new Error(`expected 401/403, got ${res.status}`);
+      return assertMcpRejected(res);
     },
   },
   {


### PR DESCRIPTION
## Problem

`recipes/brain-smoke-test/smoke-all.js` reports **4 false failures against a healthy stock `open-brain-mcp`**, because it assumes the legacy plain-JSON transport and HTTP-status-based auth. Stock `open-brain-mcp` uses the MCP **Streamable HTTP** transport:

- **`MCP tools/list` / `MCP initialize handshake`** — a valid call returns `text/event-stream` (`event: message\ndata: {...}`). `fetchJson` did `JSON.parse(text)` and threw `Unexpected token 'e', "event: mes"...`.
- **`MCP rejects missing access key` / `MCP rejects wrong access key`** — the server returns **HTTP 200 with a JSON-RPC error (`-32001`)** and no tools, which is correct MCP-over-HTTP behaviour. The harness asserted HTTP 401/403 and failed.

These are transport mismatches in the harness, not server bugs.

## Fix

- `parseJsonOrSse(text)`: parse either a plain JSON body or an SSE `data:` frame (same approach used elsewhere for MCP-over-HTTP). `fetchJson` now uses it.
- `assertMcpRejected(res)`: treat a rejection as **HTTP 401/403 _or_ HTTP 200 + JSON-RPC error with no `result.tools`**. Crucially, returning tools without a valid key still **fails** the check — so this does not weaken the security assertion.

## Verification

Run against a live deployment:

```
MCP Server:
  ✓ open-brain-mcp endpoint responds          -- HTTP 200
  ✓ MCP tools/list returns core tools         -- tools=6 (...)
  ✓ MCP initialize handshake                  -- server=open-brain

Auth:
  ✓ MCP rejects missing access key            -- HTTP 200 + JSON-RPC -32001 (rejected, no data leaked)
  ✓ MCP rejects wrong access key              -- HTTP 200 + JSON-RPC -32001 (rejected, no data leaked)
  ✓ MCP accepts correct access key (header)   -- HTTP 200
  ✓ MCP accepts correct access key (?key=)    -- HTTP 200
```

`node --check` passes; no behavioural change for servers that still return plain JSON / 401-403 (both paths remain accepted).