### PR TITLE
[skills] Add provenance-chains skill

### DIFF
--- a/skills/provenance-chains/README.md
+++ b/skills/provenance-chains/README.md
@@ -1,0 +1,58 @@
+# Provenance Chains
+
+<div align="center">
+
+![Community Contribution](https://img.shields.io/badge/OB1_COMMUNITY-Contribution-2ea44f?style=for-the-badge&logo=github)
+
+**Created by [@eazene](https://github.com/eazene)**
+
+</div>
+
+*The client-side behavioral half of the Provenance Chains schema + recipe — so derivation links get written when artifacts are captured, not just backfilled after the fact.*
+
+## What It Does
+
+The [provenance-chains schema](../../schemas/provenance-chains/) adds derivation columns to `thoughts`, and the [Provenance Chains Pipeline recipe](../../recipes/provenance-chains/) backfills, evaluates, and exposes them over MCP. Both operate on data that already exists. This skill closes the loop at **capture time**: it tells the AI client to tag each derived artifact with a valid `derived_from` / `derivation_layer` / `derivation_method` (plus the `metadata.provenance` mirror) as it writes it, and to use `trace_provenance` / `find_derivatives` when a user asks where a belief came from or what depends on a thought.
+
+Without it, a capable model still gets the mechanics wrong — it will nest `derived_from` as objects, keep legacy `#412`-style refs that break the read tools, invent `derivation_layer`/`derivation_method` values the CHECK constraints reject, and skip the `metadata.provenance` mirror that keeps provenance alive across re-captures. The skill encodes the exact contract that avoids each of those.
+
+## Supported Clients
+
+- Claude Code
+- Codex
+- Cursor
+- Any AI client that supports reusable rules, skills, or custom instructions and can call the Open Brain capture/query tools
+
+## Prerequisites
+
+- Working Open Brain setup ([guide](../../docs/01-getting-started.md))
+- The [provenance-chains schema](../../schemas/provenance-chains/) applied — adds the columns and CHECK constraints the capture contract targets. Without it, tagged captures fail on unknown columns.
+- For the read side: the [Provenance Chains Pipeline](../../recipes/provenance-chains/) `trace_provenance` / `find_derivatives` MCP handlers installed in your `open-brain-mcp` Edge Function.
+
+## Installation
+
+Copy the skill into your AI client's skills directory (or point your client's rule loader at it):
+
+```bash
+cp -r skills/provenance-chains ~/.claude/skills/provenance-chains
+```
+
+The skill fires on its own from the `description` triggers — no manual invocation needed once installed. It activates when you capture a synthesized artifact or when a user asks an origin/impact question ("why do I believe X", "what uses this thought").
+
+## How It Fits the Provenance Chains Set
+
+| Piece | Layer | Job |
+|-------|-------|-----|
+| `schemas/provenance-chains` | Database | Columns, CHECK constraints, helper SQL functions |
+| `recipes/provenance-chains` | Operations | One-time backfill, nightly eval grader, MCP tool handlers |
+| `skills/provenance-chains` (this) | AI client | Tag new artifacts correctly at capture; query the graph on demand |
+
+The recipe's `backfill.mjs` repairs the **past**; this skill keeps the **future** tagged as artifacts are produced.
+
+## Adoption by Other Skills
+
+Any skill that captures a synthesized artifact should apply this capture contract when the provenance-chains schema is installed. Natural adopters already in this repo: `panning-for-gold`, `research-synthesis`, `meeting-synthesis`, `weekly-signal-diff`, and `competitive-analysis`. Wiring those up is a follow-up per-skill change, not a prerequisite for this one.
+
+## License
+
+FSL-1.1-MIT, matching the repository.

--- a/skills/provenance-chains/SKILL.md
+++ b/skills/provenance-chains/SKILL.md
@@ -1,0 +1,112 @@
+---
+name: provenance-chains
+description: |
+  Use when capturing a derived artifact to Open Brain — a digest, wiki, research
+  summary, lint report, or any thought synthesized from other thoughts — so its
+  derivation link survives and stays queryable. Also use when answering "why do I
+  believe X", "what's this based on", "what's the evidence for this", "what uses
+  this thought", or "what breaks if I delete this". Pairs with the provenance-chains
+  schema and Provenance Chains Pipeline recipe.
+author: Ezana Azene
+version: 1.0.0
+---
+
+# Provenance Chains
+
+## Overview
+
+The [provenance-chains schema](../../schemas/provenance-chains/) turns the flat `thoughts` table into a derivation graph. This skill is how an AI client keeps that graph intact: **tag provenance every time you capture a synthesis, and reach for the trace tools when a user asks where a belief came from.**
+
+**Core principle:** A synthesis with no `derived_from` is an orphan the moment it lands. The link between a digest and its evidence only exists if the capture writes it — prose like "based on 5 thoughts" is not queryable.
+
+## When to Use
+
+**Write side — you just produced a derived artifact and are about to capture it:**
+- Weekly/daily digests, wikis, research summaries, lint reports, meeting syntheses
+- Anything built by combining or summarizing existing thoughts
+- Regenerating an artifact that replaces a prior one (set `supersedes`)
+
+**Read side — the user asks about origins or impact:**
+- "Why do I believe X" / "what's this based on" / "what's the evidence" → `trace_provenance`
+- "What uses this thought" / "what cites this" / "what breaks if I delete this" → `find_derivatives`
+
+**When NOT to use:** capturing a primary atomic thought (a raw capture, not derived from other thoughts). Leave the derivation columns unset — the schema defaults `derivation_layer` to `'primary'`.
+
+## Write Side: the capture contract
+
+When capturing a derived artifact, the `capture_thought` arguments **MUST** match this shape. Every field below is constrained by a DB CHECK or read-tool cast — get the shape wrong and the row is rejected or unreadable.
+
+```json
+{
+  "content": "This week: shipped the auth refactor, fixed three flaky tests, deferred billing migration.",
+  "type": "digest",
+  "source_type": "weekly_digest_pointer",
+  "derivation_layer": "derived",
+  "derivation_method": "synthesis",
+  "derived_from": [
+    "3f8a1c2e-1111-4a2b-9c3d-000000000001",
+    "7b2d4e6f-2222-4a2b-9c3d-000000000002",
+    "a1c3e5f7-3333-4a2b-9c3d-000000000003",
+    "d4f6a8b0-5555-4a2b-9c3d-000000000005"
+  ],
+  "metadata": {
+    "provenance": {
+      "derived_from": [
+        "3f8a1c2e-1111-4a2b-9c3d-000000000001",
+        "7b2d4e6f-2222-4a2b-9c3d-000000000002",
+        "a1c3e5f7-3333-4a2b-9c3d-000000000003",
+        "d4f6a8b0-5555-4a2b-9c3d-000000000005"
+      ],
+      "derivation_layer": "derived",
+      "derivation_method": "synthesis",
+      "unresolved_refs": ["#412"]
+    }
+  }
+}
+```
+
+### Field rules (all enforced)
+
+| Field | Valid values | Why |
+|-------|--------------|-----|
+| `derived_from` | Flat JSON array of **UUID strings** — nothing else | `trace_provenance` casts each element `::uuid`; objects or non-UUIDs raise `22P02` |
+| `derivation_layer` | `'primary'` or `'derived'` — **only these two** | `thoughts_derivation_layer_check` rejects anything else; INSERT fails |
+| `derivation_method` | `'synthesis'` or omit | `thoughts_derivation_method_check` allows only `'synthesis'` or NULL on install |
+| `supersedes` | UUID of the thought this one replaces, or omit | Use only when regenerating (e.g. today's digest replaces yesterday's) |
+| `metadata.provenance` | Mirror of the three fields above | See durability rule below — **required**, not optional |
+
+### The two rules the schema won't catch for you
+
+1. **Mirror provenance into `metadata.provenance`.** The canonical `upsert_thought` RPC preserves only the `metadata` blob on a `content_fingerprint` conflict — **not** the top-level `derived_from` / `derivation_layer` / `derivation_method` columns. If you don't mirror, a re-capture of the same content silently drops the provenance. Write both.
+
+2. **Never put a non-UUID ref in `derived_from`.** Legacy integer refs (`#412`, `412`) and titles are not valid parents. Resolve them to the real UUID first; if you can't, drop them from `derived_from` and record them under `metadata.provenance.unresolved_refs` so the loss is visible instead of poisoning the array.
+
+## Read Side: querying the graph
+
+These map to the recipe's MCP tools (`recipes/provenance-chains/mcp-tools.ts`). Call them instead of guessing from `content`.
+
+| User asks | Tool | Args |
+|-----------|------|------|
+| "Why do I believe X?" / "what's this based on?" | `trace_provenance` | `thought_id`, `max_depth` (e.g. 5), `node_cap` (e.g. 100) — walks `derived_from` **upward** to ancestors |
+| "What uses this thought?" / "what cites this?" / "safe to delete?" | `find_derivatives` | `thought_id`, `limit` — reverse lookup of thoughts whose `derived_from` contains this id |
+
+`trace_provenance` handles cycles, depth/node caps, and redacts restricted-tier ancestors. `find_derivatives` always filters restricted rows. Report what the tool returns; don't reconstruct chains by hand from thought text.
+
+## Common Mistakes
+
+Each of these is a real failure a capable agent makes without this skill:
+
+| Mistake | Fix |
+|---------|-----|
+| `derived_from: [{ "ref": "...", "id_type": "uuid" }]` | Flat array of bare UUID strings — no wrapper objects |
+| Keeping `#412` / `412` in `derived_from` | Resolve to UUID or move to `metadata.provenance.unresolved_refs` |
+| `derivation_layer: "digest"` (or any custom value) | Only `'primary'` or `'derived'` |
+| `derivation_method: "weekly_digest_synthesis"` | Only `'synthesis'` (or omit) until you extend the CHECK constraint |
+| Writing top-level columns but no `metadata.provenance` | Mirror them — otherwise re-capture drops provenance |
+| Reconstructing a chain by reading thought content | Call `trace_provenance` / `find_derivatives` |
+
+## Notes
+
+- **Adoption by other synthesis skills:** `panning-for-gold`, `research-synthesis`, `meeting-synthesis`, `weekly-signal-diff`, and `competitive-analysis` all capture derived artifacts. When any of them runs on a brain with the provenance-chains schema installed, apply this capture contract so the new artifact is tagged — this is the going-forward complement to the recipe's one-time `backfill.mjs`.
+- **Requires:** the [provenance-chains schema](../../schemas/provenance-chains/) applied (adds the columns + CHECK constraints) and, for the read tools, the [Provenance Chains Pipeline](../../recipes/provenance-chains/) MCP handlers installed in your `open-brain-mcp` Edge Function. Without the schema, the derivation columns don't exist and the capture will fail on unknown columns.
+- **Tool naming varies by client:** the capture tool is often `capture_thought`; connector prefixes differ. Use whichever Open Brain capture tool the current client exposes.

--- a/skills/provenance-chains/metadata.json
+++ b/skills/provenance-chains/metadata.json
@@ -1,0 +1,21 @@
+{
+  "name": "Provenance Chains",
+  "description": "Behavioral skill that tags every derived artifact (digests, wikis, summaries) with correct derivation columns when capturing to Open Brain, and reaches for trace_provenance / find_derivatives when a user asks where a belief came from. Pairs with the provenance-chains schema and recipe.",
+  "category": "skills",
+  "author": {
+    "name": "Ezana Azene",
+    "github": "eazene"
+  },
+  "version": "1.0.0",
+  "requires": {
+    "open_brain": true,
+    "services": [],
+    "tools": ["AI client with reusable skills/prompts (Claude Code, Codex, Cursor, etc.)"]
+  },
+  "requires_skills": [],
+  "tags": ["skill", "provenance", "derivation", "capture", "synthesis", "workflow"],
+  "difficulty": "intermediate",
+  "estimated_time": "10 minutes",
+  "created": "2026-07-05",
+  "updated": "2026-07-05"
+}


### PR DESCRIPTION
## What

Adds `skills/provenance-chains/` — the AI-client behavioral half of the existing **provenance-chains** set, pairing 1:1 with:

- `schemas/provenance-chains/` (the derivation columns + CHECK constraints)
- `recipes/provenance-chains/` (backfill, eval grader, `trace_provenance`/`find_derivatives` MCP handlers)

The schema and recipe operate on data that already exists; the recipe's `backfill.mjs` repairs the **past**. This skill closes the loop at **capture time** so new artifacts are tagged as they're produced.

## Why

Without guidance, a capable model reaches for the derivation columns but gets the mechanics wrong in ways the DB rejects or the read tools can't traverse. Verified with a RED→GREEN subagent test on an identical "capture this weekly digest" scenario:

| Baseline (no skill) | With skill |
|---|---|
| `derived_from` as `[{ref, id_type}]` objects | flat array of UUID strings |
| legacy `#412` kept in the array | dropped → `metadata.provenance.unresolved_refs` |
| `derivation_layer: "digest"` (CHECK-rejected) | `"derived"` |
| `derivation_method: "weekly_digest_synthesis"` (CHECK-rejected) | `"synthesis"` |
| no `metadata.provenance` mirror | mirrored (survives `upsert_thought` re-capture) |

The `metadata.provenance` mirror is the highest-value rule: `upsert_thought` preserves only the `metadata` blob on a `content_fingerprint` conflict, not the top-level columns, so without the mirror provenance is silently lost on re-capture — a data-loss bug with no error message.

## Scope

- **Purely additive** — one new folder, no edits to existing files.
- `metadata.json` validated against `.github/metadata.schema.json` (required fields present, enums valid, no extra keys).
- Read side maps to the recipe's existing `trace_provenance` / `find_derivatives` MCP tools.

## Follow-up (not in this PR)

Wiring existing synthesis skills (`panning-for-gold`, `research-synthesis`, `meeting-synthesis`, `weekly-signal-diff`, `competitive-analysis`) to apply this capture contract is a separate per-skill change, noted in the README.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0127BucGfQraB5dkZR38MEF1