### PR TITLE
[integrations] Add /wiki routes to open-brain-rest

### DIFF
--- a/integrations/open-brain-rest/README.md
+++ b/integrations/open-brain-rest/README.md
@@ -28,7 +28,7 @@ Agent Memory stays in `integrations/agent-memory-api`. This gateway only handles
 
 ## Expected outcome
 
-After setup, the dashboard reaches every base-thoughts surface (stats, browse, search, workflow, duplicates, audit) plus the optional CRM contact/proposal routes through this gateway, and the smoke harness passes end to end. If you expose MCP tools alongside this gateway, review your tool surface with the [MCP Tool Audit & Optimization Guide](../../docs/05-tool-audit.md).
+After setup, the dashboard reaches every base-thoughts surface (stats, browse, search, workflow, duplicates, audit) plus the optional CRM and wiki routes through this gateway, and the smoke harnesses pass end to end. If you expose MCP tools alongside this gateway, review your tool surface with the [MCP Tool Audit & Optimization Guide](../../docs/05-tool-audit.md).
 
 ## Required Secrets
 
@@ -89,6 +89,23 @@ These require the `crm-core` (and, for engagement, `crm-engagement`) schemas. On
 
 Accepting a contact edit or adding a method keeps the contact's searchable **card thought** (`crm_contacts.card_thought_id`) in sync. Write-back reuses the gateway's existing embedding path and is best-effort: it never fails the write, and degrades to a text-searchable card when no `OPENROUTER_API_KEY` is set.
 
+### Wiki (optional)
+
+These require the `wiki-pages` schema. On a brain without it the routes return a clean `404`: the gateway maps PostgREST's schema-cache errors (`PGRST205` "Could not find the table" from the direct-table list query, `PGRST202` "Could not find the function" from the RPC-backed routes) as well as raw Postgres `42P01`/`42883` "does not exist" errors to 404. The dashboard hides the section via feature detection (`GET /wiki/pages?per_page=1`).
+
+| Endpoint | Method | Purpose |
+| --- | --- | --- |
+| `/wiki/pages` | GET | List active pages (optional `page_kind` filter), each with a `section_count` |
+| `/wiki/pages` | POST | Create/update a page by slug (`wiki_upsert_page`) |
+| `/wiki/pages/:slug` | GET | Fetch one page plus its non-deleted sections, ordered like the wiki-mcp tools |
+| `/wiki/pages/:slug/sections/:sectionKey` | PUT | Write a section as a manual (human) edit, through the regen guard (`wiki_write_section`) |
+| `/wiki/sections/:id/accept-pending` | POST | Promote a parked machine draft to the live body (`wiki_accept_pending`) |
+| `/wiki/sections/:id/reject-pending` | POST | Discard a parked machine draft without applying it (`wiki_reject_pending`) |
+| `/wiki/sections/:id/lock` | POST | Freeze/unfreeze a section against machine overwrites |
+| `/wiki/pages/:slug` | DELETE | Archive a page (`status='archived'`) — never a hard delete |
+
+`GET /wiki/pages` only lists `status='active'` pages, matching `wiki_list_pages`. `GET /wiki/pages/:slug` fetches by slug with no status filter (same as `wiki_get_page` in `integrations/wiki-mcp`), so an archived page stays individually reachable by slug — and its sections stay editable via the `PUT` route, which also skips the status filter — even though it drops out of the list. Section writes from this REST surface always use `p_origin='manual'` — a human editing through the dashboard takes ownership of the section, same as an in-app manual edit; automated/generator writes still go through `wiki-mcp`'s `wiki_write_section` tool with `p_origin='generated'` and are subject to the regen guard.
+
 ## Deploy
 
 From a Supabase workdir, copy or symlink this folder to `supabase/functions/open-brain-rest`, then deploy:
@@ -124,6 +141,16 @@ node integrations/open-brain-rest/smoke/crm-smoke.mjs
 ```
 
 It creates one contact, exercises detail, list, patch, methods, notes, tasks, dates, interactions, history, timeline, field lock, and the proposal count, then archives the contact and deletes its card thought.
+
+The wiki surface has its own harness (needs the `wiki-pages` schema):
+
+```bash
+OB1_REST_URL="https://YOUR_PROJECT_REF.supabase.co/functions/v1/open-brain-rest" \
+OB1_REST_KEY="YOUR_MCP_ACCESS_KEY" \
+node integrations/open-brain-rest/smoke/wiki-smoke.mjs
+```
+
+It creates one page, exercises list (with `section_count`), get-by-slug, a two-write section edit (created then updated), lock/unlock, and a reject-pending negative check (no pending draft to reject), then archives the page.
 
 ## Dashboard Demo Seed
 

--- a/integrations/open-brain-rest/README.md
+++ b/integrations/open-brain-rest/README.md
@@ -12,6 +12,24 @@
 
 Agent Memory stays in `integrations/agent-memory-api`. This gateway only handles the base `thoughts` operational surface.
 
+## Prerequisites
+
+- A working Open Brain Supabase project (see [`docs/01-getting-started.md`](../../docs/01-getting-started.md)).
+- The Supabase CLI and Deno installed, for deploying the Edge Function.
+- The schemas listed under [Required Database Shape](#required-database-shape) applied to that project.
+
+## Setup
+
+1. Set the function secrets listed under [Required Secrets](#required-secrets).
+2. Apply the schemas listed under [Required Database Shape](#required-database-shape).
+3. Deploy the function: `supabase functions deploy open-brain-rest`.
+4. Point the dashboard's `NEXT_PUBLIC_API_URL` at the deployed function URL.
+5. Run the [Smoke Test](#smoke-test) to confirm the endpoints respond.
+
+## Expected outcome
+
+After setup, the dashboard reaches every base-thoughts surface (stats, browse, search, workflow, duplicates, audit) plus the optional CRM contact/proposal routes through this gateway, and the smoke harness passes end to end. If you expose MCP tools alongside this gateway, review your tool surface with the [MCP Tool Audit & Optimization Guide](../../docs/05-tool-audit.md).
+
 ## Required Secrets
 
 Set these as Supabase function secrets:
@@ -48,6 +66,29 @@ The function expects `thoughts.id` to be a UUID. The dashboard now treats though
 | `/ingestion-jobs` | GET | Smart-ingest placeholder for dashboard compatibility |
 | `/ingest` | POST | Current v1 fallback captures input as one thought |
 
+### CRM (optional)
+
+These require the `crm-core` (and, for engagement, `crm-engagement`) schemas. On a brain without them the routes return the underlying "function does not exist" error, and the dashboard hides the section via feature detection (`GET /crm/contacts?limit=1`).
+
+| Endpoint | Method | Purpose |
+| --- | --- | --- |
+| `/crm/contacts` | GET/POST | List (search/tier/lifecycle) and create contacts |
+| `/crm/contacts/:id` | GET/PATCH | Detail (record + methods + aliases) and guarded field write |
+| `/crm/contacts/:id/methods` | POST | Add/update a contact method |
+| `/crm/contacts/:id/field-evidence` | GET/POST | Read/attach supporting or contradicting thoughts |
+| `/crm/contacts/:id/field-lock` | POST | Freeze/unfreeze a single field |
+| `/crm/contacts/:id/history` | GET | Change-log for the contact |
+| `/crm/contacts/:id/relationship-items` | GET | Notes + tasks + important-dates bundle |
+| `/crm/contacts/:id/notes`, `/crm/notes/:noteId` | POST, PATCH | Note create / edit |
+| `/crm/contacts/:id/tasks`, `/crm/tasks/:taskId` | POST, PATCH | Task create / edit |
+| `/crm/contacts/:id/important-dates`, `/crm/important-dates/:dateId` | POST, PATCH | Important-date create / edit |
+| `/crm/contacts/:id/interactions`, `/crm/interactions`, `/crm/interactions/:id` | GET, POST, PATCH | Interaction log |
+| `/crm/contacts/:id/timeline` | GET | Change-log + interactions + evidence, newest first |
+| `/crm/proposals`, `/crm/proposals/count` | GET | Proposal inbox + open-count nav badge |
+| `/crm/proposals/:id/resolve`, `/crm/proposals/resolve-run` | POST | Accept/reject one proposal, or a whole import run |
+
+Accepting a contact edit or adding a method keeps the contact's searchable **card thought** (`crm_contacts.card_thought_id`) in sync. Write-back reuses the gateway's existing embedding path and is best-effort: it never fails the write, and degrades to a text-searchable card when no `OPENROUTER_API_KEY` is set.
+
 ## Deploy
 
 From a Supabase workdir, copy or symlink this folder to `supabase/functions/open-brain-rest`, then deploy:
@@ -73,6 +114,16 @@ node integrations/open-brain-rest/smoke/live-smoke.mjs
 ```
 
 The smoke creates three temporary rows, verifies health, capture, browse, stats, text search, workflow update, duplicate scan, and audit filtering, then deletes the rows. Pass `--keep` only when you intentionally want to inspect the created rows.
+
+The CRM surface has its own harness (needs the `crm-core` / `crm-engagement` schemas):
+
+```bash
+OB1_REST_URL="https://YOUR_PROJECT_REF.supabase.co/functions/v1/open-brain-rest" \
+OB1_REST_KEY="YOUR_MCP_ACCESS_KEY" \
+node integrations/open-brain-rest/smoke/crm-smoke.mjs
+```
+
+It creates one contact, exercises detail, list, patch, methods, notes, tasks, dates, interactions, history, timeline, field lock, and the proposal count, then archives the contact and deletes its card thought.
 
 ## Dashboard Demo Seed
 

--- a/integrations/open-brain-rest/index.ts
+++ b/integrations/open-brain-rest/index.ts
@@ -424,8 +424,17 @@ async function createThought(body: z.infer<typeof captureSchema>) {
       ? "new"
       : null;
 
-  const update = {
-    embedding,
+  // When upsert_thought resolved the row via the original-fingerprint fallback,
+  // `content`/`embedding` here were computed from the OLD pre-correction text
+  // (a reimport of the original source). The matched row is the CORRECTED one,
+  // so overwriting its embedding with the stale-text vector would silently
+  // desync it from its corrected content. Skip the embedding overwrite on that
+  // path — the RPC already merged metadata and left content untouched, so this
+  // becomes a pure dedup hit.
+  const matchedViaOriginalFingerprint =
+    upsert.data?.matched_via === "original_fingerprint";
+
+  const update: Record<string, unknown> = {
     metadata,
     type,
     source_type: sourceType,
@@ -435,6 +444,9 @@ async function createThought(body: z.infer<typeof captureSchema>) {
     status,
     status_updated_at: status ? new Date().toISOString() : null,
   };
+  if (!matchedViaOriginalFingerprint) {
+    update.embedding = embedding;
+  }
 
   const { error } = await supabase.from("thoughts").update(update).eq("id", thoughtId);
   if (error) throw new Error(error.message);
@@ -447,6 +459,153 @@ async function createThought(body: z.infer<typeof captureSchema>) {
     content_fingerprint: String(upsert.data?.fingerprint || ""),
     message: "Thought captured",
   };
+}
+
+// ─── CRM (optional) ─────────────────────────────────────────────────────────
+// Exposes the crm-core / crm-engagement RPCs as REST, and keeps each contact's
+// searchable "card" thought in sync. All routes are already behind the
+// x-brain-key middleware below. Requires the crm-core schema; on a brain
+// without it, these routes surface the RPC's "function does not exist" error
+// and the dashboard hides the section via feature detection.
+
+const crmCreateSchema = z.object({
+  display_name: z.string().min(1),
+  canonical_email: z.string().optional(),
+  organization_name: z.string().optional(),
+  job_title: z.string().optional(),
+  actor: z.string().optional(),
+});
+
+const crmPatchSchema = z.object({
+  patch: z.record(z.string(), z.unknown()),
+  actor: z.string().optional(),
+  origin: z.enum(["manual", "import", "extraction", "projection"]).optional(),
+  run_id: z.string().nullable().optional(),
+  expected_updated_at: z.string().nullable().optional(),
+});
+
+type CrmContactRecord = {
+  id: string;
+  display_name: string;
+  organization_name: string | null;
+  job_title: string | null;
+  location: string | null;
+  relationship_note: string | null;
+  lifecycle_status: string;
+  privacy_tier: string;
+  card_thought_id: string | null;
+  updated_at: string;
+} & Record<string, unknown>;
+
+type CrmContactBundle = {
+  record: CrmContactRecord;
+  methods: Array<Record<string, unknown>>;
+  aliases: Array<Record<string, unknown>>;
+};
+
+// PostgREST `.or()` takes a filter STRING, so raw user input could inject filter
+// structure (commas/parens). Strip the structural characters before building an
+// ilike pattern; the wildcards are added by us.
+function sanitizeIlike(value: string): string {
+  return value.replace(/[,()*:%\\]/g, " ").replace(/\s+/g, " ").trim();
+}
+
+async function crmGetContact(contactId: string): Promise<CrmContactBundle | null> {
+  const { data, error } = await supabase.rpc("crm_get_contact", { p_contact_id: contactId });
+  if (error) throw new Error(error.message);
+  const row = (Array.isArray(data) ? data[0] : data) as
+    | { record?: CrmContactRecord; methods?: unknown; aliases?: unknown }
+    | null;
+  if (!row || !row.record) return null;
+  return {
+    record: row.record,
+    methods: Array.isArray(row.methods) ? (row.methods as Array<Record<string, unknown>>) : [],
+    aliases: Array.isArray(row.aliases) ? (row.aliases as Array<Record<string, unknown>>) : [],
+  };
+}
+
+function buildCardContent(record: CrmContactRecord, methods: Array<Record<string, unknown>>): string {
+  const lines = [`Contact: ${record.display_name}`];
+  if (record.organization_name) lines.push(`Organization: ${record.organization_name}`);
+  if (record.job_title) lines.push(`Title: ${record.job_title}`);
+  if (record.location) lines.push(`Location: ${record.location}`);
+  if (record.relationship_note) lines.push(`Note: ${record.relationship_note}`);
+  for (const method of methods) {
+    const type = typeof method.method_type === "string" ? method.method_type : "contact";
+    const value = typeof method.value === "string" ? method.value : "";
+    if (value) lines.push(`${type}: ${value}`);
+  }
+  return lines.join("\n");
+}
+
+// Keep the contact's searchable card thought in sync. The card carries
+// metadata.generated_by='crm-write-back', so entity extraction skips it. Re-embed
+// when a key is present; degrade to a text-searchable (no-embed) card otherwise.
+async function syncContactCard(contactId: string, actor = "crm-write-back"): Promise<string | null> {
+  const contact = await crmGetContact(contactId);
+  if (!contact) return null;
+  const { record, methods } = contact;
+
+  // Archived contacts carry no live card (mirrors the schema's ON DELETE note).
+  if (record.lifecycle_status === "archived") {
+    if (record.card_thought_id) {
+      await supabase.from("crm_contacts").update({ card_thought_id: null }).eq("id", record.id);
+    }
+    return null;
+  }
+
+  const content = buildCardContent(record, methods);
+  const metadata = {
+    source_type: "crm_contact_card",
+    source: "crm_contact_card",
+    generated_by: "crm-write-back",
+    crm_contact_id: record.id,
+    sensitivity_tier: record.privacy_tier,
+  };
+
+  const upsert = await supabase.rpc("upsert_thought", { p_content: content, p_payload: { metadata } });
+  if (upsert.error) throw new Error(upsert.error.message);
+  const thoughtId = String(upsert.data?.id || "");
+  if (!thoughtId) throw new Error("upsert_thought did not return an id");
+
+  // Skip the embed overwrite when upsert resolved via the original-fingerprint
+  // path (the matched row is a corrected thought, not our card text).
+  const matchedViaOriginalFingerprint = upsert.data?.matched_via === "original_fingerprint";
+  const update: Record<string, unknown> = {
+    metadata,
+    source_type: "crm_contact_card",
+    sensitivity_tier: record.privacy_tier,
+  };
+  if (OPENROUTER_API_KEY && !matchedViaOriginalFingerprint) {
+    try {
+      update.embedding = await getEmbedding(content);
+    } catch (error) {
+      // No-embed fallback: the card is still text-searchable; do not fail the write.
+      console.error("crm card embedding skipped:", error instanceof Error ? error.message : error);
+    }
+  }
+  const { error: thoughtError } = await supabase.from("thoughts").update(update).eq("id", thoughtId);
+  if (thoughtError) throw new Error(thoughtError.message);
+
+  if (record.card_thought_id !== thoughtId) {
+    const { error: bindError } = await supabase
+      .from("crm_contacts")
+      .update({ card_thought_id: thoughtId })
+      .eq("id", record.id);
+    if (bindError) throw new Error(bindError.message);
+  }
+  return thoughtId;
+}
+
+// Best-effort wrapper: a write-back failure must never fail the contact write
+// that triggered it.
+async function syncContactCardSafe(contactId: string, actor?: string): Promise<string | null> {
+  try {
+    return await syncContactCard(contactId, actor);
+  } catch (error) {
+    console.error("crm card write-back failed (non-fatal):", error instanceof Error ? error.message : error);
+    return null;
+  }
 }
 
 const app = new Hono();
@@ -635,6 +794,686 @@ app.post("/ingest", async (c) => {
   if (!text) return c.json({ error: "text is required" }, 400, corsHeaders);
   const result = await createThought({ content: text, source_type: "dashboard_ingest" });
   return c.json({ job_id: 0, status: "complete", extracted_count: 1, thought_id: result.thought_id }, 200, corsHeaders);
+});
+
+// ─── CRM routes ─────────────────────────────────────────────────────────────
+
+const CRM_CONTACT_COLUMNS =
+  "id, display_name, canonical_email, organization_name, job_title, location, relationship_note, lifecycle_status, privacy_tier, owner_label, card_thought_id, created_at, updated_at";
+
+app.get("/crm/contacts", async (c) => {
+  try {
+    const url = new URL(c.req.url);
+    const page = intParam(url.searchParams.get("page"), 1, 1, 100000);
+    const perPage = intParam(url.searchParams.get("per_page"), 25, 1, 100);
+    const offset = (page - 1) * perPage;
+    const q = sanitizeIlike(url.searchParams.get("q") || url.searchParams.get("search") || "");
+    const tier = url.searchParams.get("privacy_tier");
+    const lifecycle = url.searchParams.get("lifecycle_status") || "active";
+    const excludeRestricted = url.searchParams.get("exclude_restricted") !== "false";
+
+    let query = supabase.from("crm_contacts").select(CRM_CONTACT_COLUMNS, { count: "exact" });
+    if (lifecycle && lifecycle !== "all") query = query.eq("lifecycle_status", lifecycle);
+    if (tier) query = query.eq("privacy_tier", tier);
+    if (excludeRestricted) query = query.neq("privacy_tier", "restricted");
+    if (q) {
+      query = query.or(
+        `display_name.ilike.%${q}%,organization_name.ilike.%${q}%,canonical_email.ilike.%${q}%`,
+      );
+    }
+
+    const { data, error, count } = await query
+      .order("display_name", { ascending: true })
+      .range(offset, offset + perPage - 1);
+    if (error) throw new Error(error.message);
+    return c.json({ data: data || [], total: count || 0, page, per_page: perPage }, 200, corsHeaders);
+  } catch (error) {
+    return c.json({ error: error instanceof Error ? error.message : "Failed to list contacts" }, 500, corsHeaders);
+  }
+});
+
+app.post("/crm/contacts", async (c) => {
+  try {
+    const parsed = crmCreateSchema.safeParse(await c.req.json());
+    if (!parsed.success) return c.json({ error: "Invalid contact payload", details: parsed.error.flatten() }, 400, corsHeaders);
+    const body = parsed.data;
+    const actor = body.actor || "dashboard";
+    const { data, error } = await supabase.rpc("crm_create_contact", {
+      p_display_name: body.display_name,
+      p_canonical_email: body.canonical_email ?? null,
+      p_organization_name: body.organization_name ?? null,
+      p_job_title: body.job_title ?? null,
+      p_actor: actor,
+    });
+    if (error) return c.json({ error: error.message }, 500, corsHeaders);
+    const contactId = String(data || "");
+    if (!contactId) return c.json({ error: "crm_create_contact did not return an id" }, 500, corsHeaders);
+    await syncContactCardSafe(contactId, "crm-write-back");
+    const contact = await crmGetContact(contactId);
+    return c.json({ contact_id: contactId, ...(contact || {}) }, 201, corsHeaders);
+  } catch (error) {
+    return c.json({ error: error instanceof Error ? error.message : "Create failed" }, 500, corsHeaders);
+  }
+});
+
+app.get("/crm/contacts/:id", async (c) => {
+  try {
+    const excludeRestricted = new URL(c.req.url).searchParams.get("exclude_restricted") !== "false";
+    const contact = await crmGetContact(c.req.param("id"));
+    if (!contact) return c.json({ error: "Contact not found" }, 404, corsHeaders);
+    if (excludeRestricted && contact.record.privacy_tier === "restricted") {
+      return c.json({ error: "Restricted contact" }, 403, corsHeaders);
+    }
+    return c.json(contact, 200, corsHeaders);
+  } catch (error) {
+    return c.json({ error: error instanceof Error ? error.message : "Failed to load contact" }, 500, corsHeaders);
+  }
+});
+
+app.patch("/crm/contacts/:id", async (c) => {
+  try {
+    const parsed = crmPatchSchema.safeParse(await c.req.json());
+    if (!parsed.success) return c.json({ error: "Invalid patch payload", details: parsed.error.flatten() }, 400, corsHeaders);
+    const body = parsed.data;
+    const id = c.req.param("id");
+    const { data, error } = await supabase.rpc("crm_patch_contact_record", {
+      p_contact_id: id,
+      p_patch: body.patch,
+      p_actor: body.actor || "dashboard",
+      p_origin: body.origin || "manual",
+      p_run_id: body.run_id ?? null,
+      p_expected_updated_at: body.expected_updated_at ?? null,
+    });
+    if (error) {
+      const message = error.message || "Patch failed";
+      if (message.includes("crm_contact_stale_write")) {
+        return c.json({ error: "The contact changed since you loaded it; reload and retry.", code: "stale_write" }, 409, corsHeaders);
+      }
+      if (message.includes("not found")) return c.json({ error: message }, 404, corsHeaders);
+      return c.json({ error: message }, 500, corsHeaders);
+    }
+    const result = (data || {}) as { applied?: unknown } & Record<string, unknown>;
+    // Refresh the card only when a canonical field actually changed.
+    if (Array.isArray(result.applied) && result.applied.length > 0) {
+      await syncContactCardSafe(id, body.actor || "crm-write-back");
+    }
+    return c.json(result, 200, corsHeaders);
+  } catch (error) {
+    return c.json({ error: error instanceof Error ? error.message : "Patch failed" }, 500, corsHeaders);
+  }
+});
+
+const crmResolveSchema = z.object({
+  decision: z.enum(["accept", "reject"]),
+  actor: z.string().optional(),
+});
+
+const crmResolveRunSchema = z.object({
+  run_id: z.string().min(1),
+  decision: z.enum(["accept", "reject"]),
+  actor: z.string().optional(),
+});
+
+const crmEvidenceSchema = z.object({
+  field_key: z.string().min(1),
+  thought_id: z.string().min(1),
+  role: z.enum(["supports", "contradicts", "source", "correction"]).optional(),
+  target_kind: z.enum(["contact_field", "contact_method", "alias", "proposal"]).optional(),
+  target_id: z.string().nullable().optional(),
+  note: z.string().optional(),
+  actor: z.string().optional(),
+});
+
+const crmLockSchema = z.object({
+  field_key: z.string().min(1),
+  locked: z.boolean(),
+  actor: z.string().optional(),
+});
+
+const crmMethodSchema = z.object({
+  method_type: z.enum(["email", "phone", "url", "social", "address", "other"]),
+  value: z.string().min(1),
+  label: z.string().optional(),
+  is_primary: z.boolean().optional(),
+  actor: z.string().optional(),
+  source: z.string().optional(),
+});
+
+async function proposalContactId(proposalId: string): Promise<string | null> {
+  const { data } = await supabase.from("crm_field_proposals").select("contact_id").eq("id", proposalId).single();
+  return (data?.contact_id as string) || null;
+}
+
+app.get("/crm/proposals", async (c) => {
+  try {
+    const url = new URL(c.req.url);
+    const page = intParam(url.searchParams.get("page"), 1, 1, 100000);
+    const perPage = intParam(url.searchParams.get("per_page"), 25, 1, 100);
+    const offset = (page - 1) * perPage;
+    const status = url.searchParams.get("status") || "open";
+    const contactId = url.searchParams.get("contact_id");
+    const runId = url.searchParams.get("run_id");
+
+    let query = supabase.from("crm_field_proposals").select("*", { count: "exact" });
+    if (status && status !== "all") query = query.eq("status", status);
+    if (contactId) query = query.eq("contact_id", contactId);
+    if (runId) query = query.eq("origin_ref->>run_id", runId);
+
+    const { data, error, count } = await query
+      .order("created_at", { ascending: false })
+      .range(offset, offset + perPage - 1);
+    if (error) throw new Error(error.message);
+    return c.json({ data: data || [], total: count || 0, page, per_page: perPage }, 200, corsHeaders);
+  } catch (error) {
+    return c.json({ error: error instanceof Error ? error.message : "Failed to list proposals" }, 500, corsHeaders);
+  }
+});
+
+app.get("/crm/proposals/count", async (c) => {
+  try {
+    const contactId = new URL(c.req.url).searchParams.get("contact_id");
+    let query = supabase.from("crm_field_proposals").select("id", { count: "exact", head: true }).eq("status", "open");
+    if (contactId) query = query.eq("contact_id", contactId);
+    const { count, error } = await query;
+    if (error) throw new Error(error.message);
+    return c.json({ open: count || 0 }, 200, corsHeaders);
+  } catch (error) {
+    return c.json({ error: error instanceof Error ? error.message : "Failed to count proposals" }, 500, corsHeaders);
+  }
+});
+
+app.post("/crm/proposals/:id/resolve", async (c) => {
+  try {
+    const parsed = crmResolveSchema.safeParse(await c.req.json());
+    if (!parsed.success) return c.json({ error: "Invalid resolve payload", details: parsed.error.flatten() }, 400, corsHeaders);
+    const proposalId = c.req.param("id");
+    const contactId = await proposalContactId(proposalId);
+    const { data, error } = await supabase.rpc("crm_resolve_field_proposal", {
+      p_proposal_id: proposalId,
+      p_decision: parsed.data.decision,
+      p_actor: parsed.data.actor || "dashboard",
+    });
+    if (error) {
+      const message = error.message || "Resolve failed";
+      if (message.includes("locked")) return c.json({ error: message, code: "field_locked" }, 409, corsHeaders);
+      if (message.includes("not found")) return c.json({ error: message }, 404, corsHeaders);
+      return c.json({ error: message }, 500, corsHeaders);
+    }
+    const result = (data || {}) as { changed?: boolean } & Record<string, unknown>;
+    if (parsed.data.decision === "accept" && result.changed && contactId) {
+      await syncContactCardSafe(contactId, parsed.data.actor || "crm-write-back");
+    }
+    return c.json(result, 200, corsHeaders);
+  } catch (error) {
+    return c.json({ error: error instanceof Error ? error.message : "Resolve failed" }, 500, corsHeaders);
+  }
+});
+
+app.post("/crm/proposals/resolve-run", async (c) => {
+  try {
+    const parsed = crmResolveRunSchema.safeParse(await c.req.json());
+    if (!parsed.success) return c.json({ error: "Invalid resolve-run payload", details: parsed.error.flatten() }, 400, corsHeaders);
+    const { data, error } = await supabase.rpc("crm_resolve_field_proposals_by_run", {
+      p_run_id: parsed.data.run_id,
+      p_decision: parsed.data.decision,
+      p_actor: parsed.data.actor || "dashboard",
+    });
+    if (error) return c.json({ error: error.message }, 500, corsHeaders);
+    // Best-effort write-back for every contact touched by an accepted run.
+    if (parsed.data.decision === "accept") {
+      const { data: touched } = await supabase
+        .from("crm_field_proposals")
+        .select("contact_id")
+        .eq("origin_ref->>run_id", parsed.data.run_id)
+        .eq("status", "accepted");
+      const ids = [...new Set((touched || []).map((row) => row.contact_id as string).filter(Boolean))];
+      for (const id of ids) await syncContactCardSafe(id, parsed.data.actor || "crm-write-back");
+    }
+    return c.json(data || {}, 200, corsHeaders);
+  } catch (error) {
+    return c.json({ error: error instanceof Error ? error.message : "Resolve-run failed" }, 500, corsHeaders);
+  }
+});
+
+app.get("/crm/contacts/:id/field-evidence", async (c) => {
+  try {
+    const url = new URL(c.req.url);
+    const { data, error } = await supabase.rpc("crm_contact_field_evidence", {
+      p_contact_id: c.req.param("id"),
+      p_field_key: url.searchParams.get("field_key"),
+      p_exclude_restricted: url.searchParams.get("exclude_restricted") !== "false",
+      p_limit: intParam(url.searchParams.get("limit"), 100, 1, 500),
+    });
+    if (error) throw new Error(error.message);
+    return c.json({ evidence: data || [] }, 200, corsHeaders);
+  } catch (error) {
+    return c.json({ error: error instanceof Error ? error.message : "Failed to load evidence" }, 500, corsHeaders);
+  }
+});
+
+app.post("/crm/contacts/:id/field-evidence", async (c) => {
+  try {
+    const parsed = crmEvidenceSchema.safeParse(await c.req.json());
+    if (!parsed.success) return c.json({ error: "Invalid evidence payload", details: parsed.error.flatten() }, 400, corsHeaders);
+    const body = parsed.data;
+    const { data, error } = await supabase.rpc("crm_add_field_evidence", {
+      p_contact_id: c.req.param("id"),
+      p_field_key: body.field_key,
+      p_thought_id: body.thought_id,
+      p_role: body.role || "supports",
+      p_target_kind: body.target_kind || "contact_field",
+      p_target_id: body.target_id ?? null,
+      p_note: body.note ?? null,
+      p_actor: body.actor || "dashboard",
+    });
+    if (error) return c.json({ error: error.message }, 500, corsHeaders);
+    return c.json({ evidence_id: data }, 201, corsHeaders);
+  } catch (error) {
+    return c.json({ error: error instanceof Error ? error.message : "Add evidence failed" }, 500, corsHeaders);
+  }
+});
+
+app.post("/crm/contacts/:id/field-lock", async (c) => {
+  try {
+    const parsed = crmLockSchema.safeParse(await c.req.json());
+    if (!parsed.success) return c.json({ error: "Invalid field-lock payload", details: parsed.error.flatten() }, 400, corsHeaders);
+    const body = parsed.data;
+    const { data, error } = await supabase.rpc("crm_set_field_lock", {
+      p_contact_id: c.req.param("id"),
+      p_field_key: body.field_key,
+      p_locked: body.locked,
+      p_actor: body.actor || "dashboard",
+    });
+    if (error) {
+      const message = error.message || "Field-lock failed";
+      if (message.includes("not found")) return c.json({ error: message }, 404, corsHeaders);
+      if (message.includes("unknown contact field")) return c.json({ error: message }, 400, corsHeaders);
+      return c.json({ error: message }, 500, corsHeaders);
+    }
+    return c.json(data || {}, 200, corsHeaders);
+  } catch (error) {
+    return c.json({ error: error instanceof Error ? error.message : "Field-lock failed" }, 500, corsHeaders);
+  }
+});
+
+app.post("/crm/contacts/:id/methods", async (c) => {
+  try {
+    const parsed = crmMethodSchema.safeParse(await c.req.json());
+    if (!parsed.success) return c.json({ error: "Invalid method payload", details: parsed.error.flatten() }, 400, corsHeaders);
+    const body = parsed.data;
+    const id = c.req.param("id");
+    const { data, error } = await supabase.rpc("crm_add_contact_method", {
+      p_contact_id: id,
+      p_method_type: body.method_type,
+      p_value: body.value,
+      p_label: body.label ?? null,
+      p_is_primary: body.is_primary ?? false,
+      p_actor: body.actor || "dashboard",
+      p_source: body.source || "manual",
+    });
+    if (error) {
+      const message = error.message || "Add method failed";
+      if (message.includes("not found")) return c.json({ error: message }, 404, corsHeaders);
+      if (message.includes("invalid contact method")) return c.json({ error: message }, 400, corsHeaders);
+      return c.json({ error: message }, 500, corsHeaders);
+    }
+    await syncContactCardSafe(id, body.actor || "crm-write-back");
+    return c.json({ method: data }, 201, corsHeaders);
+  } catch (error) {
+    return c.json({ error: error instanceof Error ? error.message : "Add method failed" }, 500, corsHeaders);
+  }
+});
+
+app.get("/crm/contacts/:id/history", async (c) => {
+  try {
+    const url = new URL(c.req.url);
+    const page = intParam(url.searchParams.get("page"), 1, 1, 100000);
+    const perPage = intParam(url.searchParams.get("per_page"), 50, 1, 200);
+    const offset = (page - 1) * perPage;
+    const { data, error, count } = await supabase
+      .from("crm_contact_change_log")
+      .select("*", { count: "exact" })
+      .eq("contact_id", c.req.param("id"))
+      .order("created_at", { ascending: false })
+      .range(offset, offset + perPage - 1);
+    if (error) throw new Error(error.message);
+    return c.json({ history: data || [], total: count || 0, page, per_page: perPage }, 200, corsHeaders);
+  } catch (error) {
+    return c.json({ error: error instanceof Error ? error.message : "Failed to load history" }, 500, corsHeaders);
+  }
+});
+
+const PRIVACY_TIERS = ["standard", "sensitive", "restricted"] as const;
+
+const crmNoteSchema = z.object({
+  body: z.string().min(1),
+  note_type: z.enum(["relationship_note", "private_note", "context"]).optional(),
+  pinned: z.boolean().optional(),
+  privacy_tier: z.enum(PRIVACY_TIERS).optional(),
+  actor: z.string().optional(),
+});
+
+const crmNotePatchSchema = z.object({
+  body: z.string().optional(),
+  note_type: z.enum(["relationship_note", "private_note", "context"]).optional(),
+  pinned: z.boolean().optional(),
+  privacy_tier: z.enum(PRIVACY_TIERS).optional(),
+  deleted: z.boolean().optional(),
+  actor: z.string().optional(),
+});
+
+const crmTaskSchema = z.object({
+  title: z.string().min(1),
+  description: z.string().optional(),
+  task_type: z.enum(["follow_up", "reminder", "todo"]).optional(),
+  status: z.enum(["open", "completed", "snoozed", "archived"]).optional(),
+  due_at: z.string().nullable().optional(),
+  snoozed_until: z.string().nullable().optional(),
+  priority: z.enum(["low", "normal", "high"]).optional(),
+  privacy_tier: z.enum(PRIVACY_TIERS).optional(),
+  actor: z.string().optional(),
+});
+
+const crmTaskPatchSchema = z.object({
+  title: z.string().optional(),
+  description: z.string().optional(),
+  task_type: z.enum(["follow_up", "reminder", "todo"]).optional(),
+  status: z.enum(["open", "completed", "snoozed", "archived"]).optional(),
+  due_at: z.string().nullable().optional(),
+  snoozed_until: z.string().nullable().optional(),
+  priority: z.enum(["low", "normal", "high"]).optional(),
+  privacy_tier: z.enum(PRIVACY_TIERS).optional(),
+  deleted: z.boolean().optional(),
+  actor: z.string().optional(),
+});
+
+const crmDateSchema = z.object({
+  label: z.string().min(1),
+  date_value: z.string().min(1),
+  date_kind: z.enum(["birthday", "anniversary", "work_anniversary", "other"]).optional(),
+  recurrence: z.enum(["none", "annual"]).optional(),
+  notes: z.string().optional(),
+  privacy_tier: z.enum(PRIVACY_TIERS).optional(),
+  actor: z.string().optional(),
+});
+
+const crmDatePatchSchema = z.object({
+  label: z.string().optional(),
+  date_value: z.string().optional(),
+  date_kind: z.enum(["birthday", "anniversary", "work_anniversary", "other"]).optional(),
+  recurrence: z.enum(["none", "annual"]).optional(),
+  notes: z.string().optional(),
+  privacy_tier: z.enum(PRIVACY_TIERS).optional(),
+  deleted: z.boolean().optional(),
+  actor: z.string().optional(),
+});
+
+const crmInteractionSchema = z.object({
+  contact_ids: z.array(z.string().min(1)).min(1),
+  kind: z.enum(["call", "meeting", "in_person", "message", "other"]),
+  occurred_at: z.string().min(1),
+  summary: z.string().min(1),
+  duration_minutes: z.number().int().nullable().optional(),
+  privacy_tier: z.enum(PRIVACY_TIERS).optional(),
+  thought_id: z.string().nullable().optional(),
+  actor: z.string().optional(),
+});
+
+const crmInteractionPatchSchema = z.object({
+  summary: z.string().optional(),
+  occurred_at: z.string().optional(),
+  duration_minutes: z.number().int().nullable().optional(),
+  privacy_tier: z.enum(PRIVACY_TIERS).optional(),
+  deleted: z.boolean().optional(),
+  actor: z.string().optional(),
+});
+
+// Compact error mapper for the engagement RPCs: zod already caught bad input, so
+// the RPC exceptions we still see are "not found" (404) or the occasional guard.
+function crmRpcErrorStatus(message: string): 404 | 409 | 400 | 500 {
+  if (message.includes("not found")) return 404;
+  if (message.includes("locked") || message.includes("stale_write")) return 409;
+  if (/\b(invalid|required|must be|cannot)\b/.test(message)) return 400;
+  return 500;
+}
+
+app.get("/crm/contacts/:id/relationship-items", async (c) => {
+  try {
+    const excludeRestricted = new URL(c.req.url).searchParams.get("exclude_restricted") !== "false";
+    const { data, error } = await supabase.rpc("crm_contact_relationship_items", {
+      p_contact_id: c.req.param("id"),
+      p_exclude_restricted: excludeRestricted,
+    });
+    if (error) throw new Error(error.message);
+    const row = (Array.isArray(data) ? data[0] : data) || { notes: [], tasks: [], important_dates: [] };
+    return c.json(row, 200, corsHeaders);
+  } catch (error) {
+    return c.json({ error: error instanceof Error ? error.message : "Failed to load relationship items" }, 500, corsHeaders);
+  }
+});
+
+app.post("/crm/contacts/:id/notes", async (c) => {
+  try {
+    const parsed = crmNoteSchema.safeParse(await c.req.json());
+    if (!parsed.success) return c.json({ error: "Invalid note payload", details: parsed.error.flatten() }, 400, corsHeaders);
+    const body = parsed.data;
+    const { data, error } = await supabase.rpc("crm_add_contact_note", {
+      p_contact_id: c.req.param("id"),
+      p_body: body.body,
+      p_note_type: body.note_type || "relationship_note",
+      p_pinned: body.pinned ?? false,
+      p_privacy_tier: body.privacy_tier || "standard",
+      p_actor: body.actor || "dashboard",
+    });
+    if (error) return c.json({ error: error.message }, crmRpcErrorStatus(error.message || ""), corsHeaders);
+    return c.json({ note: data }, 201, corsHeaders);
+  } catch (error) {
+    return c.json({ error: error instanceof Error ? error.message : "Add note failed" }, 500, corsHeaders);
+  }
+});
+
+app.patch("/crm/notes/:noteId", async (c) => {
+  try {
+    const parsed = crmNotePatchSchema.safeParse(await c.req.json());
+    if (!parsed.success) return c.json({ error: "Invalid note payload", details: parsed.error.flatten() }, 400, corsHeaders);
+    const body = parsed.data;
+    const { data, error } = await supabase.rpc("crm_update_contact_note", {
+      p_note_id: c.req.param("noteId"),
+      p_body: body.body ?? null,
+      p_note_type: body.note_type ?? null,
+      p_pinned: body.pinned ?? null,
+      p_privacy_tier: body.privacy_tier ?? null,
+      p_deleted: body.deleted ?? null,
+      p_actor: body.actor || "dashboard",
+    });
+    if (error) return c.json({ error: error.message }, crmRpcErrorStatus(error.message || ""), corsHeaders);
+    return c.json({ note: data }, 200, corsHeaders);
+  } catch (error) {
+    return c.json({ error: error instanceof Error ? error.message : "Update note failed" }, 500, corsHeaders);
+  }
+});
+
+app.post("/crm/contacts/:id/tasks", async (c) => {
+  try {
+    const parsed = crmTaskSchema.safeParse(await c.req.json());
+    if (!parsed.success) return c.json({ error: "Invalid task payload", details: parsed.error.flatten() }, 400, corsHeaders);
+    const body = parsed.data;
+    const { data, error } = await supabase.rpc("crm_add_contact_task", {
+      p_contact_id: c.req.param("id"),
+      p_title: body.title,
+      p_description: body.description ?? null,
+      p_task_type: body.task_type || "follow_up",
+      p_status: body.status || "open",
+      p_due_at: body.due_at ?? null,
+      p_snoozed_until: body.snoozed_until ?? null,
+      p_priority: body.priority || "normal",
+      p_privacy_tier: body.privacy_tier || "standard",
+      p_actor: body.actor || "dashboard",
+    });
+    if (error) return c.json({ error: error.message }, crmRpcErrorStatus(error.message || ""), corsHeaders);
+    return c.json({ task: data }, 201, corsHeaders);
+  } catch (error) {
+    return c.json({ error: error instanceof Error ? error.message : "Add task failed" }, 500, corsHeaders);
+  }
+});
+
+app.patch("/crm/tasks/:taskId", async (c) => {
+  try {
+    const parsed = crmTaskPatchSchema.safeParse(await c.req.json());
+    if (!parsed.success) return c.json({ error: "Invalid task payload", details: parsed.error.flatten() }, 400, corsHeaders);
+    const body = parsed.data;
+    const { data, error } = await supabase.rpc("crm_update_contact_task", {
+      p_task_id: c.req.param("taskId"),
+      p_title: body.title ?? null,
+      p_description: body.description ?? null,
+      p_task_type: body.task_type ?? null,
+      p_status: body.status ?? null,
+      p_due_at: body.due_at ?? null,
+      p_snoozed_until: body.snoozed_until ?? null,
+      p_priority: body.priority ?? null,
+      p_privacy_tier: body.privacy_tier ?? null,
+      p_deleted: body.deleted ?? null,
+      p_actor: body.actor || "dashboard",
+    });
+    if (error) return c.json({ error: error.message }, crmRpcErrorStatus(error.message || ""), corsHeaders);
+    return c.json({ task: data }, 200, corsHeaders);
+  } catch (error) {
+    return c.json({ error: error instanceof Error ? error.message : "Update task failed" }, 500, corsHeaders);
+  }
+});
+
+app.post("/crm/contacts/:id/important-dates", async (c) => {
+  try {
+    const parsed = crmDateSchema.safeParse(await c.req.json());
+    if (!parsed.success) return c.json({ error: "Invalid date payload", details: parsed.error.flatten() }, 400, corsHeaders);
+    const body = parsed.data;
+    const { data, error } = await supabase.rpc("crm_add_contact_important_date", {
+      p_contact_id: c.req.param("id"),
+      p_label: body.label,
+      p_date_value: body.date_value,
+      p_date_kind: body.date_kind || "other",
+      p_recurrence: body.recurrence || "annual",
+      p_notes: body.notes ?? null,
+      p_privacy_tier: body.privacy_tier || "standard",
+      p_actor: body.actor || "dashboard",
+    });
+    if (error) return c.json({ error: error.message }, crmRpcErrorStatus(error.message || ""), corsHeaders);
+    return c.json({ important_date: data }, 201, corsHeaders);
+  } catch (error) {
+    return c.json({ error: error instanceof Error ? error.message : "Add important date failed" }, 500, corsHeaders);
+  }
+});
+
+app.patch("/crm/important-dates/:dateId", async (c) => {
+  try {
+    const parsed = crmDatePatchSchema.safeParse(await c.req.json());
+    if (!parsed.success) return c.json({ error: "Invalid date payload", details: parsed.error.flatten() }, 400, corsHeaders);
+    const body = parsed.data;
+    const { data, error } = await supabase.rpc("crm_update_contact_important_date", {
+      p_important_date_id: c.req.param("dateId"),
+      p_label: body.label ?? null,
+      p_date_value: body.date_value ?? null,
+      p_date_kind: body.date_kind ?? null,
+      p_recurrence: body.recurrence ?? null,
+      p_notes: body.notes ?? null,
+      p_privacy_tier: body.privacy_tier ?? null,
+      p_deleted: body.deleted ?? null,
+      p_actor: body.actor || "dashboard",
+    });
+    if (error) return c.json({ error: error.message }, crmRpcErrorStatus(error.message || ""), corsHeaders);
+    return c.json({ important_date: data }, 200, corsHeaders);
+  } catch (error) {
+    return c.json({ error: error instanceof Error ? error.message : "Update important date failed" }, 500, corsHeaders);
+  }
+});
+
+app.get("/crm/contacts/:id/interactions", async (c) => {
+  try {
+    const url = new URL(c.req.url);
+    const { data, error } = await supabase.rpc("crm_contact_interactions", {
+      p_contact_id: c.req.param("id"),
+      p_limit: intParam(url.searchParams.get("limit"), 50, 1, 200),
+      p_offset: intParam(url.searchParams.get("offset"), 0, 0, 100000),
+      p_exclude_restricted: url.searchParams.get("exclude_restricted") !== "false",
+    });
+    if (error) throw new Error(error.message);
+    return c.json({ interactions: data || [] }, 200, corsHeaders);
+  } catch (error) {
+    return c.json({ error: error instanceof Error ? error.message : "Failed to load interactions" }, 500, corsHeaders);
+  }
+});
+
+app.post("/crm/interactions", async (c) => {
+  try {
+    const parsed = crmInteractionSchema.safeParse(await c.req.json());
+    if (!parsed.success) return c.json({ error: "Invalid interaction payload", details: parsed.error.flatten() }, 400, corsHeaders);
+    const body = parsed.data;
+    const { data, error } = await supabase.rpc("crm_log_interaction", {
+      p_contact_ids: body.contact_ids,
+      p_kind: body.kind,
+      p_occurred_at: body.occurred_at,
+      p_summary: body.summary,
+      p_duration_minutes: body.duration_minutes ?? null,
+      p_privacy_tier: body.privacy_tier || "standard",
+      p_thought_id: body.thought_id ?? null,
+      p_actor: body.actor || "dashboard",
+    });
+    if (error) return c.json({ error: error.message }, crmRpcErrorStatus(error.message || ""), corsHeaders);
+    return c.json(data || {}, 201, corsHeaders);
+  } catch (error) {
+    return c.json({ error: error instanceof Error ? error.message : "Log interaction failed" }, 500, corsHeaders);
+  }
+});
+
+app.patch("/crm/interactions/:interactionId", async (c) => {
+  try {
+    const parsed = crmInteractionPatchSchema.safeParse(await c.req.json());
+    if (!parsed.success) return c.json({ error: "Invalid interaction payload", details: parsed.error.flatten() }, 400, corsHeaders);
+    const body = parsed.data;
+    const { data, error } = await supabase.rpc("crm_update_interaction", {
+      p_interaction_id: c.req.param("interactionId"),
+      p_summary: body.summary ?? null,
+      p_occurred_at: body.occurred_at ?? null,
+      p_duration_minutes: body.duration_minutes ?? null,
+      p_privacy_tier: body.privacy_tier ?? null,
+      p_deleted: body.deleted ?? null,
+      p_actor: body.actor || "dashboard",
+    });
+    if (error) return c.json({ error: error.message }, crmRpcErrorStatus(error.message || ""), corsHeaders);
+    return c.json(data || {}, 200, corsHeaders);
+  } catch (error) {
+    return c.json({ error: error instanceof Error ? error.message : "Update interaction failed" }, 500, corsHeaders);
+  }
+});
+
+app.get("/crm/contacts/:id/timeline", async (c) => {
+  try {
+    const url = new URL(c.req.url);
+    const id = c.req.param("id");
+    const excludeRestricted = url.searchParams.get("exclude_restricted") !== "false";
+    const limit = intParam(url.searchParams.get("limit"), 50, 1, 200);
+
+    const [history, interactions, evidence] = await Promise.all([
+      supabase.from("crm_contact_change_log").select("*").eq("contact_id", id).order("created_at", { ascending: false }).limit(limit),
+      supabase.rpc("crm_contact_interactions", { p_contact_id: id, p_limit: limit, p_offset: 0, p_exclude_restricted: excludeRestricted }),
+      supabase.rpc("crm_contact_field_evidence", { p_contact_id: id, p_field_key: null, p_exclude_restricted: excludeRestricted, p_limit: limit }),
+    ]);
+
+    const events: Array<{ type: string; at: string; data: Record<string, unknown> }> = [];
+    for (const row of (history.data || []) as Array<Record<string, unknown>>) {
+      events.push({ type: "change", at: String(row.created_at ?? ""), data: row });
+    }
+    for (const row of (interactions.data || []) as Array<Record<string, unknown>>) {
+      events.push({ type: "interaction", at: String(row.occurred_at ?? row.created_at ?? ""), data: row });
+    }
+    for (const row of (evidence.data || []) as Array<Record<string, unknown>>) {
+      events.push({ type: "evidence", at: String(row.created_at ?? ""), data: row });
+    }
+    events.sort((a, b) => (a.at < b.at ? 1 : a.at > b.at ? -1 : 0));
+    return c.json({ timeline: events.slice(0, limit) }, 200, corsHeaders);
+  } catch (error) {
+    return c.json({ error: error instanceof Error ? error.message : "Failed to load timeline" }, 500, corsHeaders);
+  }
 });
 
 Deno.serve((req) => {

--- a/integrations/open-brain-rest/index.ts
+++ b/integrations/open-brain-rest/index.ts
@@ -1476,6 +1476,290 @@ app.get("/crm/contacts/:id/timeline", async (c) => {
   }
 });
 
+// ─── Wiki (optional) ────────────────────────────────────────────────────────
+// Exposes the wiki-pages schema (wiki_pages / wiki_sections / wiki_write_section
+// et al.) as REST for the dashboard. Mirrors the visibility and ordering used by
+// the wiki-mcp tools (wiki_list_pages, wiki_get_page, wiki_write_section) so the
+// two surfaces show the same thing. All routes are already behind the
+// x-brain-key middleware below. Requires the wiki-pages schema; on a brain
+// without it these routes surface a clean 404 (see wikiRpcErrorStatus) and the
+// dashboard hides the section via feature detection (GET /wiki/pages?per_page=1).
+
+const WIKI_PAGE_KINDS = ["topic", "entity", "autobiography", "custom"] as const;
+
+const WIKI_PAGE_COLUMNS = "id, slug, title, page_kind, status, metadata, created_at, updated_at";
+const WIKI_SECTION_COLUMNS =
+  "id, section_key, heading, display_order, origin, locked, body_md, pending_generated_md, pending_generated_at, generation_source, evidence_thought_ids, created_at, updated_at";
+
+const wikiCreatePageSchema = z.object({
+  slug: z.string().min(1),
+  title: z.string().min(1),
+  page_kind: z.string().optional(),
+  metadata: z.record(z.string(), z.unknown()).optional(),
+});
+
+const wikiWriteSectionSchema = z.object({
+  body_md: z.string(),
+  heading: z.string().optional(),
+  display_order: z.number().int().optional(),
+});
+
+const wikiLockSchema = z.object({
+  locked: z.boolean(),
+});
+
+// Compact error mapper for the wiki RPCs/tables, modeled on crmRpcErrorStatus
+// but fed the whole PostgrestError (message + code), not just a message string.
+// ADDITIONALLY handles the "schema not installed" case: supabase-js does not
+// surface raw Postgres "... does not exist" text for a missing schema —
+// PostgREST reports a missing table as PGRST205 and a missing function as
+// PGRST202 ("Could not find the table/function ... in the schema cache"),
+// while raw Postgres uses SQLSTATE 42P01 (undefined_table) / 42883
+// (undefined_function). All of those map to a clean 404 so
+// GET /wiki/pages?per_page=1 works as a feature-detect probe on a brain
+// without the wiki-pages schema (same philosophy as crmAvailable(); same
+// PGRST205/42P01 shapes handled by recipes/brain-backup and
+// recipes/crm-quick-start).
+const WIKI_MISSING_SCHEMA_CODES = new Set(["PGRST202", "PGRST205", "42P01", "42883"]);
+
+function wikiRpcErrorStatus(error: { message?: string | null; code?: string | null } | null | undefined): 404 | 409 | 400 | 500 {
+  const code = error?.code || "";
+  const message = error?.message || "";
+  if (
+    WIKI_MISSING_SCHEMA_CODES.has(code) ||
+    /could not find the (table|function)/i.test(message) ||
+    message.includes("does not exist") ||
+    message.includes("not found")
+  ) {
+    return 404;
+  }
+  if (message.includes("locked") || message.includes("pending")) return 409;
+  if (/\b(invalid|required|must be|cannot)\b/.test(message)) return 400;
+  return 500;
+}
+
+app.get("/wiki/pages", async (c) => {
+  try {
+    const url = new URL(c.req.url);
+    const pageKind = url.searchParams.get("page_kind");
+    if (pageKind && !WIKI_PAGE_KINDS.includes(pageKind as (typeof WIKI_PAGE_KINDS)[number])) {
+      return c.json({ error: `Invalid page_kind. Must be one of: ${WIKI_PAGE_KINDS.join(", ")}` }, 400, corsHeaders);
+    }
+    const page = intParam(url.searchParams.get("page"), 1, 1, 100000);
+    const perPage = intParam(url.searchParams.get("per_page"), 25, 1, 100);
+    const offset = (page - 1) * perPage;
+
+    let query = supabase
+      .from("wiki_pages")
+      .select(WIKI_PAGE_COLUMNS, { count: "exact" })
+      .eq("status", "active");
+    if (pageKind) query = query.eq("page_kind", pageKind);
+
+    const { data, error, count } = await query
+      .order("updated_at", { ascending: false })
+      .range(offset, offset + perPage - 1);
+    // Map query errors here (not via throw/catch) so the PostgrestError's code
+    // field reaches wikiRpcErrorStatus intact — the feature-detect 404 depends
+    // on it.
+    if (error) return c.json({ error: error.message }, wikiRpcErrorStatus(error), corsHeaders);
+
+    const rows = data || [];
+    // Grouped section count over just this page's ids — one follow-up query,
+    // no N+1 (mirrors wiki_list_pages in wiki-mcp/index.ts).
+    const pageIds = rows.map((row) => (row as { id: string }).id);
+    const sectionCounts: Record<string, number> = {};
+    if (pageIds.length > 0) {
+      const { data: sectionRows, error: sectionError } = await supabase
+        .from("wiki_sections")
+        .select("page_id")
+        .in("page_id", pageIds)
+        .is("deleted_at", null);
+      if (sectionError) return c.json({ error: sectionError.message }, wikiRpcErrorStatus(sectionError), corsHeaders);
+      for (const row of (sectionRows || []) as Array<{ page_id: string }>) {
+        sectionCounts[row.page_id] = (sectionCounts[row.page_id] || 0) + 1;
+      }
+    }
+
+    const withCounts = rows.map((row) => ({
+      ...row,
+      section_count: sectionCounts[(row as { id: string }).id] || 0,
+    }));
+
+    return c.json({ data: withCounts, total: count || 0, page, per_page: perPage }, 200, corsHeaders);
+  } catch (error) {
+    return c.json({ error: error instanceof Error ? error.message : "Failed to list wiki pages" }, 500, corsHeaders);
+  }
+});
+
+app.post("/wiki/pages", async (c) => {
+  try {
+    const parsed = wikiCreatePageSchema.safeParse(await c.req.json());
+    if (!parsed.success) return c.json({ error: "Invalid page payload", details: parsed.error.flatten() }, 400, corsHeaders);
+    const body = parsed.data;
+    const slug = body.slug.trim();
+    const title = body.title.trim();
+    if (!slug) return c.json({ error: "slug is required" }, 400, corsHeaders);
+    if (!title) return c.json({ error: "title is required" }, 400, corsHeaders);
+    // Same allowlist the GET filter validates against: reject a bogus
+    // page_kind with a 400 here instead of letting the wiki_pages CHECK
+    // constraint turn it into a 500.
+    const pageKind = body.page_kind || "topic";
+    if (!WIKI_PAGE_KINDS.includes(pageKind as (typeof WIKI_PAGE_KINDS)[number])) {
+      return c.json({ error: `Invalid page_kind. Must be one of: ${WIKI_PAGE_KINDS.join(", ")}` }, 400, corsHeaders);
+    }
+
+    const { data, error } = await supabase.rpc("wiki_upsert_page", {
+      p_slug: slug,
+      p_title: title,
+      p_page_kind: pageKind,
+      p_metadata: body.metadata || {},
+      p_actor: "dashboard",
+    });
+    if (error) return c.json({ error: error.message }, wikiRpcErrorStatus(error), corsHeaders);
+    return c.json(data || {}, 200, corsHeaders);
+  } catch (error) {
+    return c.json({ error: error instanceof Error ? error.message : "Create page failed" }, 500, corsHeaders);
+  }
+});
+
+app.get("/wiki/pages/:slug", async (c) => {
+  try {
+    const slug = c.req.param("slug");
+    // Mirrors wiki_get_page in wiki-mcp/index.ts: fetched by slug with no
+    // status filter (archived pages remain individually fetchable by slug;
+    // only the list route restricts to status='active').
+    const { data: page, error: pageError } = await supabase
+      .from("wiki_pages")
+      .select(WIKI_PAGE_COLUMNS)
+      .eq("slug", slug)
+      .maybeSingle();
+    if (pageError) return c.json({ error: pageError.message }, wikiRpcErrorStatus(pageError), corsHeaders);
+    if (!page) return c.json({ error: `Wiki page '${slug}' not found.` }, 404, corsHeaders);
+
+    const { data: sections, error: sectionError } = await supabase
+      .from("wiki_sections")
+      .select(WIKI_SECTION_COLUMNS)
+      .eq("page_id", (page as { id: string }).id)
+      .is("deleted_at", null)
+      .order("display_order", { ascending: true })
+      .order("section_key", { ascending: true });
+    if (sectionError) return c.json({ error: sectionError.message }, wikiRpcErrorStatus(sectionError), corsHeaders);
+
+    return c.json({ page, sections: sections || [] }, 200, corsHeaders);
+  } catch (error) {
+    return c.json({ error: error instanceof Error ? error.message : "Failed to load wiki page" }, 500, corsHeaders);
+  }
+});
+
+app.put("/wiki/pages/:slug/sections/:sectionKey", async (c) => {
+  try {
+    const parsed = wikiWriteSectionSchema.safeParse(await c.req.json());
+    if (!parsed.success) return c.json({ error: "Invalid section payload", details: parsed.error.flatten() }, 400, corsHeaders);
+    const body = parsed.data;
+
+    const slug = c.req.param("slug");
+    // Intentionally no status filter — mirrors wiki-mcp's wiki_write_section
+    // tool (which writes by page_id with no page-status check) and the RPC
+    // itself. A section on an archived page stays editable by slug, the same
+    // way the page stays readable via GET /wiki/pages/:slug.
+    const { data: page, error: pageError } = await supabase
+      .from("wiki_pages")
+      .select("id")
+      .eq("slug", slug)
+      .maybeSingle();
+    if (pageError) return c.json({ error: pageError.message }, wikiRpcErrorStatus(pageError), corsHeaders);
+    if (!page) return c.json({ error: `Wiki page '${slug}' not found.` }, 404, corsHeaders);
+
+    const rpcParams: Record<string, unknown> = {
+      p_page_id: (page as { id: string }).id,
+      p_section_key: c.req.param("sectionKey"),
+      p_body_md: body.body_md,
+      p_origin: "manual",
+      p_actor: "dashboard",
+    };
+    if (body.heading !== undefined) rpcParams.p_heading = body.heading;
+    if (body.display_order !== undefined) rpcParams.p_display_order = body.display_order;
+
+    const { data, error } = await supabase.rpc("wiki_write_section", rpcParams);
+    if (error) return c.json({ error: error.message }, wikiRpcErrorStatus(error), corsHeaders);
+    return c.json(data || {}, 200, corsHeaders);
+  } catch (error) {
+    return c.json({ error: error instanceof Error ? error.message : "Write section failed" }, 500, corsHeaders);
+  }
+});
+
+app.post("/wiki/sections/:id/accept-pending", async (c) => {
+  try {
+    const { data, error } = await supabase.rpc("wiki_accept_pending", {
+      p_section_id: c.req.param("id"),
+      p_actor: "dashboard",
+    });
+    if (error) return c.json({ error: error.message }, wikiRpcErrorStatus(error), corsHeaders);
+    return c.json(data || {}, 200, corsHeaders);
+  } catch (error) {
+    return c.json({ error: error instanceof Error ? error.message : "Accept pending failed" }, 500, corsHeaders);
+  }
+});
+
+app.post("/wiki/sections/:id/reject-pending", async (c) => {
+  try {
+    // wiki_reject_pending ships in a sibling schemas PR (schemas/wiki-pages) —
+    // no SQL is defined here, this route just calls the RPC by name. On a brain
+    // that hasn't applied that migration yet, the RPC-does-not-exist error maps
+    // to 404 via wikiRpcErrorStatus, same as every other wiki RPC here.
+    const { data, error } = await supabase.rpc("wiki_reject_pending", {
+      p_section_id: c.req.param("id"),
+      p_actor: "dashboard",
+    });
+    if (error) return c.json({ error: error.message }, wikiRpcErrorStatus(error), corsHeaders);
+    return c.json(data || {}, 200, corsHeaders);
+  } catch (error) {
+    return c.json({ error: error instanceof Error ? error.message : "Reject pending failed" }, 500, corsHeaders);
+  }
+});
+
+app.post("/wiki/sections/:id/lock", async (c) => {
+  try {
+    const parsed = wikiLockSchema.safeParse(await c.req.json());
+    if (!parsed.success) return c.json({ error: "Invalid lock payload", details: parsed.error.flatten() }, 400, corsHeaders);
+    const id = c.req.param("id");
+
+    const { data, error } = await supabase
+      .from("wiki_sections")
+      .update({ locked: parsed.data.locked })
+      .eq("id", id)
+      .is("deleted_at", null)
+      .select("id, locked")
+      .maybeSingle();
+    if (error) return c.json({ error: error.message }, wikiRpcErrorStatus(error), corsHeaders);
+    if (!data) return c.json({ error: `Wiki section '${id}' not found.` }, 404, corsHeaders);
+
+    return c.json({ section_id: data.id, locked: data.locked }, 200, corsHeaders);
+  } catch (error) {
+    return c.json({ error: error instanceof Error ? error.message : "Lock update failed" }, 500, corsHeaders);
+  }
+});
+
+app.delete("/wiki/pages/:slug", async (c) => {
+  try {
+    const slug = c.req.param("slug");
+    // Archive only — the schema's guard rail forbids hard deletes of wiki pages.
+    const { data, error } = await supabase
+      .from("wiki_pages")
+      .update({ status: "archived", updated_by: "dashboard" })
+      .eq("slug", slug)
+      .eq("status", "active")
+      .select("slug, status")
+      .maybeSingle();
+    if (error) return c.json({ error: error.message }, wikiRpcErrorStatus(error), corsHeaders);
+    if (!data) return c.json({ error: `Wiki page '${slug}' not found.` }, 404, corsHeaders);
+
+    return c.json({ slug: data.slug, status: data.status }, 200, corsHeaders);
+  } catch (error) {
+    return c.json({ error: error instanceof Error ? error.message : "Archive failed" }, 500, corsHeaders);
+  }
+});
+
 Deno.serve((req) => {
   const url = new URL(req.url);
   if (url.pathname === "/open-brain-rest") {

--- a/integrations/open-brain-rest/metadata.json
+++ b/integrations/open-brain-rest/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "Open Brain REST Gateway",
-  "description": "Supabase Edge Function REST gateway for the OB1 dashboard: thoughts, workflow, search, audit, duplicate-review, and (optional) CRM contact/proposal surfaces, with card write-back that keeps each contact's card thought in sync.",
+  "description": "Supabase Edge Function REST gateway for the OB1 dashboard: thoughts, workflow, search, audit, duplicate-review, and (optional) CRM contact/proposal and wiki page/section surfaces, with card write-back that keeps each contact's card thought in sync.",
   "category": "integrations",
   "author": {
     "name": "Alan Shurafa",

--- a/integrations/open-brain-rest/metadata.json
+++ b/integrations/open-brain-rest/metadata.json
@@ -1,6 +1,20 @@
 {
-  "name": "open-brain-rest",
-  "description": "Supabase Edge Function REST gateway for the OB1 dashboard thoughts, workflow, search, audit, and duplicate-review surfaces.",
-  "type": "integration",
-  "status": "experimental"
+  "name": "Open Brain REST Gateway",
+  "description": "Supabase Edge Function REST gateway for the OB1 dashboard: thoughts, workflow, search, audit, duplicate-review, and (optional) CRM contact/proposal surfaces, with card write-back that keeps each contact's card thought in sync.",
+  "category": "integrations",
+  "author": {
+    "name": "Alan Shurafa",
+    "github": "alanshurafa"
+  },
+  "version": "0.2.0",
+  "requires": {
+    "open_brain": true,
+    "services": ["Supabase", "schemas/crm-core", "schemas/crm-engagement"],
+    "tools": ["Supabase CLI", "Deno"]
+  },
+  "tags": ["rest", "gateway", "edge-function", "crm", "dashboard", "http"],
+  "difficulty": "intermediate",
+  "estimated_time": "20 minutes",
+  "created": "2026-06-14",
+  "updated": "2026-07-01"
 }

--- a/integrations/open-brain-rest/smoke/crm-smoke.mjs
+++ b/integrations/open-brain-rest/smoke/crm-smoke.mjs
@@ -1,0 +1,148 @@
+#!/usr/bin/env node
+
+// Live smoke for the CRM surface of open-brain-rest. Requires a brain with the
+// crm-core + crm-engagement schemas applied and the gateway deployed. Run:
+//   OB1_REST_URL=... OB1_REST_KEY=... node crm-smoke.mjs [--keep]
+// Self-cleaning: archives the contact it creates and deletes the card thought.
+
+const baseUrl = (process.env.OB1_REST_URL || "http://127.0.0.1:3025/open-brain-rest").replace(/\/$/, "");
+const accessKey = process.env.OB1_REST_KEY || process.env.MCP_ACCESS_KEY;
+const keep = process.argv.includes("--keep");
+
+if (!accessKey) fail("Set OB1_REST_KEY or MCP_ACCESS_KEY.");
+
+let contactId = null;
+let cardThoughtId = null;
+
+try {
+  await request("GET", "/health");
+
+  // Create -----------------------------------------------------------------
+  const created = await request("POST", "/crm/contacts", {
+    display_name: "OB1 CRM Smoke Contact",
+    canonical_email: "smoke@example.com",
+    organization_name: "Smoke Test Co",
+    actor: "crm-smoke",
+  });
+  contactId = created.contact_id;
+  assert(typeof contactId === "string" && contactId.length > 0, "create returns a contact_id");
+  cardThoughtId = created.record?.card_thought_id || null;
+
+  // Detail ------------------------------------------------------------------
+  const detail = await request("GET", `/crm/contacts/${contactId}`);
+  assert(detail.record?.id === contactId, "detail returns the contact record");
+  assert(Array.isArray(detail.methods), "detail returns a methods array");
+
+  // List (search) -----------------------------------------------------------
+  const list = await request("GET", "/crm/contacts?q=Smoke&per_page=50");
+  assert(list.data.some((row) => row.id === contactId), "list search finds the contact");
+
+  // Patch (guarded write + card write-back) ---------------------------------
+  const patched = await request("PATCH", `/crm/contacts/${contactId}`, {
+    patch: { job_title: "Head of Smoke" },
+    actor: "crm-smoke",
+  });
+  assert(Array.isArray(patched.applied) && patched.applied.includes("job_title"), "patch applies job_title");
+
+  // Method (+ write-back) ---------------------------------------------------
+  const method = await request("POST", `/crm/contacts/${contactId}/methods`, {
+    method_type: "phone",
+    value: "+15550100",
+    actor: "crm-smoke",
+  });
+  assert(method.method?.id, "method add returns a method");
+
+  // Field lock --------------------------------------------------------------
+  const lock = await request("POST", `/crm/contacts/${contactId}/field-lock`, {
+    field_key: "organization_name",
+    locked: true,
+    actor: "crm-smoke",
+  });
+  assert(lock.field === "organization_name", "field lock returns the field");
+
+  // Notes / tasks / important dates ----------------------------------------
+  const note = await request("POST", `/crm/contacts/${contactId}/notes`, {
+    body: "Smoke note about the relationship.",
+    actor: "crm-smoke",
+  });
+  assert(note.note?.id, "note add returns a note");
+
+  const task = await request("POST", `/crm/contacts/${contactId}/tasks`, {
+    title: "Follow up after smoke test",
+    actor: "crm-smoke",
+  });
+  assert(task.task?.id, "task add returns a task");
+
+  const date = await request("POST", `/crm/contacts/${contactId}/important-dates`, {
+    label: "Smoke anniversary",
+    date_value: "2020-01-15",
+    date_kind: "anniversary",
+    actor: "crm-smoke",
+  });
+  assert(date.important_date?.id, "important date add returns a date");
+
+  const items = await request("GET", `/crm/contacts/${contactId}/relationship-items`);
+  assert(items.notes.length >= 1 && items.tasks.length >= 1 && items.important_dates.length >= 1, "relationship items bundle populated");
+
+  // Interactions ------------------------------------------------------------
+  const interaction = await request("POST", "/crm/interactions", {
+    contact_ids: [contactId],
+    kind: "call",
+    occurred_at: new Date().toISOString(),
+    summary: "Smoke call to verify interaction logging.",
+    actor: "crm-smoke",
+  });
+  assert(interaction.interaction_id, "interaction log returns an id");
+
+  const interactions = await request("GET", `/crm/contacts/${contactId}/interactions`);
+  assert(interactions.interactions.length >= 1, "interaction list sees the logged call");
+
+  // History + timeline ------------------------------------------------------
+  const history = await request("GET", `/crm/contacts/${contactId}/history`);
+  assert(history.total >= 1, "history has change-log rows");
+
+  const timeline = await request("GET", `/crm/contacts/${contactId}/timeline`);
+  assert(Array.isArray(timeline.timeline) && timeline.timeline.length >= 1, "timeline merges events");
+
+  // Proposals count (nav badge) --------------------------------------------
+  const count = await request("GET", "/crm/proposals/count");
+  assert(typeof count.open === "number", "proposals count returns an open number");
+
+  await cleanup();
+  console.log(`crm smoke passed (${keep ? "kept" : "cleaned"} contact ${contactId}).`);
+} catch (error) {
+  await cleanup().catch(() => {});
+  fail(error instanceof Error ? error.message : String(error));
+}
+
+async function cleanup() {
+  if (keep) return;
+  if (contactId) {
+    await request("PATCH", `/crm/contacts/${contactId}`, { patch: { lifecycle_status: "archived" }, actor: "crm-smoke" }).catch(() => {});
+  }
+  if (cardThoughtId) {
+    await request("DELETE", `/thought/${cardThoughtId}`).catch(() => {});
+  }
+}
+
+async function request(method, path, body) {
+  const response = await fetch(`${baseUrl}${path}`, {
+    method,
+    headers: { "content-type": "application/json", "x-brain-key": accessKey },
+    body: body ? JSON.stringify(body) : undefined,
+  });
+  const data = await response.json().catch(() => ({}));
+  if (!response.ok) {
+    throw new Error(`${method} ${path} failed: ${response.status} ${JSON.stringify(data)}`);
+  }
+  return data;
+}
+
+function assert(condition, message) {
+  if (!condition) throw new Error(`Assertion failed: ${message}`);
+}
+
+function fail(message) {
+  console.error(message);
+  process.exit(1);
+}

--- a/integrations/open-brain-rest/smoke/wiki-smoke.mjs
+++ b/integrations/open-brain-rest/smoke/wiki-smoke.mjs
@@ -1,0 +1,127 @@
+#!/usr/bin/env node
+
+// Live smoke for the wiki surface of open-brain-rest. Requires a brain with the
+// wiki-pages schema applied and the gateway deployed. Run:
+//   OB1_REST_URL=... OB1_REST_KEY=... node wiki-smoke.mjs [--keep]
+// Self-cleaning: archives the page it creates (the schema never hard-deletes).
+
+const baseUrl = (process.env.OB1_REST_URL || "http://127.0.0.1:3025/open-brain-rest").replace(/\/$/, "");
+const accessKey = process.env.OB1_REST_KEY || process.env.MCP_ACCESS_KEY;
+const keep = process.argv.includes("--keep");
+
+if (!accessKey) fail("Set OB1_REST_KEY or MCP_ACCESS_KEY.");
+
+const slug = `ob1-wiki-smoke-${Date.now()}`;
+let sectionId = null;
+
+try {
+  await request("GET", "/health");
+
+  // Create -----------------------------------------------------------------
+  const created = await request("POST", "/wiki/pages", {
+    slug,
+    title: "OB1 Wiki Smoke Page",
+    page_kind: "topic",
+  });
+  assert(typeof created.page_id === "string" && created.page_id.length > 0, "create returns a page_id");
+  assert(created.created === true, "create reports created:true for a brand new slug");
+
+  // List (+ section_count present) ------------------------------------------
+  const list = await request("GET", `/wiki/pages?page_kind=topic&per_page=100`);
+  const listedRow = list.data.find((row) => row.slug === slug);
+  assert(listedRow, "list finds the created page");
+  assert(typeof listedRow.section_count === "number", "list row carries a numeric section_count");
+  assert(listedRow.section_count === 0, "brand new page has zero sections");
+
+  // Reject invalid page_kind (list filter + create) --------------------------
+  const badKindResponse = await fetch(`${baseUrl}/wiki/pages?page_kind=not-a-real-kind`, {
+    headers: { "x-brain-key": accessKey },
+  });
+  assert(badKindResponse.status === 400, "invalid page_kind filter is rejected with 400");
+
+  const badCreateResponse = await fetch(`${baseUrl}/wiki/pages`, {
+    method: "POST",
+    headers: { "content-type": "application/json", "x-brain-key": accessKey },
+    body: JSON.stringify({ slug: `${slug}-bogus-kind`, title: "Bogus Kind", page_kind: "bogus" }),
+  });
+  assert(badCreateResponse.status === 400, "invalid page_kind on create is rejected with 400");
+
+  // Get by slug (no sections yet) -------------------------------------------
+  const detail = await request("GET", `/wiki/pages/${slug}`);
+  assert(detail.page?.slug === slug, "detail returns the page");
+  assert(Array.isArray(detail.sections) && detail.sections.length === 0, "detail starts with no sections");
+
+  // PUT section: first write creates it -------------------------------------
+  const createdSection = await request("PUT", `/wiki/pages/${slug}/sections/overview`, {
+    body_md: "First draft of the overview section.",
+    heading: "Overview",
+  });
+  assert(createdSection.action === "created", "first section write action is created");
+  sectionId = createdSection.section_id;
+  assert(typeof sectionId === "string" && sectionId.length > 0, "section write returns a section_id");
+
+  // PUT section: second write updates it in place ---------------------------
+  const updatedSection = await request("PUT", `/wiki/pages/${slug}/sections/overview`, {
+    body_md: "Revised overview section text.",
+  });
+  assert(updatedSection.action === "updated", "second section write action is updated");
+  assert(updatedSection.section_id === sectionId, "update targets the same section_id");
+
+  // Detail now shows the section, with body reflecting the latest write -----
+  const detailAfterWrite = await request("GET", `/wiki/pages/${slug}`);
+  const section = detailAfterWrite.sections.find((row) => row.id === sectionId);
+  assert(section, "detail lists the written section");
+  assert(section.body_md === "Revised overview section text.", "detail reflects the latest section body");
+
+  // Lock true then false ------------------------------------------------------
+  const lockedTrue = await request("POST", `/wiki/sections/${sectionId}/lock`, { locked: true });
+  assert(lockedTrue.locked === true, "lock true is applied");
+  const lockedFalse = await request("POST", `/wiki/sections/${sectionId}/lock`, { locked: false });
+  assert(lockedFalse.locked === false, "lock false is applied");
+
+  // Reject-pending on a section with no pending draft (valid negative check).
+  // A positive pending-draft path requires a 'generated' write against a
+  // human-owned (manual/locked) section — that requires a generator/worker
+  // writer and is covered by wiki-mcp / worker E2E, not this REST smoke.
+  const rejected = await request("POST", `/wiki/sections/${sectionId}/reject-pending`);
+  assert(rejected.action === "no_pending", "reject-pending on a clean section reports no_pending");
+
+  // Archive (never hard-delete) ----------------------------------------------
+  if (!keep) {
+    const archived = await request("DELETE", `/wiki/pages/${slug}`);
+    assert(archived.slug === slug, "archive returns the slug");
+    assert(archived.status === "archived", "archive sets status to archived");
+
+    const listAfterArchive = await request("GET", `/wiki/pages?page_kind=topic&per_page=100`);
+    assert(!listAfterArchive.data.some((row) => row.slug === slug), "archived page is absent from the active list");
+  }
+
+  console.log(`wiki smoke passed (${keep ? "kept" : "archived"} page ${slug}).`);
+} catch (error) {
+  if (!keep) {
+    await request("DELETE", `/wiki/pages/${slug}`).catch(() => {});
+  }
+  fail(error instanceof Error ? error.message : String(error));
+}
+
+async function request(method, path, body) {
+  const response = await fetch(`${baseUrl}${path}`, {
+    method,
+    headers: { "content-type": "application/json", "x-brain-key": accessKey },
+    body: body ? JSON.stringify(body) : undefined,
+  });
+  const data = await response.json().catch(() => ({}));
+  if (!response.ok) {
+    throw new Error(`${method} ${path} failed: ${response.status} ${JSON.stringify(data)}`);
+  }
+  return data;
+}
+
+function assert(condition, message) {
+  if (!condition) throw new Error(`Assertion failed: ${message}`);
+}
+
+function fail(message) {
+  console.error(message);
+  process.exit(1);
+}


### PR DESCRIPTION
Adds `/wiki` routes to the `open-brain-rest` gateway: REST endpoints for listing pages, reading a page with sections, writing sections, and accept/reject of pending drafts. Includes a `smoke/wiki-smoke.mjs` script.

Additive to `integrations/open-brain-rest/index.ts`.

Depends on #399 (CRM REST routes) — stacked on top of it, so the diff shown here includes #399 until it merges, after which it narrows to just the `/wiki` routes. Runtime dependency on #365/#366 (persistent wiki pages + wiki MCP schema).