### PR TITLE
[skills] Add open-brain-capture-hook-authoring skill

### DIFF
--- a/skills/open-brain-capture-hook-authoring/README.md
+++ b/skills/open-brain-capture-hook-authoring/README.md
@@ -1,0 +1,75 @@
+# Open Brain Capture-Hook Authoring
+
+> Authoring and debugging guide for session-end auto-capture hooks that ship an AI CLI transcript to Open Brain.
+
+## What It Does
+
+Codifies the hard-won knowledge for building and debugging session-end capture
+hooks — the per-agent transcript formats and the Open Brain ingest limits that
+make these hooks fail **silently** (logging `skipped:too_short` / `turns=0`
+while capturing nothing). It complements the `auto-capture-*` reference
+implementations: those are install recipes, this is the authoring/debugging
+layer that explains *why* they are shaped the way they are and *what fails
+silently* when they aren't.
+
+## Supported Clients
+
+- Claude Code (JSONL transcripts)
+- Codex (rollout JSONL, no `SessionEnd` event)
+- Grok (native `SessionEnd`, `chat_history.jsonl`)
+
+## Prerequisites
+
+- Working Open Brain setup ([guide](../../docs/01-getting-started.md))
+- An AI client whose session-end hook writes a transcript you can parse
+- Node.js 18+ for the reference hook scripts
+
+## Installation
+
+1. Copy `SKILL.md` into the right folder for your client (e.g.
+   `~/.claude/skills/open-brain-capture-hook-authoring/SKILL.md`)
+2. Restart or reload the client so it picks up the new skill
+3. It fires automatically on the trigger conditions below
+
+## Trigger Conditions
+
+- A capture hook logs `disposition=skipped:too_short` or `turns=0` after a real,
+  multi-turn session
+- Writing a new `Stop` / `SessionEnd` hook that parses a Claude Code, Codex, or
+  Grok transcript
+- `/ingest` (or the smart-ingest edge function) returns HTTP 500 on long sessions
+- A row appears in the `thoughts` table with a null embedding
+
+## Expected Outcome
+
+You correctly parse each agent's real transcript format (not the assumed
+plaintext one), cap the payload under the embedding token limit, and recognize
+the two ingest gotchas — so the hook logs `disposition=captured` instead of
+silently skipping.
+
+## Troubleshooting
+
+**Issue: Hook always logs `skipped:too_short` (turns=0) after a long session**
+Solution: The parser assumes plaintext `Human:/Assistant:` but the transcript is
+JSONL. Parse the JSONL: Claude Code uses `type:user/assistant` with a `message`
+object; take only `text` content blocks; skip `tool_result`-only user lines and
+`isSidechain` (subagent) turns.
+
+**Issue: Codex `Stop` fires with `session=unknown, turns=0` but a rollout exists**
+Solution: Codex's stdin `transcript_path` is unreliable. Resolve the rollout by
+the `session_id` embedded in the filename under `~/.codex/sessions`, and only
+accept a path that parses as a real rollout.
+
+**Issue: `/ingest` returns HTTP 500 on long sessions**
+Solution: `/ingest` embeds with text-embedding-3-small (~8191-token limit). Cap
+the payload at ~24k chars, truncating the middle so the start and end survive.
+Note the 500 still upserts an embedding-less orphan row — verify via the DB, not
+just the HTTP status.
+
+## Notes for Other Clients
+
+Each agent's transcript format drifts independently — re-verify against a fresh
+transcript when a client updates rather than assuming the parser still holds.
+The generalizable debugging lesson: trust the log/DB, not the config. Hooks load
+at session start, so a "fixed" hook that was never reloaded is still running the
+old code.

--- a/skills/open-brain-capture-hook-authoring/SKILL.md
+++ b/skills/open-brain-capture-hook-authoring/SKILL.md
@@ -1,0 +1,127 @@
+---
+name: open-brain-capture-hook-authoring
+description: |
+  Author or debug a session-end auto-capture hook that ships an AI CLI's
+  transcript to Open Brain. Use when: (1) a capture hook logs
+  "skipped:too_short" / turns=0 even though the session was long,
+  (2) writing a Stop/SessionEnd hook that parses a Claude Code, Codex, or Grok
+  transcript, (3) /ingest returns HTTP 500 on long sessions, (4) a captured
+  thought exists in the DB but has no embedding. Covers each agent's real
+  on-disk transcript format and the Open Brain ingest limits.
+author: Ezana Azene
+version: 1.0.0
+---
+
+# Open Brain Capture-Hook Authoring
+
+## Problem
+
+Session-end capture hooks that ship an AI CLI transcript to Open Brain fail
+**silently**: they log `skipped:too_short` (turns=0) and capture nothing, even
+after a long session. The cause is almost always a wrong assumption about the
+transcript's on-disk format — each agent writes a different one, and none of
+them is the plaintext `Human:/Assistant:` shape a naive parser expects.
+
+## Context / Trigger Conditions
+
+- Hook log shows `disposition=skipped:too_short` or `turns=0` after a real,
+  multi-turn session.
+- Writing a new `Stop` / `SessionEnd` hook that must read a transcript.
+- `/ingest` (or the smart-ingest edge function) returns **HTTP 500** on long
+  sessions.
+- A row appears in the `thoughts` table but its embedding column is null.
+
+## Solution
+
+### 1. Parse each agent's real transcript format
+
+Each agent needs its **own** parser. Ground-truth the format by opening an
+actual transcript file — do not trust a reference script's assumed format.
+
+**Claude Code — JSONL** (`~/.claude/projects/<slug>/<uuid>.jsonl`)
+- One JSON object per line, with a `type` discriminator.
+- Real turns: `type:"user"` and `type:"assistant"`, each carrying a `message`
+  object whose `content` is either a string or an array of typed blocks.
+- Extract only `content[].type === "text"` blocks. Omit `thinking` and
+  `tool_use` blocks.
+- A `type:"user"` line whose content is **only** `tool_result` blocks is a tool
+  response, **not** a human turn — skip it (or it inflates `userTurns`).
+- Skip lines where `o.isSidechain === true` — those are subagent turns, not the
+  main thread.
+- Header fields (`sessionId`, `timestamp`, `gitBranch`, `cwd`) can appear on any
+  record; capture the first seen.
+- **The classic bug:** a plaintext `^(Human|Assistant):` regex parser matches
+  **zero** turns against JSONL, so the hook always skips as too-short.
+
+**Codex — "rollout" JSONL** (`~/.codex/sessions/…rollout…`)
+- Codex has **no `SessionEnd` event.** Use the `Stop` hook + a ~120s debounce +
+  a per-session state file so it fires ~once per session, not once per turn.
+- Turns live in `event_msg` records with `payload.type` of `user_message` /
+  `agent_message`.
+- **stdin's `transcript_path` is unreliable** — observed `session=unknown,
+  turns=0` on real `Stop` fires while a fully populated rollout existed on disk.
+  Resolve the transcript in preference order and only accept a path that parses
+  as a real rollout:
+  1. `session_id` — Codex embeds it in the rollout **filename**, so it needs no
+     file reads to match. Most reliable anchor.
+  2. stdin `transcript_path`, then `agent_transcript_path`.
+  3. newest rollout in `~/.codex/sessions` as a last resort.
+
+**Grok — `chat_history.jsonl`**
+- Has a native `SessionEnd` event (unlike Codex). Parse `chat_history.jsonl`.
+- Do not fall back to `CLAUDE_PROJECT_DIR` for cwd in a Grok script — it is a
+  Claude Code var and won't be set.
+
+### 2. Cap the payload before ingest
+
+Open Brain `/ingest` embeds with **text-embedding-3-small (~8191-token limit)**.
+Long sessions exceed it and `/ingest` returns HTTP 500.
+
+- Cap the payload at ~**24000 chars** (`OB_CAPTURE_MAX_CHARS`).
+- Truncate the **middle**, not the tail — preserve how the session opened and
+  concluded, drop the middle with a marker (e.g. 60% head / 40% tail).
+
+### 3. Know the two ingest gotchas
+
+- **Oversized HTTP 500 still writes a row.** The endpoint upserts the row in
+  **parallel** with the embedding call, so an embedding-failure 500 leaves an
+  **embedding-less orphan row** that looks like a clean failure but isn't.
+  Always verify by querying the DB, not just the HTTP status.
+- **`/ingest` hardcodes `source_type=dashboard_ingest`,** so captures from
+  different agents are **not** distinguishable by source at ingest time.
+
+## Verification
+
+- Tail the hook's log: `logs/ambient-capture*.log` should show
+  `disposition=captured` (not `skipped:too_short`).
+- Confirm `userTurns` matches the real turn count of a known session.
+- For the size guard: feed an oversized session and confirm the payload is
+  <24k chars and returns HTTP 200.
+- **Ground-truth over config:** hooks load at session **start**, so a config or
+  script change needs a `/hooks` reload or a fresh session before it takes
+  effect. A "fixed" hook that was never reloaded is still running the old code.
+
+## Example
+
+Reference script assumed plaintext, matched 0 turns on every real Claude Code
+transcript → always `skipped:too_short`. Rewriting `parseTranscript` to parse
+JSONL (`type:user/assistant`, text blocks only, excluding `tool_result`-only
+and `isSidechain` turns) produced a 16-turn parse and a successful capture.
+An oversized session that had returned HTTP 500 (leaving an orphan row)
+captured HTTP 200 once truncated to <24k chars.
+
+## Notes
+
+- Each agent's format drifts independently — re-verify against a fresh
+  transcript when an agent updates, rather than assuming the parser still holds.
+- The debugging lesson that generalizes: **trust the log/DB, not the config.**
+  Silent no-op hooks and orphan rows only surfaced by inspecting ground truth.
+
+## References
+
+- OB1 repo: `skills/auto-capture-claude-code/session-end-capture.mjs`
+  (Claude Code reference), `skills/auto-capture-codex/capture-codex-session.mjs`,
+  `skills/auto-capture-grok/session-end-capture-grok.mjs`.
+- PRs #388 (parser + size guard), #389 (Codex adapter), #390 (Grok adapter).
+- Companion Open Brain memories: `open-brain-multi-agent-capture`,
+  `open-brain-ingest-gotchas`.

--- a/skills/open-brain-capture-hook-authoring/metadata.json
+++ b/skills/open-brain-capture-hook-authoring/metadata.json
@@ -1,0 +1,20 @@
+{
+  "name": "Open Brain Capture-Hook Authoring",
+  "description": "Authoring and debugging guide for session-end auto-capture hooks that ship an AI CLI transcript to Open Brain, covering each agent's real transcript format and the ingest limits that make hooks fail silently.",
+  "category": "skills",
+  "author": {
+    "name": "Ezana Azene",
+    "github": "eazene"
+  },
+  "version": "1.0.0",
+  "requires": {
+    "open_brain": true,
+    "services": ["Supabase"],
+    "tools": ["Claude Code", "Codex", "Grok", "Node.js 18+"]
+  },
+  "requires_skills": ["auto-capture", "auto-capture-claude-code"],
+  "tags": ["skill", "capture", "hooks", "session-end", "debugging", "claude-code", "codex", "grok", "ingest"],
+  "difficulty": "intermediate",
+  "estimated_time": "15 minutes",
+  "created": "2026-07-05"
+}


### PR DESCRIPTION
## What

Adds a new skill, `open-brain-capture-hook-authoring`, that codifies the authoring and debugging knowledge for session-end auto-capture hooks which ship an AI CLI transcript to Open Brain.

This is distinct from the `auto-capture-*` skills — those are **install recipes**; this is the **authoring/debugging layer** that explains why they're shaped the way they are and what fails silently when they aren't.

## Why

These hooks fail *silently* — logging `skipped:too_short` / `turns=0` while capturing nothing — when the transcript format is assumed wrong. This skill preserves the traps discovered while wiring auto-capture across three agents (PRs #388–390):

- **Claude Code** transcripts are JSONL (`type:user/assistant`, text blocks only; skip `tool_result`-only and `isSidechain` turns). A plaintext `Human:/Assistant:` parser matches **0 turns**.
- **Codex** has no `SessionEnd` event (use `Stop` + debounce), and its stdin `transcript_path` is unreliable → resolve the rollout by the `session_id` embedded in the filename under `~/.codex/sessions`.
- **Grok** has a native `SessionEnd` + `chat_history.jsonl`.
- `/ingest` embeds with text-embedding-3-small (~8191-token limit): cap the payload ~24k chars truncating the middle; an oversized HTTP 500 **still** upserts an embedding-less orphan row (parallel upsert).

## Contents

- `skills/open-brain-capture-hook-authoring/SKILL.md`
- `skills/open-brain-capture-hook-authoring/README.md`
- `skills/open-brain-capture-hook-authoring/metadata.json` (schema-valid: `category: skills`, semver, `created` date, required `requires.open_brain: true`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016CdZwf3x2gJ3UiapRzWi4K