### PR TITLE
[recipes] Add brain-health-monitor: cron observability + critical-only Slack paging

### DIFF
--- a/recipes/brain-health-monitor/README.md
+++ b/recipes/brain-health-monitor/README.md
@@ -1,0 +1,108 @@
+# Brain Health Monitor
+
+> Hourly ops probe that makes cron→function outcomes observable, pages Slack only on critical breaches, and sends a weekly all-green heartbeat so a dead monitor can't masquerade as a healthy brain.
+
+## What It Does
+
+An Open Brain that runs on schedules (auditor, briefings, entity workers, consolidation) has a blind spot: **pg_cron's `job_run_details` records `succeeded` when the HTTP request was *queued* by pg_net — not when your Edge Function returned 2xx.** A function can fail every run for weeks while every cron dashboard shows green. This was observed live: a run whose function body returned `{"succeeded":0,"failed":2}` was logged `succeeded`.
+
+This recipe closes that gap with three pieces:
+
+1. **`schema.sql`** — a logged wrapper (`ops_http_post_logged`) that stores the pg_net request id of every scheduled call; a harvester that copies outcomes out of `net._http_response` before pg_net purges it; read-only failure/health views; an alert-state table (per-alert page cooldown); a snapshots table for trends; and a bounded retention function.
+2. **`monitor/index.ts`** — an Edge Function that runs hourly: harvest → evaluate critical checks → page Slack **only on breach** (24h per-alert cooldown) → weekly all-green heartbeat → store a snapshot.
+3. **`schedule.sql`** — pg_cron entries for the monitor and the monthly retention purge, plus a template for migrating your existing jobs onto the logged wrapper.
+
+### The checks
+
+| Check | Source | Pages when |
+|---|---|---|
+| Cron/function failures (24h) | `ops_cron_http_failures` | non-2xx, `"ok":false` body, or no response after a 10-min grace |
+| Entity queue poison | `ops_queue_poison` *(skipped if entity-extraction schema absent)* | items `failed`, stalled `processing` >10m, or ≥3 retry attempts |
+| Missing embeddings | `ops_null_embeddings` | any thought without an embedding for >1h (semantic-search invisible) |
+| Missing fingerprints / duplicate entity groups | `lint_hygiene_summary()` *(skipped unless editorial-policy `hygiene.sql` installed)* | any occurrence — these are structurally prevented on hardened installs, so >0 means a guard regressed |
+| Backup staleness | `_backup_receipt` row in `ops_alert_state` *(opt-in — only checked if the row exists)* | receipt older than 36h |
+
+### The dead-man switch
+
+Silence-means-healthy has a failure mode: if the monitor itself dies, silence is indistinguishable from health. So when everything is green, the monitor sends one **weekly heartbeat** (`:stethoscope: all green`). Breach → page within the hour; health → one heartbeat a week; heartbeat missing → the monitor is dead. Every state has a distinguishable signal.
+
+## Prerequisites
+
+- Working Open Brain setup ([guide](../../docs/01-getting-started.md))
+- `pg_cron` + `pg_net` extensions enabled
+- Slack bot token (same setup as the editorial-policy auditor)
+- Optional: [editorial-policy `hygiene.sql`](../editorial-policy/) for the fingerprint/entity-dedup checks
+- Optional: `schemas/entity-extraction` for the queue-poison check
+
+## Steps
+
+### Step 1: Apply the schema
+
+Run `schema.sql` in the SQL Editor. Optional pieces (queue-poison view) skip with a `NOTICE` when their tables are absent. Safe to re-run.
+
+### Step 2: Deploy the monitor
+
+```bash
+# from this recipe folder
+supabase functions deploy brain-health-monitor --project-ref <YOUR-PROJECT-REF> --no-verify-jwt
+```
+
+(`--no-verify-jwt` because the function does its own auth: `x-brain-key` matched against the `MCP_ACCESS_KEY` secret.) Confirm the secrets `MCP_ACCESS_KEY`, `SLACK_BOT_TOKEN`, and `SLACK_CAPTURE_CHANNEL` (or `SLACK_OPS_CHANNEL`) are set.
+
+### Step 3: Schedule it
+
+Run `schedule.sql` (replace the placeholders). It schedules the monitor hourly and the retention purge monthly, both through the logged wrapper.
+
+### Step 4: Migrate your existing jobs onto the logged wrapper
+
+The monitor can only see invocations that go through `ops_http_post_logged`. Recreate each existing `cron.schedule` using the template at the bottom of `schedule.sql` — same schedule, same body, same header auth, just wrapped. Until a job is migrated, its function-level failures remain invisible.
+
+### Step 5: Prove the pager works
+
+Don't trust theory — manufacture a failure:
+
+```sql
+SELECT ops_http_post_logged('zz-forced-failure-test',
+  'https://<YOUR-PROJECT-REF>.supabase.co/functions/v1/nonexistent-function',
+  '{"Content-Type":"application/json"}'::jsonb, '{}'::jsonb, 15000);
+```
+
+Wait ~30 seconds, invoke the monitor once, and confirm the `:rotating_light:` page arrives in Slack. Then clean up (deletes are in `schedule.sql`'s comments). The first healthy run also sends the initial heartbeat, which proves the green path.
+
+### Step 6 (optional): Wire in your backup
+
+If you run a scheduled backup, have it PATCH the receipt on every success:
+
+```sql
+-- seed once (opt-in):
+INSERT INTO ops_alert_state (alert_key, last_paged_at, details)
+VALUES ('_backup_receipt', now(), '{"note":"seeded"}'::jsonb)
+ON CONFLICT (alert_key) DO NOTHING;
+```
+
+Your backup job then updates `last_paged_at` via PostgREST after each successful run; the monitor pages if it goes stale (>36h). Seeding at setup time means a backup pipeline that *never works* also pages — a silently broken backup is impossible.
+
+## Expected Outcome
+
+- Hourly monitor runs, visible in `ops_health_snapshots` (one row per run).
+- Zero Slack noise while healthy, except one `:stethoscope:` heartbeat per week.
+- Any function-level cron failure, poison queue item, embedding gap, or stale backup pages within the hour, once per 24h per alert.
+
+## Troubleshooting
+
+**Monitor returns 401** — `MCP_ACCESS_KEY` secret not set, or the caller isn't sending `x-brain-key`. Note the function refuses all requests when the secret is unset (fail-closed).
+
+**`ops_cron_http_failures` shows `no_response_recorded` for a job that works** — the job was scheduled with bare `net.http_post` (no request-id captured) or pg_net purged the response before a harvest ran. Migrate the job to `ops_http_post_logged` and keep the monitor hourly.
+
+**Every run of a slow function shows `null_status_timeout_or_error`** — raise the `p_timeout_ms` argument for that job in `schedule.sql`; pg_net's default timeout frequently records NULL status for LLM-heavy functions.
+
+**Heartbeat never arrives** — check `cron.job` has `brain-health-monitor` active, then `SELECT * FROM ops_cron_invocations WHERE jobname='brain-health-monitor' ORDER BY id DESC LIMIT 5;` — the monitor logs its own invocations, so its failures are visible in its own failure view (fetch them manually if it's down).
+
+**Slack post fails** — the bot must be invited to the channel; `SLACK_OPS_CHANNEL` falls back to `SLACK_CAPTURE_CHANNEL`.
+
+## Works Well With
+
+- **[editorial-policy](../editorial-policy/)** — its optional `hygiene.sql` provides `lint_hygiene_summary()`, which unlocks this monitor's fingerprint/entity-dedup regression checks; its auditor covers *content* quality weekly while this recipe covers *pipeline* health hourly.
+- **[brain-backup](../brain-backup/)** — schedule it externally (Node — not pg_cron-able) and PATCH the `_backup_receipt` for staleness paging.
+- **[brain-health-monitoring](../brain-health-monitoring/)** — the `ops_*` dashboard views complement these alerting views; that recipe answers "show me", this one answers "wake me".
+- **[content-fingerprint-dedup](../content-fingerprint-dedup/)** — its write-time trigger is what makes the missing-fingerprint check a regression signal rather than a backlog count.

--- a/recipes/brain-health-monitor/metadata.json
+++ b/recipes/brain-health-monitor/metadata.json
@@ -1,0 +1,20 @@
+{
+  "name": "Brain Health Monitor",
+  "description": "Hourly ops probe that makes cron→function outcomes observable (pg_cron 'succeeded' only means the request was queued), pages Slack on critical breaches only, and sends a weekly all-green heartbeat so monitor-death is distinguishable from health.",
+  "category": "recipes",
+  "author": {
+    "name": "Ezana Azene",
+    "github": "eazene"
+  },
+  "version": "1.0.0",
+  "requires": {
+    "open_brain": true,
+    "services": ["Supabase (pg_cron + pg_net)", "Slack bot token"],
+    "tools": ["Supabase CLI (to deploy the Edge Function)"]
+  },
+  "tags": ["monitoring", "ops", "alerting", "observability", "cron", "health", "slack"],
+  "difficulty": "intermediate",
+  "estimated_time": "30 minutes",
+  "created": "2026-07-12",
+  "updated": "2026-07-12"
+}

--- a/recipes/brain-health-monitor/monitor/deno.json
+++ b/recipes/brain-health-monitor/monitor/deno.json
@@ -1,0 +1,5 @@
+{
+  "imports": {
+    "@supabase/functions-js": "jsr:@supabase/functions-js@^2"
+  }
+}

--- a/recipes/brain-health-monitor/monitor/index.ts
+++ b/recipes/brain-health-monitor/monitor/index.ts
@@ -1,0 +1,265 @@
+// recipes/brain-health-monitor/monitor/index.ts
+//
+// The one quiet probe that only pages when something is actually wrong.
+//
+// Every run:
+//   1. Harvests cron→function outcomes (ops_harvest_responses) before pg_net
+//      purges its response table.
+//   2. Evaluates critical checks — each tolerant of missing optional schema:
+//        - cron/function failures in the last 24h (ops_cron_http_failures)
+//        - entity-queue poison/stalled items (ops_queue_poison, if installed)
+//        - thoughts missing embeddings for >1h (ops_null_embeddings)
+//        - missing content fingerprints / duplicate entity-name groups
+//          (via lint_hygiene_summary from recipes/editorial-policy/hygiene.sql,
+//          if installed — these are structurally prevented on hardened installs,
+//          so any occurrence means a guard regressed)
+//        - stale backup receipt (opt-in: only if a '_backup_receipt' row exists
+//          in ops_alert_state; your backup job should PATCH it on success)
+//   3. Pages Slack ONLY for breaches, deduped via ops_alert_state with a 24h
+//      per-alert cooldown. Silence = healthy...
+//   4. ...except a WEEKLY heartbeat ("all green") so monitor-death is
+//      distinguishable from health (dead-man switch).
+//   5. Stores a snapshot row in ops_health_snapshots for trends.
+//
+// Auth: x-brain-key header (or ?key=) matched against MCP_ACCESS_KEY.
+// Body flags: {"dry_run":true}         — evaluate but never post/update state
+//             {"force_heartbeat":true} — send heartbeat regardless of age
+//
+// Required env: SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY, MCP_ACCESS_KEY,
+//               SLACK_BOT_TOKEN, SLACK_CAPTURE_CHANNEL (or SLACK_OPS_CHANNEL)
+
+import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
+
+const SUPABASE_URL = Deno.env.get("SUPABASE_URL")!;
+const SUPABASE_SERVICE_ROLE_KEY = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY")!;
+const SLACK_BOT_TOKEN = Deno.env.get("SLACK_BOT_TOKEN")!;
+const SLACK_CAPTURE_CHANNEL = Deno.env.get("SLACK_CAPTURE_CHANNEL")!;
+const SLACK_OPS_CHANNEL = Deno.env.get("SLACK_OPS_CHANNEL") ?? SLACK_CAPTURE_CHANNEL;
+const MCP_ACCESS_KEY = Deno.env.get("MCP_ACCESS_KEY")!;
+
+const PAGE_COOLDOWN_HOURS = 24;
+const HEARTBEAT_DAYS = 7;
+const HEARTBEAT_KEY = "_heartbeat";
+const BACKUP_RECEIPT_KEY = "_backup_receipt";
+const BACKUP_STALE_HOURS = 36;
+
+const supabase = createClient(SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY);
+
+interface Breach {
+  key: string;
+  summary: string; // one Slack line
+  details: Record<string, unknown>;
+}
+
+async function postToSlack(text: string): Promise<void> {
+  const r = await fetch("https://slack.com/api/chat.postMessage", {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${SLACK_BOT_TOKEN}`,
+      "Content-Type": "application/json; charset=utf-8",
+    },
+    body: JSON.stringify({ channel: SLACK_OPS_CHANNEL, text, unfurl_links: false }),
+  });
+  const d = await r.json();
+  if (!d.ok) throw new Error(`Slack post failed: ${d.error}`);
+}
+
+/** Tolerant table/view read: missing relation → null (check skipped), not a crash. */
+async function trySelect<T>(rel: string, cols: string): Promise<T[] | null> {
+  const { data, error } = await supabase.from(rel).select(cols);
+  if (error) {
+    console.warn(`${rel} unavailable (check skipped): ${error.message}`);
+    return null;
+  }
+  return (data ?? []) as T[];
+}
+
+async function shouldPage(key: string): Promise<boolean> {
+  const { data } = await supabase
+    .from("ops_alert_state").select("last_paged_at").eq("alert_key", key).maybeSingle();
+  if (!data?.last_paged_at) return true;
+  return Date.now() - new Date(data.last_paged_at).getTime() > PAGE_COOLDOWN_HOURS * 3600_000;
+}
+
+async function recordAlert(key: string, details: Record<string, unknown>, paged: boolean) {
+  const now = new Date().toISOString();
+  const { data } = await supabase
+    .from("ops_alert_state").select("alert_key").eq("alert_key", key).maybeSingle();
+  if (data) {
+    const patch: Record<string, unknown> = { last_seen: now, details };
+    if (paged) patch.last_paged_at = now;
+    await supabase.from("ops_alert_state").update(patch).eq("alert_key", key);
+  } else {
+    await supabase.from("ops_alert_state").insert({
+      alert_key: key, details, last_paged_at: paged ? now : null,
+    });
+  }
+}
+
+Deno.serve(async (req: Request): Promise<Response> => {
+  try {
+    const key = req.headers.get("x-brain-key") ?? new URL(req.url).searchParams.get("key");
+    if (!MCP_ACCESS_KEY || key !== MCP_ACCESS_KEY) {
+      return new Response("unauthorized", { status: 401 });
+    }
+    const body = req.method === "POST" ? await req.json().catch(() => ({})) : {};
+    const dryRun: boolean = body.dry_run ?? false;
+    const forceHeartbeat: boolean = body.force_heartbeat ?? false;
+
+    // 1. Harvest cron→function outcomes before pg_net purges them.
+    const { data: harvested, error: harvestErr } = await supabase.rpc("ops_harvest_responses");
+    if (harvestErr) console.warn("harvest failed:", harvestErr.message);
+
+    // 2. Gather check inputs (each tolerant of missing optional schema).
+    const [cronFails, poison, nullEmbeds, hygieneRes] = await Promise.all([
+      trySelectCronFailures(),
+      trySelect<Record<string, unknown>>("ops_queue_poison", "thought_id,status,attempt_count,last_error"),
+      trySelect<{ id: string; created_at: string; source: string | null }>(
+        "ops_null_embeddings", "id,created_at,source"),
+      supabase.rpc("lint_hygiene_summary"),
+    ]);
+    const hygiene = (hygieneRes.error ? null : hygieneRes.data) as Record<string, number> | null;
+    if (hygieneRes.error) {
+      console.warn("lint_hygiene_summary unavailable (install editorial-policy hygiene.sql to enable):",
+        hygieneRes.error.message);
+    }
+
+    const breaches: Breach[] = [];
+
+    for (const f of cronFails ?? []) {
+      breaches.push({
+        key: `cron_failure:${f.jobname}`,
+        summary: `cron *${f.jobname}* → ${f.failure} (${String(f.response_preview ?? "").slice(0, 80)})`,
+        details: f as Record<string, unknown>,
+      });
+    }
+
+    if (poison && poison.length > 0) {
+      breaches.push({
+        key: "queue_poison",
+        summary: `entity queue: ${poison.length} failed/stalled item(s) — first error: ${String(poison[0].last_error ?? "").slice(0, 80)}`,
+        details: { count: poison.length, sample: poison.slice(0, 3) },
+      });
+    }
+
+    // NULL embeddings: only rows older than 1h breach (in-flight writes tolerated).
+    const staleNullEmbeds = (nullEmbeds ?? []).filter(
+      (r) => Date.now() - new Date(r.created_at).getTime() > 3600_000,
+    );
+    if (staleNullEmbeds.length > 0) {
+      breaches.push({
+        key: "null_embeddings",
+        summary: `${staleNullEmbeds.length} thought(s) missing embeddings for >1h (write-path leak?) — sources: ${[...new Set(staleNullEmbeds.map((r) => r.source ?? "unknown"))].join(", ")}`,
+        details: { count: staleNullEmbeds.length, ids: staleNullEmbeds.slice(0, 5).map((r) => r.id) },
+      });
+    }
+
+    // Structurally-prevented conditions (write-time trigger / entity dedup):
+    // any occurrence means a guard regressed. Only checked when the hygiene
+    // summary is installed AND reports the key.
+    if (hygiene && (hygiene.missing_fingerprint ?? 0) > 0) {
+      breaches.push({
+        key: "missing_fingerprints",
+        summary: `${hygiene.missing_fingerprint} thought(s) missing content_fingerprint — the write-time trigger may have regressed`,
+        details: { count: hygiene.missing_fingerprint },
+      });
+    }
+    if (hygiene && (hygiene.entity_dup_groups ?? 0) > 0) {
+      breaches.push({
+        key: "entity_dup_groups",
+        summary: `${hygiene.entity_dup_groups} duplicate entity-name group(s) — entity dedup may have regressed`,
+        details: { count: hygiene.entity_dup_groups },
+      });
+    }
+
+    // Backup staleness — OPT-IN: only checked when a '_backup_receipt' row
+    // exists (seed it when you set up a scheduled backup that PATCHes it).
+    const { data: receipt } = await supabase
+      .from("ops_alert_state").select("last_paged_at")
+      .eq("alert_key", BACKUP_RECEIPT_KEY).maybeSingle();
+    if (receipt) {
+      const ageH = receipt.last_paged_at
+        ? (Date.now() - new Date(receipt.last_paged_at).getTime()) / 3600_000
+        : Infinity;
+      if (ageH > BACKUP_STALE_HOURS) {
+        breaches.push({
+          key: "backup_stale",
+          summary: `backup receipt is ${ageH === Infinity ? "empty" : Math.round(ageH) + "h old"} (>${BACKUP_STALE_HOURS}h) — check your scheduled backup`,
+          details: { receipt_age_hours: ageH === Infinity ? null : Math.round(ageH) },
+        });
+      }
+    }
+
+    // 3. Page breaches (deduped by cooldown).
+    const paged: string[] = [];
+    for (const b of breaches) {
+      const page = !dryRun && (await shouldPage(b.key));
+      if (page) {
+        await postToSlack(`:rotating_light: *brain-health:* ${b.summary}`);
+        paged.push(b.key);
+      }
+      if (!dryRun) await recordAlert(b.key, b.details, page);
+    }
+
+    // 4. Weekly heartbeat when healthy (dead-man switch).
+    let heartbeatSent = false;
+    if (breaches.length === 0 && !dryRun) {
+      const due = forceHeartbeat || (await (async () => {
+        const { data } = await supabase
+          .from("ops_alert_state").select("last_paged_at")
+          .eq("alert_key", HEARTBEAT_KEY).maybeSingle();
+        if (!data?.last_paged_at) return true;
+        return Date.now() - new Date(data.last_paged_at).getTime() > HEARTBEAT_DAYS * 86400_000;
+      })());
+      if (due) {
+        await postToSlack(
+          `:stethoscope: *brain-health:* all green — ${hygiene?.total_thoughts ?? "?"} thoughts, ` +
+          `0 cron failures (24h), queue clean, embeddings complete. Next heartbeat in ~${HEARTBEAT_DAYS}d; ` +
+          `silence in between means healthy, a page means look.`,
+        );
+        await recordAlert(HEARTBEAT_KEY, { note: "weekly all-green heartbeat" }, true);
+        heartbeatSent = true;
+      }
+    }
+
+    // 5. Snapshot for trends.
+    const snapshot = {
+      harvested: harvested ?? 0,
+      breach_count: breaches.length,
+      breach_keys: breaches.map((b) => b.key),
+      cron_failures_24h: (cronFails ?? []).length,
+      queue_poison: (poison ?? []).length,
+      null_embeddings_stale: staleNullEmbeds.length,
+      hygiene,
+    };
+    if (!dryRun) await supabase.from("ops_health_snapshots").insert({ snapshot });
+
+    return new Response(
+      JSON.stringify({
+        ok: true, dry_run: dryRun,
+        breaches: breaches.map((b) => b.summary),
+        paged, heartbeat_sent: heartbeatSent, snapshot,
+      }),
+      { headers: { "Content-Type": "application/json" } },
+    );
+  } catch (err) {
+    console.error("brain-health-monitor error:", err);
+    return new Response(JSON.stringify({ ok: false, error: (err as Error).message }), {
+      status: 500, headers: { "Content-Type": "application/json" },
+    });
+  }
+});
+
+/** ops_cron_http_failures with typed rows; missing view → null. */
+async function trySelectCronFailures(): Promise<
+  Array<{ jobname: string; failure: string; invoked_at: string; response_preview: string | null }> | null
+> {
+  const { data, error } = await supabase
+    .from("ops_cron_http_failures")
+    .select("jobname,failure,invoked_at,response_preview");
+  if (error) {
+    console.warn(`ops_cron_http_failures unavailable (install schema.sql): ${error.message}`);
+    return null;
+  }
+  return (data ?? []) as Array<{ jobname: string; failure: string; invoked_at: string; response_preview: string | null }>;
+}

--- a/recipes/brain-health-monitor/schedule.sql
+++ b/recipes/brain-health-monitor/schedule.sql
@@ -1,0 +1,53 @@
+-- ============================================================
+-- Schedule the brain-health-monitor via pg_cron (hourly at :07).
+-- Run this in your Supabase SQL Editor (one-time setup).
+--
+-- BEFORE RUNNING:
+--   Replace <YOUR-PROJECT-REF> with your Supabase project reference.
+--   Store your MCP access key in Vault once (step 0) so the key is read
+--   at fire time — never embed keys in ?key= URLs (they persist in
+--   cron.job.command and in invocation logs).
+-- ============================================================
+
+-- 0. One-time (skip if you already keep mcp_access_key in Vault):
+-- SELECT vault.create_secret('<YOUR-MCP-ACCESS-KEY>', 'mcp_access_key');
+
+-- The monitor schedules itself through ops_http_post_logged so its own
+-- invocations are observable too.
+SELECT cron.schedule('brain-health-monitor', '7 * * * *', $$
+  SELECT ops_http_post_logged('brain-health-monitor',
+    'https://<YOUR-PROJECT-REF>.supabase.co/functions/v1/brain-health-monitor',
+    jsonb_build_object('Content-Type','application/json',
+      'x-brain-key', (SELECT decrypted_secret FROM vault.decrypted_secrets
+                      WHERE name = 'mcp_access_key')),
+    '{}'::jsonb, 60000);
+$$);
+
+-- Bounded retention for operational exhaust — monthly, 1st at 02:00 UTC.
+SELECT cron.schedule('monthly-retention-purge', '0 2 1 * *',
+  'SELECT ops_retention_purge();');
+
+-- ============================================================
+-- Migrate your EXISTING jobs onto the logged wrapper so their function-level
+-- outcomes become observable (example — repeat per job, keeping each job's
+-- schedule/body/timeout):
+--
+--   SELECT cron.schedule('weekly-auditor', '0 9 * * 0', $$
+--     SELECT ops_http_post_logged('weekly-auditor',
+--       'https://<YOUR-PROJECT-REF>.supabase.co/functions/v1/auditor',
+--       jsonb_build_object('Content-Type','application/json',
+--         'x-auditor-key', (SELECT decrypted_secret FROM vault.decrypted_secrets
+--                           WHERE name = 'auditor_access_key')),
+--       jsonb_build_object('days',30,'post_to_slack',true,'dry_run',false), 150000);
+--   $$);
+--
+-- Verify:
+--   SELECT jobname, schedule, active FROM cron.job ORDER BY jobname;
+-- Prove the pager works (don't trust theory) — manufacture one failure:
+--   SELECT ops_http_post_logged('zz-forced-failure-test',
+--     'https://<YOUR-PROJECT-REF>.supabase.co/functions/v1/nonexistent-function',
+--     '{"Content-Type":"application/json"}'::jsonb, '{}'::jsonb, 15000);
+--   -- wait ~30s, invoke the monitor, confirm the Slack page, then clean up:
+--   DELETE FROM ops_cron_invocations WHERE jobname = 'zz-forced-failure-test';
+--   DELETE FROM ops_alert_state WHERE alert_key = 'cron_failure:zz-forced-failure-test';
+-- ============================================================

--- a/recipes/brain-health-monitor/schema.sql
+++ b/recipes/brain-health-monitor/schema.sql
@@ -1,0 +1,137 @@
+-- ============================================================
+-- brain-health-monitor: cron observability + alert state
+-- Run this in your Supabase SQL Editor (one-time setup, safe to re-run).
+--
+-- Core idea: pg_cron's job_run_details records 'succeeded' when the HTTP
+-- request was QUEUED by pg_net — not when your Edge Function returned 2xx.
+-- A function can fail every run for weeks while cron shows green. This
+-- schema stores the request id of every scheduled call so outcomes can be
+-- joined back deterministically, harvests them before pg_net purges its
+-- response table, and gives the monitor function alert-dedup state.
+--
+-- Requires: pg_cron + pg_net extensions (Database → Extensions).
+-- Optional pieces (entity queue view) are guarded and skip with a NOTICE.
+-- ============================================================
+
+-- Every scheduled invocation, with the pg_net request id captured.
+CREATE TABLE IF NOT EXISTS ops_cron_invocations (
+  id bigserial PRIMARY KEY,
+  jobname text NOT NULL,
+  request_id bigint NOT NULL,
+  invoked_at timestamptz NOT NULL DEFAULT now(),
+  -- harvested from net._http_response before pg_net's TTL purges it
+  status_code int,
+  response_preview text,
+  harvested_at timestamptz
+);
+CREATE INDEX IF NOT EXISTS idx_ops_cron_invocations_time
+  ON ops_cron_invocations (invoked_at DESC);
+
+-- Wrapper every scheduled job should call instead of bare net.http_post.
+CREATE OR REPLACE FUNCTION ops_http_post_logged(
+  p_jobname text, p_url text, p_headers jsonb, p_body jsonb,
+  p_timeout_ms integer DEFAULT 120000
+) RETURNS bigint LANGUAGE plpgsql AS $$
+DECLARE v_req bigint;
+BEGIN
+  v_req := net.http_post(url := p_url, headers := p_headers, body := p_body,
+                         timeout_milliseconds := p_timeout_ms);
+  INSERT INTO ops_cron_invocations (jobname, request_id) VALUES (p_jobname, v_req);
+  RETURN v_req;
+END $$;
+
+-- Copy outcomes out of net._http_response (pg_net purges it) into the log.
+CREATE OR REPLACE FUNCTION ops_harvest_responses() RETURNS int LANGUAGE plpgsql AS $$
+DECLARE v_n int;
+BEGIN
+  UPDATE ops_cron_invocations i
+  SET status_code = r.status_code,
+      response_preview = left(coalesce(r.content, r.error_msg, ''), 300),
+      harvested_at = now()
+  FROM net._http_response r
+  WHERE r.id = i.request_id AND i.harvested_at IS NULL;
+  GET DIAGNOSTICS v_n = ROW_COUNT;
+  RETURN v_n;
+END $$;
+
+-- Failures in the last 24h: bad status, function-reported failure, or no
+-- response harvested after a 10-minute grace period.
+CREATE OR REPLACE VIEW ops_cron_http_failures AS
+SELECT jobname, request_id, invoked_at, status_code, response_preview, failure
+FROM (
+  SELECT *,
+    CASE
+      WHEN harvested_at IS NULL AND invoked_at < now() - interval '10 minutes'
+        THEN 'no_response_recorded'
+      WHEN harvested_at IS NOT NULL AND status_code IS NULL
+        THEN 'null_status_timeout_or_error'
+      WHEN status_code IS NOT NULL AND status_code NOT BETWEEN 200 AND 299
+        THEN 'http_' || status_code
+      WHEN response_preview LIKE '%"ok":false%'
+        THEN 'function_reported_not_ok'
+      ELSE NULL
+    END AS failure
+  FROM ops_cron_invocations
+  WHERE invoked_at > now() - interval '24 hours'
+) x
+WHERE failure IS NOT NULL;
+
+-- Thoughts invisible to semantic search.
+CREATE OR REPLACE VIEW ops_null_embeddings AS
+SELECT id, created_at, metadata->>'source' AS source, left(content,120) AS preview
+FROM thoughts WHERE embedding IS NULL
+ORDER BY created_at DESC;
+
+-- Entity queue poison / stalled items (requires schemas/entity-extraction).
+DO $$
+BEGIN
+  IF to_regclass('public.entity_extraction_queue') IS NOT NULL THEN
+    EXECUTE $v$
+      CREATE OR REPLACE VIEW ops_queue_poison AS
+      SELECT thought_id, status, attempt_count,
+             left(coalesce(last_error,''),160) AS last_error, queued_at, started_at
+      FROM entity_extraction_queue
+      WHERE status = 'failed'
+         OR (status = 'processing' AND started_at < now() - interval '10 minutes')
+         OR (status = 'pending' AND attempt_count >= 3);
+    $v$;
+  ELSE
+    RAISE NOTICE 'entity_extraction_queue absent — ops_queue_poison view skipped';
+  END IF;
+END $$;
+
+-- Alert dedup: one row per alert_key; the monitor pages only past a cooldown.
+-- Reserved keys: '_heartbeat' (weekly all-green), '_backup_receipt' (opt-in —
+-- seed it if you run a scheduled backup and want staleness paging).
+CREATE TABLE IF NOT EXISTS ops_alert_state (
+  alert_key text PRIMARY KEY,
+  first_seen timestamptz NOT NULL DEFAULT now(),
+  last_seen timestamptz NOT NULL DEFAULT now(),
+  last_paged_at timestamptz,
+  details jsonb
+);
+
+-- Longitudinal health snapshots (a separate table on purpose — operational
+-- exhaust must not pollute the thoughts table or feed synthesis).
+CREATE TABLE IF NOT EXISTS ops_health_snapshots (
+  id bigserial PRIMARY KEY,
+  taken_at timestamptz NOT NULL DEFAULT now(),
+  snapshot jsonb NOT NULL
+);
+
+-- Bounded retention for operational exhaust (schedule monthly; see schedule.sql).
+CREATE OR REPLACE FUNCTION ops_retention_purge()
+RETURNS jsonb LANGUAGE plpgsql AS $$
+DECLARE v_cron int; v_http int; v_inv int; v_snap int;
+BEGIN
+  DELETE FROM cron.job_run_details WHERE end_time < now() - interval '30 days';
+  GET DIAGNOSTICS v_cron = ROW_COUNT;
+  DELETE FROM net._http_response WHERE created < now() - interval '7 days';
+  GET DIAGNOSTICS v_http = ROW_COUNT;
+  DELETE FROM ops_cron_invocations WHERE invoked_at < now() - interval '90 days';
+  GET DIAGNOSTICS v_inv = ROW_COUNT;
+  DELETE FROM ops_health_snapshots WHERE taken_at < now() - interval '180 days';
+  GET DIAGNOSTICS v_snap = ROW_COUNT;
+  RETURN jsonb_build_object('cron_run_details', v_cron, 'http_responses', v_http,
+                            'cron_invocations', v_inv, 'health_snapshots', v_snap);
+END $$;


### PR DESCRIPTION
## What

New recipe: an hourly ops probe that makes **cron→function outcomes observable** and pages Slack **only when something is actually wrong**.

## The problem it solves

`cron.job_run_details` records `succeeded` when pg_net **queued** the HTTP request — not when your Edge Function returned 2xx. A scheduled function can fail every run for weeks while cron shows green. Observed live: a run whose function returned `{"succeeded":0,"failed":2}` was logged `succeeded`.

## How

- **`schema.sql`** — `ops_http_post_logged()` wrapper stores the pg_net request id of every scheduled call; `ops_harvest_responses()` copies outcomes out of `net._http_response` before pg_net purges it; `ops_cron_http_failures` joins them back deterministically (bad status / `"ok":false` body / no response after grace). Plus alert-state (24h per-alert page cooldown), health snapshots, and a bounded retention purge.
- **`monitor/index.ts`** — hourly Edge Function: harvest → checks → page on breach → **weekly all-green heartbeat** (dead-man switch: breach pages within the hour, health heartbeats weekly, missing heartbeat = the monitor itself is dead — every state has a distinguishable signal) → snapshot.
- **Checks degrade gracefully**: entity-queue poison (needs entity-extraction schema), fingerprint/entity-dedup regressions (needs editorial-policy `hygiene.sql` — pairs with #439), and backup staleness (opt-in via a `_backup_receipt` row) all skip cleanly when their dependency is absent. A stock install still gets cron-failure + embedding-gap coverage.
- **`schedule.sql`** includes the migration template for existing jobs and a documented **forced-failure drill** — prove the pager works, don't trust theory.

## Provenance

Running in production for a live brain; the drill paged correctly against a manufactured 404, and the heartbeat proved the green path. Vault-header auth throughout (no `?key=` URLs — pairs with #437).

🤖 Generated with [Claude Code](https://claude.com/claude-code)