### PR TITLE
[dashboards] Fix /thoughts/[id] 404: type thought ids as UUID strings

### DIFF
--- a/dashboards/open-brain-dashboard-pro/app/api/audit/delete/route.ts
+++ b/dashboards/open-brain-dashboard-pro/app/api/audit/delete/route.ts
@@ -27,7 +27,8 @@ export async function POST(request: NextRequest) {
   try {
     const { ids } = (await request.json()) as { ids: unknown };
 
-    // BL-03: Strict input validation — array of positive integers only
+    // BL-03: Strict input validation — array of UUID thought ids only
+    // (public.thoughts.id is uuid, not a positive integer).
     if (!Array.isArray(ids) || ids.length === 0) {
       return NextResponse.json({ error: "No IDs provided" }, { status: 400 });
     }
@@ -37,15 +38,16 @@ export async function POST(request: NextRequest) {
         { status: 400 }
       );
     }
-    const sanitized: number[] = [];
+    const UUID_RE = /^[0-9a-fA-F-]{36}$/;
+    const sanitized: string[] = [];
     for (const raw of ids) {
-      if (!Number.isInteger(raw) || (raw as number) <= 0) {
+      if (typeof raw !== "string" || !UUID_RE.test(raw)) {
         return NextResponse.json(
-          { error: "All IDs must be positive integers" },
+          { error: "All IDs must be valid UUIDs" },
           { status: 400 }
         );
       }
-      sanitized.push(raw as number);
+      sanitized.push(raw);
     }
 
     // BL-03: Re-verify each thought actually has quality_score < 30 before deleting
@@ -57,7 +59,7 @@ export async function POST(request: NextRequest) {
       sanitized.map((id) => fetchThought(apiKey, id, excludeRestricted))
     );
 
-    const verifiedIds: number[] = [];
+    const verifiedIds: string[] = [];
     let rejected = 0;
     for (let i = 0; i < verifyResults.length; i++) {
       const r = verifyResults[i];

--- a/dashboards/open-brain-dashboard-pro/app/api/duplicates/resolve/route.ts
+++ b/dashboards/open-brain-dashboard-pro/app/api/duplicates/resolve/route.ts
@@ -29,20 +29,22 @@ export async function POST(request: NextRequest) {
       thought_id_b: unknown;
     };
 
-    // BL-03: Validate IDs are positive integers, not truthy-but-wrong values
+    // BL-03: Validate IDs are UUID thought ids, not truthy-but-wrong values
+    // (public.thoughts.id is uuid, not a positive integer).
+    const UUID_RE = /^[0-9a-fA-F-]{36}$/;
     if (
-      !Number.isInteger(thought_id_a) ||
-      (thought_id_a as number) <= 0 ||
-      !Number.isInteger(thought_id_b) ||
-      (thought_id_b as number) <= 0
+      typeof thought_id_a !== "string" ||
+      !UUID_RE.test(thought_id_a) ||
+      typeof thought_id_b !== "string" ||
+      !UUID_RE.test(thought_id_b)
     ) {
       return NextResponse.json(
-        { error: "Both thought_id_a and thought_id_b must be positive integers" },
+        { error: "Both thought_id_a and thought_id_b must be valid UUIDs" },
         { status: 400 }
       );
     }
-    const idA = thought_id_a as number;
-    const idB = thought_id_b as number;
+    const idA = thought_id_a;
+    const idB = thought_id_b;
 
     if (idA === idB) {
       return NextResponse.json(

--- a/dashboards/open-brain-dashboard-pro/app/api/ingest/[id]/route.ts
+++ b/dashboards/open-brain-dashboard-pro/app/api/ingest/[id]/route.ts
@@ -19,9 +19,9 @@ function normalizeItem(raw: Record<string, unknown>): IngestionItem {
     action: (raw.action ?? "skip") as string,
     reason: (raw.reason as string) ?? null,
     status: (raw.status ?? "pending") as string,
-    matched_thought_id: (raw.matched_thought_id as number) ?? null,
+    matched_thought_id: (raw.matched_thought_id as string) ?? null,
     similarity_score: raw.similarity_score != null ? Number(raw.similarity_score) : null,
-    result_thought_id: (raw.result_thought_id as number) ?? null,
+    result_thought_id: (raw.result_thought_id as string) ?? null,
     meta: parsedMeta,
   };
 }

--- a/dashboards/open-brain-dashboard-pro/app/api/thoughts/[id]/connections/route.ts
+++ b/dashboards/open-brain-dashboard-pro/app/api/thoughts/[id]/connections/route.ts
@@ -16,9 +16,9 @@ export async function GET(
 
   const { id } = await params;
 
-  // WR-04: Validate id is a positive integer before forwarding
-  const idNum = Number(id);
-  if (!Number.isInteger(idNum) || idNum <= 0) {
+  // WR-04: Validate id is a UUID (thought ids are uuid, not integers) before
+  // forwarding.
+  if (!/^[0-9a-fA-F-]{36}$/.test(id)) {
     return NextResponse.json({ error: "Invalid id" }, { status: 400 });
   }
 
@@ -36,7 +36,7 @@ export async function GET(
 
   try {
     const res = await fetch(
-      `${API_URL}/thought/${idNum}/connections?exclude_restricted=${excludeRestricted}&limit=20`,
+      `${API_URL}/thought/${id}/connections?exclude_restricted=${excludeRestricted}&limit=20`,
       {
         headers: {
           "x-brain-key": apiKey,

--- a/dashboards/open-brain-dashboard-pro/app/audit/page.tsx
+++ b/dashboards/open-brain-dashboard-pro/app/audit/page.tsx
@@ -8,7 +8,7 @@ import type { Thought, BrowseResponse } from "@/lib/types";
 
 export default function AuditPage() {
   const [data, setData] = useState<BrowseResponse | null>(null);
-  const [selected, setSelected] = useState<Set<number>>(new Set());
+  const [selected, setSelected] = useState<Set<string>>(new Set());
   const [page, setPage] = useState(1);
   const [loading, setLoading] = useState(true);
   const [showDelete, setShowDelete] = useState(false);
@@ -56,7 +56,7 @@ export default function AuditPage() {
     setPage(next);
   };
 
-  const toggleSelect = (id: number) => {
+  const toggleSelect = (id: string) => {
     setSelected((prev) => {
       const next = new Set(prev);
       if (next.has(id)) next.delete(id);

--- a/dashboards/open-brain-dashboard-pro/app/thoughts/[id]/page.tsx
+++ b/dashboards/open-brain-dashboard-pro/app/thoughts/[id]/page.tsx
@@ -24,8 +24,9 @@ export default async function ThoughtDetailPage({
   const session = await getSession();
   const excludeRestricted = !session.restrictedUnlocked;
   const { id } = await params;
-  const thoughtId = parseInt(id, 10);
-  if (isNaN(thoughtId)) notFound();
+  // Thought ids are UUIDs (public.thoughts.id uuid default gen_random_uuid()).
+  if (!/^[0-9a-fA-F-]{36}$/.test(id)) notFound();
+  const thoughtId = id;
 
   let thought;
   try {

--- a/dashboards/open-brain-dashboard-pro/components/ConnectionsPanel.tsx
+++ b/dashboards/open-brain-dashboard-pro/components/ConnectionsPanel.tsx
@@ -6,7 +6,7 @@ import { TypeBadge } from "./ThoughtCard";
 import { FormattedDate } from "./FormattedDate";
 
 interface Connection {
-  id: number;
+  id: string;
   type: string;
   importance: number;
   preview: string;
@@ -20,7 +20,7 @@ export function ConnectionsPanel({
   thoughtId,
   hasMetadata,
 }: {
-  thoughtId: number;
+  thoughtId: string;
   hasMetadata: boolean;
 }) {
   const [connections, setConnections] = useState<Connection[] | null>(

--- a/dashboards/open-brain-dashboard-pro/lib/api.ts
+++ b/dashboards/open-brain-dashboard-pro/lib/api.ts
@@ -108,7 +108,7 @@ export async function fetchThoughts(
 
 export async function fetchThought(
   apiKey: string,
-  id: number,
+  id: string,
   excludeRestricted: boolean = true
 ): Promise<Thought> {
   const qs = excludeRestricted ? "" : "?exclude_restricted=false";
@@ -117,10 +117,10 @@ export async function fetchThought(
 
 export async function updateThought(
   apiKey: string,
-  id: number,
+  id: string,
   data: { content?: string; type?: string; importance?: number }
-): Promise<{ id: number; action: string; message: string }> {
-  return apiFetch<{ id: number; action: string; message: string }>(
+): Promise<{ id: string; action: string; message: string }> {
+  return apiFetch<{ id: string; action: string; message: string }>(
     apiKey,
     `/thought/${id}`,
     {
@@ -146,8 +146,8 @@ export async function fetchDuplicates(
 
 export interface DuplicateResolveResult {
   action: string;
-  survivor_id: number | null;
-  loser_id: number | null;
+  survivor_id: string | null;
+  loser_id: string | null;
   reattached: {
     reflections: number;
     thought_entities: number;
@@ -157,8 +157,8 @@ export interface DuplicateResolveResult {
 export async function resolveDuplicate(
   apiKey: string,
   params: {
-    thought_id_a: number;
-    thought_id_b: number;
+    thought_id_a: string;
+    thought_id_b: string;
     action: "keep_a" | "keep_b" | "keep_both";
   }
 ): Promise<DuplicateResolveResult> {
@@ -170,7 +170,7 @@ export async function resolveDuplicate(
 
 export async function deleteThought(
   apiKey: string,
-  id: number
+  id: string
 ): Promise<void> {
   await apiFetch<unknown>(apiKey, `/thought/${id}`, { method: "DELETE" });
 }
@@ -213,7 +213,7 @@ export async function fetchStats(
 }
 
 export interface CaptureResult {
-  thought_id: number;
+  thought_id: string;
   action: string;
   type: string;
   sensitivity_tier: string;

--- a/dashboards/open-brain-dashboard-pro/lib/types.ts
+++ b/dashboards/open-brain-dashboard-pro/lib/types.ts
@@ -1,5 +1,5 @@
 export interface Thought {
-  id: number;
+  id: string;
   uuid?: string;
   content: string;
   type: string;
@@ -40,8 +40,8 @@ export interface StatsResponse {
 }
 
 export interface DuplicatePair {
-  thought_id_a: number;
-  thought_id_b: number;
+  thought_id_a: string;
+  thought_id_b: string;
   similarity: number;
   content_a: string;
   content_b: string;
@@ -76,9 +76,9 @@ export interface IngestionItem {
   action: string; // add, skip, create_revision, append_evidence
   reason: string | null;
   status: string;
-  matched_thought_id: number | null;
+  matched_thought_id: string | null;
   similarity_score: number | null;
-  result_thought_id: number | null;
+  result_thought_id: string | null;
   /** Parsed metadata — type, importance, tags, source_snippet */
   meta: IngestionItemMeta;
 }
@@ -92,7 +92,7 @@ export type AddToBrainMode = "auto" | "single" | "extract";
 
 export interface AddToBrainResult {
   path: "single" | "extract";
-  thought_id?: number;
+  thought_id?: string;
   job_id?: number;
   type?: string;
   status?: string;


### PR DESCRIPTION
## What

Types thought ids as `string` (UUID) throughout **Open Brain Dashboard Pro**, fixing a 404 on
`/thoughts/[id]` (and any thought-id fetch) against an Open Brain whose `thoughts.id` is a UUID.

## Why

OB1's canonical schema defines `thoughts.id uuid default gen_random_uuid() primary key`
(`docs/01-getting-started.md`), but the dashboard typed thought ids as `number` and the
`/thoughts/[id]` route coerced the param with `Number(id)`. A UUID becomes `NaN` / fails numeric
validation → the detail page 404s before the request is even made.

## Fix (dashboard-only — no gateway or schema change)

- `lib/types.ts`: `Thought.id`, and the thought-referencing `matched_thought_id` /
  `result_thought_id`, are now `string`. Entity and ingestion-job ids stay numeric (those tables
  use BIGSERIAL — correct as-is).
- `lib/api.ts`: `fetchThought` / `updateThought` / `deleteThought` / `resolveDuplicate` and the
  thought-id result fields take/return `string`.
- `app/thoughts/[id]/page.tsx`: pass the UUID param through; validate with a UUID pattern instead
  of digits-only.
- Threaded the string id through the connections / audit / duplicates call sites.

Verified the deployed REST gateway already accepts UUID thought ids (`GET /thought/<uuid>` → 200),
so this is purely a client-side typing fix.

## Test plan

- `npx tsc --noEmit`, `npm run lint`, `npm run build` all pass; `/thoughts/[id]` in the route table
- Verified end-to-end against a live UUID-id Open Brain: thought detail pages render (previously 404)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
