### PR TITLE
[extensions] Fix add_household_item storing details as an escaped JSON string

### DIFF
--- a/extensions/household-knowledge/index.ts
+++ b/extensions/household-knowledge/index.ts
@@ -64,6 +64,18 @@ app.post("*", async (c) => {
     },
     async ({ name, category, location, details, notes }) => {
       try {
+        // `details` is stored as jsonb — parse the JSON string into an
+        // object before inserting, or it lands in the column as an
+        // escaped string blob instead of a queryable object.
+        let parsedDetails: Record<string, unknown> = {};
+        if (details) {
+          try {
+            parsedDetails = JSON.parse(details);
+          } catch (e) {
+            throw new Error(`add_household_item: details is not valid JSON: ${(e as Error).message}`);
+          }
+        }
+
         const { data, error } = await supabase
           .from("household_items")
           .insert({
@@ -71,7 +83,7 @@ app.post("*", async (c) => {
             name,
             category: category || null,
             location: location || null,
-            details: details || {},
+            details: parsedDetails,
             notes: notes || null,
           })
           .select()


### PR DESCRIPTION
## What it does
`add_household_item` (extensions/household-knowledge) documents `details` as a JSON string — the tool description's own example is `'{"brand": "Sherwin Williams", "color": "Sea Salt"}'` — and `household_items.details` is a `jsonb` column, but the value is inserted unparsed (`details: details || {}`). supabase-js serializes that raw string as a JSON scalar, so it lands in the `jsonb` column as an escaped string blob (`"{\"brand\": ...}"`) instead of a queryable object — breaking any downstream query that expects `details->>'brand'` etc. to work.

Parses the JSON string before insert, with a clear error (surfaced via this file's existing try/catch → `isError: true` pattern) if it isn't valid JSON.

## What it requires
No new services/tools — pure logic fix, no schema or dependency changes.

## Testing
- `deno check` passes.
- Verified the same bug (and this fix) in my own deployed fork of this extension before porting it back here.

Companion PR (same root-cause pattern, different files): #411

🤖 Generated with [Claude Code](https://claude.com/claude-code)