### PR TITLE
[skills] Fix auto-capture hook registration: Stop to SessionEnd

### DIFF
--- a/skills/auto-capture-claude-code/SKILL.md
+++ b/skills/auto-capture-claude-code/SKILL.md
@@ -74,7 +74,7 @@ extends it — it does not replace it.
    ```json
    {
      "hooks": {
-       "Stop": [
+       "SessionEnd": [
          {
            "matcher": "",
            "hooks": [

--- a/skills/auto-capture-claude-code/session-end-capture.mjs
+++ b/skills/auto-capture-claude-code/session-end-capture.mjs
@@ -18,7 +18,7 @@
  * Install in .claude/settings.json:
  *   {
  *     "hooks": {
- *       "Stop": [{
+ *       "SessionEnd": [{
  *         "matcher": "",
  *         "hooks": [{ "type": "command", "command": "node /path/to/session-end-capture.mjs" }]
  *       }]


### PR DESCRIPTION
## Contribution Type

- [ ] Recipe (`/recipes`)
- [ ] Schema (`/schemas`)
- [ ] Dashboard (`/dashboards`)
- [ ] Integration (`/integrations`)
- [x] Skill (`/skills`)
- [ ] Repo improvement (docs, CI, templates)

## What does this do?

Fixes the `auto-capture-claude-code` hook registration. The capture script
`session-end-capture.mjs` is written for the `SessionEnd` hook (its header calls
it a "Session-End Capture Hook," and it reads the `reason` field and skips
`reason === "clear" || reason === "resume"`), but the install snippet registers
it under `Stop`. The `Stop` hook never sends a `reason` and fires after every
assistant response, so as documented the hook captures duplicates (one POST per
turn, with distinct import_keys that defeat dedup) and the `/clear` and `/resume`
skip-guards never trigger.

This changes the hook key from `Stop` to `SessionEnd` in both the
`session-end-capture.mjs` header comment and `SKILL.md`. No code logic changes,
because the script already expects the SessionEnd payload.

Fixes #376

## Requirements

None. One-line documentation/config change to an existing skill. No new services
or tools.

## Checklist

- [x] I've read CONTRIBUTING.md
- [x] My contribution has a `README.md` with prerequisites, step-by-step instructions, and expected outcome
- [x] My `metadata.json` has all required fields
- [x] If my contribution depends on a skill or primitive, I declared it in metadata.json and linked it in the README (n/a: no new dependencies)
- [x] I tested this on my own Open Brain instance
- [x] No credentials, API keys, or secrets are included