### PR TITLE
[skills] Fix auto-capture-claude-code parser and add ingest size guard

### DIFF
--- a/skills/auto-capture-claude-code/metadata.json
+++ b/skills/auto-capture-claude-code/metadata.json
@@ -6,7 +6,7 @@
     "name": "Alan Shurafa",
     "github": "alanshurafa"
   },
-  "version": "1.0.0",
+  "version": "1.0.1",
   "requires": {
     "open_brain": true,
     "services": ["Supabase"],
@@ -16,5 +16,6 @@
   "tags": ["skill", "capture", "claude-code", "hooks", "session-end", "ambient"],
   "difficulty": "beginner",
   "estimated_time": "10 minutes",
-  "created": "2026-04-06"
+  "created": "2026-04-06",
+  "updated": "2026-07-05"
 }

--- a/skills/auto-capture-claude-code/session-end-capture.mjs
+++ b/skills/auto-capture-claude-code/session-end-capture.mjs
@@ -35,6 +35,9 @@ import { fileURLToPath } from "node:url";
 
 const HARD_TIMEOUT_MS = 25000;
 const MIN_USER_TURNS = 3;
+// Cap the ingest payload under the embedding model's ~8191-token limit
+// (text-embedding-3-small). Long sessions otherwise make /ingest return HTTP 500.
+const MAX_INGEST_CHARS = Number(process.env.OB_CAPTURE_MAX_CHARS) || 24000;
 const RETRY_MAX_ATTEMPTS = 5;
 const RETRY_BATCH_SIZE = 3;
 // Per-request fetch timeout. Must be less than HARD_TIMEOUT_MS so an
@@ -91,7 +94,31 @@ function appendLog(sessionId, projectName, turns, disposition) {
   }
 }
 
-// ── Transcript parsing (simplified) ─────────────────────────────────────────
+// ── Transcript parsing (JSONL) ──────────────────────────────────────────────
+// Claude Code writes transcripts as JSON Lines: one JSON object per line, with
+// a `type` discriminator. Real conversation turns are type "user" / "assistant"
+// carrying a `message` object. Metadata lines (mode, attachment, system, etc.)
+// and sidechain (subagent) turns are ignored. A type:"user" line whose content
+// is only tool_result blocks is a tool response, not a human turn.
+
+function textFromContent(content) {
+  if (typeof content === "string") return content;
+  if (Array.isArray(content)) {
+    return content
+      .filter((b) => b && b.type === "text" && typeof b.text === "string")
+      .map((b) => b.text)
+      .join("\n");
+  }
+  return "";
+}
+
+function isToolResultOnly(content) {
+  return (
+    Array.isArray(content) &&
+    content.length > 0 &&
+    content.every((b) => b && b.type === "tool_result")
+  );
+}
 
 function parseTranscript(transcriptPath) {
   const raw = fs.readFileSync(transcriptPath, "utf8");
@@ -103,35 +130,36 @@ function parseTranscript(transcriptPath) {
   let cwd = "";
 
   const turns = [];
-  let currentRole = null;
-  let currentContent = [];
 
   for (const line of lines) {
-    // Parse header lines
-    if (line.startsWith("Session ID: ")) { sessionId = line.slice(12).trim(); continue; }
-    if (line.startsWith("Created: ")) { createdAt = line.slice(9).trim(); continue; }
-    if (line.startsWith("Branch: ")) { gitBranch = line.slice(8).trim(); continue; }
-    if (line.startsWith("CWD: ")) { cwd = line.slice(5).trim(); continue; }
+    if (!line.trim()) continue;
+    let o;
+    try {
+      o = JSON.parse(line);
+    } catch {
+      continue; // skip any non-JSON line defensively
+    }
 
-    // Detect role markers
-    const roleMatch = line.match(/^(Human|Assistant|System):\s*(.*)/);
-    if (roleMatch) {
-      if (currentRole && currentContent.length > 0) {
-        turns.push({ role: currentRole, content: currentContent.join("\n").trim() });
-      }
-      currentRole = roleMatch[1].toLowerCase();
-      currentContent = roleMatch[2] ? [roleMatch[2]] : [];
-    } else {
-      currentContent.push(line);
+    // Header/metadata can appear on any record — capture the first seen.
+    if (sessionId === "unknown" && o.sessionId) sessionId = o.sessionId;
+    if (!createdAt && o.timestamp) createdAt = o.timestamp;
+    if (!gitBranch && o.gitBranch) gitBranch = o.gitBranch;
+    if (!cwd && o.cwd) cwd = o.cwd;
+
+    if (o.isSidechain) continue; // subagent turn, not part of the main thread
+
+    if (o.type === "user" && o.message?.role === "user") {
+      if (isToolResultOnly(o.message.content)) continue; // tool response, not a human turn
+      const text = textFromContent(o.message.content).trim();
+      if (text) turns.push({ role: "human", content: text });
+    } else if (o.type === "assistant" && o.message?.role === "assistant") {
+      // text blocks only — thinking and tool_use blocks are omitted from capture
+      const text = textFromContent(o.message.content).trim();
+      if (text) turns.push({ role: "assistant", content: text });
     }
   }
 
-  // Flush last turn
-  if (currentRole && currentContent.length > 0) {
-    turns.push({ role: currentRole, content: currentContent.join("\n").trim() });
-  }
-
-  const userTurns = turns.filter(t => t.role === "human").length;
+  const userTurns = turns.filter((t) => t.role === "human").length;
 
   return { sessionId, createdAt, gitBranch, cwd, turns, userTurns };
 }
@@ -155,12 +183,26 @@ function formatTranscript(parsed, projectName) {
     "---",
   ].join("\n");
 
-  const body = parsed.turns
+  let body = parsed.turns
     .filter(t => t.content.trim())
     .map(t => `[${t.role}]\n${escapeThoughtContent(t.content)}`)
     .join("\n\n");
 
+  // Keep the payload under the embedding token limit: preserve the start and
+  // end of the session, drop the middle.
+  body = truncateMiddle(body, MAX_INGEST_CHARS - header.length - 40);
+
   return `${header}\n\n<thought_content>\n${body}\n</thought_content>`;
+}
+
+function truncateMiddle(text, budget) {
+  if (!Number.isFinite(budget) || budget <= 0 || text.length <= budget) return text;
+  const marker = "\n\n[... transcript truncated to fit capture size limit ...]\n\n";
+  const keep = budget - marker.length;
+  if (keep <= 0) return text.slice(0, budget);
+  const headLen = Math.floor(keep * 0.6);
+  const tailLen = keep - headLen;
+  return text.slice(0, headLen) + marker + text.slice(text.length - tailLen);
 }
 
 // ── Import key (idempotency) ────────────────────────────────────────────────


### PR DESCRIPTION
## Contribution Type

- [x] Repo improvement (bug fix to an existing skill)

## What does this do?

Fixes two bugs in `skills/auto-capture-claude-code/session-end-capture.mjs` that made the reference hook capture **nothing** against real Claude Code sessions:

1. **Transcript parser** — `parseTranscript` expected a plaintext `Human:/Assistant:` format, but Claude Code writes transcripts as **JSONL** (one type-tagged JSON object per line). The plaintext parser matched **zero turns** on every real transcript → the hook always logged `skipped:too_short` and captured nothing. Rewrote it to parse JSONL: extract `type:user`/`assistant` turns, exclude tool-result messages and sidechain (subagent) turns.
2. **No payload size guard** — long sessions exceed the ingest embedding model's ~8191-token limit, so `/ingest` returned **HTTP 500** (and, because the endpoint upserts in parallel with the embedding call, left an embedding-less row). Added a 24k-char cap (`OB_CAPTURE_MAX_CHARS`) that keeps the session start and end and drops the middle with a marker.

Only `session-end-capture.mjs` + a version bump in `metadata.json`. No behavior change to any Edge Function.

## Requirements

Node.js 18+, a deployed Open Brain (`open-brain-rest` `/ingest` + `MCP_ACCESS_KEY`). No new dependencies.

## Checklist

- [x] I've read CONTRIBUTING.md
- [x] Tested on my own Open Brain instance (real 16-turn transcript parses; oversized session truncates to <24k and captures HTTP 200)
- [x] No credentials, API keys, or secrets are included

🤖 Generated with [Claude Code](https://claude.com/claude-code)