### PR TITLE
fix(update-thought-mcp): complete deno.json import map, zod v4 z.record signature

### DIFF
--- a/integrations/update-thought-mcp/deno.json
+++ b/integrations/update-thought-mcp/deno.json
@@ -1,5 +1,9 @@
 {
   "imports": {
-    "@supabase/supabase-js": "npm:@supabase/supabase-js@2.47.10"
+    "@hono/mcp": "npm:@hono/mcp@0.1.1",
+    "@modelcontextprotocol/sdk": "npm:@modelcontextprotocol/sdk@1.24.3",
+    "@supabase/supabase-js": "npm:@supabase/supabase-js@2.47.10",
+    "hono": "npm:hono@4.9.2",
+    "zod": "npm:zod@4.1.13"
   }
 }

--- a/integrations/update-thought-mcp/index.ts
+++ b/integrations/update-thought-mcp/index.ts
@@ -87,7 +87,7 @@ server.registerTool(
         .optional()
         .describe("New text content — triggers re-embedding when provided"),
       metadata_patch: z
-        .record(z.unknown())
+        .record(z.string(), z.unknown())
         .optional()
         .describe(
           "Partial metadata to shallow-merge into the existing metadata JSONB. New keys are added; existing keys are overwritten; keys not mentioned are left alone.",


### PR DESCRIPTION
## Summary
- `update-thought-mcp/deno.json` only mapped `@supabase/supabase-js`, but `index.ts` also imports `zod`, `hono`, `@hono/mcp`, and `@modelcontextprotocol/sdk` — bundling fails with `Relative import path "zod" not prefixed...`. Import map now matches `delete-thought-mcp` (same pinned versions).
- `z.record(z.unknown())` is the zod v3 single-argument form. With the pinned `zod@4.1.13` it produces a broken schema that throws `Cannot read properties of undefined (reading '_zod')` at tool-call time. Switched to the two-argument form `z.record(z.string(), z.unknown())`, valid in both zod 3 and 4.

## Test plan
- [x] Deployed to a live Supabase project (`supabase functions deploy update-thought-mcp --no-verify-jwt`)
- [x] Exercised `update_thought` end-to-end against a real thought: content replace + re-embed, metadata_patch merge, confirmed `updated_at` advanced
- [x] Confirmed `delete-thought-mcp` (unaffected by this fix) still deploys and works — same import map pattern used as the reference

🤖 Generated with [Claude Code](https://claude.com/claude-code)