### PR TITLE
[dashboards] Kanban fixes — 1) reorder cards within columns, 2) add cards to full columns, 3) opaque modals to see task detail

### DIFF
--- a/dashboards/open-brain-dashboard-next/README.md
+++ b/dashboards/open-brain-dashboard-next/README.md
@@ -107,7 +107,7 @@ Or connect the folder to Vercel via the dashboard. Set the environment variables
 
 ### Step 5 (alternative): Deploy to Cloudflare Workers (optional)
 
-If you're already on Cloudflare for the [`open-brain-rest`](../../integrations/cloudflare-rest-worker/) gateway, you can host the dashboard on the same platform via the [`@opennextjs/cloudflare`](https://opennext.js.org/cloudflare) adapter. The older `@cloudflare/next-on-pages` adapter caps at Next 15.5.x and doesn't support this dashboard's Next 16.
+If you're already on Cloudflare for the [`open-brain-rest`](../../integrations/open-brain-rest/) gateway, you can host the dashboard on the same platform via the [`@opennextjs/cloudflare`](https://opennext.js.org/cloudflare) adapter. The older `@cloudflare/next-on-pages` adapter caps at Next 15.5.x and doesn't support this dashboard's Next 16.
 
 The repo ships the two config files this needs out of the box (`open-next.config.ts` and `wrangler.jsonc`); rename the Worker in `wrangler.jsonc` if you want something other than `ob-dashboard`.
 

--- a/dashboards/open-brain-dashboard-next/README.md
+++ b/dashboards/open-brain-dashboard-next/README.md
@@ -147,7 +147,8 @@ The Workflow page adds a visual kanban board for managing `task` and `idea` thou
 
 ### Features
 
-- **Drag-and-drop** between status columns using @dnd-kit (touch-friendly with 200ms hold delay)
+- **Drag-and-drop** between status columns using @dnd-kit (touch-friendly with 200ms hold delay) — drop on a column or directly onto a card to insert at that position, including into full columns
+- **Drag to reorder within a column** — cards render in priority order, and dropping a card above another persists the new order via the existing `importance` field (renumbered 99→1, no schema changes)
 - **Collapsible columns** — click the arrow to collapse any column to a slim vertical bar (persisted in localStorage)
 - **Auto-adjusting widths** — expanded columns share available space equally, no horizontal scrollbar
 - **Inline editing** — tap a card to open the edit modal (status, priority, type, content)
@@ -275,3 +276,5 @@ Do not enable `OB1_DEMO_AUTH_BYPASS` in shared previews or production. It exists
 4. **Search returns no results** — Ensure your thoughts have embeddings. Semantic search requires the `embedding` column to be populated. Run an embedding backfill if needed.
 
 5. **Ingest page shows "extracting" forever** — Check that the `smart-ingest` Edge Function is deployed. The ingest feature depends on a separate Edge Function for document extraction.
+
+6. **Kanban card order reverts after a drag** — Reordering persists by rewriting `importance` on the repositioned cards (one `/api/kanban/update` call per changed card). If the order snaps back with a "Failed to update board. Reverted." banner, one of those calls failed — check that your REST gateway is reachable and that the [workflow-status schema](../../schemas/workflow-status/) migration has been applied. Note that card priority dots and column position are the same value: dragging a card to the top of a column raises its importance.

--- a/dashboards/open-brain-dashboard-next/app/globals.css
+++ b/dashboards/open-brain-dashboard-next/app/globals.css
@@ -4,6 +4,9 @@
   --color-bg-primary: #1d201e;
   --color-bg-surface: rgba(255, 255, 255, 0.045);
   --color-bg-elevated: rgba(255, 255, 255, 0.07);
+  /* Opaque equivalent of bg-elevated over bg-primary — for floating layers
+     (modals, dropdowns) that have no opaque page background behind them */
+  --color-bg-overlay: #2d302e;
   --color-bg-hover: rgba(255, 255, 255, 0.085);
   --color-border: rgba(236, 229, 209, 0.16);
   --color-border-subtle: rgba(236, 229, 209, 0.085);

--- a/dashboards/open-brain-dashboard-next/components/DeleteModal.tsx
+++ b/dashboards/open-brain-dashboard-next/components/DeleteModal.tsx
@@ -77,7 +77,7 @@ export function DeleteModal({
         aria-hidden="true"
         onClick={onCancel}
       />
-      <div className="relative bg-bg-surface border border-border rounded-xl p-6 w-full max-w-md shadow-2xl">
+      <div className="relative bg-bg-overlay border border-border rounded-xl p-6 w-full max-w-md shadow-2xl">
         <h3
           id={titleId}
           className="text-lg font-semibold text-text-primary mb-2"

--- a/dashboards/open-brain-dashboard-next/components/KanbanBoard.tsx
+++ b/dashboards/open-brain-dashboard-next/components/KanbanBoard.tsx
@@ -99,6 +99,8 @@ export function KanbanBoard() {
         groups["new"].push(t);
       }
     }
+    // Column order is priority order — keep it stable through optimistic updates
+    for (const s of Object.keys(groups)) groups[s].sort((a, b) => b.importance - a.importance);
     return groups;
   }
 
@@ -113,27 +115,69 @@ export function KanbanBoard() {
     if (!over) return;
 
     const thoughtId = String(active.id);
-    const newStatus = over.id as string;
-
-    // Find which column the thought is currently in
     const thought = thoughts.find((t) => t.id === thoughtId);
-    if (!thought || thought.status === newStatus) return;
+    if (!thought) return;
+
+    // The drop target is either a column (status id) or another card —
+    // dropping on a card targets that card's column at that card's position.
+    const overId = String(over.id);
+    const isColumn = ([...KANBAN_STATUSES, "archived"] as string[]).includes(overId);
+    const overCard = isColumn ? null : thoughts.find((t) => t.id === overId);
+    if (!isColumn && !overCard) return;
+    const targetStatus = isColumn ? overId : (overCard!.status ?? "new");
+
+    // Rebuild the target column's priority order with the card inserted
+    const columnCards = thoughts
+      .filter((t) => t.id !== thoughtId && (t.status ?? "new") === targetStatus)
+      .sort((a, b) => b.importance - a.importance);
+    let insertIdx = columnCards.length;
+    if (overCard) {
+      const idx = columnCards.findIndex((t) => t.id === overId);
+      if (idx >= 0) insertIdx = idx;
+    }
+    const newOrder = [
+      ...columnCards.slice(0, insertIdx),
+      thought,
+      ...columnCards.slice(insertIdx),
+    ];
+
+    // Renumber importance top-down (evenly spaced 99→1) so order persists
+    const step = Math.max(1, Math.floor(98 / Math.max(newOrder.length, 1)));
+    const changes = new Map<string, { importance: number; status?: string }>();
+    newOrder.forEach((t, i) => {
+      const importance = Math.max(1, 99 - i * step);
+      const statusChanged = t.id === thoughtId && (thought.status ?? "new") !== targetStatus;
+      if (t.importance !== importance || statusChanged) {
+        changes.set(t.id, {
+          importance,
+          ...(statusChanged ? { status: targetStatus } : {}),
+        });
+      }
+    });
+    if (changes.size === 0) return;
 
     // Optimistic update
     previousThoughts.current = [...thoughts];
     setThoughts((prev) =>
-      prev.map((t) =>
-        t.id === thoughtId
-          ? { ...t, status: newStatus, status_updated_at: new Date().toISOString() }
-          : t
-      )
+      prev.map((t) => {
+        const c = changes.get(t.id);
+        if (!c) return t;
+        return {
+          ...t,
+          importance: c.importance,
+          ...(c.status
+            ? { status: c.status, status_updated_at: new Date().toISOString() }
+            : {}),
+        };
+      })
     );
 
-    // API call in background
-    apiUpdateKanban(thoughtId, { status: newStatus }).catch(() => {
-      // Revert on failure
+    // Persist all affected cards; revert everything on any failure
+    Promise.all(
+      [...changes.entries()].map(([id, c]) => apiUpdateKanban(id, c))
+    ).catch(() => {
       setThoughts(previousThoughts.current);
-      setError("Failed to update status. Reverted.");
+      setError("Failed to update board. Reverted.");
       setTimeout(() => setError(null), 5000);
     });
   }

--- a/dashboards/open-brain-dashboard-next/components/KanbanCardModal.tsx
+++ b/dashboards/open-brain-dashboard-next/components/KanbanCardModal.tsx
@@ -119,7 +119,7 @@ export function KanbanCardModal({
     >
       <div
         onClick={(e) => e.stopPropagation()}
-        className="bg-bg-surface border border-border rounded-xl w-full max-h-full max-w-lg flex flex-col shadow-2xl overflow-hidden mx-auto"
+        className="bg-bg-overlay border border-border rounded-xl w-full max-h-full max-w-lg flex flex-col shadow-2xl overflow-hidden mx-auto"
       >
         {/* Discard confirmation banner */}
         {showDiscardConfirm && (
@@ -297,7 +297,7 @@ export function KanbanCardModal({
     >
       <div
         onClick={(e) => e.stopPropagation()}
-        className="bg-bg-surface border border-border rounded-xl p-6 w-full max-w-sm shadow-2xl mx-4"
+        className="bg-bg-overlay border border-border rounded-xl p-6 w-full max-w-sm shadow-2xl mx-4"
       >
         <h3 className="text-base font-semibold text-text-primary mb-2">Delete thought?</h3>
         <p className="text-sm text-text-secondary mb-5">

--- a/dashboards/open-brain-dashboard-next/components/PriorityDot.tsx
+++ b/dashboards/open-brain-dashboard-next/components/PriorityDot.tsx
@@ -42,7 +42,7 @@ export function PriorityDot({ importance, onPriorityChange }: PriorityDotProps) 
       </button>
 
       {isOpen && (
-        <div className="absolute left-0 top-full mt-1 z-50 bg-bg-surface border border-border rounded-lg shadow-lg py-1 min-w-[120px]">
+        <div className="absolute left-0 top-full mt-1 z-50 bg-bg-overlay border border-border rounded-lg shadow-lg py-1 min-w-[120px]">
           {PRIORITY_LEVELS.map((p) => {
             const isCurrentLevel = level.label === p.label;
             return (

--- a/dashboards/open-brain-dashboard-next/metadata.json
+++ b/dashboards/open-brain-dashboard-next/metadata.json
@@ -6,7 +6,7 @@
     "name": "Alan Shurafa",
     "github": "alanshurafa"
   },
-  "version": "1.1.0",
+  "version": "1.1.1",
   "requires": {
     "open_brain": true,
     "services": [],
@@ -28,5 +28,5 @@
   "difficulty": "intermediate",
   "estimated_time": "30 minutes",
   "created": "2026-03-23",
-  "updated": "2026-03-31"
+  "updated": "2026-07-13"
 }


### PR DESCRIPTION
## Contribution Type

<!-- Check one -->
- [ ] Recipe (`/recipes`)
- [ ] Schema (`/schemas`)
- [x] Dashboard (`/dashboards`)
- [ ] Integration (`/integrations`)
- [ ] Skill (`/skills`)
- [ ] Repo improvement (docs, CI, templates)

## What does this do?

Fixes four bugs in the Next.js dashboard's kanban board:

1. **Dropping a card onto another card fails.** `handleDragEnd` treated `over.id` as a status unconditionally, so dropping onto a card sent that card's UUID as the `status` and the update failed. Since full columns have no empty drop space, they effectively couldn't receive cards at all.
2. **Intra-column reordering was scaffolded but never worked.** `SortableContext`/`useSortable` are wired up in the column/card components, but `onDragEnd` never handled same-column drops.
3. **Column order wasn't stable.** Cards rendered in fetch order, so any persisted priority wasn't reflected.
4. **The card edit modal was nearly transparent.** The modal (and the delete dialogs and priority dropdown) used `bg-surface`, a 4.5% white wash designed for cards sitting on the opaque page background. Floating over the board with only a dimmed backdrop behind them, these panels were see-through and hard to read.

**The drag fix** (`components/KanbanBoard.tsx`): `handleDragEnd` now resolves a card drop target to its column and insertion position, renumbers that column's `importance` values top-down (evenly spaced 99→1) so the order persists via the existing field, and batches the `apiUpdateKanban` calls behind an optimistic update that reverts on any failure. `groupByStatus` sorts each column by `importance` so order stays stable through optimistic updates. **No schema or API changes** — priority order rides on the existing `importance` field.

**The opacity fix** (`app/globals.css` + 3 components): adds an opaque `--color-bg-overlay` token (`#2d302e` — the existing `bg-elevated` wash composited over `bg-primary`, so the same intended color, just solid) and applies it to the four floating panels: the kanban card modal, its delete confirmation, `DeleteModal`, and the `PriorityDot` dropdown. Card and page surfaces are unchanged, and `bg-elevated` itself is untouched (it has ~31 usages that sit on opaque backgrounds).

Also included:
- README updated: Workflow Board features now document drop-on-card and intra-column reordering, plus a new troubleshooting entry for reverted reorders. (The README already had the required What It Does / Prerequisites / Steps / Expected Outcome / Troubleshooting sections.)
- `metadata.json` bumped to 1.1.1 with a fresh `updated` date (author credit unchanged).
- One pre-existing repo-wide gate failure fixed: the README's Cloudflare deploy section linked to `integrations/cloudflare-rest-worker`, which never existed; it now points to `integrations/open-brain-rest/` (see PR comment for details).

**One trade-off to flag:** a reorder in a long column fires one update request per repositioned card. Renumbering is already gated to only-changed cards (unchanged cards are skipped), which keeps this small in practice, but flagging it in case maintainers want a batch endpoint later.

## Requirements

No new requirements — same stack as the existing dashboard (Next.js, @dnd-kit, existing `/api/kanban/update` route). No new dependencies, env vars, or schema changes.

## Checklist

- [x] I've read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] My contribution has a `README.md` with prerequisites, step-by-step instructions, and expected outcome
- [x] My `metadata.json` has all required fields
- [ ] If my contribution depends on a skill or primitive, I declared it in metadata.json and linked it in the README — *N/A, no skill/primitive dependencies*
- [x] I tested this on my own Open Brain instance
- [x] No credentials, API keys, or secrets are included

Validated locally with `npx tsc --noEmit`, `npm run build`, and `npm run lint` — all clean.