### PR TITLE
[recipes] editorial-policy: schedule.sql header+Vault auth (no key in URL)

### DIFF
--- a/recipes/editorial-policy/schedule.sql
+++ b/recipes/editorial-policy/schedule.sql
@@ -4,34 +4,49 @@
 --
 -- BEFORE RUNNING:
 --   Replace <YOUR-PROJECT-REF> with your Supabase project reference.
---   Replace <YOUR-AUDITOR-KEY> with the value of your AUDITOR_ACCESS_KEY
---   secret (any random string you choose — used to gate the function URL).
+--   Store your AUDITOR_ACCESS_KEY in Supabase Vault (step 0 below) so the
+--   key is read at fire time instead of being pasted into the job command.
 -- ============================================================
 --
 -- Prerequisites:
 --   pg_cron + pg_net extensions enabled.
 --   To enable: Database → Extensions → search for pg_cron and pg_net → enable both.
 --
+-- SECURITY NOTE — why header auth + Vault, not ?key= in the URL:
+--   A key embedded in the URL is stored verbatim in cron.job.command (readable
+--   by anyone with SQL access) AND appears in Supabase's function-invocation
+--   logs on every run. Passing the key as a request header, read from Vault at
+--   fire time, keeps it out of both. The auditor accepts the same key via the
+--   x-auditor-key header.
+--
 -- Default timing: Sunday 09:00 UTC. Adjust the cron expression
 -- to fit your weekly summary schedule. The auditor should run BEFORE
 -- the weekly summary so it has the full week to inspect.
 -- ============================================================
+
+-- 0. One-time: store the auditor key in Vault (same value as the
+--    AUDITOR_ACCESS_KEY function secret). Run once; to change it later use
+--    vault.update_secret rather than re-running create_secret.
+-- SELECT vault.create_secret('<YOUR-AUDITOR-KEY>', 'auditor_access_key');
 
 SELECT cron.schedule(
   'weekly-auditor',
   '0 9 * * 0',
   $$
   SELECT net.http_post(
-    url := 'https://<YOUR-PROJECT-REF>.supabase.co/functions/v1/auditor?key=<YOUR-AUDITOR-KEY>',
+    url := 'https://<YOUR-PROJECT-REF>.supabase.co/functions/v1/auditor',
     headers := jsonb_build_object(
-      'Content-Type', 'application/json'
+      'Content-Type', 'application/json',
+      'x-auditor-key', (SELECT decrypted_secret FROM vault.decrypted_secrets
+                        WHERE name = 'auditor_access_key')
     ),
     body := jsonb_build_object(
       'days', 30,
       'post_to_slack', true,
       'dry_run', false,
       'prior_audit_count', 4
-    )
+    ),
+    timeout_milliseconds := 150000
   );
   $$
 );
@@ -40,7 +55,9 @@ SELECT cron.schedule(
 -- Verify scheduled:
 --   SELECT jobname, schedule FROM cron.job WHERE jobname = 'weekly-auditor';
 --
--- Run history:
+-- Run history (NOTE: pg_cron records 'succeeded' when the HTTP request was
+-- QUEUED, not when the function returned 2xx — check net._http_response for
+-- the function-level outcome):
 --   SELECT jobname, start_time, status, return_message
 --   FROM cron.job_run_details
 --   WHERE jobid = (SELECT jobid FROM cron.job WHERE jobname = 'weekly-auditor')
@@ -48,8 +65,12 @@ SELECT cron.schedule(
 --
 -- Manual test (dry run, no Slack post, no audit_report stored):
 --   SELECT net.http_post(
---     url := 'https://<YOUR-PROJECT-REF>.supabase.co/functions/v1/auditor?key=<YOUR-AUDITOR-KEY>',
---     headers := jsonb_build_object('Content-Type', 'application/json'),
+--     url := 'https://<YOUR-PROJECT-REF>.supabase.co/functions/v1/auditor',
+--     headers := jsonb_build_object(
+--       'Content-Type', 'application/json',
+--       'x-auditor-key', (SELECT decrypted_secret FROM vault.decrypted_secrets
+--                         WHERE name = 'auditor_access_key')
+--     ),
 --     body := jsonb_build_object('days', 30, 'post_to_slack', false, 'dry_run', true)
 --   );
 --


### PR DESCRIPTION
## What

Fixes the scheduling example in `recipes/editorial-policy/schedule.sql` to stop embedding the auditor access key in the function URL.

## Why

The stock example puts `?key=<AUDITOR-KEY>` in the URL, which persists the secret in two places: `cron.job.command` (readable by anyone with SQL access, forever) and Supabase's function-invocation logs (on every run). I hit this live — the key had to be rotated after being carried in cron commands and logs.

## How

- Auth moves to the `x-auditor-key` **header** (already accepted by the stock auditor), with the key read from **Supabase Vault at fire time** (`vault.decrypted_secrets`) so it never sits in the job command.
- Adds an explicit `timeout_milliseconds` — without it, pg_net frequently records `NULL` status codes for slower LLM functions, making outcomes unobservable.
- Documents the pg_cron gotcha: `job_run_details.status='succeeded'` only means the HTTP request was **queued**, not that the function returned 2xx — check `net._http_response` for the real outcome.

Docs/SQL-only change; no function code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)