### PR TITLE
[extensions] Fix PostgREST filter-injection in ILIKE fallback (professional-crm, household-knowledge)

### DIFF
--- a/.github/metadata.schema.json
+++ b/.github/metadata.schema.json
@@ -79,6 +79,31 @@
       "items": { "type": "string" },
       "description": "Slugs of primitives this contribution depends on (e.g., [\"rls\", \"shared-mcp\"]). Primarily used by extensions."
     },
+    "contributors": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["name", "contribution"],
+        "properties": {
+          "name": {
+            "type": "string",
+            "minLength": 1,
+            "description": "Contributor's display name."
+          },
+          "github": {
+            "type": "string",
+            "description": "Contributor's GitHub username (without @)."
+          },
+          "contribution": {
+            "type": "string",
+            "minLength": 1,
+            "description": "What this contributor added or changed."
+          }
+        },
+        "additionalProperties": false
+      },
+      "description": "Additional contributors beyond the primary author, each with a note on their specific contribution."
+    },
     "requires_skills": {
       "type": "array",
       "items": { "type": "string" },

--- a/.github/metadata.schema.json
+++ b/.github/metadata.schema.json
@@ -79,31 +79,6 @@
       "items": { "type": "string" },
       "description": "Slugs of primitives this contribution depends on (e.g., [\"rls\", \"shared-mcp\"]). Primarily used by extensions."
     },
-    "contributors": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "required": ["name", "contribution"],
-        "properties": {
-          "name": {
-            "type": "string",
-            "minLength": 1,
-            "description": "Contributor's display name."
-          },
-          "github": {
-            "type": "string",
-            "description": "Contributor's GitHub username (without @)."
-          },
-          "contribution": {
-            "type": "string",
-            "minLength": 1,
-            "description": "What this contributor added or changed."
-          }
-        },
-        "additionalProperties": false
-      },
-      "description": "Additional contributors beyond the primary author, each with a note on their specific contribution."
-    },
     "requires_skills": {
       "type": "array",
       "items": { "type": "string" },

--- a/extensions/household-knowledge/index.ts
+++ b/extensions/household-knowledge/index.ts
@@ -14,6 +14,17 @@ import { createClient } from "@supabase/supabase-js";
 
 const app = new Hono();
 
+/**
+ * PostgREST's `.or()` filter string treats `,` `.` `(` `)` `\` as syntax
+ * (condition separator, column.operator.value separator, grouping, escape).
+ * Unescaped user input in an ILIKE fallback can reshape the filter instead
+ * of just matching text — escape those characters before interpolating.
+ * https://postgrest.org/en/stable/references/api/tables_views.html#operators
+ */
+function escapePostgrestFilterValue(value: string): string {
+  return value.replace(/[,.()\\]/g, "\\$&");
+}
+
 app.post("*", async (c) => {
   // Fix: Claude Desktop connectors don't send the Accept header that
   // StreamableHTTPTransport requires. Build a patched request if missing.
@@ -126,8 +137,9 @@ app.post("*", async (c) => {
         }
 
         if (query) {
+          const escaped = escapePostgrestFilterValue(query);
           queryBuilder = queryBuilder.or(
-            `name.ilike.%${query}%,category.ilike.%${query}%,location.ilike.%${query}%,notes.ilike.%${query}%`
+            `name.ilike.%${escaped}%,category.ilike.%${escaped}%,location.ilike.%${escaped}%,notes.ilike.%${escaped}%`
           );
         }
 

--- a/extensions/professional-crm/index.ts
+++ b/extensions/professional-crm/index.ts
@@ -19,6 +19,17 @@ import { createClient } from "@supabase/supabase-js";
 
 const app = new Hono();
 
+/**
+ * PostgREST's `.or()` filter string treats `,` `.` `(` `)` `\` as syntax
+ * (condition separator, column.operator.value separator, grouping, escape).
+ * Unescaped user input in an ILIKE fallback can reshape the filter instead
+ * of just matching text — escape those characters before interpolating.
+ * https://postgrest.org/en/stable/references/api/tables_views.html#operators
+ */
+function escapePostgrestFilterValue(value: string): string {
+  return value.replace(/[,.()\\]/g, "\\$&");
+}
+
 // POST /mcp - Main MCP endpoint
 app.post("*", async (c) => {
   if (!c.req.header("accept")?.includes("text/event-stream")) {
@@ -137,8 +148,9 @@ app.post("*", async (c) => {
             .select("*")
             .eq("user_id", userId);
 
+          const escaped = escapePostgrestFilterValue(query);
           queryBuilder = queryBuilder.or(
-            `name.ilike.%${query}%,company.ilike.%${query}%,title.ilike.%${query}%,notes.ilike.%${query}%`
+            `name.ilike.%${escaped}%,company.ilike.%${escaped}%,title.ilike.%${escaped}%,notes.ilike.%${escaped}%`
           );
 
           if (tags && tags.length > 0) {


### PR DESCRIPTION
## What it does
`crm_search_contacts` (extensions/professional-crm) and `search_household_items` (extensions/household-knowledge) both build a PostgREST `.or()` filter string by splicing raw user input directly into filter syntax:

```ts
`name.ilike.%${query}%,company.ilike.%${query}%,...`
```

PostgREST's `.or()` filter grammar treats `,` `.` `(` `)` `\` as structural characters (condition separator, `column.operator.value` separator, grouping, escape). A `query` containing any of them reshapes the filter instead of just matching text — not exploitable for data exfiltration since both tools still scope by `user_id`, but a real correctness bug: an ordinary search like `"Smith, John"` or `"Dr. Jane (Referral)"` silently produces wrong or broken results instead of an error.

Each file gets its own small inline `escapePostgrestFilterValue` helper (no shared module — keeps these files independently copy-pasteable, matching this repo's single-file extension convention) that escapes the four reserved characters before interpolating.

## What it requires
No new services/tools — pure logic fix, no schema or dependency changes.

## Testing
- `deno check` passes on both files.
- The identical fix (same vulnerable `.or()` pattern, verbatim) is deployed and running against my own Open Brain instance in a downstream fork of these two extensions. Table/column names differ there (a later refactor unified contacts/vendors into a shared `contacts` table with tag filters) but the vulnerable line itself — and the fix — is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)