### PR TITLE
[integrations] Reject non-POST MCP requests with 405 to prevent GET handshake hang

### DIFF
--- a/integrations/delete-thought-mcp/index.ts
+++ b/integrations/delete-thought-mcp/index.ts
@@ -128,6 +128,17 @@ const app = new Hono();
 app.options("*", (c) => c.text("ok", 200, corsHeaders));
 
 app.all("*", async (c) => {
+  // Reject non-POST requests up front. This server is stateless over
+  // streamable HTTP: there is no standalone SSE stream (GET) or session
+  // termination (DELETE) to serve. Without this guard a GET falls through to
+  // StreamableHTTPTransport.handleRequest, which parks it on an SSE stream
+  // that never emits and never closes. mcp-remote always sends a GET probe
+  // (OAuth discovery) before its initialize POST, so that probe hangs and
+  // the MCP handshake times out at the client with no error server-side.
+  if (c.req.method !== "POST") {
+    return c.json({ error: "Method not allowed" }, 405, { ...corsHeaders, Allow: "POST, OPTIONS" });
+  }
+
   const provided =
     c.req.header("x-brain-key") || new URL(c.req.url).searchParams.get("key");
   if (!provided || provided !== MCP_ACCESS_KEY) {

--- a/integrations/enhanced-mcp/index.ts
+++ b/integrations/enhanced-mcp/index.ts
@@ -1596,6 +1596,17 @@ app.options("*", (c) => {
 });
 
 app.all("*", async (c) => {
+  // Reject non-POST requests up front. This server is stateless over
+  // streamable HTTP: there is no standalone SSE stream (GET) or session
+  // termination (DELETE) to serve. Without this guard a GET falls through to
+  // StreamableHTTPTransport.handleRequest, which parks it on an SSE stream
+  // that never emits and never closes. mcp-remote always sends a GET probe
+  // (OAuth discovery) before its initialize POST, so that probe hangs and
+  // the MCP handshake times out at the client with no error server-side.
+  if (c.req.method !== "POST") {
+    return c.json({ error: "Method not allowed" }, 405, { ...corsHeaders, Allow: "POST, OPTIONS" });
+  }
+
   // Header-only auth: `x-brain-key: <key>` or `Authorization: Bearer <key>`.
   // We do NOT accept the key via a `?key=` query parameter — URL query
   // strings end up in Supabase/CDN/proxy access logs, which leaks the

--- a/integrations/kubernetes-deployment/README.md
+++ b/integrations/kubernetes-deployment/README.md
@@ -49,6 +49,12 @@ EMBEDDING/CHAT API
 
 ## Steps
 
+1. Build the MCP server Docker image
+2. Configure secrets
+3. Deploy to Kubernetes
+4. Verify the deployment
+5. Connect your MCP client
+
 ### 1. Build the MCP Server Docker Image
 
 From this directory, build and import the image:
@@ -163,6 +169,8 @@ After deployment you should see:
 - PostgreSQL with `thoughts` table and `match_thoughts` function
 - MCP endpoint responding to `tools/list` with 4 tools: `search_thoughts`, `list_thoughts`, `thought_stats`, `capture_thought`
 - Thoughts captured via any MCP client are stored in your self-hosted database
+
+> **Tool hygiene:** This integration adds MCP tools to your AI's context window. As your deployment grows, the total tool count grows — and with it, the context cost and risk of your AI picking the wrong tool. See the [MCP Tool Audit & Optimization Guide](../../docs/05-tool-audit.md) for strategies on auditing, merging, and scoping your tools.
 
 ## Troubleshooting
 

--- a/integrations/kubernetes-deployment/index.ts
+++ b/integrations/kubernetes-deployment/index.ts
@@ -580,6 +580,17 @@ const app = new Hono();
 app.options("*", (c) => c.text("ok", 200, corsHeaders));
 
 app.all("*", async (c) => {
+  // Reject non-POST requests up front. This server is stateless over
+  // streamable HTTP: there is no standalone SSE stream (GET) or session
+  // termination (DELETE) to serve. Without this guard a GET falls through to
+  // StreamableHTTPTransport.handleRequest, which parks it on an SSE stream
+  // that never emits and never closes. mcp-remote always sends a GET probe
+  // (OAuth discovery) before its initialize POST, so that probe hangs and
+  // the MCP handshake times out at the client with no error server-side.
+  if (c.req.method !== "POST") {
+    return c.json({ error: "Method not allowed" }, 405, { ...corsHeaders, Allow: "POST, OPTIONS" });
+  }
+
   const provided = c.req.header("x-brain-key") || new URL(c.req.url).searchParams.get("key");
   if (!provided || provided !== MCP_ACCESS_KEY) {
     return c.json({ error: "Invalid or missing access key" }, 401, corsHeaders);

--- a/integrations/update-thought-mcp/index.ts
+++ b/integrations/update-thought-mcp/index.ts
@@ -242,6 +242,17 @@ const app = new Hono();
 app.options("*", (c) => c.text("ok", 200, corsHeaders));
 
 app.all("*", async (c) => {
+  // Reject non-POST requests up front. This server is stateless over
+  // streamable HTTP: there is no standalone SSE stream (GET) or session
+  // termination (DELETE) to serve. Without this guard a GET falls through to
+  // StreamableHTTPTransport.handleRequest, which parks it on an SSE stream
+  // that never emits and never closes. mcp-remote always sends a GET probe
+  // (OAuth discovery) before its initialize POST, so that probe hangs and
+  // the MCP handshake times out at the client with no error server-side.
+  if (c.req.method !== "POST") {
+    return c.json({ error: "Method not allowed" }, 405, { ...corsHeaders, Allow: "POST, OPTIONS" });
+  }
+
   const provided =
     c.req.header("x-brain-key") || new URL(c.req.url).searchParams.get("key");
   if (!provided || provided !== MCP_ACCESS_KEY) {

--- a/recipes/edge-function-cost-optimization/README.md
+++ b/recipes/edge-function-cost-optimization/README.md
@@ -66,7 +66,7 @@ Plus a moderate cache layer with tag-based invalidation: `thought_stats` (5 min,
 | Invocations per "open Claude" | ~16 | ~4 (drops to 1 after warm session) |
 | `thought_stats` data transferred | full table scan | single aggregated row |
 
-Free tier: **500,000/month**. This recipe brings a 1.8M/month workload comfortably under the cap.
+Expected outcome: a 1.8M/month workload drops to roughly 440k invocations — comfortably under the free tier cap of **500,000/month** — with one edge function and one connector to maintain instead of four.
 
 ## Prerequisites
 
@@ -114,6 +114,17 @@ const sessions = new Map<string, Session>();
 const SESSION_TTL_MS = 30 * 60 * 1000;
 
 app.all("*", async (c) => {
+  // Reject non-POST requests up front. This server is stateless over
+  // streamable HTTP: there is no standalone SSE stream (GET) or session
+  // termination (DELETE) to serve. Without this guard a GET falls through to
+  // StreamableHTTPTransport.handleRequest, which parks it on an SSE stream
+  // that never emits and never closes. mcp-remote always sends a GET probe
+  // (OAuth discovery) before its initialize POST, so that probe hangs and
+  // the MCP handshake times out at the client with no error server-side.
+  if (c.req.method !== "POST") {
+    return c.json({ error: "Method not allowed" }, 405, { ...corsHeaders, Allow: "POST, OPTIONS" });
+  }
+
   // ... auth check first ...
 
   const sid = c.req.header("mcp-session-id") || undefined;

--- a/recipes/edge-function-cost-optimization/examples/after/index.ts
+++ b/recipes/edge-function-cost-optimization/examples/after/index.ts
@@ -44,6 +44,17 @@ const app = new Hono();
 app.options("*", (c) => c.text("ok", 200, corsHeaders));
 
 app.all("*", async (c) => {
+  // Reject non-POST requests up front. This server is stateless over
+  // streamable HTTP: there is no standalone SSE stream (GET) or session
+  // termination (DELETE) to serve. Without this guard a GET falls through to
+  // StreamableHTTPTransport.handleRequest, which parks it on an SSE stream
+  // that never emits and never closes. mcp-remote always sends a GET probe
+  // (OAuth discovery) before its initialize POST, so that probe hangs and
+  // the MCP handshake times out at the client with no error server-side.
+  if (c.req.method !== "POST") {
+    return c.json({ error: "Method not allowed" }, 405, { ...corsHeaders, Allow: "POST, OPTIONS" });
+  }
+
   const provided =
     c.req.header("x-brain-key") ||
     c.req.header("x-access-key") ||

--- a/recipes/work-operating-model-activation/index.ts
+++ b/recipes/work-operating-model-activation/index.ts
@@ -832,6 +832,14 @@ app.get("/health", (c) =>
 );
 
 app.all("*", async (c) => {
+  // Reject non-POST requests (OPTIONS excepted — no preflight route exists
+  // above): a GET would fall through to StreamableHTTPTransport.handleRequest
+  // and park on an SSE stream that never emits and never closes, hanging
+  // mcp-remote's OAuth-discovery GET probe and timing out the MCP handshake.
+  if (c.req.method !== "POST" && c.req.method !== "OPTIONS") {
+    return c.json({ error: "Method not allowed" }, 405);
+  }
+
   if (!c.req.header("accept")?.includes("text/event-stream")) {
     const headers = new Headers(c.req.raw.headers);
     headers.set("Accept", "application/json, text/event-stream");


### PR DESCRIPTION
Companion to #425 (core server fix). Addresses the same root cause as #424 in the contribution folders.

### What

Adds the same `405 Method Not Allowed` guard ahead of `StreamableHTTPTransport.handleRequest()` in every integration and recipe that routes `app.all("*")` into the transport. Without it, a GET request parks forever on a never-emitting, never-closing SSE stream inside `@hono/mcp` — and `mcp-remote` always sends a GET probe (OAuth discovery) before its initialize POST, so the MCP handshake times out at 60s with no error server-side. Full wire-level diagnosis in #424.

### Files changed

| File | Change |
|---|---|
| `integrations/delete-thought-mcp/index.ts` | Guard after `app.all("*")` opens, with CORS headers + `Allow` |
| `integrations/update-thought-mcp/index.ts` | Same |
| `integrations/kubernetes-deployment/index.ts` | Same |
| `integrations/enhanced-mcp/index.ts` | Same |
| `recipes/edge-function-cost-optimization/examples/after/index.ts` | Same |
| `recipes/edge-function-cost-optimization/README.md` | Same guard in the code snippet so it matches the example; adds an expected-outcome summary |
| `recipes/work-operating-model-activation/index.ts` | Guard exempts OPTIONS — this handler has no `app.options` route above it, so preflight must keep flowing through unchanged |
| `integrations/kubernetes-deployment/README.md` | Adds numbered step overview and the tool-audit guide link (gate requirements for touched folders) |

Not changed: extensions using `app.post("*")` (meal-planning, professional-crm, job-hunt, home-maintenance, family-calendar, household-knowledge) — Hono already 404s non-POST there, no hang possible.

### One design note for maintainers

The cost-optimization recipe reuses transports across requests via a session map. A maximal reading of the spec could support GET-with-`mcp-session-id` for stream resumption there. I went with POST-only anyway because:
- (a) no OB1 server sends server-initiated messages, so an SSE stream has nothing to deliver, and
- (b) mcp-remote's probe GET carries no session id — under the current code it mints a brand-new session, leaks it into the map, and hangs. [If you'd rather support GET-with-session in that recipe, happy to adjust.]

### Testing

Same verification as #425: on a live deployment, GET returns 405 in ~1s (previously hung until killed), POST initialize returns `serverInfo` in ~0.5s, and the full initialize → `tools/list` → tool-call path works through mcp-remote.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KpuWP7DYkoWnS2gT8Fd192
