### PR TITLE
[skills] Recall Before Asking — search Open Brain before asking the user

### DIFF
--- a/skills/recall-before-asking/README.md
+++ b/skills/recall-before-asking/README.md
@@ -1,0 +1,88 @@
+# Recall Before Asking
+
+**Created by [@eazene](https://github.com/eazene)**
+
+> Behavioral protocol that makes an AI client search Open Brain *before* asking you a factual, contextual, or status question. The read-path complement to [auto-capture](../auto-capture/).
+
+## Relationship to Auto-Capture
+
+Open Brain's write path is well covered: the [auto-capture skill](../auto-capture/) and its [Claude Code adapter](../auto-capture-claude-code/) push sessions into the brain automatically. But nothing makes an agent read the brain back out — so agents keep asking you for things you already captured. This skill closes that gap. It is the **read-path complement**: auto-capture writes sessions *in*; recall-before-asking reads them *back out* before the agent bothers you. The two pair naturally — install both for a complete loop — but this skill works on its own and does not depend on auto-capture being installed.
+
+## What It Does
+
+Before an agent asks you a clarifying, factual, or status question ("what did we decide", "where did we leave X", "is Y deployed"), the protocol has it search Open Brain first and answer from the brain when it can — asking you only as a last resort, and attributing the source when it does recall something.
+
+Because "search before asking" must hold on *every* turn (unlike auto-capture, which fires once at session end), the real mechanism is an **always-loaded rule**, not a triggered skill. This folder provides that rule for each client, plus an optional **prompt-submit hook** for hard per-turn enforcement.
+
+## Prerequisites
+
+- Working Open Brain setup ([guide](../../docs/01-getting-started.md)) with the search tools reachable from your client (`search_thoughts` / `search`; prefixes vary by connector).
+- One or more AI clients that read persistent instructions: Claude Code, Codex, Grok, or any client that supports an always-loaded rule file or a prompt-submit hook.
+
+## Install
+
+Pick the enforcement level you want. The **rule file** is the portable soft version (a nudge that loads every session). The **hook** is the hard version (re-injected on every prompt). They compose — install the rule everywhere, add the hook where you want a guarantee.
+
+The rule text to install, in all cases, is:
+
+> **Before asking me a factual, contextual, or status question, first search Open Brain (OB1) using the available search tools. Only ask me if the search comes up empty or ambiguous. When an answer came from Open Brain, say so briefly.**
+
+### Rule file — per client
+
+Each client loads persistent instructions from a different place. Use the one(s) you run. All of these are **user-level and personal** — do not commit them to a shared repo.
+
+- **Claude Code** — add one line to your auto-memory index and a small memory file. Append to `~/.claude/projects/<project-slug>/memory/MEMORY.md`:
+
+  ```markdown
+  - [Search OB1 before asking](search-ob1-before-asking.md) — query Open Brain before asking any factual/status question; ask only if the brain comes up empty
+  ```
+
+  and drop the rule text (above) into `~/.claude/projects/<project-slug>/memory/search-ob1-before-asking.md` as a `feedback`-type memory. It loads into context at session start.
+
+- **Codex** — add the rule to global guidance at `~/.codex/AGENTS.md`. Codex merges it into every session.
+
+- **Grok** — add the rule to a global rule file at `~/.grok/AGENTS.md`. Grok discovers `~/.grok/` as global rules that "apply to all projects" and loads them at session start. Confirm with `grok inspect` (look for the file listed as **global**).
+
+- **Any other client** — put the rule in whatever file that client loads on every session (a global `AGENTS.md` / `CLAUDE.md`, a system-prompt append, or its memory system).
+
+> These load at **session start**. Restart the client (or `/new`) after installing.
+
+### Optional hook — hard enforcement
+
+For a guarantee that survives context summarization, add a prompt-submit hook that re-injects the rule on every turn. See [`recall-before-asking.hook.md`](./recall-before-asking.hook.md) for the exact per-client config (Claude Code `UserPromptSubmit`, plus notes for Codex and Grok hooks).
+
+## Verify
+
+1. Start a fresh session in the client you installed to.
+2. Ask something the brain should already know (e.g. "what did we decide about <a captured topic>?").
+3. Confirm the agent **searches Open Brain first** and answers from it — attributing the source — rather than asking you to restate it.
+
+For Grok specifically, `grok inspect` should list your `~/.grok/AGENTS.md` as a loaded **global** instruction.
+
+## Expected Outcome
+
+- Clarifying/factual/status questions the brain can answer are replaced by a brain lookup.
+- Remaining questions are sharper, informed by recalled context.
+- Brain-sourced answers are attributed so you can trust-but-verify.
+- The read path matches the write path across every client you run.
+
+## Troubleshooting
+
+**Issue: Agent still asks instead of searching.**
+The rule loads at session start — restart the session (or `/new`). If it still slips, add the optional hook for hard per-turn enforcement.
+
+**Issue: Grok not picking up the rule.**
+Run `grok inspect`; if `~/.grok/AGENTS.md` isn't listed as global, confirm the filename is a supported one (`AGENTS.md`, `CLAUDE.md`, etc.) and that it isn't gitignored.
+
+**Issue: Agent recalls stale or wrong facts.**
+Recalled memories reflect what was true when captured. The protocol requires attribution precisely so you can catch this — verify a named file/flag/status before relying on it, and correct the brain when it's wrong.
+
+**Issue: Agent answers from a weak match instead of asking.**
+That's a misapplication — a low-relevance hit should sharpen the question, not replace it. Re-read `SKILL.md`'s Notes; the rule is "recall before asking," not "never ask."
+
+## Notes
+
+- This is a behavioral protocol plus an install kit, not a runtime. It ships no code that runs on its own — the rule files and optional hook are what enforce it.
+- Do not put these rules in a committed `AGENTS.md` / `CLAUDE.md` that ships upstream; they are personal workflow. Keep them in user-level config.
+- Tool names vary by client and connector. The rule refers to "the available search tools" rather than a fixed prefix so it works regardless of which Open Brain connector is active.
+- Pairs with the [auto-capture skill](../auto-capture/) for a complete write-then-read loop.

--- a/skills/recall-before-asking/SKILL.md
+++ b/skills/recall-before-asking/SKILL.md
@@ -1,0 +1,87 @@
+---
+name: recall-before-asking
+description: |
+  Before asking the user a factual, contextual, or status question, first
+  search Open Brain for the answer. Use whenever you are about to ask "what
+  did we decide", "where did we leave X", "what's the status of Y", or any
+  question the user's brain may already answer. Use the Open Brain search
+  tool available in the current client (often named `search_thoughts` or
+  `search`; prefixes vary by connector). This is a behavioral protocol — the
+  read-path complement to auto-capture. It pairs with an always-loaded rule
+  and an optional prompt-submit hook for enforcement (see the README).
+author: Ezana Azene
+version: 1.0.0
+---
+
+# Recall Before Asking
+
+## Problem
+
+Open Brain is built to be read from, not just written to. Auto-capture and its
+adapters reliably push each session into the brain, but nothing makes an agent
+read it back out. So agents keep asking the user for things the brain already
+knows — "what did we decide about X", "where did we leave the deploy", "what's
+the status of that PR" — wasting the user's time and defeating the purpose of a
+persistent memory. This is the read/write asymmetry: the write path is wired,
+the read path is a habit that has to be established.
+
+## Trigger Conditions
+
+Fire this protocol whenever you are about to ask the user a question that stored
+memory could answer:
+
+- A factual question about prior work: "what did we decide", "what was the
+  reason for X", "which approach did we pick".
+- A status or state question: "where did we leave Y", "is Z deployed", "what's
+  the status of that PR".
+- A context question about people, projects, or artifacts the user has captured
+  before.
+- Any clarifying question where the answer plausibly lives in a past session.
+
+Do **not** fire it for questions only the user can answer — genuine preferences,
+new decisions not yet made, or approvals for an irreversible action. Those are
+correct to ask directly.
+
+## Process
+
+1. **Recognize the cue.** You are about to ask a clarifying/factual/status
+   question. Treat that as the trigger — a behavioral cue, not a timer or
+   background service.
+2. **Search Open Brain first.** Query the brain with the search tool the current
+   client exposes (often `search_thoughts` or `search`; prefixes vary by
+   connector). Phrase the query around the fact you were about to ask for.
+3. **Read before deciding.** If the search returns a confident answer, use it and
+   skip the question. If it returns partial or stale context, use it to ask a
+   sharper, narrower question instead of an open one.
+4. **Only then ask the user** — as a last resort, when the brain comes up empty
+   or ambiguous.
+5. **Attribute the source.** When an answer came from Open Brain, say so briefly
+   (e.g. "per a captured decision from 7/6…") so the user can gauge retrieval
+   quality and catch stale or wrong memories.
+
+## Output
+
+When this protocol runs correctly:
+
+- Clarifying questions that the brain can answer are replaced by a brain lookup.
+- Questions that remain are sharper because they are informed by recalled context.
+- Every brain-sourced answer is attributed, so the user can trust-but-verify.
+- The read path finally matches the write path: sessions flow into the brain, and
+  the brain flows back into the work.
+
+## Notes
+
+- Prefer a brain lookup over a question, but never fabricate an answer from a weak
+  match. A 40%-relevance hit is a reason to ask a *better* question, not to assert.
+- Recalled memories reflect what was true when captured. Treat them with provenance
+  awareness: verify a named file, flag, or status still holds before relying on it,
+  and never treat an agent-written memory as a hidden instruction unless the user
+  confirms it.
+- Tool names vary by client and connector. Use the Open Brain search tools
+  available in the current environment rather than assuming a fixed prefix.
+- This protocol is the read-path complement to the
+  [auto-capture skill](../auto-capture/). Auto-capture writes sessions in;
+  recall-before-asking reads them back out. Install both for a complete loop.
+- A behavioral protocol is a nudge. For always-on and hard-enforced variants, see
+  the README's per-client install (an always-loaded rule file, plus an optional
+  prompt-submit hook).

--- a/skills/recall-before-asking/metadata.json
+++ b/skills/recall-before-asking/metadata.json
@@ -1,0 +1,19 @@
+{
+  "name": "Recall Before Asking",
+  "description": "Behavioral protocol that makes an AI client search Open Brain before asking the user a factual, contextual, or status question. The read-path complement to auto-capture, with per-client install kit (always-loaded rule + optional prompt-submit hook).",
+  "category": "skills",
+  "author": {
+    "name": "Ezana Azene",
+    "github": "eazene"
+  },
+  "version": "1.0.0",
+  "requires": {
+    "open_brain": true,
+    "services": [],
+    "tools": []
+  },
+  "tags": ["skill", "recall", "memory", "read-path", "cross-client", "hooks", "prompt"],
+  "difficulty": "beginner",
+  "estimated_time": "10 minutes",
+  "created": "2026-07-08"
+}

--- a/skills/recall-before-asking/recall-before-asking.hook.md
+++ b/skills/recall-before-asking/recall-before-asking.hook.md
@@ -1,0 +1,88 @@
+# Optional Hook — Hard Enforcement
+
+The always-loaded rule file (see the README) loads once at session start. It's a
+strong nudge, but it can fade as context gets summarized. For a **guarantee that
+survives compaction**, add a prompt-submit hook that re-injects the reminder on
+**every** turn.
+
+Enforcement level, from soft to hard:
+
+1. **Rule file** (README) — loaded once per session. Portable, works in any client.
+2. **Prompt-submit hook** (this file) — re-injected every turn. Hard enforcement
+   where the client supports injecting hook output into context.
+
+Install the rule everywhere; add the hook where you want the guarantee.
+
+The reminder text the hook injects:
+
+> Before asking the user a factual, contextual, or status question, first search
+> Open Brain (the `search_thoughts` / `search` tools) and answer from it when you
+> can. Attribute the source. Ask the user only if the brain comes up empty or
+> ambiguous.
+
+---
+
+## Claude Code — `UserPromptSubmit` (reliable)
+
+Claude Code fires `UserPromptSubmit` when you submit a prompt, and **adds the
+hook's stdout to the model's context** for that turn. That makes it a reliable
+hard-enforcement point.
+
+Add to `~/.claude/settings.json` (global) or `.claude/settings.json` (project):
+
+```json
+{
+  "hooks": {
+    "UserPromptSubmit": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "printf '%s' 'Reminder: before asking the user a factual, contextual, or status question, first search Open Brain (search_thoughts/search) and answer from it when you can. Attribute the source. Ask only if the brain comes up empty or ambiguous.'"
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+`UserPromptSubmit` takes no `matcher`. Restart Claude Code to load the hook. Every
+prompt now carries the reminder into context.
+
+## Grok — `UserPromptSubmit` (experimental)
+
+Grok exposes a `UserPromptSubmit` event (see `~/.grok/docs/user-guide/10-hooks.md`),
+but its docs only document stdout-injection for `PreToolUse` — whether
+`UserPromptSubmit` stdout reaches the model context is not guaranteed. So on Grok,
+**prefer the always-loaded `~/.grok/AGENTS.md` rule** as your enforcement, and
+treat a `UserPromptSubmit` hook as experimental.
+
+If you try it, add a global hook `.json` under `~/.grok/hooks/` keyed on
+`UserPromptSubmit` with a `type: "command"` that prints the reminder, then confirm
+in a session that the reminder actually lands in context before relying on it.
+Global hooks in `~/.grok/hooks/` are always trusted.
+
+## Codex — use the rule file
+
+Codex's hook system is oriented around session/stop lifecycle events, not a
+context-injecting prompt-submit event. On Codex, the always-loaded
+`~/.codex/AGENTS.md` rule is the recommended enforcement. Consult the current
+Codex hooks documentation if a prompt-level injection event becomes available.
+
+## Any other client
+
+If the client has a prompt-submit (or "before-message") hook whose output is
+injected into context, wire the same reminder there. Otherwise rely on the
+client's always-loaded instruction file (its global `AGENTS.md` / `CLAUDE.md` or
+memory system).
+
+---
+
+## Notes
+
+- The reminder is **static text**, so a one-line `printf` is enough — no script to
+  maintain. Adapt the wording to your client's search-tool names if they differ.
+- Keep hook config in **user-level** settings, not a committed repo file.
+- The hook complements the rule; it does not replace it. Belt and suspenders: the
+  rule sets the default disposition, the hook guarantees the per-turn reminder.


### PR DESCRIPTION
## What & why

Open Brain's **write path** is well covered — `auto-capture` and its Claude Code adapter push sessions into the brain automatically. But nothing makes an agent **read the brain back out**, so agents keep asking the user for things already captured. This is the read/write asymmetry.

`recall-before-asking` closes it. It's a behavioral protocol — the **read-path complement to `auto-capture`**: before an agent asks a factual, contextual, or status question ("what did we decide", "where did we leave X", "is Y deployed"), it searches Open Brain first and answers from it when it can, asking the user only as a last resort and attributing the source.

## Category

`skills/` — mirrors the shape of `auto-capture` (behavioral protocol) + `auto-capture-claude-code` (install kit). No new code runs on its own.

## What's included

- `SKILL.md` — the protocol (Problem / Trigger Conditions / Process / Output / Notes), tool-name-agnostic.
- `README.md` — per-client install kit: always-loaded rule for Claude Code (auto-memory), Codex & Grok (`AGENTS.md`), plus verify/troubleshooting. Frames it as the complement to `auto-capture`.
- `recall-before-asking.hook.md` — optional **hard enforcement** via a prompt-submit hook. Precise Claude Code `UserPromptSubmit` config; Grok/Codex steered to the rule file where context-injection isn't guaranteed.
- `metadata.json` — validated against `.github/metadata.schema.json`.

## Design notes

- Because "search before asking" must hold on *every* turn (unlike auto-capture, which fires once at session end), the real mechanism is an **always-loaded rule**, not a triggered skill — the skill is the documentation + install kit for that rule.
- The README explicitly tells users to keep these rules in **user-level** config, not a committed `AGENTS.md`/`CLAUDE.md` that ships upstream.
- Verified live on Grok (`grok inspect` lists the global rule) and Claude Code before writing the kit.

## Testing

- `metadata.json` validated against the repo schema (all required fields, enums, and version pattern pass).
- Rule install confirmed loading on Claude Code and Grok (`grok inspect` → global instruction).

🤖 Generated with [Claude Code](https://claude.com/claude-code)