### PR TITLE
[skills] Add wiki-compiler orchestrator skill

### DIFF
--- a/skills/wiki-compiler/README.md
+++ b/skills/wiki-compiler/README.md
@@ -1,0 +1,78 @@
+# Wiki Compiler (Skill)
+
+> A triggerable operator that makes the [Wiki Compiler recipe](../../recipes/wiki-compiler/)
+> run reliably from a natural-language request — bootstrapping credentials,
+> verifying schemas, driving the compile, draining the queue, and recovering from
+> the failure modes that silently produce nothing on a first run.
+
+## What This Is
+
+The Wiki Compiler *recipe* is a Node wrapper that turns Open Brain thoughts and
+graph data into regenerable wiki pages. This *skill* is the thin operational
+layer on top: it tells an AI client **when** to reach for the recipe and **how**
+to run it end to end without stalling on setup.
+
+It holds no synthesis logic. The recipe scripts and schemas remain the source of
+truth; the skill only bootstraps, verifies, and recovers.
+
+## Why It Exists
+
+A first compile reliably hits five silent walls, each of which lets the run
+"succeed" while producing nothing:
+
+1. **No root `.env.local`** — the scripts want `OPEN_BRAIN_URL` /
+   `OPEN_BRAIN_SERVICE_KEY` / `LLM_API_KEY`, but existing recipe `.env` files use
+   `SUPABASE_URL` / `SUPABASE_SERVICE_ROLE_KEY` / `OPENROUTER_API_KEY`.
+2. **Missing `typed-reasoning-edges` schema** — `thought_edges` does not exist,
+   so the edge phase has nowhere to write.
+3. **OpenRouter dated model-id** — the classifier's default filter model is a
+   dated Anthropic snapshot id that OpenRouter rejects with HTTP 400, so every
+   pair returns `filter_error` and no edges are inserted.
+4. **Batched extraction** — one compile processes only `--extract-limit` queued
+   thoughts (default 25); the rest sit unprocessed.
+5. **No verification** — the manifest reports `ok` per phase even when a phase
+   produced zero rows or files.
+
+The skill encodes the fix for each. See `SKILL.md` for the exact protocol.
+
+## When to Use
+
+- "Compile my wiki", "regenerate the entity wiki", "run wiki-compiler".
+- After importing/capturing a batch of new thoughts, to fold them into the graph
+  and refresh the compiled pages.
+- When a compile ran but `thought_edges` is empty or the queue didn't drain.
+
+## When Not to Use
+
+- You only need the raw SQL/graph data — query Open Brain directly.
+- You want to change *what* the wiki says — fix the underlying thoughts, then
+  recompile. Never hand-edit generated pages (that is the recipe's core rule).
+
+## Prerequisites
+
+- A working Open Brain install with the `entity-extraction` schema applied.
+- Supabase CLI, authenticated, with the target project linked
+  (`supabase projects list` → `linked: true`).
+- Node.js 18+ and an OpenRouter (or Anthropic) API key.
+
+## Files
+
+- `SKILL.md` — the trigger conditions and step-by-step operational protocol.
+- `metadata.json` — contribution metadata.
+- `README.md` — this file.
+
+## Works Well With
+
+- [Wiki Compiler recipe](../../recipes/wiki-compiler/) — the build this skill drives.
+- [`typed-edge-classifier`](../../recipes/typed-edge-classifier/),
+  [`entity-wiki`](../../recipes/entity-wiki/),
+  [`wiki-synthesis`](../../recipes/wiki-synthesis/) — the component recipes.
+- [`schemas/entity-extraction`](../../schemas/entity-extraction/) and
+  [`schemas/typed-reasoning-edges`](../../schemas/typed-reasoning-edges/) — the
+  graph tables the compile reads and writes.
+
+## Design Rule
+
+SQL is authoritative; `compiled-wiki/` is a regenerable artifact and stays
+gitignored (personal brain data). Fix data, then recompile — do not patch
+generated pages.

--- a/skills/wiki-compiler/README.md
+++ b/skills/wiki-compiler/README.md
@@ -70,6 +70,20 @@ The skill encodes the fix for each. See `SKILL.md` for the exact protocol.
 - [`schemas/entity-extraction`](../../schemas/entity-extraction/) and
   [`schemas/typed-reasoning-edges`](../../schemas/typed-reasoning-edges/) — the
   graph tables the compile reads and writes.
+- [Open Brain Dashboard Pro](../../dashboards/open-brain-dashboard-pro/) `/wiki` route —
+  the live viewer for compiled pages, published via `sync-wiki-to-brain.mjs`.
+
+## Viewing the output
+
+After compiling, publish the pages into your brain so the dashboard can render them live:
+
+```bash
+node recipes/wiki-compiler/compile-wiki.mjs        # -> compiled-wiki/ (gitignored)
+node recipes/wiki-compiler/sync-wiki-to-brain.mjs  # -> wiki_entity / wiki_topic thoughts
+```
+
+Then browse them at the Open Brain Dashboard Pro `/wiki` route. Content lives only in the
+database (behind login); nothing personal is committed to git.
 
 ## Design Rule
 

--- a/skills/wiki-compiler/SKILL.md
+++ b/skills/wiki-compiler/SKILL.md
@@ -1,0 +1,153 @@
+---
+name: wiki-compiler
+description: |
+  Triggerable operator for the Wiki Compiler recipe. Use for prompts like
+  "compile my wiki", "regenerate the entity wiki", "run wiki-compiler",
+  "rebuild the compiled understanding layer", or "turn my Open Brain into
+  browsable wiki pages". It bootstraps credentials, verifies the required
+  schemas, runs the compile pipeline (entity extraction -> typed edges ->
+  entity wiki -> topic wiki), drains the extraction queue, and recovers
+  from the known failure modes. This skill does not replace the recipe's
+  own scripts — it drives them reliably.
+author: Ezana Azene
+version: 1.0.0
+---
+
+# Wiki Compiler
+
+## Problem
+
+The Wiki Compiler recipe (`recipes/wiki-compiler/compile-wiki.mjs`) is a solid
+wrapper, but a first run reliably stalls on the same operational walls: no root
+`.env.local`, a missing `typed-reasoning-edges` schema, an OpenRouter model-id
+that 400s, extraction that only processes one batch at a time, and no obvious
+verification step. Each wall is silent — the run "succeeds" while producing
+nothing. This skill encodes the fixes so the compile actually completes.
+
+## Trigger Conditions
+
+- "compile my wiki", "run wiki-compiler", "regenerate the entity wiki pages"
+- "rebuild the compiled understanding layer", "make my brain browsable"
+- Any request to run `recipes/wiki-compiler/compile-wiki.mjs`
+- Symptoms that map to this recipe: `filter_error: N` from the edge classifier,
+  `thought_edges` empty after a compile, extraction queue not draining.
+
+## Required Context
+
+Confirm before running:
+
+- Which Open Brain (Supabase) project is the target, and that it is ACTIVE.
+- That the Supabase CLI is authenticated and the project is linked
+  (`supabase projects list` shows `linked: true`).
+- Whether an LLM key (OpenRouter preferred) is available. Every LLM phase needs
+  it; the run spends real tokens (edge classifier is cost-capped, default $2).
+
+## Process
+
+Run from the OB1 repo root. Do each gate in order; a phase that "succeeds" with
+zero output is a failure — verify, don't assume.
+
+1. **Bootstrap credentials.** If no `.env.local` exists at the repo root, build a
+   gitignored one from an existing sibling recipe `.env`
+   (`recipes/provenance-chains/.env`, `recipes/brain-smoke-test/.env.local`,
+   etc.). Remap the names the wiki-compiler scripts expect — **never print secret
+   values**:
+   - `SUPABASE_URL` → `OPEN_BRAIN_URL`
+   - `SUPABASE_SERVICE_ROLE_KEY` → `OPEN_BRAIN_SERVICE_KEY`
+   - `OPENROUTER_API_KEY` → also set `LLM_API_KEY` to the **same** value
+     (entity-wiki and wiki-synthesis read `LLM_API_KEY`; the classifier reads
+     `OPENROUTER_API_KEY` — they are the same key)
+   - `MCP_ACCESS_KEY` → keep as-is (used to trigger the extraction worker)
+   - defaults: `LLM_BASE_URL=https://openrouter.ai/api/v1`,
+     `LLM_MODEL=anthropic/claude-haiku-4-5`
+
+2. **Schema preflight (Supabase CLI).** Confirm the graph tables exist:
+   ```bash
+   supabase db query --linked "select table_name from information_schema.tables
+     where table_schema='public'
+       and table_name in ('thoughts','entities','edges','thought_entities','thought_edges');"
+   ```
+   `entity-extraction` ships `entities/edges/thought_entities`. If `thought_edges`
+   is missing, install the typed-edges schema. **Pass an absolute path** — the CLI
+   resolves `-f` relative to the Supabase workdir (the OB1 *parent* dir), not cwd:
+   ```bash
+   supabase db query --linked -f "$(pwd)/schemas/typed-reasoning-edges/schema.sql"
+   ```
+   The schema is idempotent and additive (no destructive statements).
+
+3. **Dry run.** `node recipes/wiki-compiler/compile-wiki.mjs --dry-run`. This
+   validates credentials and connectivity. Note: `--dry-run` is not uniformly
+   free — topic-wiki honors it, but entity-wiki still calls the LLM to preview.
+
+4. **Compile.** `node recipes/wiki-compiler/compile-wiki.mjs`. Outputs land in
+   `compiled-wiki/` (entity pages, topic pages, `compile-manifest.json`).
+
+5. **Verify each phase actually did work** (the manifest says `ok` even when a
+   phase produced nothing):
+   ```bash
+   supabase db query --linked "select relation, count(*) from public.thought_edges group by relation;"
+   ls compiled-wiki/entities/ compiled-wiki/topics/
+   ```
+   If `thought_edges` is still empty, apply the edge-phase fix in the next section.
+
+6. **Drain the extraction queue (optional, for full coverage).** One compile
+   processes only `--extract-limit` items (default 25). To fold every thought
+   into the graph, loop extraction-only passes until pending hits zero, then do
+   one final compile so the wiki reflects every entity:
+   ```bash
+   # pending: select count(*) from entity_extraction_queue where processed_at is null;
+   while [ "$(pending)" != "0" ]; do
+     node recipes/wiki-compiler/compile-wiki.mjs \
+       --skip-edges --skip-entity-wiki --skip-topic-wiki --extract-limit 50
+   done
+   ```
+   A large `--extract-limit` can 502 (edge-function timeout); the worker still
+   makes progress, so the loop absorbs it — keep looping until pending is 0.
+
+## Known Failure Modes
+
+- **`status counts: { filter_error: N }`, `$0.00 spent`, `thought_edges` empty.**
+  The classifier's default filter model is a *dated* Anthropic id
+  (`claude-haiku-4-5-20251001`); OpenRouter rejects dated ids with HTTP 400.
+  Fix: if your tree has the `resolveModel` date-stripping fix, defaults work.
+  Otherwise run the edge phase standalone with an undated slug (the wrapper does
+  not expose `--filter-model`), then `--skip-edges` for the rest:
+  ```bash
+  node recipes/typed-edge-classifier/classify-edges.mjs \
+    --filter-model claude-haiku-4-5 --classify-model claude-opus-4-7
+  ```
+- **502 on extraction.** Edge-function timeout on a large batch. Lower
+  `--extract-limit` and keep looping.
+- **`supabase db query -f` "file not found".** The path is resolved from the
+  Supabase workdir (repo parent). Always pass an absolute path.
+
+## Design Rule (do not violate)
+
+SQL is the source of truth; `compiled-wiki/` pages are regenerable artifacts.
+Never hand-edit generated pages — fix the underlying thought/entity data and
+recompile. This is what prevents wiki drift. Keep `compiled-wiki/` gitignored:
+it is personal brain data.
+
+## Output
+
+- a populated `compiled-wiki/` (per-entity pages, topic pages, manifest)
+- `public.thought_edges` populated with typed reasoning relations
+- an entity graph fed by every processed thought (when the queue is drained)
+- verification query results confirming each phase produced real rows/files
+
+## Works Well With
+
+- The [Wiki Compiler recipe](../../recipes/wiki-compiler/) — the build this skill
+  drives, and the source of truth for flags and architecture.
+- The component recipes it orchestrates: `typed-edge-classifier`, `entity-wiki`,
+  `wiki-synthesis`, and the `entity-extraction` / `typed-reasoning-edges` schemas.
+
+## Notes
+
+- This skill holds no synthesis logic — the recipe scripts own all behavior. It
+  only bootstraps, verifies, and recovers.
+- The model-id workaround in "Known Failure Modes" is temporary: once the
+  `resolveModel` fix lands upstream, the wrapper's default models work and the
+  standalone override is unnecessary. Prefer updating over overriding.
+- Adapt for non–Claude Code clients: the Supabase CLI + Node steps are portable;
+  only the credential-file bootstrap assumes a local filesystem.

--- a/skills/wiki-compiler/SKILL.md
+++ b/skills/wiki-compiler/SKILL.md
@@ -90,7 +90,15 @@ zero output is a failure — verify, don't assume.
    ```
    If `thought_edges` is still empty, apply the edge-phase fix in the next section.
 
-6. **Drain the extraction queue (optional, for full coverage).** One compile
+6. **Publish to the brain (for dashboard viewing).** After a successful compile,
+   run `node recipes/wiki-compiler/sync-wiki-to-brain.mjs` to upsert each compiled
+   page into `public.thoughts` as a `wiki_entity` / `wiki_topic` thought (idempotent,
+   keyed on `metadata.wiki_slug`; needs `OPEN_BRAIN_URL` + `OPEN_BRAIN_SERVICE_KEY`).
+   The pages are then browsable at the Open Brain Dashboard Pro `/wiki` route, fetched
+   live — personal content stays in the DB and is never committed to git. Use
+   `--dry-run` first; `--only entities|topics` to scope.
+
+7. **Drain the extraction queue (optional, for full coverage).** One compile
    processes only `--extract-limit` items (default 25). To fold every thought
    into the graph, loop extraction-only passes until pending hits zero, then do
    one final compile so the wiki reflects every entity:
@@ -141,6 +149,8 @@ it is personal brain data.
   drives, and the source of truth for flags and architecture.
 - The component recipes it orchestrates: `typed-edge-classifier`, `entity-wiki`,
   `wiki-synthesis`, and the `entity-extraction` / `typed-reasoning-edges` schemas.
+- `sync-wiki-to-brain.mjs` + the [Open Brain Dashboard Pro](../../dashboards/open-brain-dashboard-pro/)
+  `/wiki` route — publish the compiled pages into the DB and browse them live (step 6).
 
 ## Notes
 

--- a/skills/wiki-compiler/metadata.json
+++ b/skills/wiki-compiler/metadata.json
@@ -1,0 +1,21 @@
+{
+  "name": "Wiki Compiler",
+  "description": "Triggerable operator for the Wiki Compiler recipe. Bootstraps credentials, verifies the entity-extraction and typed-reasoning-edges schemas, runs the compile pipeline (entity extraction -> typed edges -> entity wiki -> topic wiki), drains the extraction queue, and recovers from known failure modes (OpenRouter dated model-id 400s, extraction 502s, missing .env.local).",
+  "category": "skills",
+  "author": {
+    "name": "Ezana Azene",
+    "github": "eazene"
+  },
+  "version": "1.0.0",
+  "requires": {
+    "open_brain": true,
+    "services": ["OpenRouter (or Anthropic) API", "Supabase CLI (authenticated, project linked)"],
+    "tools": ["Node.js 18+", "Claude Code or similar AI coding tool with reusable skills/system prompts"]
+  },
+  "requires_skills": [],
+  "tags": ["workflow", "wiki", "knowledge-graph", "compiled-views", "orchestration", "supabase-cli"],
+  "difficulty": "intermediate",
+  "estimated_time": "20 minutes",
+  "created": "2026-07-08",
+  "updated": "2026-07-08"
+}


### PR DESCRIPTION
## What

A triggerable **operator skill** for the [Wiki Compiler recipe](../../recipes/wiki-compiler/) — it makes the recipe run end to end from a natural-language request ("compile my wiki", "regenerate the entity wiki", "run wiki-compiler") instead of stalling on setup.

Follows the `skills/` shape and the precedent set by `research-to-decision-workflow`:

```
skills/wiki-compiler/
  SKILL.md        # trigger conditions + operational protocol
  metadata.json   # validates against .github/metadata.schema.json
  README.md       # when/why + failure-mode index
```

## Why

The recipe is a capable wrapper, but a first run reliably hits five *silent* walls — each lets the run report success while producing nothing:

1. **No root `.env.local`** — sibling recipe `.env` files use `SUPABASE_*` / `OPENROUTER_API_KEY`; the compile scripts want `OPEN_BRAIN_*` / `LLM_API_KEY`.
2. **Missing `typed-reasoning-edges` schema** — `thought_edges` doesn't exist, so the edge phase has nowhere to write.
3. **OpenRouter dated model-id** — the classifier's default filter model is a dated Anthropic snapshot id that OpenRouter rejects with HTTP 400 → `filter_error` on every pair, zero edges. (Root-cause fix proposed separately in #415; the skill documents both the fix and the standalone override.)
4. **Batched extraction** — one compile drains only `--extract-limit` queued thoughts (default 25); the rest sit unprocessed.
5. **No verification** — the manifest reports `ok` per phase even when a phase produced zero rows/files.

`SKILL.md` encodes the recovery for each: a credential-bootstrap remap table (with an explicit **never-print-secrets** rule), the Supabase-CLI schema preflight (including the `-f` absolute-path gotcha, since the CLI resolves paths from the Supabase workdir), the compile + per-phase verification queries, and the drain-until-empty loop.

## Scope & guarantees

- **No synthesis logic** — the recipe scripts and schemas remain the source of truth; the skill only bootstraps, verifies, and recovers.
- Reinforces the recipe's core rule: SQL is authoritative, `compiled-wiki/` is regenerable and stays gitignored (personal brain data).
- `metadata.json` validated against `.github/metadata.schema.json` (passes).

## Related

- #415 — root-cause fix for failure mode #3 (classifier OpenRouter model routing). This skill is useful with or without that fix and notes the workaround as temporary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CLGjuPiQUa2E1yJZrxCLvi