### PR TITLE
[integrations] Fix OpenClaw tools-only activation and project scope overrides

### DIFF
--- a/integrations/openclaw-agent-memory/README.md
+++ b/integrations/openclaw-agent-memory/README.md
@@ -48,6 +48,12 @@ OPENCLAW
 
 ## Steps
 
+1. Apply the OB1 Agent Memory schema and deploy the Agent Memory API.
+2. Build the OpenClaw plugin package from `integrations/openclaw-agent-memory/plugin`.
+3. Install the plugin into an isolated OpenClaw profile with `openclaw plugins install --link`.
+4. Install the paired `nbj-ob1-agent-memory-openclaw` skill.
+5. Verify `openbrain_recall` and `openbrain_writeback` are available before enabling team workflows.
+
 ![Step 1](https://img.shields.io/badge/Step_1-Prepare_OB1_Agent_Memory-1E88E5?style=for-the-badge)
 
 Apply the schema and deploy the API.

--- a/integrations/openclaw-agent-memory/plugin/openclaw.plugin.json
+++ b/integrations/openclaw-agent-memory/plugin/openclaw.plugin.json
@@ -3,7 +3,6 @@
   "name": "NBJ OB1 Agent Memory for OpenClaw",
   "description": "Typed OpenClaw tools for governed Nate Jones OB1 memory recall, write-back, review, inspection, and trace debugging.",
   "skills": ["./skills/openclaw-agent-memory"],
-  "kind": "memory",
   "contracts": {
     "tools": [
       "openbrain_recall",

--- a/integrations/openclaw-agent-memory/plugin/package.json
+++ b/integrations/openclaw-agent-memory/plugin/package.json
@@ -36,6 +36,8 @@
   "scripts": {
     "build": "esbuild src/index.ts --bundle --platform=node --format=esm --target=node20 --external:openclaw/* --external:typebox --outfile=dist/index.js",
     "schema:check": "node scripts/check-tool-schemas.mjs",
+    "scope:check": "node scripts/check-project-scope.mjs",
+    "test": "npm run build && npm run schema:check && npm run scope:check",
     "smoke:native": "bash smoke/native-openclaw-smoke.sh"
   },
   "dependencies": {

--- a/integrations/openclaw-agent-memory/plugin/scripts/check-project-scope.mjs
+++ b/integrations/openclaw-agent-memory/plugin/scripts/check-project-scope.mjs
@@ -1,0 +1,97 @@
+import fs from "node:fs";
+
+const typeStub = new Proxy({}, { get: () => (...args) => ({ args }) });
+let code = fs.readFileSync(new URL("../dist/index.js", import.meta.url), "utf8");
+
+code = code
+  .replace('import { Type as Type2 } from "typebox";\n', "const Type2 = typeStub;\n")
+  .replace('import { definePluginEntry } from "openclaw/plugin-sdk/plugin-entry";\n', "const definePluginEntry = (entry) => entry;\n")
+  .replace(
+    'import { resolveConfiguredSecretInputString } from "openclaw/plugin-sdk/secret-input-runtime";\n',
+    'const resolveConfiguredSecretInputString = async ({ value }) => ({ value: typeof value === "string" ? value : "test-key" });\n',
+  )
+  .replace('import { Type } from "typebox";\n', "const Type = typeStub;\n")
+  .replace(/export \{\s*index_default as default\s*\};\s*$/s, "return index_default;");
+
+const plugin = new Function("typeStub", code)(typeStub);
+const registered = new Map();
+const api = {
+  pluginConfig: {
+    endpoint: "https://example.invalid/agent-memory-api",
+    accessKey: "test-key",
+    workspaceId: "ratiocore",
+    projectId: "ratiocore-ops",
+    requireReviewByDefault: true,
+    includeUnconfirmedRecall: false,
+  },
+  config: {},
+  registerTool(tool) {
+    registered.set(tool.name, tool);
+  },
+};
+
+plugin.register(api);
+
+const calls = [];
+globalThis.fetch = async (url, options = {}) => {
+  calls.push({
+    url: String(url),
+    body: options.body ? JSON.parse(options.body) : null,
+  });
+  return {
+    ok: true,
+    status: 200,
+    async text() {
+      return JSON.stringify({ ok: true });
+    },
+  };
+};
+
+function fail(message, details = {}) {
+  console.error(JSON.stringify({ ok: false, error: message, ...details }, null, 2));
+  process.exit(1);
+}
+
+function assertEqual(name, actual, expected) {
+  if (actual !== expected) fail(`${name} mismatch`, { actual, expected });
+}
+
+await registered.get("openbrain_recall").execute("test", {
+  query: "clubhouse constraints",
+  project_id: "clubhouse",
+  scope: { project_only: true },
+});
+await registered.get("openbrain_recall").execute("test", {
+  query: "default project fallback",
+});
+await registered.get("openbrain_recall").execute("test", {
+  query: "workspace-wide explicit null",
+  project_id: null,
+});
+await registered.get("openbrain_writeback").execute("test", {
+  project_id: "teacher-loloy",
+  memory_payload: { decisions: ["test decision"] },
+});
+await registered.get("openbrain_list_review_queue").execute("test", {
+  project_id: "paperclip",
+});
+
+const summary = {
+  registered_tool_count: registered.size,
+  recall_override: calls[0]?.body?.project_id,
+  recall_default: calls[1]?.body?.project_id,
+  recall_explicit_null: calls[2]?.body?.project_id,
+  writeback_override: calls[3]?.body?.project_id,
+  review_queue_url: calls[4]?.url,
+};
+
+assertEqual("registered_tool_count", summary.registered_tool_count, 7);
+assertEqual("recall_override", summary.recall_override, "clubhouse");
+assertEqual("recall_default", summary.recall_default, "ratiocore-ops");
+assertEqual("recall_explicit_null", summary.recall_explicit_null, null);
+assertEqual("writeback_override", summary.writeback_override, "teacher-loloy");
+if (!summary.review_queue_url?.includes("project_id=paperclip")) {
+  fail("review_queue_url missing project_id override", summary);
+}
+
+console.log(JSON.stringify({ ok: true, ...summary }, null, 2));

--- a/integrations/openclaw-agent-memory/plugin/src/client.ts
+++ b/integrations/openclaw-agent-memory/plugin/src/client.ts
@@ -17,8 +17,8 @@ function requestInput(input: Record<string, unknown>) {
 }
 
 function projectIdFrom(input: Record<string, unknown>, configuredProjectId?: string) {
-  if (configuredProjectId) return configuredProjectId;
   if (typeof input.project_id === "string" || input.project_id === null) return input.project_id;
+  if (configuredProjectId) return configuredProjectId;
   return null;
 }
 

--- a/integrations/openclaw-agent-memory/plugin/src/index.ts
+++ b/integrations/openclaw-agent-memory/plugin/src/index.ts
@@ -179,7 +179,6 @@ export default definePluginEntry({
   id: "nbj-ob1-agent-memory",
   name: "NBJ OB1 Agent Memory for OpenClaw",
   description: "Recall and write governed Nate Jones OB1 memory from OpenClaw workflows.",
-  kind: "memory",
   register(api) {
     registerTool(api, {
       name: "openbrain_recall",


### PR DESCRIPTION
## Summary

This PR fixes two OpenClaw integration issues found while validating the OB1 Agent Memory plugin in a tools-only deployment beside OpenClaw's native `memory-core` slot.

- Remove the plugin's `kind: "memory"` declaration so OpenClaw can activate the OB1 tools as a sidecar/tools-only provider instead of disabling the plugin when `memory-core` is selected.
- Make per-call `project_id` override the configured default project id in request bodies and review queue URLs.
- Add a project-scope regression check that verifies recall override, configured fallback, explicit `project_id: null`, writeback override, and review queue URL scoping.
- Add `npm test` for schema + scope checks, with build first so this source-only PR does not depend on checked-in generated output.

## Root Cause

OpenClaw treats plugins declared with `kind: "memory"` as mutually exclusive with the configured memory slot. In a setup where `memory-core` remains primary and OB1 is intended to provide review-gated shared memory tools, the plugin is disabled after gateway restart and no `openbrain_*` tools are registered.

Separately, `projectIdFrom()` returned the configured default before inspecting per-call input, so a configured project could override an explicit tool-call `project_id`. That affected recall as well as writeback/review queue calls.

## Validation

Run from `integrations/openclaw-agent-memory/plugin`:

```bash
npm test
```

Observed locally:

```text
npm run build
npm run schema:check
npm run scope:check
```

`scope:check` asserted:

- `registered_tool_count: 7`
- `recall_override: clubhouse`
- `recall_default: ratiocore-ops`
- `recall_explicit_null: null`
- `writeback_override: teacher-loloy`
- review queue URL includes `project_id=paperclip`

This was also validated in a live OpenClaw install after gateway restart with `memory-core` still selected: runtime doctor reported OB1 active with 7 tools, and native `openbrain_recall` returned the correct project-scoped memories.

## Dist Sync Note

This PR is intentionally source-only. Running `npm run build` regenerates `integrations/openclaw-agent-memory/plugin/dist/index.js`, but I left generated `dist` churn out of the PR to keep review focused. If this repository expects committed generated bundles, I can follow up with a separate dist-sync commit.
