### PR TITLE
[schemas] Reading list with ratings and review metadata

### DIFF
--- a/schemas/README.md
+++ b/schemas/README.md
@@ -7,13 +7,13 @@ Database table extensions and metadata schemas for your Supabase database. Drop 
 | Schema | What It Does |
 | ------ | ------------ |
 | [Agent Memory](agent-memory/) | Sidecar tables that turn existing `thoughts` into governed, provenance-labeled operational memory for agent workflows |
+| [Reading List](reading-list/) | Standalone `reading_list` table for books, articles, podcasts, and videos with ratings, review notes, tags, and want-to-read → reading → finished status tracking |
 
 > **Looking for CRM?** See [`extensions/professional-crm`](../extensions/professional-crm/) — it includes schema + a full MCP server.
 
 ## Ideas
 
 - Taste preferences tracker
-- Reading list with rating metadata
 
 ## Contributing
 

--- a/schemas/reading-list/README.md
+++ b/schemas/reading-list/README.md
@@ -1,0 +1,122 @@
+# Reading List
+
+> Adds a `reading_list` table for tracking books, articles, podcasts, and videos with ratings, review notes, and status tracking (want to read → reading → finished).
+
+## What It Does
+
+Creates a standalone `reading_list` table — books, articles, podcasts, and videos you want to consume, are consuming, or have finished — with a 1–5 rating, free-form review notes, start/finish dates, and JSONB tags. It also installs an auto-updating `updated_at` trigger and a `currently_reading` convenience view.
+
+This is the reading-list schema listed as planned in the repo README. It does **not** modify the core `thoughts` table; if you highlight while you read, pair it with the [readwise-books](../readwise-books/) schema, which caches book-level metadata for highlights stored in `thoughts`.
+
+**Valid types:** `book`, `article`, `podcast`, `video`
+**Valid statuses:** `want_to_read`, `reading`, `finished`, `abandoned`
+
+## Prerequisites
+
+- Working Open Brain setup ([guide](../../docs/01-getting-started.md))
+- Access to the Supabase SQL Editor or CLI
+
+## Credential Tracker
+
+```text
+READING LIST -- CREDENTIAL TRACKER
+--------------------------------------
+
+SUPABASE (from your Open Brain setup)
+  Project URL:           ____________
+  Secret key:            ____________
+
+--------------------------------------
+```
+
+## Steps
+
+![Step 1](https://img.shields.io/badge/Step_1-Run_Migration-1E88E5?style=for-the-badge)
+
+1. Open your **Supabase SQL Editor** (Dashboard > SQL Editor)
+2. Paste and run the contents of [`schema.sql`](schema.sql)
+
+Or via the Supabase CLI, save it under `supabase/migrations/` and run:
+
+```bash
+supabase db push
+```
+
+![Step 2](https://img.shields.io/badge/Step_2-Verify-1E88E5?style=for-the-badge)
+
+1. Verify the table exists with the expected columns:
+
+   ```sql
+   SELECT column_name, data_type, is_nullable
+   FROM information_schema.columns
+   WHERE table_name = 'reading_list'
+   ORDER BY ordinal_position;
+   ```
+
+2. Insert a test row and read it back through the view:
+
+   ```sql
+   INSERT INTO reading_list (title, author, type, status, started_date, tags)
+   VALUES ('Thinking, Fast and Slow', 'Daniel Kahneman', 'book', 'reading', CURRENT_DATE, '["psychology"]');
+
+   SELECT * FROM currently_reading;
+   ```
+
+![Step 3](https://img.shields.io/badge/Step_3-Use_It-1E88E5?style=for-the-badge)
+
+Common queries:
+
+```sql
+-- Finish a book and rate it
+UPDATE reading_list
+SET status = 'finished', finished_date = CURRENT_DATE, rating = 5,
+    review_notes = 'System 1 vs System 2 framing changed how I plan my mornings.'
+WHERE title = 'Thinking, Fast and Slow';
+
+-- Want-to-read queue, articles only
+SELECT title, author, url FROM reading_list
+WHERE status = 'want_to_read' AND type = 'article'
+ORDER BY created_at;
+
+-- Everything tagged "ai" rated 4+
+SELECT title, type, rating FROM reading_list
+WHERE tags @> '["ai"]' AND rating >= 4
+ORDER BY rating DESC;
+
+-- Reading history, most recent finishes first
+SELECT title, author, rating, finished_date FROM reading_list
+WHERE status = 'finished'
+ORDER BY finished_date DESC;
+```
+
+## Expected Outcome
+
+After running the migration:
+
+- A `reading_list` table exists with columns: `id`, `title`, `author`, `type`, `status`, `rating`, `review_notes`, `url`, `started_date`, `finished_date`, `tags`, `created_at`, `updated_at`
+- `type`, `status`, and `rating` are constrained to valid values (`rating` must be 1–5; a `finished_date` can never precede `started_date`)
+- Five indexes support the common filters (status, type, rating, tag containment, finish-date timeline)
+- Updating any row automatically refreshes its `updated_at` timestamp
+- A `currently_reading` view returns in-progress items, most recently started first
+
+> [!TIP]
+> The migration is idempotent — safe to run multiple times. `IF NOT EXISTS` / `CREATE OR REPLACE` prevent duplicate objects.
+
+## Troubleshooting
+
+**Issue: `new row for relation "reading_list" violates check constraint`**
+Solution: One of the constrained fields has an invalid value. Check that `type` is one of `book | article | podcast | video`, `status` is one of `want_to_read | reading | finished | abandoned`, `rating` is between 1 and 5 (or NULL), and `finished_date` is not earlier than `started_date`.
+
+**Issue: Tag queries return nothing**
+Solution: `tags` is a JSONB *array* — insert `'["ai", "productivity"]'`, not `'{"ai": true}'` or a comma-separated string. Query containment with `tags @> '["ai"]'`.
+
+**Issue: `updated_at` isn't changing on UPDATE**
+Solution: The trigger may not have been created (e.g. the migration was only partially run). Re-run `schema.sql` — the `DROP TRIGGER IF EXISTS` + `CREATE TRIGGER` block is safe to repeat.
+
+**Issue: I want statuses the schema doesn't allow (e.g. `on_hold`)**
+Solution: Extend the CHECK constraint:
+```sql
+ALTER TABLE reading_list DROP CONSTRAINT reading_list_status_check;
+ALTER TABLE reading_list ADD CONSTRAINT reading_list_status_check
+  CHECK (status IN ('want_to_read', 'reading', 'finished', 'abandoned', 'on_hold'));
+```

--- a/schemas/reading-list/metadata.json
+++ b/schemas/reading-list/metadata.json
@@ -1,0 +1,20 @@
+{
+  "name": "Reading List",
+  "description": "Adds a reading_list table for tracking books, articles, podcasts, and videos with ratings, review notes, tags, and status tracking from want-to-read through finished.",
+  "category": "schemas",
+  "author": {
+    "name": "Kaitlin Cort",
+    "github": "kaizengrowth"
+  },
+  "version": "1.0.0",
+  "requires": {
+    "open_brain": true,
+    "services": [],
+    "tools": []
+  },
+  "tags": ["reading-list", "books", "media", "ratings", "tracking"],
+  "difficulty": "beginner",
+  "estimated_time": "10 minutes",
+  "created": "2026-07-13",
+  "updated": "2026-07-13"
+}

--- a/schemas/reading-list/schema.sql
+++ b/schemas/reading-list/schema.sql
@@ -1,0 +1,104 @@
+-- Reading List
+-- Standalone table for tracking books, articles, podcasts, and videos
+-- with status (want to read → reading → finished), 1-5 ratings, review
+-- notes, and tags. Listed in the repo README as a planned schema.
+--
+-- Does NOT modify the core thoughts table.
+-- Safe to run multiple times (fully idempotent).
+
+-- ============================================================
+-- 1. TABLE
+-- ============================================================
+
+CREATE TABLE IF NOT EXISTS reading_list (
+  id            UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  title         TEXT NOT NULL,
+  author        TEXT,
+  type          TEXT NOT NULL DEFAULT 'book'
+                CHECK (type IN ('book', 'article', 'podcast', 'video')),
+  status        TEXT NOT NULL DEFAULT 'want_to_read'
+                CHECK (status IN ('want_to_read', 'reading', 'finished', 'abandoned')),
+  rating        SMALLINT
+                CHECK (rating BETWEEN 1 AND 5),
+  review_notes  TEXT,
+  url           TEXT,
+  started_date  DATE,
+  finished_date DATE,
+  tags          JSONB NOT NULL DEFAULT '[]'::jsonb,
+  created_at    TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at    TIMESTAMPTZ NOT NULL DEFAULT now(),
+  -- A finish date before the start date is always a data-entry error
+  CONSTRAINT reading_list_dates_ordered
+    CHECK (finished_date IS NULL OR started_date IS NULL OR finished_date >= started_date)
+);
+
+-- ============================================================
+-- 2. INDEXES
+-- ============================================================
+
+-- The two most common filters: "what am I reading" / "what do I want to read"
+CREATE INDEX IF NOT EXISTS idx_reading_list_status
+  ON reading_list (status);
+
+CREATE INDEX IF NOT EXISTS idx_reading_list_type
+  ON reading_list (type);
+
+-- Rated-items queries ("my 5-star books") skip unrated rows entirely
+CREATE INDEX IF NOT EXISTS idx_reading_list_rating
+  ON reading_list (rating) WHERE rating IS NOT NULL;
+
+-- Tag containment queries: tags @> '["ai"]'
+CREATE INDEX IF NOT EXISTS idx_reading_list_tags
+  ON reading_list USING gin (tags);
+
+-- Reading-history timeline
+CREATE INDEX IF NOT EXISTS idx_reading_list_finished
+  ON reading_list (finished_date DESC) WHERE finished_date IS NOT NULL;
+
+-- ============================================================
+-- 3. KEEP updated_at FRESH
+-- ============================================================
+
+CREATE OR REPLACE FUNCTION reading_list_touch_updated_at()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+AS $$
+BEGIN
+  NEW.updated_at = now();
+  RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS trg_reading_list_updated_at ON reading_list;
+CREATE TRIGGER trg_reading_list_updated_at
+  BEFORE UPDATE ON reading_list
+  FOR EACH ROW
+  EXECUTE FUNCTION reading_list_touch_updated_at();
+
+-- ============================================================
+-- 4. CONVENIENCE VIEW — the shelf you look at most
+-- ============================================================
+
+CREATE OR REPLACE VIEW currently_reading AS
+  SELECT id, title, author, type, url, started_date, tags
+  FROM reading_list
+  WHERE status = 'reading'
+  ORDER BY started_date DESC NULLS LAST, created_at DESC;
+
+-- ============================================================
+-- 5. OPTIONAL: ROW LEVEL SECURITY
+--    The standard Open Brain setup accesses tables with the
+--    service role key (which bypasses RLS), so RLS is left
+--    disabled by default — matching the core thoughts table and
+--    the readwise-books schema. If you expose this table to
+--    authenticated or anon clients (e.g. a public dashboard),
+--    uncomment and adapt:
+-- ============================================================
+
+-- ALTER TABLE reading_list ENABLE ROW LEVEL SECURITY;
+--
+-- CREATE POLICY "authenticated can manage reading list"
+--   ON reading_list FOR ALL
+--   TO authenticated
+--   USING (true)
+--   WITH CHECK (true);


### PR DESCRIPTION
Fixes #16

## Contribution Type

<!-- Check one -->
- [ ] Recipe (`/recipes`)
- [x] Schema (`/schemas`)
- [ ] Dashboard (`/dashboards`)
- [ ] Integration (`/integrations`)
- [ ] Skill (`/skills`)
- [ ] Repo improvement (docs, CI, templates)

## What does this do?

Adds the reading-list schema that was listed as planned in `schemas/README.md`: a standalone `reading_list` table for tracking books, articles, podcasts, and videos through `want_to_read → reading → finished` (plus `abandoned`), with a 1–5 rating, review notes, url, start/finish dates, and JSONB tags — all the fields recommended in the issue.

Beyond the table itself:
- **CHECK constraints** on `type`, `status`, `rating` (1–5), and date ordering (`finished_date` can't precede `started_date`)
- **Five indexes** for the common access patterns: status, type, rating (partial), tag containment (GIN), and finish-date timeline (partial)
- **`updated_at` touch trigger** so edits keep the timestamp fresh
- **`currently_reading` view** for the shelf you check most often
- **RLS**: included as a commented optional block. The standard Open Brain setup accesses tables with the service role key (which bypasses RLS), so RLS defaults off — matching the core `thoughts` table and the `readwise-books` schema precedent. The README explains when to enable it.

The migration is fully idempotent and does not touch the core `thoughts` table. Also updates `schemas/README.md`: adds the schema to the catalog table and removes the fulfilled entry from the Ideas list.

**Design note:** `abandoned` is included alongside the three statuses from the issue — DNF-ing is a real reading outcome, and adding it later would mean an ALTER for everyone. The README's troubleshooting section shows how to extend the status list if you want more (e.g. `on_hold`).

**Tested:** applied against Postgres 16 twice in a row (idempotency), verified the trigger updates `updated_at`, the view returns in-progress items, and all four constraint classes reject invalid rows.

## Requirements

No external services or tools — just the Supabase SQL Editor (or CLI) from a working Open Brain setup.

## Checklist

- [x] I've read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] My contribution has a `README.md` with prerequisites, step-by-step instructions, and expected outcome
- [x] My `metadata.json` has all required fields
- [ ] If my contribution depends on a skill or primitive, I declared it in metadata.json and linked it in the README — *N/A, no dependencies*
- [x] I tested this on my own Open Brain instance — *specifically: applied twice against a clean Postgres 16 (idempotency), then exercised the trigger, view, and all four constraint classes with real inserts/updates*
- [x] No credentials, API keys, or secrets are included
