### PR TITLE
[integrations] Fix Smart Ingest for uuid thought ids + persist embeddings

### DIFF
--- a/integrations/open-brain-rest/index.ts
+++ b/integrations/open-brain-rest/index.ts
@@ -1,6 +1,7 @@
 import "jsr:@supabase/functions-js/edge-runtime.d.ts";
 
 import { Hono } from "hono";
+import type { ContentfulStatusCode } from "hono/utils/http-status";
 import { createClient } from "@supabase/supabase-js";
 import { z } from "zod";
 
@@ -626,15 +627,87 @@ app.post("/thought/:id/reflection", async (c) => {
   return c.json(data, 200, corsHeaders);
 });
 
-app.get("/ingestion-jobs", (c) => c.json({ jobs: [], count: 0 }, 200, corsHeaders));
-app.get("/ingestion-jobs/:id", (c) => c.json({ job: null, items: [] }, 200, corsHeaders));
-app.post("/ingestion-jobs/:id/execute", (c) => c.json({ job_id: c.req.param("id"), status: "not_configured" }, 200, corsHeaders));
+// ── Smart Ingest wiring ─────────────────────────────────────────────────────
+// These routes proxy the dashboard's "Add to Brain" extract path to the
+// deployed `smart-ingest` Edge Function and expose the ingestion_jobs /
+// ingestion_items pipeline tables. The gateway calls smart-ingest
+// server-to-server with the shared MCP access key (smart-ingest runs
+// verify_jwt=false and authenticates via x-brain-key).
+
+const SMART_INGEST_URL = `${SUPABASE_URL}/functions/v1/smart-ingest`;
+
+async function callSmartIngest(path: string, payload: unknown) {
+  const res = await fetch(`${SMART_INGEST_URL}${path}`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json", "x-brain-key": MCP_ACCESS_KEY },
+    body: JSON.stringify(payload),
+  });
+  const data = await res.json().catch(() => ({ error: "smart-ingest returned non-JSON" }));
+  return { status: res.status, data };
+}
+
+app.get("/ingestion-jobs", async (c) => {
+  const limit = intParam(new URL(c.req.url).searchParams.get("limit"), 50, 1, 200);
+  const { data, error } = await supabase
+    .from("ingestion_jobs")
+    .select("*")
+    .order("created_at", { ascending: false })
+    .limit(limit);
+  if (error) return c.json({ error: error.message }, 500, corsHeaders);
+  return c.json({ jobs: data ?? [], count: (data ?? []).length }, 200, corsHeaders);
+});
+
+app.get("/ingestion-jobs/:id", async (c) => {
+  const id = Number(c.req.param("id"));
+  if (!Number.isInteger(id) || id <= 0) return c.json({ error: "Invalid id" }, 400, corsHeaders);
+  const { data: job, error: jobErr } = await supabase
+    .from("ingestion_jobs")
+    .select("*")
+    .eq("id", id)
+    .maybeSingle();
+  if (jobErr) return c.json({ error: jobErr.message }, 500, corsHeaders);
+  if (!job) return c.json({ error: "Job not found" }, 404, corsHeaders);
+  const { data: items, error: itemsErr } = await supabase
+    .from("ingestion_items")
+    .select("*")
+    .eq("job_id", id)
+    .order("id", { ascending: true });
+  if (itemsErr) return c.json({ error: itemsErr.message }, 500, corsHeaders);
+  return c.json({ job, items: items ?? [] }, 200, corsHeaders);
+});
+
+app.post("/ingestion-jobs/:id/execute", async (c) => {
+  const id = Number(c.req.param("id"));
+  if (!Number.isInteger(id) || id <= 0) return c.json({ error: "Invalid id" }, 400, corsHeaders);
+  const body = await c.req.json().catch(() => ({}));
+  try {
+    const { status, data } = await callSmartIngest("/execute", {
+      job_id: id,
+      skip_classification: body.skip_classification,
+    });
+    return c.json(data, status as ContentfulStatusCode, corsHeaders);
+  } catch (error) {
+    return c.json({ error: error instanceof Error ? error.message : "Execute failed" }, 502, corsHeaders);
+  }
+});
+
 app.post("/ingest", async (c) => {
   const body = await c.req.json().catch(() => ({}));
   const text = String(body.text || "").trim();
   if (!text) return c.json({ error: "text is required" }, 400, corsHeaders);
-  const result = await createThought({ content: text, source_type: "dashboard_ingest" });
-  return c.json({ job_id: 0, status: "complete", extracted_count: 1, thought_id: result.thought_id }, 200, corsHeaders);
+  try {
+    const { status, data } = await callSmartIngest("", {
+      text,
+      dry_run: body.dry_run,
+      skip_classification: body.skip_classification,
+      source_label: body.source_label ?? "dashboard",
+      source_type: body.source_type ?? "dashboard_ingest",
+      source_metadata: { source_client: "dashboard", capture_mode: "add_to_brain" },
+    });
+    return c.json(data, status as ContentfulStatusCode, corsHeaders);
+  } catch (error) {
+    return c.json({ error: error instanceof Error ? error.message : "Ingest failed" }, 502, corsHeaders);
+  }
 });
 
 Deno.serve((req) => {

--- a/integrations/smart-ingest/README.md
+++ b/integrations/smart-ingest/README.md
@@ -98,7 +98,7 @@ This Edge Function depends on these database functions:
 |-----|--------|---------|
 | `upsert_thought(text, jsonb)` | Core OB1 schema (Step 2.6) | Creates or updates a thought with content and payload |
 | `match_thoughts(vector, float, int)` | Core OB1 schema | Semantic similarity search for deduplication |
-| `append_thought_evidence(bigint, jsonb)` | `schemas/smart-ingest-tables` | Appends corroborating evidence to an existing thought's metadata |
+| `append_thought_evidence(uuid, jsonb)` | `schemas/smart-ingest-tables` | Appends corroborating evidence to an existing thought's metadata |
 
 ## Credential Tracker
 

--- a/integrations/smart-ingest/index.ts
+++ b/integrations/smart-ingest/index.ts
@@ -39,6 +39,7 @@ import {
   CLASSIFIER_MODEL_OPENAI,
   CLASSIFIER_MODEL_ANTHROPIC,
   MAX_TAGS_PER_THOUGHT,
+  type PreparedPayload,
 } from "./_shared/config.ts";
 
 // ── Environment ─────────────────────────────────────────────────────────────
@@ -141,7 +142,7 @@ interface IngestionItem {
   content_fingerprint: string;
   action: ReconcileAction;
   reason: string;
-  matched_thought_id: number | null;
+  matched_thought_id: ThoughtId | null;
   similarity_score: number | null;
   status: "pending" | "executed" | "failed";
   error_message: string | null;
@@ -163,9 +164,12 @@ interface IngestionJob {
   error_message: string | null;
 }
 
+/** A thought's primary key. Open Brain instances use bigint or uuid. */
+type ThoughtId = number | string;
+
 type UpsertThoughtResult = {
-  thought_id?: number;
-  id?: number;
+  thought_id?: ThoughtId;
+  id?: ThoughtId;
 };
 
 // ── Auth ────────────────────────────────────────────────────────────────────
@@ -347,15 +351,27 @@ function mergeTags(existing: unknown, extras: string[]): string[] {
   ]);
 }
 
-function extractThoughtId(value: unknown): number | null {
+/**
+ * Normalize a thought id returned by the DB. Open Brain instances key the
+ * thoughts table by either bigint or uuid; accept both. A number must be
+ * finite; a string must be non-empty after trimming.
+ */
+function normalizeThoughtId(value: unknown): ThoughtId | null {
   if (typeof value === "number" && Number.isFinite(value)) return value;
+  if (typeof value === "string" && value.trim() !== "") return value;
+  return null;
+}
+
+function extractThoughtId(value: unknown): ThoughtId | null {
+  const direct = normalizeThoughtId(value);
+  if (direct !== null) return direct;
   if (value && typeof value === "object" && "thought_id" in value) {
-    const thoughtId = (value as UpsertThoughtResult).thought_id;
-    if (typeof thoughtId === "number" && Number.isFinite(thoughtId)) return thoughtId;
+    const byThoughtId = normalizeThoughtId((value as UpsertThoughtResult).thought_id);
+    if (byThoughtId !== null) return byThoughtId;
   }
   if (value && typeof value === "object" && "id" in value) {
-    const id = (value as UpsertThoughtResult).id;
-    if (typeof id === "number" && Number.isFinite(id)) return id;
+    const byId = normalizeThoughtId((value as UpsertThoughtResult).id);
+    if (byId !== null) return byId;
   }
   return null;
 }
@@ -595,7 +611,7 @@ async function reconcileThought(
     tags: thought.tags,
     source_snippet: thought.source_snippet,
     content_fingerprint: fingerprint,
-    matched_thought_id: null as number | null,
+    matched_thought_id: null as ThoughtId | null,
     similarity_score: null as number | null,
   };
 
@@ -649,7 +665,7 @@ async function reconcileThought(
 
   const topMatch = matches[0];
   const similarity = topMatch.similarity as number;
-  const matchedId = topMatch.id as number;
+  const matchedId = topMatch.id as ThoughtId;
   const existingContent = (topMatch.content ?? "") as string;
 
   base.matched_thought_id = matchedId;
@@ -672,6 +688,32 @@ async function reconcileThought(
 
 // ── Execution ───────────────────────────────────────────────────────────────
 
+/**
+ * Backfill the enhanced-thoughts columns after upsert_thought.
+ *
+ * This instance's `upsert_thought` RPC only persists content, fingerprint, and
+ * metadata — it ignores the typed columns and the embedding. Mirroring the REST
+ * gateway's own capture path, we follow the upsert with a direct UPDATE so the
+ * thought gets its type/importance/source_type/quality_score/sensitivity_tier
+ * and, critically, its embedding — without which future semantic dedup could
+ * never match this thought. Non-fatal: a failed enrichment leaves a valid
+ * thought (content + metadata already written), so we log and continue.
+ */
+async function enrichThoughtColumns(thoughtId: ThoughtId, prepared: PreparedPayload): Promise<void> {
+  const updates: Record<string, unknown> = {
+    type: prepared.type,
+    importance: prepared.importance,
+    quality_score: prepared.quality_score,
+    source_type: prepared.source_type,
+    sensitivity_tier: prepared.sensitivity_tier,
+  };
+  if (safeEmbedding(prepared.embedding)) updates.embedding = prepared.embedding;
+  const { error } = await supabase.from("thoughts").update(updates).eq("id", thoughtId);
+  if (error) {
+    console.warn(`enrichThoughtColumns failed for thought ${thoughtId}: ${error.message}`);
+  }
+}
+
 async function executeItem(
   item: IngestionItem,
   embedding: number[],
@@ -679,7 +721,7 @@ async function executeItem(
   sourceType: string | null,
   sourceMetadata?: Record<string, unknown> | null,
   skipClassification = false,
-): Promise<number | null> {
+): Promise<ThoughtId | null> {
   switch (item.action) {
     case "add": {
       const prepared = await prepareThoughtPayload(item.content, {
@@ -717,6 +759,7 @@ async function executeItem(
       if (error) throw new Error(`upsert_thought failed: ${error.message}`);
       const thoughtId = extractThoughtId(data);
       if (thoughtId === null) throw new Error("upsert_thought returned no thought_id");
+      await enrichThoughtColumns(thoughtId, prepared);
       return thoughtId;
     }
 
@@ -772,6 +815,7 @@ async function executeItem(
       if (error) throw new Error(`upsert_thought (revision) failed: ${error.message}`);
       const thoughtId = extractThoughtId(data);
       if (thoughtId === null) throw new Error("upsert_thought (revision) returned no thought_id");
+      await enrichThoughtColumns(thoughtId, prepared);
       return thoughtId;
     }
 

--- a/schemas/smart-ingest/README.md
+++ b/schemas/smart-ingest/README.md
@@ -55,7 +55,7 @@ After running the migration:
 - Two new tables: `ingestion_jobs` (tracks job lifecycle with status, counters, and metadata) and `ingestion_items` (stores extracted thoughts with action codes, dedup reasons, and execution results). Both tables include a nullable `user_id uuid` column; on Supabase it references `auth.users(id) ON DELETE CASCADE`.
 - Three indexes: `ingestion_items_job_idx` on `ingestion_items(job_id)` for fast job-to-item lookups, plus partial indexes `idx_ingestion_jobs_pending` (jobs in `status = 'pending'`) and `idx_ingestion_items_pending` (items in `status IN ('pending','ready')`) to keep the worker's queue polling small.
 - Row Level Security enabled on both tables with a `service_role ALL` policy on each, and — on Supabase — an `authenticated SELECT` policy scoped to `user_id = auth.uid()` so a signed-in user can read only their own rows.
-- One RPC function `append_thought_evidence(bigint, jsonb)` that idempotently appends evidence entries to a thought's metadata.
+- One RPC function `append_thought_evidence(uuid, jsonb)` that idempotently appends evidence entries to a thought's metadata.
 - Service role has full access to both tables and their sequences. The `append_thought_evidence` RPC is **service-role only** — it is `SECURITY DEFINER` and bypasses RLS on `thoughts`, so it is revoked from `public` and granted only to `service_role`. The companion Edge Function (`integrations/smart-ingest/`) must call it with the Supabase service role key, never the anon key.
 
 ## Job Claim Semantics

--- a/schemas/smart-ingest/schema.sql
+++ b/schemas/smart-ingest/schema.sql
@@ -40,9 +40,11 @@ CREATE TABLE IF NOT EXISTS public.ingestion_items (
   action text NOT NULL DEFAULT 'pending',   -- pending, add, skip, append_evidence, create_revision
   status text NOT NULL DEFAULT 'pending',   -- pending, ready, executed, failed
   reason text,
-  matched_thought_id bigint,
+  -- Open Brain keys public.thoughts by uuid (see docs/01-getting-started.md),
+  -- so references to a thought id must be uuid, not bigint.
+  matched_thought_id uuid,
   similarity_score numeric(5,4),
-  result_thought_id bigint,
+  result_thought_id uuid,
   error_message text,
   metadata jsonb DEFAULT '{}',
   created_at timestamptz DEFAULT now()
@@ -118,7 +120,7 @@ $$;
 -- ============================================================
 
 CREATE OR REPLACE FUNCTION public.append_thought_evidence(
-  p_thought_id bigint,
+  p_thought_id uuid,  -- thoughts.id is uuid (see docs/01-getting-started.md)
   p_evidence jsonb  -- {source, extracted_at, excerpt, source_label}
 )
 RETURNS jsonb
@@ -201,8 +203,8 @@ GRANT ALL ON TABLE public.ingestion_jobs TO service_role;
 GRANT ALL ON TABLE public.ingestion_items TO service_role;
 GRANT USAGE, SELECT ON SEQUENCE public.ingestion_jobs_id_seq TO service_role;
 GRANT USAGE, SELECT ON SEQUENCE public.ingestion_items_id_seq TO service_role;
-REVOKE EXECUTE ON FUNCTION public.append_thought_evidence(bigint, jsonb) FROM public;
-GRANT EXECUTE ON FUNCTION public.append_thought_evidence(bigint, jsonb)
+REVOKE EXECUTE ON FUNCTION public.append_thought_evidence(uuid, jsonb) FROM public;
+GRANT EXECUTE ON FUNCTION public.append_thought_evidence(uuid, jsonb)
   TO service_role;
 
 -- ============================================================


### PR DESCRIPTION
## Contribution Type

- [x] Integration (`/integrations`)
- [x] Schema (`/schemas`)

## What does this do?

Fixes the **Smart Ingest** pipeline so its extract → dedup → execute path works on a canonical Open Brain instance. Open Brain keys `public.thoughts` by **uuid** (`docs/01-getting-started.md`), but Smart Ingest assumed **bigint** thought ids. The dry-run preview works, but executing a job fails on every item with `upsert_thought returned no thought_id` and leaves orphaned rows. This also stores embeddings on ingested thoughts (previously omitted), and wires the `open-brain-rest` gateway's ingest routes so the dashboard "Add to Brain" extract path works end to end.

### Changes
1. **uuid-agnostic thought ids** (`integrations/smart-ingest/index.ts`) — `extractThoughtId` accepts uuid strings; a `ThoughtId = number | string` alias is threaded through the reconciliation/execute types. Job/item ids stay numeric (bigserial); only *thought* ids were ever uuid.
2. **Schema matches uuid** (`schemas/smart-ingest`) — `ingestion_items.matched_thought_id` / `result_thought_id` `bigint → uuid`; `append_thought_evidence(p_thought_id …)` `bigint → uuid` (grants + README updated).
3. **Persist enhanced columns + embedding** — the canonical `upsert_thought` only writes content/fingerprint/metadata, so executed thoughts never got their embedding and semantic dedup could never match them (fingerprint-only). Mirroring the REST gateway's own capture path, each write is followed by a direct `UPDATE` that backfills `type`/`importance`/`source_type`/`quality_score`/`sensitivity_tier` + `embedding`. Non-fatal on error.
4. **Wire the gateway** (`integrations/open-brain-rest/index.ts`) — the four ingest routes were stubs (`POST /ingest` saved the whole blob as one thought; job routes returned empty / `not_configured`). They now proxy to the `smart-ingest` Edge Function and read the `ingestion_jobs` / `ingestion_items` tables.

## Requirements

No new external services. Same prerequisites as Smart Ingest today: the `enhanced-thoughts` schema (adds the columns the enrichment backfills), the `smart-ingest` tables schema, an LLM key (OpenRouter/OpenAI/Anthropic) and an embedding key. `open-brain-rest` reaches `smart-ingest` server-to-server with the shared `MCP_ACCESS_KEY`.

## Checklist

- [x] I've read CONTRIBUTING.md
- [x] My contribution has a `README.md` with prerequisites, step-by-step instructions, and expected outcome
- [x] My `metadata.json` has all required fields
- [x] If my contribution depends on a skill or primitive, I declared it in metadata.json and linked it in the README
- [x] I tested this on my own Open Brain instance
- [x] No credentials, API keys, or secrets are included

## Testing

Verified end to end on a live uuid instance through the dashboard → gateway → `smart-ingest` path:
- **Extract:** raw text → atomic thoughts, correctly typed (`decision` / `person_note` / `lesson`)
- **Execute:** `added_count: 3`, items `executed` and linked via `result_thought_id`, thoughts written with populated columns **and** embeddings
- **Semantic dedup:** a paraphrase of an ingested thought resolves to `create_revision` (not a duplicate `add`) — impossible before, since the original had no stored embedding

All test jobs and thoughts were cleaned up after verification. `deno check` passes on both functions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
