### PR TITLE
[skills] Wire synthesis skills to the provenance capture contract

### DIFF
--- a/skills/competitive-analysis/SKILL.md
+++ b/skills/competitive-analysis/SKILL.md
@@ -74,6 +74,13 @@ Useful but optional:
 6. Optionally use Open Brain.
    - Search for prior notes before repeating known findings.
    - Capture the finished brief or the highest-value strategic takeaways after the work is done.
+   - Preserve provenance when capturing the brief: if the Open Brain setup has
+     the provenance-chains capability (a `capture_derived_thought` tool, or
+     `derived_from`/`derivation_layer` columns), capture it as a derived
+     artifact — `derivation_layer='derived'`, `derivation_method='synthesis'`,
+     and `derived_from` = the UUIDs of the prior Open Brain notes you retrieved
+     and built on (omit if the sources were all external). Falls back to a plain
+     capture, and is a no-op, when that capability isn't present.
 
 ## Evidence and Judgment Rules
 

--- a/skills/competitive-analysis/metadata.json
+++ b/skills/competitive-analysis/metadata.json
@@ -6,7 +6,7 @@
     "name": "Nate B. Jones",
     "github": "NateBJones"
   },
-  "version": "1.0.0",
+  "version": "1.0.1",
   "requires": {
     "open_brain": true,
     "services": [],
@@ -16,5 +16,5 @@
   "difficulty": "intermediate",
   "estimated_time": "10 minutes",
   "created": "2026-03-31",
-  "updated": "2026-03-31"
+  "updated": "2026-07-05"
 }

--- a/skills/meeting-synthesis/SKILL.md
+++ b/skills/meeting-synthesis/SKILL.md
@@ -62,6 +62,14 @@ Gather or confirm:
 6. Optionally use Open Brain.
    - Search for prior related meetings or project notes before starting.
    - Capture key decisions or the final synthesis after the work is complete.
+   - Preserve provenance when capturing the synthesis: if the Open Brain setup
+     has the provenance-chains capability (a `capture_derived_thought` tool, or
+     `derived_from`/`derivation_layer` columns), capture it as a derived
+     artifact — `derivation_layer='derived'`, `derivation_method='synthesis'`,
+     and `derived_from` = the UUIDs of the prior Open Brain thoughts you
+     retrieved and built on (omit if the meeting notes were the only source).
+     Falls back to a plain capture, and is a no-op, when that capability isn't
+     present. (Individual decisions captured as new atomic facts stay primary.)
 
 ## Evidence and Judgment Rules
 

--- a/skills/meeting-synthesis/metadata.json
+++ b/skills/meeting-synthesis/metadata.json
@@ -6,7 +6,7 @@
     "name": "Nate B. Jones",
     "github": "NateBJones"
   },
-  "version": "1.0.0",
+  "version": "1.0.1",
   "requires": {
     "open_brain": true,
     "services": [],
@@ -16,5 +16,5 @@
   "difficulty": "intermediate",
   "estimated_time": "10 minutes",
   "created": "2026-03-31",
-  "updated": "2026-03-31"
+  "updated": "2026-07-05"
 }

--- a/skills/panning-for-gold/SKILL.md
+++ b/skills/panning-for-gold/SKILL.md
@@ -300,6 +300,16 @@ After writing the gold-found file, capture to Open Brain automatically (do not a
 2. **Session summary** as one `capture_thought`:
    - `content`: "Panning session: [source], [N] threads, [M] ACT NOW, [K] RESEARCH MORE. Threads: [all thread titles + categories]. Gold-found: [file path]"
 
+3. **Provenance (session summary only).** The session summary is a derived
+   synthesis of the whole run. If the Open Brain setup has the provenance-chains
+   capability (a `capture_derived_thought` tool, or `derived_from`/
+   `derivation_layer` columns), capture the session summary as a derived
+   artifact instead of a plain `capture_thought` — `derivation_layer='derived'`,
+   `derivation_method='synthesis'`, and `derived_from` = the UUIDs of any related
+   Open Brain thoughts you pulled via `search_thoughts` and actually built on
+   (omit if none — the raw transcript is not a thought). The ACT NOW items stay
+   primary captures. No-op when that capability isn't present.
+
 This closes the flywheel: panning extracts and evaluates, OB1 stores, Gate 0 finds it next session.
 
 ## Phase 4: Self-Improvement

--- a/skills/panning-for-gold/metadata.json
+++ b/skills/panning-for-gold/metadata.json
@@ -6,7 +6,7 @@
     "name": "Jared Irish",
     "github": "jaredirish"
   },
-  "version": "2.0.0",
+  "version": "2.0.1",
   "requires": {
     "open_brain": true,
     "services": [],
@@ -16,5 +16,5 @@
   "difficulty": "intermediate",
   "estimated_time": "5 minutes",
   "created": "2026-03-27",
-  "updated": "2026-03-27"
+  "updated": "2026-07-05"
 }

--- a/skills/research-synthesis/SKILL.md
+++ b/skills/research-synthesis/SKILL.md
@@ -65,6 +65,14 @@ Gather or confirm:
 7. Optionally use Open Brain.
    - Search for prior related notes before starting.
    - Capture the final synthesis or highest-value findings after completion.
+   - Preserve provenance when capturing: if the Open Brain setup has the
+     provenance-chains capability (a `capture_derived_thought` tool, or
+     `derived_from`/`derivation_layer` columns), capture the synthesis as a
+     derived artifact — `derivation_layer='derived'`,
+     `derivation_method='synthesis'`, and `derived_from` = the UUIDs of the
+     prior Open Brain thoughts you retrieved and actually built on (omit if the
+     sources were all external). Falls back to a plain capture, and is a no-op,
+     when that capability isn't present.
 
 ## Evidence and Judgment Rules
 

--- a/skills/research-synthesis/metadata.json
+++ b/skills/research-synthesis/metadata.json
@@ -6,7 +6,7 @@
     "name": "Nate B. Jones",
     "github": "NateBJones"
   },
-  "version": "1.0.0",
+  "version": "1.0.1",
   "requires": {
     "open_brain": true,
     "services": [],
@@ -16,5 +16,5 @@
   "difficulty": "intermediate",
   "estimated_time": "10 minutes",
   "created": "2026-03-31",
-  "updated": "2026-03-31"
+  "updated": "2026-07-05"
 }

--- a/skills/weekly-signal-diff/SKILL.md
+++ b/skills/weekly-signal-diff/SKILL.md
@@ -122,6 +122,15 @@ Use this default structure:
      important follow-up items.
    - Include provenance: week ending date, topic scope, and major entities
      covered.
+   - Structured provenance when the provenance-chains capability is available (a
+     `capture_derived_thought` tool, or `derived_from`/`derivation_layer`
+     columns): capture the digest as a derived artifact —
+     `derivation_layer='derived'`, `derivation_method='synthesis'`,
+     `derived_from` = the UUIDs of the prior Open Brain digests and thoughts you
+     pulled and re-ranked against in step 1, and `supersedes` = the prior week's
+     digest ID when this run regenerates it. This makes each week's diff
+     traceable to the memory it was built from. No-op when that capability
+     isn't present.
 
 ## Output
 

--- a/skills/weekly-signal-diff/metadata.json
+++ b/skills/weekly-signal-diff/metadata.json
@@ -6,7 +6,7 @@
     "name": "Jonathan Edwards",
     "github": "justfinethanku"
   },
-  "version": "1.0.0",
+  "version": "1.0.1",
   "requires": {
     "open_brain": true,
     "services": ["Optional: OpenRouter (Perplexity Sonar family) for live search"],
@@ -23,5 +23,5 @@
   "difficulty": "intermediate",
   "estimated_time": "15 minutes",
   "created": "2026-04-13",
-  "updated": "2026-04-13"
+  "updated": "2026-07-05"
 }


### PR DESCRIPTION
## What

Completes the #397 checklist: the five synthesis skills that capture derived artifacts now tag provenance when the provenance-chains capability is present. Each skill already **searches Open Brain first**, so it has candidate UUID parents from its own retrieval step — the wiring just carries those into the capture.

| Skill | Fit | What it tags |
|-------|-----|--------------|
| `weekly-signal-diff` | **strong** | `derived_from` = prior digests/thoughts re-ranked against; `supersedes` = last week's digest on regeneration |
| `panning-for-gold` | partial | session summary → `derived` (ACT NOW items stay primary); `derived_from` = related thoughts pulled via `search_thoughts` |
| `research-synthesis` | light | final synthesis → `derived`; `derived_from` = retrieved Open Brain notes it built on |
| `meeting-synthesis` | light | final synthesis → `derived`; parents = retrieved prior notes |
| `competitive-analysis` | light | finished brief → `derived`; parents = retrieved prior notes |

## Guard (the thing that de-risks it)

Every addition is **conditional and a no-op** when the provenance-chains capability (a `capture_derived_thought` tool, or `derived_from`/`derivation_layer` columns) isn't installed. On a stock brain the skills behave exactly as before. Honest scoping: the three "light" skills usually synthesize from external sources, so `derived_from` is often empty — the value there is marking the artifact `derivation_layer='derived'` and capturing any retrieved-thought parents when they exist.

## Verified

Subagent GREEN check on the strongest case: given the `weekly-signal-diff` instruction and three pulled thoughts (incl. a prior digest), the agent emitted the correct call — `derived_from` = all 3, `derivation_layer='derived'`, `derivation_method='synthesis'`, `supersedes` = the prior digest. All five `metadata.json` files bumped (patch version + date).

## Dependencies

Depends on the interactive write path from #409 / #401 (the `capture_derived_thought` tool). The conditional guard means these skills are safe to merge independently — they simply don't tag until that capability is present.

Closes #397.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0127BucGfQraB5dkZR38MEF1