### PR TITLE
[server] Lower search similarity threshold from 0.5 to 0.3

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -84,7 +84,7 @@ server.registerTool(
     inputSchema: {
       query: z.string().describe("What to search for"),
       limit: z.number().optional().default(10),
-      threshold: z.number().optional().default(0.5),
+      threshold: z.number().optional().default(0.3),
     },
   },
   async ({ query, limit, threshold }) => {


### PR DESCRIPTION
## Summary

- Lowers the default `threshold` for the `search_thoughts` MCP tool from `0.5` to `0.3`
- This broadens semantic search results, reducing false negatives where relevant thoughts were silently excluded because their cosine similarity fell just below the old cutoff

## Why

A threshold of `0.5` was too strict in practice — semantically related thoughts were being missed during recall, especially for shorter or more abstract captures. `0.3` is a more permissive starting point that still filters out noise while returning more useful matches.

## What a reviewer should know

- Change is in `server/index.ts`, the default parameter of the `threshold` field in `inputSchema`
- Users can still pass a custom threshold at call time; this only changes the default
- No schema, DB, or MCP protocol changes

## Test plan

- [ ] Run `search_thoughts` with a query that previously returned too few results and confirm broader recall
- [ ] Confirm results at threshold `0.3` are still semantically relevant (no obvious noise)

🤖 Generated with [Claude Code](https://claude.com/claude-code)