### PR TITLE
[recipes] provenance-chains: fix eval.mjs default model (dated id 404s on OpenRouter)

### DIFF
--- a/recipes/provenance-chains/eval.mjs
+++ b/recipes/provenance-chains/eval.mjs
@@ -34,7 +34,7 @@
  *   --ids a,b,c                        grade specific thought IDs only
  *   --force                            re-grade thoughts already scored
  *   --dry-run                          skip PATCH back to DB
- *   --model NAME                       openrouter model (default: anthropic/claude-3.5-haiku)
+ *   --model NAME                       openrouter model (default: anthropic/claude-haiku-4-5)
  *   --concurrency N                    openrouter grader concurrency (default 3)
  *   --out FILE                         queue mode prompts output path
  *   --apply-scores FILE                write scores from a queue-mode JSONL back to DB
@@ -52,7 +52,7 @@ function parseArgs(argv) {
     ids: null,
     force: false,
     dryRun: false,
-    model: "anthropic/claude-3.5-haiku",
+    model: "anthropic/claude-haiku-4-5",
     concurrency: 3,
     out: null,
     applyScores: null,


### PR DESCRIPTION
## What
`eval.mjs` defaults to `anthropic/claude-3.5-haiku`, which OpenRouter no longer serves — every grading call fails with `404 No endpoints found`, so a stock run scores 0/N and exits 1.

## How
Default switched to `anthropic/claude-haiku-4-5` (2 occurrences: the usage comment and the parseArgs default). `--model` still overrides.

Hit live while scheduling the nightly/weekly eval the recipe README recommends. Same failure class as the typed-edge-classifier fix in #415 — dated OpenRouter model ids rot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)