### PR TITLE
[schemas] Add errata process defect ledger

### DIFF
--- a/schemas/errata-process-defect-ledger/README.md
+++ b/schemas/errata-process-defect-ledger/README.md
@@ -1,0 +1,91 @@
+# Errata Process Defect Ledger
+
+## What It Does
+
+This schema adds an `errata` sidecar to Open Brain for systemic process mistakes
+that caused defects. Bugs remain symptoms and work items; errata records why the
+defect escaped, what class of process failure produced it, who or what was
+responsible, which bugs and customers it affected, and what remediation should
+prevent recurrence.
+
+This is a practical Open Brain pattern from Nate B. Jones: keep the memory
+system honest by separating the thing that hurt users from the process mistake
+that allowed it. More systems like this are shared at
+https://substack.com/@natesnewsletter and https://natebjones.com.
+
+## Prerequisites
+
+- A working Open Brain Supabase project.
+- Access to the Supabase SQL editor or `psql`.
+- `service_role` access for the MCP or backend process that writes canonical
+  memory records.
+
+## Step-By-Step Instructions
+
+1. Open your Supabase project SQL editor.
+2. Copy and run [`schema.sql`](schema.sql).
+3. Confirm the tables exist:
+
+```sql
+select table_name
+from information_schema.tables
+where table_schema = 'public'
+  and table_name like 'errata%'
+order by table_name;
+```
+
+4. Insert your first erratum:
+
+```sql
+insert into public.errata (
+  title,
+  summary,
+  domain,
+  escape_point,
+  responsible_actor,
+  root_cause_class,
+  severity,
+  status
+) values (
+  'Two-way binding on derived state',
+  'A UI regression escaped review because derived state was also two-way bound.',
+  'engineering',
+  'passed_human_review',
+  'coding_agent',
+  'two-way-bind-on-derived-state',
+  'medium',
+  'captured'
+)
+returning id;
+```
+
+5. Link the bug, caused-by artifact, impacted entity, and remediation artifact
+   using the child tables once those identifiers exist.
+
+Done when your Open Brain project has the `errata`, `errata_*`, and
+`root_cause_classes` tables and you can insert a row through the same
+service-role path your MCP server uses.
+
+## Expected Outcome
+
+You get a canonical cause ledger that can be searched, linked to bugs and
+customers, and projected into a graph as typed facts such as `CAUSED_BY`,
+`CAUSES`, `IMPACTED`, `REMEDIATED_BY`, `HAS_STATUS`, `RECURRENCE_OF`, and
+`DUPLICATE_OF`.
+
+The schema intentionally does not include dashboards, bug-close enforcement, or
+automatic remediation agents. Those are application-layer workflows that can be
+built on top of this canonical table set.
+
+## Troubleshooting
+
+- **`gen_random_uuid()` is missing:** rerun the first line of `schema.sql`, or
+  enable the `pgcrypto` extension in Supabase.
+- **Your MCP cannot write rows:** confirm the `service_role` key is used by the
+  server process and that the GRANT section in `schema.sql` completed.
+- **You need a new root-cause class:** insert it into `root_cause_classes`.
+  Keep `errata.root_cause_class` as text until you have enough real examples to
+  stabilize the vocabulary.
+- **You want to close an erratum after a hotfix:** keep the erratum open until
+  the systemic remediation has landed and been verified. The immediate fix and
+  the systemic fix are different child links.

--- a/schemas/errata-process-defect-ledger/metadata.json
+++ b/schemas/errata-process-defect-ledger/metadata.json
@@ -1,0 +1,21 @@
+{
+  "name": "Errata Process Defect Ledger",
+  "description": "Add a canonical Open Brain sidecar for systemic process mistakes, their caused bugs, impacted entities, and remediation links.",
+  "category": "schemas",
+  "author": {
+    "name": "Nate B. Jones",
+    "github": "NateBJones"
+  },
+  "version": "1.0.0",
+  "requires": {
+    "open_brain": true,
+    "services": ["Supabase"],
+    "tools": ["SQL editor or psql"]
+  },
+  "requires_skills": [],
+  "tags": ["errata", "root-cause-analysis", "process", "defects", "schema"],
+  "difficulty": "intermediate",
+  "estimated_time": "20 minutes",
+  "created": "2026-06-24",
+  "updated": "2026-06-24"
+}

--- a/schemas/errata-process-defect-ledger/schema.sql
+++ b/schemas/errata-process-defect-ledger/schema.sql
@@ -1,0 +1,298 @@
+create extension if not exists pgcrypto;
+
+do $$
+begin
+  create type public.errata_domain as enum (
+    'engineering',
+    'product',
+    'ops',
+    'customer_success',
+    'finance',
+    'gtm',
+    'other'
+  );
+exception when duplicate_object then null;
+end $$;
+
+do $$
+begin
+  create type public.errata_escape_point as enum (
+    'authored_unreviewed',
+    'passed_ai_review',
+    'passed_human_review',
+    'passed_ci',
+    'reached_prod',
+    'no_guardrail_existed'
+  );
+exception when duplicate_object then null;
+end $$;
+
+do $$
+begin
+  create type public.errata_responsible_actor as enum (
+    'coding_agent',
+    'review_agent',
+    'human',
+    'pair',
+    'process_absent',
+    'external'
+  );
+exception when duplicate_object then null;
+end $$;
+
+do $$
+begin
+  create type public.errata_severity as enum (
+    'low',
+    'medium',
+    'high',
+    'critical'
+  );
+exception when duplicate_object then null;
+end $$;
+
+do $$
+begin
+  create type public.errata_status as enum (
+    'captured',
+    'rca',
+    'remediation_proposed',
+    'remediating',
+    'resolved',
+    'accepted_risk',
+    'recurred'
+  );
+exception when duplicate_object then null;
+end $$;
+
+do $$
+begin
+  create type public.errata_artifact_kind as enum (
+    'pr',
+    'commit',
+    'bead',
+    'spec',
+    'doctrine_page',
+    'config_change'
+  );
+exception when duplicate_object then null;
+end $$;
+
+create table if not exists public.root_cause_classes (
+  slug text primary key,
+  label text not null,
+  description text,
+  domain public.errata_domain,
+  status text not null default 'active'
+    check (status in ('active', 'merged_into', 'deprecated')),
+  merged_into text references public.root_cause_classes(slug),
+  metadata jsonb not null default '{}'::jsonb,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+create table if not exists public.errata (
+  id uuid primary key default gen_random_uuid(),
+  canonical_thought_id uuid,
+  workspace_id text not null default 'default',
+  title text not null,
+  summary text not null default '',
+  domain public.errata_domain not null default 'other',
+  escape_point public.errata_escape_point not null default 'authored_unreviewed',
+  responsible_actor public.errata_responsible_actor not null default 'process_absent',
+  actor_agent text,
+  actor_model text,
+  actor_harness text,
+  root_cause_class text not null,
+  caught_by text,
+  introduced_at timestamptz,
+  detected_at timestamptz,
+  severity public.errata_severity not null default 'medium',
+  impact jsonb not null default '{}'::jsonb,
+  status public.errata_status not null default 'captured',
+  idempotency_key text unique,
+  metadata jsonb not null default '{}'::jsonb,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+create table if not exists public.errata_cause_links (
+  id uuid primary key default gen_random_uuid(),
+  erratum_id uuid not null references public.errata(id) on delete cascade,
+  target_kind text not null check (target_kind in ('pr', 'commit')),
+  target_ref text not null,
+  repo text,
+  author_actor text,
+  merged_at timestamptz,
+  role text not null default 'suspected'
+    check (role in ('introduced', 'contributed', 'suspected')),
+  confidence numeric check (confidence is null or (confidence >= 0 and confidence <= 1)),
+  source_timestamp timestamptz,
+  metadata jsonb not null default '{}'::jsonb,
+  created_at timestamptz not null default now(),
+  unique (erratum_id, target_kind, target_ref, role)
+);
+
+create table if not exists public.errata_resolution_links (
+  id uuid primary key default gen_random_uuid(),
+  erratum_id uuid not null references public.errata(id) on delete cascade,
+  target_kind public.errata_artifact_kind not null,
+  target_ref text not null,
+  repo text,
+  kind text not null
+    check (kind in ('immediate_fix', 'systemic_remediation')),
+  scope text not null
+    check (scope in ('repo', 'openclaw', 'doctrine', 'review_process', 'business_process')),
+  status_mirror text,
+  source_timestamp timestamptz,
+  metadata jsonb not null default '{}'::jsonb,
+  created_at timestamptz not null default now(),
+  unique (erratum_id, target_kind, target_ref, kind)
+);
+
+create table if not exists public.errata_bug_links (
+  id uuid primary key default gen_random_uuid(),
+  erratum_id uuid not null references public.errata(id) on delete cascade,
+  bug_ref text not null,
+  bug_kind text not null default 'stakeholder_request',
+  role text not null default 'caused',
+  contribution_weight numeric check (
+    contribution_weight is null or (contribution_weight >= 0 and contribution_weight <= 1)
+  ),
+  metadata jsonb not null default '{}'::jsonb,
+  created_at timestamptz not null default now(),
+  unique (erratum_id, bug_ref, role)
+);
+
+create table if not exists public.errata_impact_links (
+  id uuid primary key default gen_random_uuid(),
+  erratum_id uuid not null references public.errata(id) on delete cascade,
+  target_kind text not null check (target_kind in ('account', 'customer', 'company', 'person')),
+  target_ref text not null,
+  display_name text,
+  organization_id text,
+  user_id text,
+  metadata jsonb not null default '{}'::jsonb,
+  created_at timestamptz not null default now(),
+  unique (erratum_id, target_kind, target_ref)
+);
+
+create table if not exists public.errata_thought_links (
+  id uuid primary key default gen_random_uuid(),
+  erratum_id uuid not null references public.errata(id) on delete cascade,
+  thought_id uuid not null,
+  link_kind text not null default 'source_evidence'
+    check (link_kind in ('canonical_summary', 'source_evidence', 'rca', 'fix', 'verification', 'related')),
+  is_current boolean not null default true,
+  source_timestamp timestamptz,
+  metadata jsonb not null default '{}'::jsonb,
+  created_at timestamptz not null default now(),
+  unique (erratum_id, thought_id, link_kind)
+);
+
+create table if not exists public.errata_status_events (
+  id uuid primary key default gen_random_uuid(),
+  erratum_id uuid not null references public.errata(id) on delete cascade,
+  from_status public.errata_status,
+  to_status public.errata_status not null,
+  actor text,
+  at timestamptz not null default now(),
+  note text,
+  metadata jsonb not null default '{}'::jsonb,
+  created_at timestamptz not null default now()
+);
+
+create table if not exists public.errata_relations (
+  id uuid primary key default gen_random_uuid(),
+  from_erratum_id uuid not null references public.errata(id) on delete cascade,
+  to_erratum_id uuid not null references public.errata(id) on delete cascade,
+  relation text not null check (relation in ('duplicate_of', 'recurrence_of', 'related')),
+  metadata jsonb not null default '{}'::jsonb,
+  created_at timestamptz not null default now(),
+  check (from_erratum_id <> to_erratum_id),
+  unique (from_erratum_id, to_erratum_id, relation)
+);
+
+create table if not exists public.errata_audit_events (
+  id uuid primary key default gen_random_uuid(),
+  erratum_id uuid not null references public.errata(id) on delete cascade,
+  event_type text not null,
+  actor text,
+  detail jsonb not null default '{}'::jsonb,
+  created_at timestamptz not null default now()
+);
+
+create or replace function public.errata_touch_updated_at()
+returns trigger
+language plpgsql
+as $$
+begin
+  new.updated_at = now();
+  return new;
+end;
+$$;
+
+do $$
+begin
+  if not exists (select 1 from pg_trigger where tgname = 'root_cause_classes_touch_updated_at') then
+    create trigger root_cause_classes_touch_updated_at
+    before update on public.root_cause_classes
+    for each row execute function public.errata_touch_updated_at();
+  end if;
+
+  if not exists (select 1 from pg_trigger where tgname = 'errata_touch_updated_at') then
+    create trigger errata_touch_updated_at
+    before update on public.errata
+    for each row execute function public.errata_touch_updated_at();
+  end if;
+end $$;
+
+create index if not exists errata_status_idx on public.errata(status);
+create index if not exists errata_domain_idx on public.errata(domain);
+create index if not exists errata_root_cause_class_idx on public.errata(root_cause_class);
+create index if not exists errata_detected_at_idx on public.errata(detected_at desc nulls last);
+create index if not exists errata_cause_links_erratum_idx on public.errata_cause_links(erratum_id);
+create index if not exists errata_resolution_links_erratum_idx on public.errata_resolution_links(erratum_id);
+create index if not exists errata_bug_links_erratum_idx on public.errata_bug_links(erratum_id);
+create index if not exists errata_bug_links_bug_ref_idx on public.errata_bug_links(bug_ref);
+create index if not exists errata_impact_links_erratum_idx on public.errata_impact_links(erratum_id);
+create index if not exists errata_thought_links_erratum_idx on public.errata_thought_links(erratum_id);
+create index if not exists errata_thought_links_thought_idx on public.errata_thought_links(thought_id);
+create index if not exists errata_status_events_erratum_idx on public.errata_status_events(erratum_id);
+create index if not exists errata_relations_from_idx on public.errata_relations(from_erratum_id);
+create index if not exists errata_relations_to_idx on public.errata_relations(to_erratum_id);
+create index if not exists errata_audit_events_erratum_idx on public.errata_audit_events(erratum_id);
+
+do $$
+declare
+  table_name text;
+begin
+  foreach table_name in array array[
+    'root_cause_classes',
+    'errata',
+    'errata_cause_links',
+    'errata_resolution_links',
+    'errata_bug_links',
+    'errata_impact_links',
+    'errata_thought_links',
+    'errata_status_events',
+    'errata_relations',
+    'errata_audit_events'
+  ] loop
+    execute format('alter table public.%I enable row level security', table_name);
+    execute format('grant select, insert, update, delete on table public.%I to service_role', table_name);
+
+    if not exists (
+      select 1
+      from pg_policies
+      where schemaname = 'public'
+        and tablename = table_name
+        and policyname = 'service_role_all'
+    ) then
+      execute format(
+        'create policy service_role_all on public.%I for all to service_role using (true) with check (true)',
+        table_name
+      );
+    end if;
+  end loop;
+end $$;

--- a/schemas/errata-process-defect-ledger/schema.sql
+++ b/schemas/errata-process-defect-ledger/schema.sql
@@ -155,7 +155,7 @@ create table if not exists public.errata_bug_links (
   erratum_id uuid not null references public.errata(id) on delete cascade,
   bug_ref text not null,
   bug_kind text not null default 'stakeholder_request',
-  role text not null default 'caused',
+  role text not null default 'cause',
   contribution_weight numeric check (
     contribution_weight is null or (contribution_weight >= 0 and contribution_weight <= 1)
   ),
@@ -181,8 +181,8 @@ create table if not exists public.errata_thought_links (
   id uuid primary key default gen_random_uuid(),
   erratum_id uuid not null references public.errata(id) on delete cascade,
   thought_id uuid not null,
-  link_kind text not null default 'source_evidence'
-    check (link_kind in ('canonical_summary', 'source_evidence', 'rca', 'fix', 'verification', 'related')),
+  link_kind text not null default 'discussion'
+    check (link_kind in ('canonical_summary', 'intake', 'rca', 'fix', 'discussion', 'status_change', 'related', 'source_evidence', 'verification')),
   is_current boolean not null default true,
   source_timestamp timestamptz,
   metadata jsonb not null default '{}'::jsonb,


### PR DESCRIPTION
## Summary
- Add a self-contained `schemas/errata-process-defect-ledger` contribution package.
- Includes `README.md`, `metadata.json`, and additive `schema.sql` for the errata sidecar and child link/event tables.
- Keeps the public OB1 package reusable: no MVMNT-only seed data, no dashboards, no automation layer.

## Validation
- `jq . schemas/errata-process-defect-ledger/metadata.json`
- `git diff --check`
- destructive SQL grep for `DROP TABLE`, `DROP DATABASE`, `TRUNCATE`, `DELETE FROM`: no matches

## Notes
- This PR is fork-based because the authenticated account has read-only access to `NateBJones-Projects/OB1`.
