### PR TITLE
[skills] Make synthesis skills provenance-aware + surface read-path tools

### DIFF
--- a/skills/competitive-analysis/SKILL.md
+++ b/skills/competitive-analysis/SKILL.md
@@ -74,6 +74,8 @@ Useful but optional:
 6. Optionally use Open Brain.
    - Search for prior notes before repeating known findings.
    - Capture the finished brief or the highest-value strategic takeaways after the work is done.
+   - **Record provenance when the capability exists.** This skill produces a *derived* artifact synthesized from other thoughts. If the Open Brain setup exposes provenance-chains — a `capture_derived_thought` tool (the name may carry a connector prefix) or `derived_from` / `derivation_layer` columns — save the final brief as a derived artifact: set `derivation_layer = 'derived'`, `derivation_method = 'synthesis'`, and `derived_from` to the UUIDs of the Open Brain thoughts you actually pulled and built on (resolve ids with the search/read tool; drop any ref you cannot resolve to a UUID). If provenance is unavailable, capture normally — the synthesis is still saved, just without the derivation link.
+   - **Read-path tools.** To retrieve a specific prior thought in full, fetch it by id with `get_thought` (or the connector's `fetch` tool); use `related_thoughts` to surface what a thought connects to. Tool names may carry a connector prefix — use whatever the environment exposes.
 
 ## Evidence and Judgment Rules
 

--- a/skills/deal-memo-drafting/SKILL.md
+++ b/skills/deal-memo-drafting/SKILL.md
@@ -65,6 +65,8 @@ Gather or confirm:
 6. Optionally use Open Brain.
    - Search for prior deal notes, past meetings, or earlier thesis fragments.
    - Capture the final memo summary or recommendation after the draft is complete.
+   - **Record provenance when the capability exists.** This skill produces a *derived* artifact synthesized from other thoughts. If the Open Brain setup exposes provenance-chains — a `capture_derived_thought` tool (the name may carry a connector prefix) or `derived_from` / `derivation_layer` columns — save the final memo as a derived artifact: set `derivation_layer = 'derived'`, `derivation_method = 'synthesis'`, and `derived_from` to the UUIDs of the Open Brain thoughts you actually pulled and built on (resolve ids with the search/read tool; drop any ref you cannot resolve to a UUID). If provenance is unavailable, capture normally — the synthesis is still saved, just without the derivation link.
+   - **Read-path tools.** To retrieve a specific prior thought in full, fetch it by id with `get_thought` (or the connector's `fetch` tool); use `related_thoughts` to surface what a thought connects to. Tool names may carry a connector prefix — use whatever the environment exposes.
 
 ## Evidence and Judgment Rules
 

--- a/skills/financial-model-review/SKILL.md
+++ b/skills/financial-model-review/SKILL.md
@@ -71,6 +71,8 @@ Useful but optional:
 7. Optionally use Open Brain.
    - Search for prior model assumptions, earlier reviews, or management claims.
    - Capture the final review memo or most important flags after completion.
+   - **Record provenance when the capability exists.** This skill produces a *derived* artifact synthesized from other thoughts. If the Open Brain setup exposes provenance-chains — a `capture_derived_thought` tool (the name may carry a connector prefix) or `derived_from` / `derivation_layer` columns — save the final review memo as a derived artifact: set `derivation_layer = 'derived'`, `derivation_method = 'synthesis'`, and `derived_from` to the UUIDs of the Open Brain thoughts you actually pulled and built on (resolve ids with the search/read tool; drop any ref you cannot resolve to a UUID). If provenance is unavailable, capture normally — the synthesis is still saved, just without the derivation link.
+   - **Read-path tools.** To retrieve a specific prior thought in full, fetch it by id with `get_thought` (or the connector's `fetch` tool); use `related_thoughts` to surface what a thought connects to. Tool names may carry a connector prefix — use whatever the environment exposes.
 
 ## Evidence and Judgment Rules
 

--- a/skills/meeting-synthesis/SKILL.md
+++ b/skills/meeting-synthesis/SKILL.md
@@ -62,6 +62,8 @@ Gather or confirm:
 6. Optionally use Open Brain.
    - Search for prior related meetings or project notes before starting.
    - Capture key decisions or the final synthesis after the work is complete.
+   - **Record provenance when the capability exists.** This skill produces a *derived* artifact synthesized from other thoughts. If the Open Brain setup exposes provenance-chains — a `capture_derived_thought` tool (the name may carry a connector prefix) or `derived_from` / `derivation_layer` columns — save the final synthesis / decisions as a derived artifact: set `derivation_layer = 'derived'`, `derivation_method = 'synthesis'`, and `derived_from` to the UUIDs of the Open Brain thoughts you actually pulled and built on (resolve ids with the search/read tool; drop any ref you cannot resolve to a UUID). If provenance is unavailable, capture normally — the synthesis is still saved, just without the derivation link.
+   - **Read-path tools.** To retrieve a specific prior thought in full, fetch it by id with `get_thought` (or the connector's `fetch` tool); use `related_thoughts` to surface what a thought connects to. Tool names may carry a connector prefix — use whatever the environment exposes.
 
 ## Evidence and Judgment Rules
 

--- a/skills/research-synthesis/SKILL.md
+++ b/skills/research-synthesis/SKILL.md
@@ -65,6 +65,8 @@ Gather or confirm:
 7. Optionally use Open Brain.
    - Search for prior related notes before starting.
    - Capture the final synthesis or highest-value findings after completion.
+   - **Record provenance when the capability exists.** This skill produces a *derived* artifact synthesized from other thoughts. If the Open Brain setup exposes provenance-chains — a `capture_derived_thought` tool (the name may carry a connector prefix) or `derived_from` / `derivation_layer` columns — save the final synthesis as a derived artifact: set `derivation_layer = 'derived'`, `derivation_method = 'synthesis'`, and `derived_from` to the UUIDs of the Open Brain thoughts you actually pulled and built on (resolve ids with the search/read tool; drop any ref you cannot resolve to a UUID). If provenance is unavailable, capture normally — the synthesis is still saved, just without the derivation link.
+   - **Read-path tools.** To retrieve a specific prior thought in full, fetch it by id with `get_thought` (or the connector's `fetch` tool); use `related_thoughts` to surface what a thought connects to. Tool names may carry a connector prefix — use whatever the environment exposes.
 
 ## Evidence and Judgment Rules
 

--- a/skills/weekly-signal-diff/SKILL.md
+++ b/skills/weekly-signal-diff/SKILL.md
@@ -122,6 +122,20 @@ Use this default structure:
      important follow-up items.
    - Include provenance: week ending date, topic scope, and major entities
      covered.
+   - **Record provenance when the capability exists.** This skill produces a
+     *derived* artifact synthesized from other thoughts. If the Open Brain setup
+     exposes provenance-chains — a `capture_derived_thought` tool (the name may
+     carry a connector prefix) or `derived_from` / `derivation_layer` columns —
+     save the final digest as a derived artifact: set
+     `derivation_layer = 'derived'`, `derivation_method = 'synthesis'`, and
+     `derived_from` to the UUIDs of the Open Brain thoughts you actually pulled
+     and built on (resolve ids with the search/read tool; drop any ref you cannot
+     resolve to a UUID). If provenance is unavailable, capture normally — the
+     digest is still saved, just without the derivation link.
+   - **Read-path tools.** To retrieve a specific prior thought in full, fetch it
+     by id with `get_thought` (or the connector's `fetch` tool); use
+     `related_thoughts` to surface what a thought connects to. Tool names may
+     carry a connector prefix — use whatever the environment exposes.
 
 ## Output
 


### PR DESCRIPTION
## Summary

The six operator/investor **synthesis** skills each produce a *derived* artifact — a research brief, IC memo, competitive brief, review memo, or weekly digest — synthesized from source thoughts. Until now they only ever captured that output as a **plain, orphaned thought**, so the "why do I believe this?" / "what uses this?" chain was lost.

This teaches them to:

1. **Record provenance when the capability exists** — if the Open Brain setup exposes provenance-chains (a `capture_derived_thought` tool, or `derived_from`/`derivation_layer` columns), save the final artifact as *derived*: `derivation_layer = 'derived'`, `derivation_method = 'synthesis'`, `derived_from = ` the UUIDs of the thoughts actually built on. Falls back to a normal capture when unavailable.
2. **Reach for read-path tools** — fetch a specific prior thought in full with `get_thought` (or the connector's `fetch`), and surface connections with `related_thoughts`.

Both additions follow the repo's existing **connector-agnostic** convention — tool names "may carry a connector prefix," and everything degrades gracefully when a tool isn't present. **No hardcoded `brain_` prefix**, so stock-only installs are unaffected. This mirrors the pattern `panning-for-gold` already uses for provenance.

## Files (6)

- `skills/research-synthesis/SKILL.md`
- `skills/meeting-synthesis/SKILL.md`
- `skills/competitive-analysis/SKILL.md`
- `skills/deal-memo-drafting/SKILL.md`
- `skills/financial-model-review/SKILL.md`
- `skills/weekly-signal-diff/SKILL.md`

Each change is a pure insertion under the skill's existing "capture the output" step (weekly-signal-diff integrates into its richer capture section). No existing text rewritten.

## Notes

- `updating-thoughts` / `deleting-thoughts` would also benefit (inspect via `get_thought` before editing; run `find_derivatives` before deleting so derived thoughts aren't orphaned) — deferred because those skills aren't on `main` yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
