### PR TITLE
[recipes] Fix typed-edge-classifier model routing for OpenRouter

### DIFF
--- a/recipes/typed-edge-classifier/README.md
+++ b/recipes/typed-edge-classifier/README.md
@@ -57,7 +57,7 @@ COST CAP FOR FIRST RUN
    export ANTHROPIC_API_KEY="sk-ant-..."
    ```
 
-   When OpenRouter is used, the default Anthropic model names (`claude-haiku-4-5-20251001`, `claude-opus-4-7`) are auto-prefixed with `anthropic/` so OpenRouter routes correctly. Pass an already-prefixed string via `--filter-model` / `--classify-model` to override. If both keys are set, OpenRouter wins (matches the priority order in `entity-extraction-worker`).
+   When OpenRouter is used, the default Anthropic model names (`claude-haiku-4-5-20251001`, `claude-opus-4-7`) are mapped to their OpenRouter slugs (`anthropic/claude-haiku-4.5`, `anthropic/claude-opus-4.7`) so OpenRouter routes correctly. Pass an already-prefixed string via `--filter-model` / `--classify-model` to override. If both keys are set, OpenRouter wins (matches the priority order in `entity-extraction-worker`).
 
 3. Run a **dry run** first with a small limit and a low cost cap:
 

--- a/recipes/typed-edge-classifier/classify-edges.mjs
+++ b/recipes/typed-edge-classifier/classify-edges.mjs
@@ -43,8 +43,9 @@
  *     ANTHROPIC_API_KEY       sk-ant-...     (direct, retained for back-compat)
  *
  *   When using OpenRouter, the default models (claude-haiku-4-5-20251001
- *   and claude-opus-4-7) are auto-prefixed with "anthropic/". Pass an
- *   already-prefixed string (e.g. "anthropic/claude-haiku-4-5") via
+ *   and claude-opus-4-7) are mapped to their OpenRouter slugs
+ *   ("anthropic/claude-haiku-4.5", "anthropic/claude-opus-4.7"). Pass an
+ *   already-prefixed string (e.g. "anthropic/claude-haiku-4.5") via
  *   --filter-model / --classify-model to override.
  *
  * USAGE
@@ -291,15 +292,34 @@ function loadEnv() {
 // keep that switch contained so callLlmOnce stays readable.
 
 /**
+ * Anthropic's canonical model names use dated API IDs ("claude-opus-4-7"
+ * -> "claude-opus-4-7-YYYYMMDD") or dashed shorthands, but OpenRouter
+ * exposes the same models under *dotted* slugs ("anthropic/claude-opus-4.7",
+ * "anthropic/claude-haiku-4.5"). A bare "anthropic/" prefix is therefore not
+ * enough — "anthropic/claude-haiku-4-5-20251001" 404s on OpenRouter. Map the
+ * model names OB1 ships as defaults to their OpenRouter slugs so the classifier
+ * works out-of-the-box on the recommended provider. PRICING lookups are
+ * unaffected: estimateCost() is always called with the raw (pre-resolve) name.
+ */
+const OPENROUTER_MODEL_MAP = {
+  "claude-haiku-4-5-20251001": "anthropic/claude-haiku-4.5",
+  "claude-haiku-4-5": "anthropic/claude-haiku-4.5",
+  "claude-opus-4-7": "anthropic/claude-opus-4.7",
+  "claude-opus-4-6": "anthropic/claude-opus-4.6",
+};
+
+/**
  * When the operator passes a bare Anthropic model name like
  * "claude-haiku-4-5-20251001" but the active provider is OpenRouter,
- * prefix it with "anthropic/" so OpenRouter routes correctly. Already-
+ * translate it to OpenRouter's slug (preferring the explicit map above,
+ * falling back to an "anthropic/" prefix for names we don't know). Already-
  * prefixed names ("anthropic/...", "openai/...", etc.) pass through.
  */
 function resolveModel(model, provider) {
   if (provider !== "openrouter") return model;
   if (!model) return model;
   if (model.includes("/")) return model;
+  if (OPENROUTER_MODEL_MAP[model]) return OPENROUTER_MODEL_MAP[model];
   return `anthropic/${model}`;
 }
 


### PR DESCRIPTION
## Problem

`recipes/typed-edge-classifier/classify-edges.mjs` ships with Anthropic's canonical model names as defaults (`claude-haiku-4-5-20251001` for the filter, `claude-opus-4-7` for classify). When the provider is **OpenRouter** — the recipe's recommended provider — `resolveModel()` only prepends `anthropic/`, producing slugs like `anthropic/claude-haiku-4-5-20251001` that don't exist on OpenRouter. OpenRouter exposes these models under **dotted** slugs (`anthropic/claude-haiku-4.5`, `anthropic/claude-opus-4.7`).

The result is that every Haiku-filter and Opus-classify call fails, so a default run writes nothing:

```
[classify-edges] status counts: { filter_error: 3 }
[classify-edges] estimated spend: $0.0000 of $0.50 cap
```

## Fix

Add an explicit `OPENROUTER_MODEL_MAP` and consult it in `resolveModel()` before falling back to the bare `anthropic/` prefix, mapping the names OB1 ships as defaults to their OpenRouter slugs.

- **Anthropic-direct path unchanged** — guarded by `provider !== "openrouter"`.
- **Cost cap unaffected** — `estimateCost()` / `assertPricingKnown()` are always called with the raw, pre-resolve names, which remain keys in `PRICING`. No `PRICING` changes and no default-model changes.
- Docstring + README updated to describe mapping rather than prefixing.

## Verification

With OpenRouter configured, the same run now classifies and writes edges:

```
[classify-edges] status counts: { inserted: 2, filter_rejected: 1 }
[classify-edges] estimated spend: $0.0541 of $1.00 cap
  [ok] inserted   conf=0.85  ... -[evolved_into]-> ...
  [ok] inserted   conf=0.75  ... -[related_to]-> ...
```

Rows confirmed present in `public.thought_edges`.
