### PR TITLE
[recipes] Add capture_derived_thought MCP tool to provenance-chains

### DIFF
--- a/recipes/provenance-chains/README.md
+++ b/recipes/provenance-chains/README.md
@@ -8,7 +8,7 @@ The [Provenance Chains schema](../../schemas/provenance-chains/) adds four colum
 
 1. **`backfill.mjs`** — One-time script to mark existing derived artifacts (weekly digests, wikis, lint reports, etc.) as `derivation_layer='derived'` and, where the saved artifact exposes thought IDs, populate `derived_from`.
 2. **`eval.mjs`** — Nightly (or on-demand) grader that scores each derived thought on existence / relevance / sufficiency using an LLM, and writes the scores into the thought's metadata so dashboards can surface low-quality chains. Three grader backends: `openrouter` (hosted, default), `stdin` (manual), and `queue` (emit prompts → another worker grades → apply back).
-3. **`mcp-tools.ts`** — Two MCP tool handler snippets (`trace_provenance`, `find_derivatives`) to drop into your `open-brain-mcp` Edge Function. They wrap the SQL helpers and handle redaction of restricted ancestors, cycle tolerance, and node caps.
+3. **`mcp-tools.ts`** — Three MCP tool handler snippets to drop into your `open-brain-mcp` Edge Function: two read tools (`trace_provenance`, `find_derivatives`) that wrap the SQL helpers and handle redaction of restricted ancestors, cycle tolerance, and node caps; plus one write tool (`capture_derived_thought`) that captures a synthesized artifact *with* its provenance so the graph gets populated at capture time — not just by the one-time `backfill.mjs`. The write tool is deliberately separate from the canonical `capture_thought`, so the everyday capture path is untouched.
 
 Together, the schema + this recipe turn a flat thoughts table into a directed provenance graph that any Claude/GPT client can query through MCP.
 
@@ -104,7 +104,7 @@ Legacy names (still accepted with a deprecation warning):
 
 ![Step 6](https://img.shields.io/badge/Step_6-Install_MCP_Tools-1E88E5?style=for-the-badge)
 
-1. Open your `open-brain-mcp` server (in this repo, [`server/index.ts`](../../server/index.ts); in a deployed Supabase copy, usually `supabase/functions/open-brain-mcp/index.ts`) and paste the two `server.registerTool(...)` blocks from [`mcp-tools.ts`](./mcp-tools.ts) alongside your other tool registrations.
+1. Open your `open-brain-mcp` server (in this repo, [`server/index.ts`](../../server/index.ts); in a deployed Supabase copy, usually `supabase/functions/open-brain-mcp/index.ts`) and paste the three `server.registerTool(...)` blocks from [`mcp-tools.ts`](./mcp-tools.ts) alongside your other tool registrations. The `capture_derived_thought` block reuses the canonical `getEmbedding` and `extractMetadata` helpers already defined in `index.ts` — paste it after those are in scope.
 
    Deploy the function:
 
@@ -112,7 +112,7 @@ Legacy names (still accepted with a deprecation warning):
    supabase functions deploy open-brain-mcp
    ```
 
-   In Claude Desktop, open your Open Brain connector — you should now see `trace_provenance` and `find_derivatives` in the tool list.
+   In Claude Desktop, open your Open Brain connector — you should now see `trace_provenance`, `find_derivatives`, and `capture_derived_thought` in the tool list.
 
 ## Expected Outcome
 
@@ -122,7 +122,7 @@ After the full pipeline:
 - The same fields (plus `backfilled_at`, `backfill_reason`, and, when parsed, `derived_from`) are mirrored into `metadata.provenance` so the canonical `upsert_thought` RPC — which only preserves the metadata blob on `content_fingerprint` conflicts — round-trips provenance if the row is ever re-upserted.
 - Rows whose artifact files expose thought IDs have a non-empty top-level `derived_from` array.
 - Derived rows have `metadata.eval_score` and the three `eval_dimensions` set.
-- Two new MCP tools are live: `trace_provenance(thought_id, depth?)` and `find_derivatives(thought_id, limit?)`. Restricted-tier rows are always filtered out by `find_derivatives` at the SQL layer — there is no caller-visible override.
+- Three new MCP tools are live: `trace_provenance(thought_id, depth?)` and `find_derivatives(thought_id, limit?)` for reading, plus `capture_derived_thought(content, derived_from?, derivation_layer?, derivation_method?, supersedes?)` for writing. Restricted-tier rows are always filtered out by `find_derivatives` at the SQL layer — there is no caller-visible override. `capture_derived_thought` validates provenance before writing: non-UUID `derived_from` refs (e.g. `#412`) are moved to `metadata.provenance.unresolved_refs` instead of corrupting the array, `derivation_layer`/`derivation_method` are constrained to the CHECK-valid values, and provenance is written both to the top-level columns and mirrored into `metadata.provenance` so it survives `upsert_thought` re-captures.
 - Claude can now answer questions like:
   - "Show me the sources that feed into my March weekly digest."
   - "What wikis or digests cite the thought about the bug I fixed on Friday?"
@@ -132,7 +132,7 @@ After the full pipeline:
 
 This recipe assumes `public.thoughts.id` is a `UUID` (the canonical Open Brain setup). If you have customized your schema to a `BIGINT` primary key:
 
-- In `mcp-tools.ts`, change the `z.string().uuid()` input schemas to `z.number().int().positive()` and remove the UUID casts.
+- In `mcp-tools.ts`, change the `z.string().uuid()` input schemas to `z.number().int().positive()` and remove the UUID casts. In `capture_derived_thought`, also replace the `UUID_RE` partition (which routes non-UUID `derived_from` refs to `unresolved_refs`) with an integer check, or the tool will treat every integer parent id as unresolved.
 - In `backfill.mjs`, **integer-style `#123` references raise a hard error** on the canonical UUID install — the script logs `parse error: refusing to write N integer ref(s) ...` and continues. That row is still flipped to `derivation_layer='derived'` but without any `derived_from`, so operators can fix the artifact and re-run with `--force`. Nothing corrupt reaches PostgREST. Users on a BIGINT fork must skip this recipe's backfill and repopulate `derived_from` themselves (or edit the `parseParentIds` helper to emit the integers uncasted). Mixing UUID and integer elements in one `derived_from` array also breaks the GIN containment index; keep one ID shape per array.
 - In `eval.mjs`, PostgREST `in.(…)` accepts either shape without changes.
 

--- a/recipes/provenance-chains/mcp-tools.ts
+++ b/recipes/provenance-chains/mcp-tools.ts
@@ -1,7 +1,7 @@
 // Provenance Chains — MCP tool handlers for open-brain-mcp (Supabase Edge Function).
 //
-// Drop these two tool registrations into your existing open-brain-mcp
-// index.ts after the other registerTool() calls. Both tools assume the
+// Drop these three tool registrations into your existing open-brain-mcp
+// index.ts after the other registerTool() calls. All three assume the
 // schemas/provenance-chains SQL migration has been applied to your
 // Supabase project (adds the derived_from / derivation_* columns and the
 // trace_provenance / find_derivatives helper functions).
@@ -12,9 +12,16 @@
 // and update the id casts accordingly.
 //
 // Expected surrounding context (already present in index.ts):
-//   - `server`    instance of McpServer
-//   - `supabase`  createClient<...>(…, service_role_key)
-//   - `z`         imported from "npm:zod@3"
+//   - `server`          instance of McpServer
+//   - `supabase`        createClient<...>(…, service_role_key)
+//   - `z`               imported from "npm:zod@3"
+//   - `getEmbedding`    (Tool 3 only) canonical index.ts helper — text → vector
+//   - `extractMetadata` (Tool 3 only) canonical index.ts helper — text → metadata
+//
+// Tool 3 (capture_derived_thought) is a WRITE tool and is deliberately a
+// SEPARATE tool from the canonical `capture_thought`, so the everyday
+// capture hot path used by every connected client is left untouched. Use
+// it only when saving an artifact derived from other thoughts.
 //
 // Return envelopes are inlined as the literal
 //   { content: [{ type: "text", text: JSON.stringify(...) }] }
@@ -346,6 +353,186 @@ server.registerTool(
       };
     } catch (error) {
       console.error("find_derivatives failed", error);
+      return {
+        content: [{ type: "text", text: String(error) }],
+        isError: true,
+      };
+    }
+  },
+);
+
+// ---------------------------------------------------------------------------
+// Tool 3: capture_derived_thought
+//   WRITE tool. Saves a synthesized/derived artifact (digest, wiki, summary)
+//   together with its provenance — the parent thoughts it was built from —
+//   so the derivation graph is populated at capture time instead of only by
+//   the recipe's one-time backfill.mjs.
+//
+//   Deliberately a SEPARATE tool from the canonical `capture_thought`
+//   (Option B): the everyday capture path used by every connected client is
+//   never touched, so a bug here can only affect callers that opt into
+//   provenance.
+//
+//   The 3-step write path mirrors canonical capture_thought because
+//   upsert_thought writes only content/content_fingerprint/metadata and
+//   MERGES metadata on a fingerprint conflict — it never touches the
+//   top-level derived_from / derivation_* columns:
+//     1. embed + extract metadata, folding a `provenance` mirror INTO
+//        metadata so it rides through upsert_thought and survives the
+//        conflict-time `metadata || EXCLUDED.metadata` merge on re-capture;
+//     2. upsert_thought(content, { metadata }) -> id;
+//     3. a single UPDATE writes the embedding AND the top-level provenance
+//        columns that upsert_thought ignored.
+// ---------------------------------------------------------------------------
+
+server.registerTool(
+  "capture_derived_thought",
+  {
+    title: "Capture Derived Thought",
+    description:
+      "Save a synthesized/derived artifact (digest, wiki, research summary, report) to Open Brain WITH its provenance. Use this instead of capture_thought ONLY when the thing you are saving was derived from other thoughts already in the brain. Records the parent thought IDs so 'why do I believe this?' and 'what uses this?' stay answerable.",
+    annotations: {
+      readOnlyHint: false,
+      openWorldHint: false,
+      destructiveHint: false,
+      idempotentHint: false,
+    },
+    inputSchema: z.object({
+      content: z.string().describe(
+        "The derived artifact text — a clear, standalone statement that will make sense when retrieved later"),
+      derived_from: z.array(z.string()).optional().describe(
+        "Parent thought IDs this artifact was synthesized from. UUID strings only; non-UUID refs (e.g. legacy #412) are moved to metadata.provenance.unresolved_refs rather than rejected"),
+      derivation_layer: z.enum(["primary", "derived"]).optional().describe(
+        "'derived' for a synthesized artifact (default when derived_from is provided). The DB CHECK allows only these two values"),
+      derivation_method: z.enum(["synthesis"]).optional().describe(
+        "How it was produced. 'synthesis' is the only value a stock install accepts; defaults to 'synthesis' when derived_from is provided"),
+      supersedes: z.string().uuid().optional().describe(
+        "UUID of a prior thought this one replaces (e.g. a regenerated digest replacing yesterday's)"),
+    }),
+  },
+  async (params) => {
+    try {
+      const raw = params as Record<string, unknown>;
+      const content = String(raw.content ?? "").trim();
+      if (!content) {
+        return {
+          content: [{ type: "text", text: "content is required" }],
+          isError: true,
+        };
+      }
+
+      // Partition derived_from into valid UUID parents vs. unresolved refs.
+      // We accept z.array(z.string()) (not z.array(z.string().uuid())) on
+      // purpose: a single legacy ref like "#412" must NOT reject the whole
+      // capture. Valid UUIDs go into the derived_from column; everything else
+      // is preserved under metadata.provenance.unresolved_refs so the loss is
+      // visible instead of silently poisoning the array (trace_provenance
+      // casts each element ::uuid and would raise 22P02 on a non-UUID).
+      const UUID_RE =
+        /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+      const rawRefs = Array.isArray(raw.derived_from)
+        ? (raw.derived_from as unknown[]).map((r) => String(r).trim())
+        : [];
+      const derivedFrom = rawRefs.filter((r) => UUID_RE.test(r));
+      const unresolvedRefs = rawRefs.filter((r) => !UUID_RE.test(r));
+
+      // Defaults: when parents are present but layer/method were omitted, fill
+      // in the CHECK-valid values so the caller doesn't have to. z.enum already
+      // guarantees any PROVIDED value is legal, so no clamping is needed.
+      const layer =
+        (raw.derivation_layer as string | undefined) ??
+        (derivedFrom.length > 0 ? "derived" : undefined);
+      const method =
+        (raw.derivation_method as string | undefined) ??
+        (derivedFrom.length > 0 ? "synthesis" : undefined);
+      const supersedes = raw.supersedes as string | undefined;
+
+      const hasProvenance =
+        derivedFrom.length > 0 ||
+        unresolvedRefs.length > 0 ||
+        layer !== undefined ||
+        method !== undefined ||
+        supersedes !== undefined;
+
+      // Step 1: embed + extract metadata, folding in the provenance mirror.
+      // The mirror lives inside metadata so it survives upsert_thought's
+      // conflict-time `metadata || EXCLUDED.metadata` merge: a later stock
+      // capture of identical content won't drop it.
+      const [embedding, extracted] = await Promise.all([
+        getEmbedding(content),
+        extractMetadata(content),
+      ]);
+      const metadata: Record<string, unknown> = { ...extracted, source: "mcp" };
+      if (hasProvenance) {
+        metadata.provenance = {
+          ...(derivedFrom.length ? { derived_from: derivedFrom } : {}),
+          ...(layer ? { derivation_layer: layer } : {}),
+          ...(method ? { derivation_method: method } : {}),
+          ...(supersedes ? { supersedes } : {}),
+          ...(unresolvedRefs.length ? { unresolved_refs: unresolvedRefs } : {}),
+        };
+      }
+
+      // Step 2: upsert content + metadata. upsert_thought returns the row id
+      // and, on a fingerprint conflict, merges the incoming metadata.
+      const { data: upsertResult, error: upsertError } = await supabase.rpc(
+        "upsert_thought",
+        { p_content: content, p_payload: { metadata } },
+      );
+      if (upsertError) {
+        return {
+          content: [{ type: "text", text: `Failed to capture: ${upsertError.message}` }],
+          isError: true,
+        };
+      }
+      const thoughtId = (upsertResult as { id?: string } | null)?.id;
+      if (!thoughtId) {
+        return {
+          content: [{ type: "text", text: "upsert_thought returned no id" }],
+          isError: true,
+        };
+      }
+
+      // Step 3: one UPDATE for the embedding AND the top-level provenance
+      // columns upsert_thought ignored. On a re-capture this overwrites the
+      // columns with the new values, which is intended.
+      const patch: Record<string, unknown> = { embedding };
+      if (derivedFrom.length) patch.derived_from = derivedFrom;
+      if (layer) patch.derivation_layer = layer;
+      if (method) patch.derivation_method = method;
+      if (supersedes) patch.supersedes = supersedes;
+
+      const { error: patchError } = await supabase
+        .from("thoughts")
+        .update(patch)
+        .eq("id", thoughtId);
+      if (patchError) {
+        // The thought IS saved; only the provenance/embedding write failed.
+        // Surface it explicitly rather than pretending success.
+        return {
+          content: [{
+            type: "text",
+            text:
+              `Captured thought ${thoughtId}, but failed to write provenance/embedding: ` +
+              `${patchError.message}`,
+          }],
+          isError: true,
+        };
+      }
+
+      // Confirmation.
+      const parts = [`Captured derived thought ${thoughtId}`];
+      if (derivedFrom.length) parts.push(`from ${derivedFrom.length} parent(s)`);
+      if (layer) parts.push(`[layer=${layer}${method ? `, method=${method}` : ""}]`);
+      if (supersedes) parts.push(`supersedes ${supersedes}`);
+      if (unresolvedRefs.length) {
+        parts.push(
+          `— ${unresolvedRefs.length} non-UUID ref(s) moved to ` +
+          `metadata.provenance.unresolved_refs: ${unresolvedRefs.join(", ")}`);
+      }
+      return { content: [{ type: "text", text: parts.join(" ") }] };
+    } catch (error) {
+      console.error("capture_derived_thought failed", error);
       return {
         content: [{ type: "text", text: String(error) }],
         isError: true,


### PR DESCRIPTION
## What

Adds a third MCP tool — **`capture_derived_thought`** — to `recipes/provenance-chains/mcp-tools.ts`, alongside `trace_provenance` and `find_derivatives`. It captures a synthesized artifact **together with its provenance**, so the derivation graph is populated at capture time instead of only by the one-time `backfill.mjs`.

Prerequisite for #401 / #397. Recipe-only, additive (`2 files changed`): the canonical `capture_thought` is **not modified**, so the everyday capture hot path used by every connected client is untouched (Option B).

## Why

Verified on a live Open Brain: the schema and read tools were installed, but the deployed `capture_thought` accepts only `content`, so nothing could write `derived_from`/`derivation_*` interactively — 0 of 158 thoughts had any provenance. This tool closes that gap.

## How it works

`upsert_thought` writes only `content`/`content_fingerprint`/`metadata` and merges metadata on a fingerprint conflict, so the tool:
1. folds a `provenance` mirror into `metadata` (survives the `||` merge on re-capture);
2. writes the top-level `derived_from`/`derivation_*`/`supersedes` columns via a follow-up `UPDATE` (same patch as the embedding).

Validation matches the schema CHECK constraints: non-UUID `derived_from` refs (e.g. `#412`) are routed to `metadata.provenance.unresolved_refs` instead of poisoning the array; `derivation_layer`/`derivation_method` are constrained to the legal values; layer/method default to `derived`/`synthesis` when parents are present. No provenance inputs → behaves like a normal capture.

## Verified end-to-end (deployed to a live `open-brain-mcp`, then exercised over MCP)

- `tools/list` exposes all 9 tools including `capture_derived_thought`; existing tools unaffected (`verify_jwt` unchanged).
- Capturing with 4 UUID parents + 1 legacy `#412` → row has 4 UUIDs in `derived_from`, `#412` in `metadata.provenance.unresolved_refs`, `derivation_layer='derived'`, `derivation_method='synthesis'`, mirror present.
- `trace_provenance` on the new thought returns all 4 parents.
- Re-capturing identical content dedupes (same id) and the mirror survives.
- Test row cleaned up; parent thoughts untouched.

`deno check` shows no new error class vs. the untouched `server/index.ts` baseline — only the same implicit-any diagnostics the existing `trace_provenance`/`find_derivatives` handlers already have (type-only; Deno Deploy strips types).

Refs #401. Blocks #397.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0127BucGfQraB5dkZR38MEF1