### PR TITLE
[recipes] editorial-policy: add mechanical hygiene block to the auditor

### DIFF
--- a/recipes/editorial-policy/README.md
+++ b/recipes/editorial-policy/README.md
@@ -30,6 +30,7 @@ Three failure modes the policy + auditor pair catches that scattered prompt-tuni
 - **`schema.sql`** — adds one helper RPC (`get_recent_audit_reports`) and one partial index on the `thoughts` table. No new tables.
 - **`auditor/index.ts`** + **`deno.json`** — Supabase Edge Function that runs weekly, scans recent thoughts, returns structured JSON findings, stores them as `type=audit_report` thoughts, and posts to Slack on critical findings only.
 - **`schedule.sql`** — pg_cron entry to fire the auditor weekly.
+- **`hygiene.sql`** *(optional, recommended)* — read-only lint views + a `lint_hygiene_summary()` function. When installed, the auditor computes mechanical hygiene counts (orphans, exact duplicates, missing fingerprints, low-signal noise, over-tagging, and — with the entity-extraction schema — isolated high-importance thoughts and zero-edge entities) **before** the LLM pass and stores them in `metadata.hygiene` on every audit_report, plus a human-readable section in the report content. Hygiene never posts to Slack. Without this file the auditor runs LLM-only, exactly as before.
 
 ## Prerequisites
 
@@ -128,6 +129,16 @@ cp <recipe>/auditor/index.ts  supabase/functions/auditor/index.ts
 cp <recipe>/auditor/deno.json supabase/functions/auditor/deno.json
 supabase functions deploy auditor
 ```
+
+### Step 5b (optional): Install the mechanical hygiene layer
+
+Run `hygiene.sql` in the SQL Editor. Everything in it is guarded — on installs missing the enhanced-thoughts schema, content-fingerprint dedup, or the entity-extraction schema, the corresponding views are skipped with a `NOTICE` and the summary reports what it can. Verify with:
+
+```sql
+SELECT lint_hygiene_summary();
+```
+
+Two design decisions worth knowing: hygiene is computed **before** the LLM call, and the LLM pass is wrapped so a provider failure stores a hygiene-only report with `metadata.llm_error` set instead of discarding the run — the free SQL pass is never gated behind the flaky paid one. And hygiene counts live in a separate `metadata.hygiene` block, never mixed into `findings`, so they stay independently queryable and can't inflate finding counts.
 
 ### Step 6: Schedule the weekly run
 

--- a/recipes/editorial-policy/auditor/index.ts
+++ b/recipes/editorial-policy/auditor/index.ts
@@ -88,6 +88,8 @@ interface AuditResult {
   findings: Finding[];
   slack_summary: string; // mrkdwn; only surfaced when critical findings exist
   baseline_note: string | null; // first-run context message
+  hygiene: Record<string, unknown> | null; // mechanical lint counts (never paged)
+  llm_error: string | null; // set when the LLM pass failed but hygiene was still stored
 }
 
 // ── Data fetching ────────────────────────────────────────────────────────
@@ -116,6 +118,21 @@ async function fetchPriorAudits(limit: number): Promise<PriorAudit[]> {
     return [];
   }
   return (data ?? []) as PriorAudit[];
+}
+
+// Mechanical lint hygiene (SQL-only, free). Definitions live in the lint_*
+// views installed by hygiene.sql; lint_hygiene_summary() aggregates their
+// counts into one JSON. Read this BEFORE the LLM call so a flaky/costly model
+// can never take the free hygiene metrics down with it. Returns null (not
+// throw) when hygiene.sql is not installed, so the auditor still works on a
+// stock LLM-only setup.
+async function fetchHygiene(): Promise<Record<string, unknown> | null> {
+  const { data, error } = await supabase.rpc("lint_hygiene_summary");
+  if (error) {
+    console.warn(`lint_hygiene_summary rpc unavailable (install hygiene.sql to enable): ${error.message}`);
+    return null;
+  }
+  return (data ?? null) as Record<string, unknown> | null;
 }
 
 // ── Prompt construction ──────────────────────────────────────────────────
@@ -428,6 +445,25 @@ function buildAuditContent(result: AuditResult): string {
     lines.push("_No findings. Brain looks clean for this window._");
   }
 
+  // Mechanical hygiene (lint Tier 1 + Tier 2) — informational, never paged.
+  if (result.hygiene) {
+    const h = result.hygiene as Record<string, number | boolean>;
+    lines.push("");
+    lines.push("*Hygiene (mechanical — not paged):*");
+    lines.push(
+      `• Tier 1: orphans-by-tag: ${h.orphans_by_tag ?? "?"} · exact-dup groups: ${h.exact_duplicate_groups ?? "?"} · missing fingerprint: ${h.missing_fingerprint ?? "?"} · low-signal: ${h.low_signal ?? "?"} · over-tagged: ${h.over_tagged ?? "?"} · very-long: ${h.very_long ?? "?"} (of ${h.total_thoughts ?? "?"} thoughts)`,
+    );
+    if (h.tier2_available) {
+      lines.push(
+        `• Tier 2 (graph): isolated high-importance: ${h.high_importance_isolated ?? "?"} · entities with zero edges: ${h.entities_zero_edges ?? "?"} (of ${h.entities_total ?? "?"} entities)`,
+      );
+    }
+  }
+  if (result.llm_error) {
+    lines.push("");
+    lines.push(`_LLM findings pass skipped this run: ${result.llm_error}_`);
+  }
+
   return lines.join("\n").trim();
 }
 
@@ -452,6 +488,8 @@ async function storeAuditReport(result: AuditResult): Promise<string> {
         moderate_count: result.findings.filter((f) => f.severity === "moderate").length,
         minor_count: result.findings.filter((f) => f.severity === "minor").length,
         findings: result.findings, // structured, queryable
+        hygiene: result.hygiene,   // mechanical lint counts (separate from findings)
+        llm_error: result.llm_error, // non-null when the LLM pass failed but hygiene stored
       },
     })
     .select("id")
@@ -503,6 +541,9 @@ Deno.serve(async (req: Request): Promise<Response> => {
 
     const corpus = await fetchAuditCorpus(days);
     const priorAudits = await fetchPriorAudits(priorAuditCount);
+    // Hygiene is computed regardless of the LLM path and even on an empty
+    // window, so mechanical metrics are recorded every run.
+    const hygiene = await fetchHygiene();
 
     const since = new Date(Date.now() - days * 24 * 60 * 60 * 1000).toISOString();
     const now = new Date().toISOString();
@@ -517,6 +558,8 @@ Deno.serve(async (req: Request): Promise<Response> => {
         slack_summary: "",
         baseline_note:
           "No synthesizable thoughts in window. Audit skipped LLM call; storing empty report for time-series continuity (R8.3).",
+        hygiene,
+        llm_error: null,
       };
       let storedId: string | null = null;
       if (!dryRun) storedId = await storeAuditReport(baselineResult);
@@ -534,10 +577,21 @@ Deno.serve(async (req: Request): Promise<Response> => {
 
     const systemPrompt = buildSystemPrompt();
     const userMessage = buildUserMessage(corpus, priorAudits, days);
-    const { findings, slack_summary } = await callAuditor(
-      systemPrompt,
-      userMessage,
-    );
+
+    // The LLM pass is flaky and costly; the hygiene pass above already
+    // succeeded. Don't let an OpenRouter failure discard the whole run —
+    // fall back to a hygiene-only report with the error recorded.
+    let findings: Finding[] = [];
+    let slack_summary = "";
+    let llmError: string | null = null;
+    try {
+      const res = await callAuditor(systemPrompt, userMessage);
+      findings = res.findings;
+      slack_summary = res.slack_summary;
+    } catch (e) {
+      llmError = (e as Error).message;
+      console.error("auditor LLM pass failed; storing hygiene-only report:", llmError);
+    }
 
     const result: AuditResult = {
       audit_window: { start: since, end: now, thought_count: corpus.length },
@@ -549,6 +603,8 @@ Deno.serve(async (req: Request): Promise<Response> => {
         priorAudits.length === 0
           ? "First audit run — no prior audits to chain against. This becomes the baseline."
           : null,
+      hygiene,
+      llm_error: llmError,
     };
 
     let storedId: string | null = null;
@@ -574,6 +630,8 @@ Deno.serve(async (req: Request): Promise<Response> => {
         minor_count: findings.filter((f) => f.severity === "minor").length,
         posted_to_slack: shouldPostSlack,
         dry_run: dryRun,
+        hygiene,
+        llm_error: llmError,
       }),
       { headers: { "Content-Type": "application/json" } },
     );

--- a/recipes/editorial-policy/hygiene.sql
+++ b/recipes/editorial-policy/hygiene.sql
@@ -1,0 +1,197 @@
+-- ============================================================
+-- editorial-policy: mechanical hygiene layer (optional, recommended)
+-- Run this in your Supabase SQL Editor (one-time setup, safe to re-run).
+--
+-- Installs read-only lint views plus a lint_hygiene_summary() function the
+-- auditor calls BEFORE its LLM pass. The auditor then stores the counts in
+-- metadata.hygiene on every audit_report and appends a human-readable
+-- hygiene section to the report content. Hygiene never triggers Slack —
+-- it is informational, following the same low-noise discipline as findings.
+--
+-- Everything is guarded: on a stock install without the enhanced-thoughts
+-- schema, content-fingerprint dedup, or the entity-extraction schema, the
+-- optional views are skipped and the summary reports what it can.
+-- Without this file installed at all, the auditor still works (LLM-only) —
+-- fetchHygiene() logs a warning and stores hygiene: null.
+--
+-- Adapted from recipes/lint-sweep views (Tier 1 SQL lint + Tier 2 graph lint).
+-- ============================================================
+
+-- ── Tier 1: thoughts-table lint (works on any install) ──────────────────────
+-- Column shapes match recipes/lint-sweep/views.sql exactly where the
+-- enhanced-thoughts columns exist, so CREATE OR REPLACE upgrades cleanly over
+-- a prior lint-sweep install (REPLACE cannot drop or reorder view columns).
+
+DO $$
+DECLARE has_enhanced boolean;
+BEGIN
+  SELECT EXISTS (SELECT 1 FROM information_schema.columns
+                 WHERE table_schema='public' AND table_name='thoughts'
+                   AND column_name='importance') INTO has_enhanced;
+  IF has_enhanced THEN
+    EXECUTE $v$
+      CREATE OR REPLACE VIEW lint_orphans_by_tag AS
+      SELECT id, created_at, importance, left(content,160) AS preview, source_type
+      FROM public.thoughts
+      WHERE COALESCE(jsonb_array_length(metadata->'topics'),0)=0
+        AND COALESCE(jsonb_array_length(metadata->'tags'),0)=0
+        AND COALESCE(jsonb_array_length(metadata->'people'),0)=0
+      ORDER BY id DESC;
+
+      CREATE OR REPLACE VIEW lint_empty_content AS
+      SELECT id, created_at, source_type, importance
+      FROM public.thoughts
+      WHERE content IS NULL OR btrim(content)=''
+      ORDER BY id DESC;
+    $v$;
+  ELSE
+    EXECUTE $v$
+      CREATE OR REPLACE VIEW lint_orphans_by_tag AS
+      SELECT id, created_at, left(content,160) AS preview
+      FROM public.thoughts
+      WHERE COALESCE(jsonb_array_length(metadata->'topics'),0)=0
+        AND COALESCE(jsonb_array_length(metadata->'tags'),0)=0
+        AND COALESCE(jsonb_array_length(metadata->'people'),0)=0
+      ORDER BY id DESC;
+
+      CREATE OR REPLACE VIEW lint_empty_content AS
+      SELECT id, created_at
+      FROM public.thoughts
+      WHERE content IS NULL OR btrim(content)=''
+      ORDER BY id DESC;
+    $v$;
+  END IF;
+END $$;
+
+CREATE OR REPLACE VIEW lint_over_tagged AS
+SELECT id, created_at, jsonb_array_length(metadata->'tags') AS tag_count, left(content,160) AS preview
+FROM public.thoughts
+WHERE COALESCE(jsonb_array_length(metadata->'tags'),0) > 10
+ORDER BY tag_count DESC;
+
+CREATE OR REPLACE VIEW lint_very_long AS
+SELECT id, created_at, length(content) AS chars, left(content,200) AS preview
+FROM public.thoughts
+WHERE length(content) > 20000
+ORDER BY chars DESC;
+
+-- Low-signal requires the enhanced-thoughts `importance` column; skipped if absent.
+DO $$
+BEGIN
+  IF EXISTS (SELECT 1 FROM information_schema.columns
+             WHERE table_schema='public' AND table_name='thoughts' AND column_name='importance') THEN
+    EXECUTE $v$
+      CREATE OR REPLACE VIEW lint_low_signal AS
+      SELECT id, created_at, importance, content
+      FROM public.thoughts
+      WHERE importance IS NOT NULL AND importance <= 2
+        AND length(COALESCE(btrim(content),'')) < 40
+      ORDER BY id DESC;
+    $v$;
+  ELSE
+    RAISE NOTICE 'importance column absent (schemas/enhanced-thoughts) — lint_low_signal skipped';
+  END IF;
+END $$;
+
+-- Duplicate detection requires content_fingerprint (recipes/content-fingerprint-dedup).
+DO $$
+BEGIN
+  IF EXISTS (SELECT 1 FROM information_schema.columns
+             WHERE table_schema='public' AND table_name='thoughts' AND column_name='content_fingerprint') THEN
+    EXECUTE $v$
+      CREATE OR REPLACE VIEW lint_exact_duplicates AS
+      SELECT content_fingerprint, count(*) AS copies, array_agg(id ORDER BY id) AS ids
+      FROM public.thoughts
+      WHERE content_fingerprint IS NOT NULL
+      GROUP BY content_fingerprint
+      HAVING count(*) > 1
+      ORDER BY copies DESC;
+    $v$;
+  ELSE
+    RAISE NOTICE 'content_fingerprint column absent (recipes/content-fingerprint-dedup) — lint_exact_duplicates skipped';
+  END IF;
+END $$;
+
+-- ── Tier 2: graph lint (requires schemas/entity-extraction) ─────────────────
+
+DO $$
+BEGIN
+  IF to_regclass('public.thought_entities') IS NOT NULL
+     AND to_regclass('public.entities') IS NOT NULL
+     AND to_regclass('public.edges') IS NOT NULL
+     AND EXISTS (SELECT 1 FROM information_schema.columns
+                 WHERE table_schema='public' AND table_name='thoughts' AND column_name='importance') THEN
+    EXECUTE $v$
+      CREATE OR REPLACE VIEW lint_high_importance_isolated AS
+      SELECT t.id, t.created_at, t.importance, left(t.content,200) AS preview
+      FROM public.thoughts t
+      LEFT JOIN public.thought_entities te ON te.thought_id = t.id
+      WHERE t.importance >= 4 AND te.thought_id IS NULL
+      ORDER BY t.importance DESC, t.id DESC;
+
+      CREATE OR REPLACE VIEW lint_entities_zero_edges AS
+      SELECT e.id, e.entity_type, e.canonical_name
+      FROM public.entities e
+      WHERE NOT EXISTS (
+        SELECT 1 FROM public.edges g
+        WHERE g.from_entity_id = e.id OR g.to_entity_id = e.id
+      )
+      ORDER BY e.id;
+    $v$;
+  ELSE
+    RAISE NOTICE 'entity-extraction schema absent — Tier 2 graph lint views skipped';
+  END IF;
+END $$;
+
+-- ── Aggregator the auditor calls ─────────────────────────────────────────────
+
+CREATE OR REPLACE FUNCTION lint_hygiene_summary()
+RETURNS jsonb
+LANGUAGE plpgsql
+STABLE
+AS $$
+DECLARE
+  result jsonb;
+BEGIN
+  result := jsonb_build_object(
+    'total_thoughts', (SELECT count(*) FROM public.thoughts),
+    'orphans_by_tag', (SELECT count(*) FROM lint_orphans_by_tag),
+    'over_tagged',    (SELECT count(*) FROM lint_over_tagged),
+    'empty_content',  (SELECT count(*) FROM lint_empty_content),
+    'very_long',      (SELECT count(*) FROM lint_very_long)
+  );
+
+  IF to_regclass('public.lint_low_signal') IS NOT NULL THEN
+    result := result || jsonb_build_object(
+      'low_signal', (SELECT count(*) FROM lint_low_signal));
+  END IF;
+
+  IF to_regclass('public.lint_exact_duplicates') IS NOT NULL THEN
+    result := result || jsonb_build_object(
+      'exact_duplicate_groups', (SELECT count(*) FROM lint_exact_duplicates),
+      'missing_fingerprint',    (SELECT count(*) FROM public.thoughts WHERE content_fingerprint IS NULL));
+  END IF;
+
+  IF to_regclass('public.lint_entities_zero_edges') IS NOT NULL THEN
+    result := result || jsonb_build_object(
+      'tier2_available',          true,
+      'entities_total',           (SELECT count(*) FROM public.entities),
+      'high_importance_isolated', (SELECT count(*) FROM lint_high_importance_isolated),
+      'entities_zero_edges',      (SELECT count(*) FROM lint_entities_zero_edges),
+      'entity_dup_groups',        (SELECT count(*) FROM (
+                                     SELECT normalized_name FROM public.entities
+                                     GROUP BY normalized_name HAVING count(*) > 1
+                                   ) d));
+  ELSE
+    result := result || jsonb_build_object('tier2_available', false);
+  END IF;
+
+  RETURN result;
+END $$;
+
+-- ============================================================
+-- Verify:
+--   SELECT lint_hygiene_summary();
+-- Then run the auditor (dry run) and confirm the response includes a
+-- non-null "hygiene" object.
+-- ============================================================

--- a/recipes/editorial-policy/metadata.json
+++ b/recipes/editorial-policy/metadata.json
@@ -24,5 +24,5 @@
   "difficulty": "intermediate",
   "estimated_time": "30 minutes",
   "created": "2026-05-09",
-  "updated": "2026-05-09"
+  "updated": "2026-07-12"
 }


### PR DESCRIPTION
## What

Extends the weekly auditor with a **mechanical hygiene layer**: free SQL lint counts computed before the LLM pass and stored on every `audit_report`.

New optional `hygiene.sql` installs read-only lint views (adapted from `recipes/lint-sweep`) plus a `lint_hygiene_summary()` aggregator. The auditor calls it first, stores the result in a separate `metadata.hygiene` block (never mixed into `findings`), and appends a human-readable section to the report content.

## Why

The auditor's LLM findings and the lint-sweep recipe's mechanical checks answer different questions but naturally share one weekly cadence and one report. Folding Tier 1/2 lint into the auditor gives every install orphan/duplicate/staleness counts for $0 extra — without running a second scheduled job. (Running this in production surfaced real issues: fingerprint gaps that led to a write-time dedup fix, and 51 duplicate entity groups.)

## Design

- **Optional + guarded**: without `hygiene.sql`, the auditor runs LLM-only exactly as before. Within it, enhanced-thoughts columns, `content_fingerprint`, and the entity-extraction schema are each detected; missing pieces skip with a `NOTICE` and the summary reports what it can.
- **Upgrade-safe**: view column shapes match `recipes/lint-sweep/views.sql` where columns exist, so `CREATE OR REPLACE` works over a prior lint-sweep install (REPLACE can't drop view columns — found this the hard way in testing).
- **Compute hygiene before the LLM; never gate the free pass behind the flaky paid one**: the LLM call is now wrapped, so a provider failure stores a hygiene-only report with `metadata.llm_error` set instead of discarding the run.
- **Low-noise discipline preserved**: hygiene never posts to Slack; critical-only paging on findings is unchanged.

Tested: `hygiene.sql` executed against a live brain (282 thoughts, entity graph installed) and over pre-existing lint-sweep views; `deno check` clean on the function.

🤖 Generated with [Claude Code](https://claude.com/claude-code)