### PR TITLE
[recipes] Fix editorial-policy auditor JSON parse under claude-haiku-4-5

### DIFF
--- a/recipes/editorial-policy/auditor/index.ts
+++ b/recipes/editorial-policy/auditor/index.ts
@@ -297,9 +297,21 @@ async function callAuditor(
     throw new Error("OpenRouter returned empty content");
   }
 
+  // Some models (e.g. Anthropic claude-haiku-4-5 via OpenRouter — the stricter
+  // reasoner this recipe recommends in Troubleshooting) wrap JSON in a ```json
+  // fence even when response_format=json_object is requested. Strip it before
+  // parse so the model swap doesn't break the parser.
+  let jsonText = text.trim();
+  if (jsonText.startsWith("```")) {
+    jsonText = jsonText
+      .replace(/^```(?:json)?\s*/i, "")
+      .replace(/\s*```$/, "")
+      .trim();
+  }
+
   let parsed: unknown;
   try {
-    parsed = JSON.parse(text);
+    parsed = JSON.parse(jsonText);
   } catch (e) {
     throw new Error(`Auditor returned non-JSON: ${(e as Error).message}`);
   }


### PR DESCRIPTION
## What

The editorial-policy **auditor** Edge Function requests `response_format: { type: "json_object" }` from OpenRouter, then does `JSON.parse(text)` on the reply.

- `openai/gpt-4o-mini` (the recipe default) returns **bare** JSON → parses fine.
- `anthropic/claude-haiku-4-5` — the stricter reasoner this recipe's **own Troubleshooting section recommends** ("_Switch to a stricter reasoner like `claude-haiku-4-5`_") — wraps its reply in a ```` ```json … ``` ```` markdown fence even with `response_format=json_object`. `JSON.parse` then throws `Unexpected token '`'` and **every run 500s** (`{"ok":false,"error":"Auditor returned non-JSON..."}`).

So the recipe's documented "upgrade for stricter compliance reasoning" path is currently broken out of the box.

## Fix

Strip a leading/trailing code fence before parsing:

```ts
let jsonText = text.trim();
if (jsonText.startsWith("```")) {
  jsonText = jsonText.replace(/^```(?:json)?\s*/i, "").replace(/\s*```$/, "").trim();
}
```

- **No behavior change for `gpt-4o-mini`** — bare JSON doesn't start with a fence, so the branch is skipped.
- **Recipe default model is unchanged** (`openai/gpt-4o-mini`). This only unblocks the documented swap.

## Testing

Reproduced live against a real ~260-thought Open Brain:

- **Before:** every invocation returned HTTP 500, `Auditor returned non-JSON: Unexpected token '`'`.
- **After:** the same corpus returns valid structured findings (verified dry-run + a stored `audit_report`), severity rubric behaving as intended (0 critical / mostly moderate), no malformed UUIDs surviving validation.

One-line change to `recipes/editorial-policy/auditor/index.ts`; no schema, prompt, or interface changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)