### PR TITLE
[recipes] Fix typed-edge-classifier OpenRouter model routing (dated model id → HTTP 400)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,6 @@ docs/walkthroughs/*/public/
 docs/assets/agent-memory/promotional/generated-backgrounds/**/result.json
 docs/assets/agent-memory/screenshots/**/.chrome-*/
 integrations/openclaw-agent-memory/dist/
+
+# Wiki Compiler recipe default output (personal brain data, regenerable)
+compiled-wiki/

--- a/recipes/typed-edge-classifier/classify-edges.mjs
+++ b/recipes/typed-edge-classifier/classify-edges.mjs
@@ -300,7 +300,13 @@ function resolveModel(model, provider) {
   if (provider !== "openrouter") return model;
   if (!model) return model;
   if (model.includes("/")) return model;
-  return `anthropic/${model}`;
+  // OpenRouter rejects Anthropic's dated snapshot ids (e.g.
+  // "claude-haiku-4-5-20251001" -> HTTP 400 "not a valid model id"),
+  // but the Anthropic-direct API *requires* those dates. Since this
+  // branch only runs for the OpenRouter provider, strip a trailing
+  // -YYYYMMDD suffix so a dated default still routes correctly.
+  const undated = model.replace(/-\d{8}$/, "");
+  return `anthropic/${undated}`;
 }
 
 /**


### PR DESCRIPTION
## Problem

Running the **Wiki Compiler** recipe against an OpenRouter-backed brain, the typed-edge classification phase silently produced zero edges:

```
[classify-edges] processing 42 pairs
[classify-edges] status counts: { filter_error: 42 }
[classify-edges] estimated spend: $0.0000 of $2.00 cap
```

Every candidate pair returned `filter_error`, `$0` was spent, and `thought_edges` stayed empty.

## Root cause

`recipes/typed-edge-classifier/classify-edges.mjs` defaults its Haiku pre-filter to the dated Anthropic snapshot id `claude-haiku-4-5-20251001`. In hybrid mode over OpenRouter, `resolveModel()` prefixed it to `anthropic/claude-haiku-4-5-20251001`, which **OpenRouter rejects with HTTP 400** ("not a valid model id"). The per-pair filter call threw before any tokens were spent, so every pair fell to `filter_error` and no edges were inserted.

OpenRouter accepts the **undated** slugs (`anthropic/claude-haiku-4-5`, `anthropic/claude-opus-4-7` both return 200); only the `-YYYYMMDD` snapshot suffix is rejected. The classify-model default (`claude-opus-4-7`, undated) was already fine — the filter default was the sole break.

## Fix

The Anthropic **direct** API *requires* dated ids, so the fix is scoped to the OpenRouter branch of `resolveModel()`: strip a trailing `-YYYYMMDD` snapshot suffix before prefixing `anthropic/`. Direct-API routing is untouched.

```js
const undated = model.replace(/-\d{8}$/, "");
return `anthropic/${undated}`;
```

Verified end-to-end via `node recipes/wiki-compiler/compile-wiki.mjs` with **default** models (no `--filter-model` override): pairs now classify and upsert into `thought_edges` instead of erroring — status counts became `{ filter_rejected, skip_already_classified, below_confidence }` with real spend within the cost cap.

Also gitignores `compiled-wiki/` (the recipe's default output directory) so running the compile from the repo root doesn't leave personal brain data as untracked commit candidates.

## Scope

- `recipes/typed-edge-classifier/classify-edges.mjs` — one-line routing fix + comment
- `.gitignore` — ignore `compiled-wiki/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CLGjuPiQUa2E1yJZrxCLvi