### PR TITLE
[integrations] Fix thought ID type mismatch in enhanced-mcp

### DIFF
--- a/integrations/enhanced-mcp/index.ts
+++ b/integrations/enhanced-mcp/index.ts
@@ -37,7 +37,7 @@ const supabase = createClient(SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY);
 // ── Types ─────────────────────────────────────────────────────────────────
 
 type ThoughtRow = {
-  id: number;
+  id: string;
   content: string;
   content_fingerprint?: string | null;
   type: string;
@@ -52,7 +52,7 @@ type ThoughtRow = {
 };
 
 type UpsertThoughtResult = {
-  thought_id: number;
+  thought_id: string;
   action: string;
   content_fingerprint: string;
 };
@@ -387,17 +387,12 @@ server.registerTool(
     description:
       "Fetch a thought by ID with its full metadata and provenance.",
     inputSchema: z.object({
-      id: z.number().int().min(1).describe("Thought ID"),
+      id: z.string().uuid().describe("Thought ID (UUID)"),
     }),
   },
   async (params) => {
     try {
-      const id = asInteger(
-        (params as Record<string, unknown>).id,
-        0,
-        1,
-        Number.MAX_SAFE_INTEGER,
-      );
+      const id = asString((params as Record<string, unknown>).id, "").trim();
 
       if (!id) {
         return toolFailure("id is required");
@@ -455,7 +450,7 @@ server.registerTool(
     description:
       "Update the content of an existing thought. Re-generates embedding and metadata.",
     inputSchema: z.object({
-      id: z.number().int().min(1).describe("Thought ID to update"),
+      id: z.string().uuid().describe("Thought ID (UUID) to update"),
       content: z
         .string()
         .min(1)
@@ -464,12 +459,7 @@ server.registerTool(
   },
   async (params) => {
     try {
-      const id = asInteger(
-        (params as Record<string, unknown>).id,
-        0,
-        1,
-        Number.MAX_SAFE_INTEGER,
-      );
+      const id = asString((params as Record<string, unknown>).id, "").trim();
       const content = asString(
         (params as Record<string, unknown>).content,
         "",
@@ -915,22 +905,16 @@ server.registerTool(
       "Find thoughts related to a given thought via the knowledge graph connections.",
     inputSchema: z.object({
       thought_id: z
-        .number()
-        .int()
-        .min(1)
-        .describe("Thought ID to find connections for"),
+        .string()
+        .uuid()
+        .describe("Thought ID (UUID) to find connections for"),
       limit: z.number().int().min(1).max(20).default(10).optional(),
     }),
   },
   async (params) => {
     try {
       const raw = params as Record<string, unknown>;
-      const thoughtId = asInteger(
-        raw.thought_id,
-        0,
-        1,
-        Number.MAX_SAFE_INTEGER,
-      );
+      const thoughtId = asString(raw.thought_id, "").trim();
       const limit = asInteger(raw.limit, 10, 1, 20);
 
       if (!thoughtId) {
@@ -1267,7 +1251,7 @@ server.registerTool(
       if (thoughtLinks && thoughtLinks.length > 0) {
         const thoughtIds = (
           thoughtLinks as Record<string, unknown>[]
-        ).map((tl) => tl.thought_id as number);
+        ).map((tl) => tl.thought_id as string);
         const { data: thoughtRows, error: tError } = await supabase
           .from("thoughts")
           .select("id, content, type, created_at, sensitivity_tier")
@@ -1279,10 +1263,10 @@ server.registerTool(
         if (tError) {
           console.error("thoughts fetch failed", tError);
         } else if (thoughtRows) {
-          const roleMap = new Map<number, string>();
+          const roleMap = new Map<string, string>();
           for (const tl of thoughtLinks as Record<string, unknown>[]) {
             roleMap.set(
-              tl.thought_id as number,
+              tl.thought_id as string,
               tl.mention_role as string,
             );
           }
@@ -1293,7 +1277,7 @@ server.registerTool(
               type: t.type,
               created_at: t.created_at,
               mention_role:
-                roleMap.get(t.id as number) ?? "mentioned",
+                roleMap.get(t.id as string) ?? "mentioned",
             }),
           );
         }

--- a/integrations/enhanced-mcp/metadata.json
+++ b/integrations/enhanced-mcp/metadata.json
@@ -16,5 +16,5 @@
   "difficulty": "intermediate",
   "estimated_time": "30 minutes",
   "created": "2026-04-06",
-  "updated": "2026-04-06"
+  "updated": "2026-07-06"
 }


### PR DESCRIPTION
## Contribution Type

- [x] Integration (`/integrations`)

## What does this do?

Fixes a genuine type bug in `integrations/enhanced-mcp/index.ts`: `thoughts.id` is a `uuid` in the canonical Open Brain schema (see `docs/01-getting-started.md`, `schemas/enhanced-thoughts/schema.sql`, `schemas/entity-extraction/schema.sql` — all consistently use `UUID` for thought ids and `BIGINT`/`BIGSERIAL` only for entity ids), but `get_thought`, `update_thought`, and `related_thoughts` typed their `id`/`thought_id` input params as `z.number().int().min(1)`, and `ThoughtRow.id` / `UpsertThoughtResult.thought_id` were typed `number`. Against a stock Open Brain install, a real UUID would fail zod validation before the query ever ran.

This was not a documented alternate-schema variant — the README and metadata.json never mention an integer/bigserial id scheme, and the enhanced-thoughts/entity-extraction schemas this integration explicitly depends on use UUID throughout. It's a straightforward oversight.

Changes:
- `ThoughtRow.id`, `UpsertThoughtResult.thought_id`: `number` → `string`
- `get_thought`, `update_thought`: `id` param → `z.string().uuid()`
- `related_thoughts`: `thought_id` param → `z.string().uuid()`
- `entity_detail`: fixed internal `thought_id` map/cast types (`Map<number,string>` → `Map<string,string>`) since `thought_entities.thought_id` references the UUID `thoughts.id`

Entity ids (`entity_id`, `graph_search`, edges) are untouched — those are genuinely `BIGINT`/`BIGSERIAL` per `schemas/entity-extraction/schema.sql`.

## Requirements

No new external services/tools. Same prerequisites as before (Open Brain + `schemas/enhanced-thoughts`).

## Checklist

- [x] I've read CONTRIBUTING.md
- [x] My contribution has a README.md with prerequisites, step-by-step instructions, and expected outcome (unchanged, no id-type claims existed there to correct)
- [x] My metadata.json has all required fields (bumped `updated` date)
- [x] If my contribution depends on a skill or primitive, I declared it in metadata.json and linked it in the README (n/a, no change)
- [x] I tested this on my own Open Brain instance (verified with `deno check index.ts` — no type errors; no existing test suite for this integration)
- [x] No credentials, API keys, or secrets are included

🤖 Generated with [Claude Code](https://claude.com/claude-code)