### PR TITLE
[integrations] Fix update-thought-mcp deploy-blocking bugs

### DIFF
--- a/integrations/update-thought-mcp/deno.json
+++ b/integrations/update-thought-mcp/deno.json
@@ -1,5 +1,9 @@
 {
   "imports": {
-    "@supabase/supabase-js": "npm:@supabase/supabase-js@2.47.10"
+    "@hono/mcp": "npm:@hono/mcp@0.1.1",
+    "@modelcontextprotocol/sdk": "npm:@modelcontextprotocol/sdk@1.24.3",
+    "@supabase/supabase-js": "npm:@supabase/supabase-js@2.47.10",
+    "hono": "npm:hono@4.9.2",
+    "zod": "npm:zod@4.1.13"
   }
 }

--- a/integrations/update-thought-mcp/index.ts
+++ b/integrations/update-thought-mcp/index.ts
@@ -87,7 +87,7 @@ server.registerTool(
         .optional()
         .describe("New text content — triggers re-embedding when provided"),
       metadata_patch: z
-        .record(z.unknown())
+        .record(z.string(), z.unknown())
         .optional()
         .describe(
           "Partial metadata to shallow-merge into the existing metadata JSONB. New keys are added; existing keys are overwritten; keys not mentioned are left alone.",


### PR DESCRIPTION
## What

Two bugs prevented the `update-thought-mcp` integration from running when deployed as-is. Both are fixed here (2 files, 6 insertions, 2 deletions).

### 1. `deno.json` import map is incomplete
The import map only declared `@supabase/supabase-js`, but `index.ts` also imports `@modelcontextprotocol/sdk`, `@hono/mcp`, `hono`, and `zod` as **bare** specifiers. Deno cannot resolve those, so the Edge Function fails to boot. Added the four missing imports, pinned to the same versions the sibling `delete-thought-mcp` integration and the core `open-brain-mcp` server already use (sdk `1.24.3`, `@hono/mcp` `0.1.1`, hono `4.9.2`, zod `4.1.13`).

### 2. `metadata_patch` uses Zod 3 `z.record()` syntax
`z.record(z.unknown())` (single argument) is Zod 3. Under Zod 4 — which the pinned `zod@4.1.13` is — `z.record()` requires an explicit key type, and the malformed schema makes `tools/list` fail with:

```
-32603 Cannot read properties of undefined (reading '_zod')
```

Changed to `z.record(z.string(), z.unknown())`.

## Verification

Deployed both fixes to a live Supabase Edge Function and confirmed:
- The function boots (previously failed on unresolved imports).
- `tools/list` returns `update_thought` (previously `-32603 … '_zod'`).
- Round-trips behave as documented: `metadata_patch`-only merges without re-embedding; `content` triggers re-embedding and advances `updated_at`; a stale `if_unchanged_since` is rejected with `STALE_READ`.

## Scope
Bugfix only — no behavior change to the tool's documented contract, no new files, README/metadata untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Nz1dhrcZAGurh7FZfwesZb