### PR TITLE
docs: update knowledge graph schema reference in README

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,8 @@ docs/walkthroughs/*/public/
 docs/assets/agent-memory/promotional/generated-backgrounds/**/result.json
 docs/assets/agent-memory/screenshots/**/.chrome-*/
 integrations/openclaw-agent-memory/dist/
+open-brain-credential-tracker.xlsx
+~$open-brain-credential-tracker.xlsx
+integrations/consolidation-workers/_shared/tmp.txt
+
+zebras/

--- a/docs/walkthroughs/ob1-agent-dashboard/output/OB1-Agent-Dashboard-Walkthrough.html
+++ b/docs/walkthroughs/ob1-agent-dashboard/output/OB1-Agent-Dashboard-Walkthrough.html
@@ -132,7 +132,7 @@
 <body>
   <section class="page">
     <div class="brand">
-      <img src="file:///Users/jonathanedwards/AUTOMATION/NATE/OB1/docs/assets/agent-memory/brand/ob1-logo.png" alt="" />
+      <img src="file:///D:/Repos/KeithBarrows/OB1/docs/assets/agent-memory/brand/ob1-logo.png" alt="" />
       <span>Nate B. Jones / OB1</span>
     </div>
     <div class="title">OB1 Agent Dashboard Walkthrough</div>
@@ -142,7 +142,7 @@
 
   <section class="page">
     <div class="grid">
-      <img class="shot" src="file:///Users/jonathanedwards/AUTOMATION/NATE/OB1/docs/assets/agent-memory/screenshots/dashboard-walkthrough/dashboard-overview.png" alt="Dashboard screenshot" />
+      <img class="shot" src="file:///D:/Repos/KeithBarrows/OB1/docs/assets/agent-memory/screenshots/dashboard-walkthrough/dashboard-overview.png" alt="Dashboard screenshot" />
       <div>
         <div class="eyebrow">One operational scan</div>
         <h1>Dashboard</h1>
@@ -161,7 +161,7 @@
   </section>
 <section class="page">
     <div class="grid">
-      <img class="shot" src="file:///Users/jonathanedwards/AUTOMATION/NATE/OB1/docs/assets/agent-memory/screenshots/dashboard-walkthrough/thoughts-table.png" alt="Thoughts screenshot" />
+      <img class="shot" src="file:///D:/Repos/KeithBarrows/OB1/docs/assets/agent-memory/screenshots/dashboard-walkthrough/thoughts-table.png" alt="Thoughts screenshot" />
       <div>
         <div class="eyebrow">Canonical memory list</div>
         <h1>Thoughts</h1>
@@ -180,7 +180,7 @@
   </section>
 <section class="page">
     <div class="grid">
-      <img class="shot" src="file:///Users/jonathanedwards/AUTOMATION/NATE/OB1/docs/assets/agent-memory/screenshots/dashboard-walkthrough/workflow-board.png" alt="Workflow screenshot" />
+      <img class="shot" src="file:///D:/Repos/KeithBarrows/OB1/docs/assets/agent-memory/screenshots/dashboard-walkthrough/workflow-board.png" alt="Workflow screenshot" />
       <div>
         <div class="eyebrow">Task and idea continuity</div>
         <h1>Workflow</h1>
@@ -199,7 +199,7 @@
   </section>
 <section class="page">
     <div class="grid">
-      <img class="shot" src="file:///Users/jonathanedwards/AUTOMATION/NATE/OB1/docs/assets/agent-memory/screenshots/dashboard-walkthrough/agent-memory-review.png" alt="Agent Memory screenshot" />
+      <img class="shot" src="file:///D:/Repos/KeithBarrows/OB1/docs/assets/agent-memory/screenshots/dashboard-walkthrough/agent-memory-review.png" alt="Agent Memory screenshot" />
       <div>
         <div class="eyebrow">Governed write-back</div>
         <h1>Agent Memory</h1>
@@ -218,7 +218,7 @@
   </section>
 <section class="page">
     <div class="grid">
-      <img class="shot" src="file:///Users/jonathanedwards/AUTOMATION/NATE/OB1/docs/assets/agent-memory/screenshots/dashboard-walkthrough/recall-trace.png" alt="Recall Trace screenshot" />
+      <img class="shot" src="file:///D:/Repos/KeithBarrows/OB1/docs/assets/agent-memory/screenshots/dashboard-walkthrough/recall-trace.png" alt="Recall Trace screenshot" />
       <div>
         <div class="eyebrow">Debug retrieval</div>
         <h1>Recall Trace</h1>
@@ -237,7 +237,7 @@
   </section>
 <section class="page">
     <div class="grid">
-      <img class="shot" src="file:///Users/jonathanedwards/AUTOMATION/NATE/OB1/docs/assets/agent-memory/screenshots/dashboard-walkthrough/duplicates-review.png" alt="Duplicates screenshot" />
+      <img class="shot" src="file:///D:/Repos/KeithBarrows/OB1/docs/assets/agent-memory/screenshots/dashboard-walkthrough/duplicates-review.png" alt="Duplicates screenshot" />
       <div>
         <div class="eyebrow">Memory graph hygiene</div>
         <h1>Duplicates</h1>
@@ -256,7 +256,7 @@
   </section>
 <section class="page">
     <div class="grid">
-      <img class="shot" src="file:///Users/jonathanedwards/AUTOMATION/NATE/OB1/docs/assets/agent-memory/screenshots/dashboard-walkthrough/audit-quality.png" alt="Audit screenshot" />
+      <img class="shot" src="file:///D:/Repos/KeithBarrows/OB1/docs/assets/agent-memory/screenshots/dashboard-walkthrough/audit-quality.png" alt="Audit screenshot" />
       <div>
         <div class="eyebrow">Quality and safety pass</div>
         <h1>Audit</h1>

--- a/integrations/consolidation-workers/README.md
+++ b/integrations/consolidation-workers/README.md
@@ -27,7 +27,7 @@ For the full tool and worker inventory, see `docs/05-tool-audit.md` in the repos
 
 - Working Open Brain setup ([guide](../../docs/01-getting-started.md))
 - **Enhanced thoughts schema** applied — install `schemas/enhanced-thoughts` for the `type`, `importance`, `sensitivity_tier`, and `source_type` columns
-- **Knowledge graph schema** applied — install `schemas/knowledge-graph` for the `consolidation_log` table
+- **Knowledge graph schema** applied — install `schemas/entity-extraction` for the `consolidation_log` table
 - At least one LLM API key: OpenRouter (recommended), OpenAI, or Anthropic
 - Supabase CLI installed for deployment
 
@@ -196,7 +196,7 @@ Solution: Candidates must have `type = 'reference'` with confidence < 0.7, or `i
 Solution: Verify your API keys are set correctly. Check the Supabase function logs for specific error messages. The worker tries OpenRouter first, then OpenAI, then Anthropic.
 
 **Issue: consolidation_log insert fails**
-Solution: Ensure the knowledge graph schema is applied. The `consolidation_log` table is created by `schemas/knowledge-graph`. This is a non-fatal error — the thought updates still succeed.
+Solution: Ensure the knowledge graph schema is applied. The `consolidation_log` table is created by `schemas/entity-extraction`. This is a non-fatal error — the thought updates still succeed.
 
 ## Architecture
 


### PR DESCRIPTION
## Contribution Type

<!-- Check one -->
- [ ] Recipe (`/recipes`)
- [ ] Schema (`/schemas`)
- [ ] Dashboard (`/dashboards`)
- [ ] Integration (`/integrations`)
- [ ] Skill (`/skills`)
- [X] Repo improvement (docs, CI, templates)

## What does this do?

<!-- 1-3 sentences describing what this contribution adds or changes -->
Corrects path to schema needed (schemas/entity-extraction) as the path currently in the README does not exist (name was changed?)

NOTE: This is a path correction in the README. No code changes, no changes to the existing `metadata.json`

## Requirements

<!-- What external services, tools, or APIs does this need? (e.g., Gmail API, Node.js 18+) -->
<!-- If this depends on a canonical skill or primitive, mention it here and declare it in metadata.json -->

## Checklist

- [X] I've read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [X] My contribution has a `README.md` with prerequisites, step-by-step instructions, and expected outcome
- [ ] My `metadata.json` has all required fields
- [ ] If my contribution depends on a skill or primitive, I declared it in metadata.json and linked it in the README
- [X] I tested this on my own Open Brain instance
- [X] No credentials, API keys, or secrets are included
