### PR TITLE
[skills] Research-to-Decision Workflow orchestrator skill

### DIFF
--- a/recipes/research-to-decision-workflow/README.md
+++ b/recipes/research-to-decision-workflow/README.md
@@ -2,6 +2,9 @@
 
 > Composition recipe for chaining canonical OB1 skills into operator and investor decision workflows.
 
+> To run this as a triggerable workflow instead of a manual checklist, use the
+> [Research-to-Decision Workflow skill](../../skills/research-to-decision-workflow/).
+
 ## What It Does
 
 This recipe shows how to use five reusable skill packs together without duplicating their prompt logic. The skills handle the canonical behavior; this recipe defines the install order, workspace structure, handoffs, skip rules, and two recommended paths from raw inputs to a reusable decision artifact.

--- a/skills/README.md
+++ b/skills/README.md
@@ -10,6 +10,7 @@ Reusable AI client skills and prompt packs for Open Brain workflows. These are t
 | [Deal Memo Drafting Skill Pack](deal-memo-drafting/) | Turns existing diligence materials into structured deal, IC, or partnership memos | [@NateBJones](https://github.com/NateBJones) |
 | [Research Synthesis Skill Pack](research-synthesis/) | Synthesizes source sets into findings, contradictions, confidence markers, and next questions | [@NateBJones](https://github.com/NateBJones) |
 | [Meeting Synthesis Skill Pack](meeting-synthesis/) | Converts meeting notes or transcripts into decisions, action items, risks, and follow-up artifacts | [@NateBJones](https://github.com/NateBJones) |
+| [Research-to-Decision Workflow Skill Pack](research-to-decision-workflow/) | Orchestrates the five canonical decision skills into a triggerable operator or investor pipeline with enforced handoffs and Open Brain capture | [@eazene](https://github.com/eazene) |
 | [Heavy File Ingestion Skill Pack](heavy-file-ingestion/) | Converts PDFs, decks, spreadsheets, and other bulky files into markdown, CSV, and a cheap structural index before analysis | [@NateBJones](https://github.com/NateBJones) |
 | [Panning for Gold Skill Pack](panning-for-gold/) | Turns brain dumps and transcripts into evaluated idea inventories | [@jaredirish](https://github.com/jaredirish) |
 | [Aiception Skill Pack (formerly Claudeception)](claudeception/) | Extracts reusable lessons from work sessions into new skills | [@jaredirish](https://github.com/jaredirish) |

--- a/skills/research-to-decision-workflow/README.md
+++ b/skills/research-to-decision-workflow/README.md
@@ -1,0 +1,47 @@
+# Research-to-Decision Workflow
+
+> Triggerable orchestrator skill that runs the research-to-decision pipeline end
+> to end.
+
+## What It Does
+
+This skill makes the [Research-to-Decision Workflow recipe](../../recipes/research-to-decision-workflow/)
+executable. It scaffolds the workspace, writes the decision brief, picks the
+operator or investor path, chains the five canonical skills with enforced
+handoffs, applies the skip rules, and captures durable outputs to Open Brain.
+
+It holds no analytical logic of its own. The five canonical skills remain the
+source of truth for behavior:
+
+- [Competitive Analysis](../competitive-analysis/)
+- [Financial Model Review](../financial-model-review/)
+- [Research Synthesis](../research-synthesis/)
+- [Meeting Synthesis](../meeting-synthesis/)
+- [Deal Memo Drafting](../deal-memo-drafting/)
+
+## When to Use
+
+Use it for a multi-step run — a decision that needs two or more of the canonical
+skills chained together. For a single step, call that one skill directly.
+
+- Operator path → strategy/GTM brief: `competitive-analysis → research-synthesis → meeting-synthesis`
+- Investor path → recommendation memo: adds `financial-model-review` and `deal-memo-drafting`
+
+## Files
+
+- `SKILL.md` — the orchestration protocol (triggering, path selection, handoffs, capture).
+- `workflow-template.md` — bundled snapshot of the recipe's workspace template.
+  The **canonical copy lives in the recipe folder**; this snapshot keeps the
+  skill self-contained. If the recipe template changes, refresh this snapshot.
+- `metadata.json` — contribution metadata.
+
+## Prerequisites
+
+- A working Open Brain setup (optional search/capture during the run).
+- The five canonical skills installed (see `requires_skills` in `metadata.json`).
+
+## Expected Outcome
+
+A populated `docs/research-to-decision/` workspace with ordered handoff files and
+a final operator brief or investor memo, built from explicit handoffs rather than
+loose chat context.

--- a/skills/research-to-decision-workflow/SKILL.md
+++ b/skills/research-to-decision-workflow/SKILL.md
@@ -1,0 +1,123 @@
+---
+name: research-to-decision-workflow
+description: |
+  Triggerable orchestrator that runs the full research-to-decision pipeline
+  end to end. Use for prompts like "take this from research to a decision",
+  "run the research-to-decision workflow", "build me a decision brief from
+  these materials", or "turn this diligence packet into a memo". It scaffolds
+  the workspace, picks the operator or investor path, chains the five canonical
+  skills with enforced handoffs, and captures durable outputs to Open Brain.
+  Use this only for a multi-step run — for a single step, call that one skill
+  directly.
+author: Ezana Azene
+version: 1.0.0
+---
+
+# Research-to-Decision Workflow
+
+## Problem
+
+The research-to-decision recipe describes a five-skill pipeline but nothing
+executes it. Users who want to go from raw materials to a decision artifact must
+invoke each skill by hand and manage the handoffs themselves. This skill runs
+the pipeline as one orchestrated workflow.
+
+## Audience
+
+- Primary: operators and investors making a multi-input decision that needs two
+  or more of the canonical skills chained together.
+
+## When to Use
+
+- A decision needs more than one canonical step (e.g. competitive work *and*
+  synthesis *and* meeting outputs).
+- The end goal is a reusable artifact: a strategy brief (operator path) or a
+  recommendation memo (investor path).
+- You want the workspace, handoffs, and capture points handled for you.
+
+## When Not to Use
+
+- You only need one step. Route directly to the single canonical skill:
+  - Market/competitor mapping only → `competitive-analysis`
+  - Source synthesis only → `research-synthesis`
+  - Transcript/action extraction only → `meeting-synthesis`
+  - Model assumption review only → `financial-model-review`
+  - Memo drafting when synthesis already exists → `deal-memo-drafting`
+- There is no real decision to support yet (define the decision first).
+
+## Required Context
+
+Gather or confirm before running:
+
+- the decision the workflow must support
+- the primary audience (operator / investor / partnership / board / internal)
+- the path (operator or investor), or enough to infer it
+- where the source materials, meetings, and any model live
+
+## Process
+
+1. **Write the decision brief.** Create `docs/research-to-decision/00-brief.md`
+   with: decision, audience, path, inputs, success condition. **Gate: do not
+   proceed until the decision is explicitly defined.** Use the bundled
+   `workflow-template.md` for the brief and file structure.
+2. **Scaffold the workspace.**
+   ```bash
+   mkdir -p docs/research-to-decision/sources \
+            docs/research-to-decision/meetings \
+            docs/research-to-decision/models
+   ```
+3. **Optionally search Open Brain** for prior related context and note anything
+   that changes the brief.
+4. **Select the path** from the brief:
+   - Operator: `00 -> 01-competitive-analysis -> 03-research-synthesis -> 04-meeting-synthesis`
+   - Investor: `00 -> 01-competitive-analysis -> 02-financial-model-review -> 03-research-synthesis -> 04-meeting-synthesis -> 05-deal-memo`
+5. **Run each step in path order by invoking its canonical skill**, and write its
+   handoff file before starting the next step. Do not reconstruct context in the
+   next step — read the prior file:
+   - `competitive-analysis` → `01-competitive-analysis.md`
+   - `financial-model-review` → `02-financial-model-review.md` (investor only)
+   - `research-synthesis` → `03-research-synthesis.md`
+   - `meeting-synthesis` → `04-meeting-synthesis.md`
+   - `deal-memo-drafting` → `05-deal-memo.md` (investor only)
+6. **Apply skip rules.** Skip `financial-model-review` if there is no meaningful
+   model. Skip `meeting-synthesis` if no call/interview/review feeds the
+   decision. Skip `deal-memo-drafting` if the deliverable is a brief, not a memo.
+7. **Capture durable outputs to Open Brain** at the checkpoints below. Do not
+   capture raw packet noise just because it passed through the workflow.
+
+## Handoff Enforcement
+
+Each step consumes the prior artifact(s) and produces exactly one file. A step is
+ready only when its file makes the next step runnable without re-deriving
+context. Never start a downstream skill before its upstream handoff file exists.
+
+## Capture Checkpoints
+
+- after a strong competitive brief (`01`)
+- after research synthesis identifies durable findings (`03`)
+- after meeting synthesis produces real decisions (`04`)
+- after the final memo or recommendation (`05`)
+
+## Output
+
+- a populated `docs/research-to-decision/` workspace
+- the path's ordered handoff files (`00`–`04` operator, `00`–`05` investor)
+- a final operator brief or investor memo built from explicit handoffs
+- optional Open Brain captures at the four checkpoints
+
+## Works Well With
+
+- The five canonical skills it orchestrates:
+  `competitive-analysis`, `financial-model-review`, `research-synthesis`,
+  `meeting-synthesis`, `deal-memo-drafting`.
+- The [Research-to-Decision Workflow recipe](../../recipes/research-to-decision-workflow/)
+  — the fuller build this skill makes triggerable.
+
+## Notes
+
+- This skill holds no analytical logic. The five canonical skills are the source
+  of truth for behavior; this skill only sequences them, enforces handoffs, and
+  manages capture.
+- The bundled `workflow-template.md` is a snapshot. The canonical copy lives in
+  the recipe folder; if the recipe template changes, refresh the snapshot.
+- Use the skip rules aggressively. A small decision should not run all five steps.

--- a/skills/research-to-decision-workflow/metadata.json
+++ b/skills/research-to-decision-workflow/metadata.json
@@ -1,0 +1,27 @@
+{
+  "name": "Research-to-Decision Workflow",
+  "description": "Orchestrator skill that runs the research-to-decision pipeline: scaffolds the workspace, picks the operator or investor path, chains competitive-analysis, financial-model-review, research-synthesis, meeting-synthesis, and deal-memo-drafting with enforced handoffs, and captures durable outputs to Open Brain.",
+  "category": "skills",
+  "author": {
+    "name": "Ezana Azene",
+    "github": "eazene"
+  },
+  "version": "1.0.0",
+  "requires": {
+    "open_brain": true,
+    "services": [],
+    "tools": ["Claude Code or similar AI coding tool with reusable skills/system prompts"]
+  },
+  "requires_skills": [
+    "competitive-analysis",
+    "financial-model-review",
+    "deal-memo-drafting",
+    "research-synthesis",
+    "meeting-synthesis"
+  ],
+  "tags": ["workflow", "decision-support", "orchestration", "skill-composition", "diligence", "memo"],
+  "difficulty": "intermediate",
+  "estimated_time": "20 minutes",
+  "created": "2026-07-06",
+  "updated": "2026-07-06"
+}

--- a/skills/research-to-decision-workflow/workflow-template.md
+++ b/skills/research-to-decision-workflow/workflow-template.md
@@ -1,0 +1,133 @@
+# Research-to-Decision Workflow Template
+
+Use this file as the working scaffold for either the operator path or the investor path.
+
+## Recommended Workspace Structure
+
+```text
+docs/research-to-decision/
+├── 00-brief.md
+├── 01-competitive-analysis.md
+├── 02-financial-model-review.md
+├── 03-research-synthesis.md
+├── 04-meeting-synthesis.md
+├── 05-deal-memo.md
+├── meetings/
+│   └── raw-notes-or-transcripts.md
+├── models/
+│   └── model-export-or-assumptions.md
+└── sources/
+    └── source-packet.md
+```
+
+Use only the files you need. For the operator path, `02-financial-model-review.md` and `05-deal-memo.md` are often unnecessary.
+
+## 00-brief.md
+
+```markdown
+# Decision Brief
+
+## Decision
+- What decision are we trying to support?
+
+## Audience
+- Operator / investor / partnership / board / internal team
+
+## Path
+- Operator path / investor path
+
+## Inputs
+- Sources:
+- Meetings:
+- Model:
+
+## Success Condition
+- What should the final artifact make easier to decide?
+```
+
+## Handoff Checklist
+
+| Step | Consumes | Produces | Ready When |
+| --- | --- | --- | --- |
+| Competitive Analysis | Product/company context, ICP, competitor set | `01-competitive-analysis.md` | Market and competitor picture is clear enough to inform later work |
+| Financial Model Review | Model export or assumptions, business model, decision context | `02-financial-model-review.md` | Key assumption risks and scenario gaps are explicit |
+| Research Synthesis | Source packet plus any prior outputs that matter | `03-research-synthesis.md` | Findings, contradictions, confidence, and gaps are visible |
+| Meeting Synthesis | Transcript or notes plus context | `04-meeting-synthesis.md` | Decisions, actions, and unresolved questions are cleanly extracted |
+| Deal Memo Drafting | Prior outputs plus target memo audience | `05-deal-memo.md` | Final recommendation memo is decision-ready |
+
+## Operator Path
+
+```text
+00-brief.md
+    ->
+01-competitive-analysis.md
+    ->
+03-research-synthesis.md
+    ->
+04-meeting-synthesis.md
+```
+
+### Operator Path Prompt Stubs
+
+```text
+Use Competitive Analysis on the materials in 00-brief.md and sources/ to produce 01-competitive-analysis.md.
+```
+
+```text
+Use Research Synthesis on 01-competitive-analysis.md plus the source packet to produce 03-research-synthesis.md.
+```
+
+```text
+Use Meeting Synthesis on meetings/raw-notes-or-transcripts.md plus 03-research-synthesis.md to produce 04-meeting-synthesis.md.
+```
+
+## Investor Path
+
+```text
+00-brief.md
+    ->
+01-competitive-analysis.md
+    ->
+02-financial-model-review.md
+    ->
+03-research-synthesis.md
+    ->
+04-meeting-synthesis.md
+    ->
+05-deal-memo.md
+```
+
+### Investor Path Prompt Stubs
+
+```text
+Use Competitive Analysis on the materials in 00-brief.md and sources/ to produce 01-competitive-analysis.md.
+```
+
+```text
+Use Financial Model Review on models/model-export-or-assumptions.md plus 00-brief.md to produce 02-financial-model-review.md.
+```
+
+```text
+Use Research Synthesis on the source packet plus 01-competitive-analysis.md and 02-financial-model-review.md to produce 03-research-synthesis.md.
+```
+
+```text
+Use Meeting Synthesis on meetings/raw-notes-or-transcripts.md plus 03-research-synthesis.md to produce 04-meeting-synthesis.md.
+```
+
+```text
+Use Deal Memo Drafting on 01-competitive-analysis.md, 02-financial-model-review.md, 03-research-synthesis.md, and 04-meeting-synthesis.md to produce 05-deal-memo.md.
+```
+
+## Skip Rules
+
+- Skip the model review step if there is no meaningful model artifact.
+- Skip the meeting synthesis step if no call, interview, or meeting is informing the decision.
+- Skip the deal memo step if the final artifact is a strategic brief, not a memo.
+
+## Optional Open Brain Capture Moments
+
+- Capture the strongest competitive brief after `01-competitive-analysis.md`
+- Capture durable findings after `03-research-synthesis.md`
+- Capture key decisions after `04-meeting-synthesis.md`
+- Capture the final recommendation after `05-deal-memo.md`


### PR DESCRIPTION
Adds a triggerable orchestrator skill that runs the existing research-to-decision recipe's five-skill pipeline (workspace scaffolding, operator/investor path selection, enforced handoffs, Open Brain capture) without duplicating sub-skill logic. Bundles a snapshot of the recipe's workflow-template and cross-links recipe <-> skill.

## What's included
- `skills/research-to-decision-workflow/` — SKILL.md (orchestration protocol), README.md, metadata.json, and a bundled workflow-template.md snapshot
- One-line cross-links in `skills/README.md` and the recipe README for mutual discoverability

## Boundary
The skill holds zero analytical logic — it sequences the five canonical skills (competitive-analysis, financial-model-review, research-synthesis, meeting-synthesis, deal-memo-drafting), enforces handoffs, and manages Open Brain capture. The five skills remain the source of truth for behavior.

metadata.json validates against .github/metadata.schema.json.