### PR TITLE
[schemas] Guard search_thoughts_text and its FTS index against the 1MB tsvector cap

### DIFF
--- a/schemas/enhanced-thoughts/metadata.json
+++ b/schemas/enhanced-thoughts/metadata.json
@@ -6,7 +6,7 @@
     "name": "Alan Shurafa",
     "github": "alanshurafa"
   },
-  "version": "1.0.0",
+  "version": "1.0.1",
   "requires": {
     "open_brain": true
   },
@@ -14,5 +14,5 @@
   "difficulty": "beginner",
   "estimated_time": "15 minutes",
   "created": "2026-04-06",
-  "updated": "2026-04-17"
+  "updated": "2026-07-09"
 }

--- a/schemas/enhanced-thoughts/schema.sql
+++ b/schemas/enhanced-thoughts/schema.sql
@@ -25,8 +25,14 @@ CREATE INDEX IF NOT EXISTS idx_thoughts_source_type ON thoughts (source_type);
 CREATE INDEX IF NOT EXISTS idx_thoughts_status ON thoughts (status) WHERE status IS NOT NULL;
 
 -- Full-text search index (speeds up search_thoughts_text)
+-- Partial: skip any row whose content exceeds Postgres's ~1MB tsvector cap.
+-- to_tsvector() raises "ERROR 54000: string is too long for tsvector" on larger
+-- input, which aborts the entire index build; the partial predicate excludes such
+-- rows so the build always succeeds. search_thoughts_text carries the matching
+-- octet_length guard so it stays consistent with this predicate and can use the index.
 CREATE INDEX IF NOT EXISTS idx_thoughts_content_tsvector
-  ON thoughts USING gin (to_tsvector('simple', coalesce(content, '')));
+  ON thoughts USING gin (to_tsvector('simple', coalesce(content, '')))
+  WHERE octet_length(coalesce(content, '')) < 977000;
 
 -- ============================================================
 -- 2. FULL-TEXT SEARCH RPC
@@ -71,6 +77,9 @@ BEGIN
     FROM public.thoughts t
     CROSS JOIN query_input q
     WHERE q.raw_query <> ''
+      -- Skip rows over the ~1MB tsvector cap; also matches the partial index predicate
+      -- so this CTE can use idx_thoughts_content_tsvector.
+      AND octet_length(coalesce(t.content, '')) < 977000
       AND to_tsvector('simple', coalesce(t.content, '')) @@ q.ts_query
       AND t.metadata @> coalesce(p_filter, '{}'::jsonb)
     LIMIT 2000
@@ -81,6 +90,8 @@ BEGIN
     FROM public.thoughts t
     CROSS JOIN query_input q
     WHERE q.raw_query <> ''
+      -- Skip rows over the ~1MB tsvector cap (the ranked CTE re-computes to_tsvector on hits).
+      AND octet_length(coalesce(t.content, '')) < 977000
       AND (SELECT count(*) FROM tsvector_hits) < (p_limit + p_offset)
       AND t.content ILIKE '%' || q.raw_query || '%'
       AND t.metadata @> coalesce(p_filter, '{}'::jsonb)


### PR DESCRIPTION
## Problem

`schemas/enhanced-thoughts` installs `idx_thoughts_content_tsvector` and `search_thoughts_text`. Both break once any single thought's `content` exceeds Postgres's hard ~1 MB `tsvector` limit:

- The `CREATE INDEX` aborts with `ERROR: 54000: string is too long for tsvector (N bytes, max 1048575 bytes)`. Because that aborts the whole build, **one** oversized row makes the FTS index un-buildable for the entire table.
- `search_thoughts_text` computes `to_tsvector()` inline over candidate rows, so it throws the same error at query time whenever the scan reaches an oversized row.

Easy to hit in practice with large "Full Document Contents" imports (Readwise/Obsidian articles, PDFs, etc.).

## Fix

- Make the index **partial**, excluding rows whose content is over the cap: `WHERE octet_length(coalesce(content,'')) < 977000`.
- Add the matching `octet_length(...) < 977000` guard to the `tsvector_hits` and `ilike_hits` CTEs in `search_thoughts_text`.

Effects:
- The index always builds.
- The function can now **use** the partial index (its query shares the predicate) and never computes `to_tsvector` on an oversized row.
- Oversized thoughts stay fully **vector**-searchable via `match_thoughts`; they're just excluded from full-text.

Additive and idempotent — no data changes, no table-structure changes. `metadata.json` bumped 1.0.0 → 1.0.1.

## Testing

Verified on a live brain (~17.6k thoughts, one ~2.35 MB import):
- Before: `CREATE INDEX` → `ERROR 54000`; `search_thoughts_text('safety', …)` → `ERROR 54000`.
- After: partial index builds (valid, ~22 MB); `search_thoughts_text('safety', …)` returns 295 hits, no error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)