### PR TITLE
[integrations] update-thought-mcp: complete deno.json import map

### DIFF
--- a/integrations/update-thought-mcp/deno.json
+++ b/integrations/update-thought-mcp/deno.json
@@ -1,5 +1,9 @@
 {
   "imports": {
-    "@supabase/supabase-js": "npm:@supabase/supabase-js@2.47.10"
+    "@hono/mcp": "npm:@hono/mcp@0.1.1",
+    "@modelcontextprotocol/sdk": "npm:@modelcontextprotocol/sdk@1.24.3",
+    "@supabase/supabase-js": "npm:@supabase/supabase-js@2.47.10",
+    "hono": "npm:hono@4.9.2",
+    "zod": "npm:zod@4.1.13"
   }
 }


### PR DESCRIPTION
## Summary

`integrations/update-thought-mcp/deno.json` only maps `@supabase/supabase-js`, but `index.ts` also imports:

- `@modelcontextprotocol/sdk/server/mcp.js`
- `@hono/mcp`
- `hono`
- `zod`

Without those in the import map, Deno can't resolve the module graph and the function fails to boot when deployed as a Supabase Edge Function. The sibling integrations `delete-thought-mcp` and `enhanced-mcp` already have the full import map.

## What this PR does

Adds the four missing entries. Versions match the sibling MCP integrations exactly (`@modelcontextprotocol/sdk@1.24.3`, `@hono/mcp@0.1.1`, `hono@4.9.2`, `zod@4.1.13`, `@supabase/supabase-js@2.47.10`) so all three MCP integrations pin to the same versions.

## Test plan

- [ ] `supabase functions deploy update-thought-mcp` succeeds
- [ ] Deployed function responds 204 on `OPTIONS /`
- [ ] MCP client (Claude Code, Claude.ai custom connector) can invoke the `update_thought` tool end-to-end

Verified locally by deploying against my own Supabase project — the patched import map boots the function; the upstream one does not.

🤖 Generated with [Claude Code](https://claude.com/claude-code)