### PR TITLE
[server] Reject non-POST MCP requests with 405 to prevent GET handshake hang

### DIFF
--- a/extensions/_template/AGENT_SPEC.md
+++ b/extensions/_template/AGENT_SPEC.md
@@ -148,6 +148,14 @@ const server = new McpServer({
 const app = new Hono();
 
 app.all("*", async (c) => {
+  // Reject non-POST requests: a GET would fall through to
+  // StreamableHTTPTransport.handleRequest and park on an SSE stream that
+  // never emits and never closes, hanging mcp-remote's OAuth-discovery GET
+  // probe and timing out the MCP handshake.
+  if (c.req.method !== "POST") {
+    return c.json({ error: "Method not allowed" }, 405);
+  }
+
   const provided = c.req.header("x-brain-key") || new URL(c.req.url).searchParams.get("key");
   if (!provided || provided !== MCP_ACCESS_KEY) {
     return c.json({ error: "Invalid or missing access key" }, 401);

--- a/server/index.ts
+++ b/server/index.ts
@@ -601,6 +601,17 @@ app.options("*", (c) => {
 });
 
 app.all("*", async (c) => {
+  // Reject non-POST requests up front. This server is stateless over
+  // streamable HTTP: there is no standalone SSE stream (GET) or session
+  // termination (DELETE) to serve. Without this guard a GET falls through to
+  // StreamableHTTPTransport.handleRequest, which parks it on an SSE stream
+  // that never emits and never closes. mcp-remote always sends a GET probe
+  // (OAuth discovery) before its initialize POST, so that probe hangs and
+  // the MCP handshake times out at the client with no error server-side.
+  if (c.req.method !== "POST") {
+    return c.json({ error: "Method not allowed" }, 405, { ...corsHeaders, Allow: "POST, OPTIONS" });
+  }
+
   // Accept access key via header OR URL query parameter
   const provided = c.req.header("x-brain-key") || new URL(c.req.url).searchParams.get("key");
   if (!provided || provided !== MCP_ACCESS_KEY) {


### PR DESCRIPTION
Fixes #424.

### What

Adds a `405 Method Not Allowed` guard ahead of `StreamableHTTPTransport.handleRequest()` in the core server, and in the extension template's handler so new extensions don't reinherit the pattern. Per the MCP streamable-HTTP spec, a server that doesn't offer a standalone SSE stream (GET) or session termination (DELETE) must answer those methods with 405.

### Why

Without the guard, a GET request parks forever on a never-emitting, never-closing SSE stream inside `@hono/mcp`. `mcp-remote` — the client the OB1 docs recommend — always sends a GET probe (OAuth `WWW-Authenticate` discovery) before its initialize POST. The hung probe poisons the function instance, the initialize that follows hangs, and the agent times out after 60 seconds with the server showing "running" and no error logged anywhere. A curl POST smoke test passes throughout, which sends diagnosis in the wrong direction (see #424 for the full wire-level trace).

### Files changed

| File | Change |
|---|---|
| `server/index.ts` | Guard after `app.all("*")` opens, with CORS headers + `Allow` |
| `extensions/_template/AGENT_SPEC.md` | Same guard in the template handler so new extensions don't reintroduce the bug |

### Companion PR

The same `app.all("*")` → `handleRequest` pattern exists in 4 integrations and 2 recipes. A companion PR (`[integrations]`) applies the identical guard there — split out per the PR gate's scoping rules. Extensions using `app.post("*")` are unaffected (Hono 404s other methods before the transport).

### Testing

- Tested against my own live deployment (per CONTRIBUTING: run it yourself first): before the guard, every `mcp-remote` attach timed out at 60s; after deploying it, GET returns 405 in ~1s, POST initialize returns `serverInfo` in ~0.5s, and the full initialize → `tools/list` → tool-call path works through mcp-remote.
- `deno check` output on patched files is identical to `main` (pre-existing import-map resolution notes only; nothing new introduced).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KpuWP7DYkoWnS2gT8Fd192
