### PR TITLE
[recipes] Daily digest — implement the Supabase Edge Function approach

### DIFF
--- a/recipes/daily-digest/README.md
+++ b/recipes/daily-digest/README.md
@@ -10,8 +10,8 @@ There are two approaches — pick the one that fits your setup:
 
 | Approach | Infrastructure | Difficulty | Auto-send? |
 | -------- | -------------- | ---------- | ---------- |
-| **Claude Code Scheduled Task** (below) | None — uses MCP tools you already have | Beginner | Draft only (one-tap send) |
-| **Supabase Edge Function** (planned) | Edge Function + pg_cron + email service | Intermediate | Full auto-send |
+| **Claude Code Scheduled Task** ([Approach A](#approach-a-claude-code-scheduled-task)) | None — uses MCP tools you already have | Beginner | Draft only (one-tap send) |
+| **Supabase Edge Function** ([Approach B](#approach-b-supabase-edge-function)) | Edge Function + pg_cron + Resend | Beginner | Full auto-send |
 
 ---
 
@@ -106,17 +106,20 @@ Solution: Verify your Gmail MCP connector is working. Try `gmail_create_draft` m
 
 ---
 
-## Approach B: Supabase Edge Function (Planned)
+## Approach B: Supabase Edge Function
 
-A fully self-contained approach using a Supabase Edge Function, pg_cron trigger, and an email service (Resend or SendGrid) for true automated delivery without Claude running. This approach is not yet implemented — contributions welcome.
+A fully self-contained approach using a Supabase Edge Function, a pg_cron trigger, and [Resend](https://resend.com) for true automated delivery — no Claude session or local machine required. The digest is formatted with plain template code, so **no LLM key is needed**.
 
-### Prerequisites (planned)
+The function ([`edge-function/index.ts`](edge-function/index.ts)) queries thoughts from the last 24 hours, groups them by type with a summary header (counts, top topics), and emails the result. Thoughts with `sensitivity_tier` of `personal` or `restricted` (from the [enhanced-thoughts](../../schemas/enhanced-thoughts/) schema) are excluded by default.
 
+### Prerequisites
+
+- Working Open Brain setup ([guide](../../docs/01-getting-started.md))
 - Supabase CLI available ([Homebrew/Scoop/standalone binary or `npx supabase`](https://supabase.com/docs/guides/local-development/cli/getting-started); `npm i -g supabase` is not supported)
-- OpenRouter API key (for generating the summary)
-- Email service: Resend or SendGrid (free tier)
+- [Resend](https://resend.com) account (free tier: 100 emails/day — plenty for one digest)
+- `pg_cron` and `pg_net` extensions enabled (Database → Extensions in the Supabase dashboard)
 
-### Credential Tracker (for future Edge Function approach)
+### Credential Tracker
 
 ```text
 DAILY DIGEST -- CREDENTIAL TRACKER
@@ -124,13 +127,124 @@ DAILY DIGEST -- CREDENTIAL TRACKER
 
 FROM YOUR OPEN BRAIN SETUP
   Supabase Project URL:  ____________
-  Supabase Secret key:   ____________
-  OpenRouter API key:    ____________
+  Supabase project ref:  ____________
 
-DELIVERY METHOD
-  Email service (Resend/SendGrid): ____________
-  API key:                         ____________
-  Sender email:                    ____________
+DELIVERY
+  Resend API key:        ____________
+  Recipient email:       ____________
+  Sender email:          ____________ (optional — needs a verified domain)
+
+SECURITY
+  DIGEST_ACCESS_KEY:     ____________ (any random string you generate)
 
 --------------------------------------
+```
+
+### Steps
+
+![Step 1](https://img.shields.io/badge/Step_1-Get_a_Resend_Key-1E88E5?style=for-the-badge)
+
+Sign up at [resend.com](https://resend.com) and create an API key.
+
+> [!NOTE]
+> Without a verified domain, Resend's default `onboarding@resend.dev` sender can only deliver to **the email address of your own Resend account** — which is exactly what a personal digest needs. To send from your own address instead, verify a domain in Resend and set `DIGEST_FROM_EMAIL` in Step 3.
+
+---
+
+![Step 2](https://img.shields.io/badge/Step_2-Deploy_the_Function-1E88E5?style=for-the-badge)
+
+From your Supabase project directory:
+
+```bash
+mkdir -p supabase/functions/daily-digest
+cp recipes/daily-digest/edge-function/index.ts supabase/functions/daily-digest/index.ts
+supabase functions deploy daily-digest --no-verify-jwt
+```
+
+`--no-verify-jwt` is required because pg_cron calls the function without a user JWT — access is gated by the `DIGEST_ACCESS_KEY` secret instead.
+
+---
+
+![Step 3](https://img.shields.io/badge/Step_3-Set_Secrets-1E88E5?style=for-the-badge)
+
+```bash
+supabase secrets set \
+  RESEND_API_KEY=re_your_key_here \
+  DIGEST_TO_EMAIL=you@example.com \
+  DIGEST_ACCESS_KEY=$(openssl rand -hex 16)
+
+# Optional — only with a domain verified in Resend:
+# supabase secrets set DIGEST_FROM_EMAIL="Open Brain <digest@yourdomain.com>"
+```
+
+Note the `DIGEST_ACCESS_KEY` value (`supabase secrets list` shows digests only, not values, so save it in your credential tracker).
+
+---
+
+![Step 4](https://img.shields.io/badge/Step_4-Test-1E88E5?style=for-the-badge)
+
+Dry run first — returns the digest as JSON without sending anything:
+
+```bash
+curl -s -X POST \
+  "https://YOUR-PROJECT-REF.supabase.co/functions/v1/daily-digest?key=YOUR_DIGEST_ACCESS_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"hours": 24, "dry_run": true}'
+```
+
+Then send a real one by dropping `dry_run`:
+
+```bash
+curl -s -X POST \
+  "https://YOUR-PROJECT-REF.supabase.co/functions/v1/daily-digest?key=YOUR_DIGEST_ACCESS_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"hours": 24}'
+```
+
+Check your inbox. The response includes `{"sent": true, "thought_count": N, ...}`.
+
+Optional body parameters: `hours` (1–168, default 24) widens the window; `include_personal: true` includes `personal`/`restricted` sensitivity tiers, which are excluded by default.
+
+---
+
+![Step 5](https://img.shields.io/badge/Step_5-Schedule_It-1E88E5?style=for-the-badge)
+
+Open [`schedule.sql`](schedule.sql), replace `<YOUR-PROJECT-REF>` and `<YOUR-DIGEST-KEY>` with your values, then run it in the Supabase SQL Editor. This adds a pg_cron job that fires daily at 07:00 UTC — adjust the cron expression to land the email in your morning.
+
+Verify it's scheduled:
+
+```sql
+SELECT jobname, schedule FROM cron.job WHERE jobname = 'daily-digest';
+```
+
+### Expected Outcome
+
+Every morning, an email arrives with:
+
+- A summary header: total thoughts captured in the last 24 hours, breakdown by type, top topics
+- Thoughts grouped by type, each with a content preview (truncated to ~200 chars) and topic/people tags
+- On a quiet day, a short "no new thoughts" note instead
+
+The function responds to the cron trigger in a few seconds; no LLM calls, so runs are effectively free beyond Supabase's Edge Function quota.
+
+### Troubleshooting
+
+**Issue: `{"error": "unauthorized"}`**
+Solution: The `?key=` query parameter doesn't match the `DIGEST_ACCESS_KEY` secret. Re-check the value in `schedule.sql` and your curl command. If you've lost it, set a new one (`supabase secrets set DIGEST_ACCESS_KEY=...`) — no redeploy needed, secrets apply on the next invocation.
+
+**Issue: Resend returns 403 / email never arrives**
+Solution: Without a verified domain, the default `onboarding@resend.dev` sender can only deliver to your own Resend account email — make sure `DIGEST_TO_EMAIL` matches it, or verify a domain and set `DIGEST_FROM_EMAIL`. Also check Resend's dashboard → Logs for delivery status, and your spam folder.
+
+**Issue: `thoughts query failed: 401`**
+Solution: The function's auto-injected service role key isn't reaching PostgREST — this usually means the function was deployed to a different project than your thoughts database. Run `supabase link --project-ref YOUR-REF` and redeploy.
+
+**Issue: Digest is empty but I captured thoughts yesterday**
+Solution: The window is measured from *now*, not calendar days. If the cron fires at 07:00 UTC, it covers 07:00→07:00. Widen the window in `schedule.sql` (`'hours', 36`) or shift the cron time. Also note `personal`/`restricted` thoughts are excluded unless you pass `include_personal: true`.
+
+**Issue: Cron job exists but nothing fires**
+Solution: Confirm both `pg_cron` *and* `pg_net` are enabled (the job runs but the HTTP call silently fails without pg_net). Check run history:
+```sql
+SELECT start_time, status, return_message FROM cron.job_run_details
+WHERE jobid = (SELECT jobid FROM cron.job WHERE jobname = 'daily-digest')
+ORDER BY start_time DESC LIMIT 5;
 ```

--- a/recipes/daily-digest/edge-function/index.ts
+++ b/recipes/daily-digest/edge-function/index.ts
@@ -1,0 +1,235 @@
+// supabase/functions/daily-digest/index.ts
+//
+// Daily digest of recent Open Brain thoughts, delivered by email via Resend.
+// This is Approach B of the daily-digest recipe: fully automated — no Claude
+// session or local machine required. Formatting is pure template code, so no
+// LLM key is needed either.
+//
+// What it does:
+//   1. Fetches thoughts captured in the last N hours (default 24).
+//   2. Skips personal/restricted sensitivity tiers unless asked not to.
+//   3. Groups them by type with a summary header (counts, top topics).
+//   4. Emails the digest through Resend (or returns it with dry_run: true).
+//
+// Required secrets (supabase secrets set KEY=value):
+//   RESEND_API_KEY      Resend API key (https://resend.com — free tier is fine)
+//   DIGEST_TO_EMAIL     Where the digest goes
+//   DIGEST_ACCESS_KEY   Random secret gating the function URL (?key=...)
+// Optional:
+//   DIGEST_FROM_EMAIL   Verified Resend sender (default: onboarding@resend.dev,
+//                       which can only deliver to your own Resend account email)
+//
+// SUPABASE_URL and SUPABASE_SERVICE_ROLE_KEY are injected automatically by
+// the Edge Function runtime.
+//
+// Request body (all optional):
+//   { "hours": 24, "dry_run": false, "include_personal": false }
+//
+// Schedule: see schedule.sql in this recipe folder.
+
+const SUPABASE_URL = Deno.env.get("SUPABASE_URL")!;
+const SERVICE_ROLE_KEY = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY")!;
+const RESEND_API_KEY = Deno.env.get("RESEND_API_KEY")!;
+const DIGEST_TO_EMAIL = Deno.env.get("DIGEST_TO_EMAIL")!;
+const DIGEST_ACCESS_KEY = Deno.env.get("DIGEST_ACCESS_KEY")!;
+const DIGEST_FROM_EMAIL =
+  Deno.env.get("DIGEST_FROM_EMAIL") ?? "Open Brain <onboarding@resend.dev>";
+
+// Hard cap on thoughts per digest — one day of heavy capture stays readable.
+const FETCH_LIMIT = 200;
+// Per-thought preview length in the email.
+const PREVIEW_CHARS = 200;
+
+// Sensitivity tiers excluded by default (enhanced-thoughts schema). Rows
+// without the column are always included.
+const PRIVATE_TIERS = new Set(["personal", "restricted"]);
+
+interface ThoughtRow {
+  id: string;
+  content: string;
+  created_at: string;
+  metadata: Record<string, unknown> | null;
+  // Optional columns from the enhanced-thoughts schema:
+  type?: string | null;
+  sensitivity_tier?: string | null;
+  [key: string]: unknown;
+}
+
+function thoughtType(t: ThoughtRow): string {
+  return (
+    t.type ??
+    (t.metadata?.type as string | undefined) ??
+    "uncategorized"
+  );
+}
+
+function stringList(value: unknown): string[] {
+  return Array.isArray(value) ? value.filter((v) => typeof v === "string") : [];
+}
+
+function truncate(text: string, max: number): string {
+  const oneLine = text.replace(/\s+/g, " ").trim();
+  return oneLine.length <= max ? oneLine : oneLine.slice(0, max - 1) + "…";
+}
+
+function escapeHtml(text: string): string {
+  return text
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;");
+}
+
+async function fetchRecentThoughts(hours: number): Promise<ThoughtRow[]> {
+  const since = new Date(Date.now() - hours * 3600 * 1000).toISOString();
+  const url =
+    `${SUPABASE_URL}/rest/v1/thoughts` +
+    `?select=*&created_at=gte.${encodeURIComponent(since)}` +
+    `&order=created_at.desc&limit=${FETCH_LIMIT}`;
+  const res = await fetch(url, {
+    headers: {
+      apikey: SERVICE_ROLE_KEY,
+      Authorization: `Bearer ${SERVICE_ROLE_KEY}`,
+    },
+  });
+  if (!res.ok) {
+    throw new Error(`thoughts query failed: ${res.status} ${await res.text()}`);
+  }
+  return await res.json();
+}
+
+function buildDigest(thoughts: ThoughtRow[], hours: number) {
+  const today = new Date().toISOString().slice(0, 10);
+  const subject = `Open Brain Daily Digest — ${today}`;
+
+  if (thoughts.length === 0) {
+    const empty = `No new thoughts captured in the last ${hours} hours.`;
+    return { subject, text: empty, html: `<p>${empty}</p>` };
+  }
+
+  // Group by type, count topics for the summary header
+  const byType = new Map<string, ThoughtRow[]>();
+  const topicCounts = new Map<string, number>();
+  for (const t of thoughts) {
+    const type = thoughtType(t);
+    if (!byType.has(type)) byType.set(type, []);
+    byType.get(type)!.push(t);
+    for (const topic of stringList(t.metadata?.topics)) {
+      topicCounts.set(topic, (topicCounts.get(topic) ?? 0) + 1);
+    }
+  }
+  const topTopics = [...topicCounts.entries()]
+    .sort((a, b) => b[1] - a[1])
+    .slice(0, 5)
+    .map(([topic, n]) => `${topic} (${n})`);
+  const typeBreakdown = [...byType.entries()]
+    .sort((a, b) => b[1].length - a[1].length)
+    .map(([type, rows]) => `${type}: ${rows.length}`);
+
+  const textParts: string[] = [
+    `${thoughts.length} thought${thoughts.length === 1 ? "" : "s"} captured in the last ${hours} hours.`,
+    `By type: ${typeBreakdown.join(" · ")}`,
+  ];
+  if (topTopics.length > 0) textParts.push(`Top topics: ${topTopics.join(", ")}`);
+  textParts.push("");
+
+  const htmlParts: string[] = [
+    `<p><strong>${thoughts.length}</strong> thought${thoughts.length === 1 ? "" : "s"} captured in the last ${hours} hours.<br>`,
+    `By type: ${escapeHtml(typeBreakdown.join(" · "))}` +
+      (topTopics.length > 0 ? `<br>Top topics: ${escapeHtml(topTopics.join(", "))}` : "") +
+      `</p>`,
+  ];
+
+  for (const [type, rows] of byType) {
+    textParts.push(`## ${type} (${rows.length})`, "");
+    htmlParts.push(`<h3>${escapeHtml(type)} (${rows.length})</h3><ul>`);
+    for (const t of rows) {
+      const preview = truncate(t.content, PREVIEW_CHARS);
+      const tags = [
+        ...stringList(t.metadata?.topics),
+        ...stringList(t.metadata?.people),
+      ];
+      const suffix = tags.length > 0 ? ` [${tags.join(", ")}]` : "";
+      textParts.push(`- ${preview}${suffix}`);
+      htmlParts.push(
+        `<li>${escapeHtml(preview)}${suffix ? ` <em>${escapeHtml(suffix)}</em>` : ""}</li>`
+      );
+    }
+    textParts.push("");
+    htmlParts.push("</ul>");
+  }
+
+  return { subject, text: textParts.join("\n"), html: htmlParts.join("\n") };
+}
+
+async function sendEmail(digest: { subject: string; text: string; html: string }) {
+  const res = await fetch("https://api.resend.com/emails", {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${RESEND_API_KEY}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      from: DIGEST_FROM_EMAIL,
+      to: [DIGEST_TO_EMAIL],
+      subject: digest.subject,
+      text: digest.text,
+      html: digest.html,
+    }),
+  });
+  if (!res.ok) {
+    throw new Error(`Resend send failed: ${res.status} ${await res.text()}`);
+  }
+  return await res.json();
+}
+
+Deno.serve(async (req) => {
+  // Gate: the URL must carry the shared secret (?key=...)
+  const url = new URL(req.url);
+  if (url.searchParams.get("key") !== DIGEST_ACCESS_KEY) {
+    return new Response(JSON.stringify({ error: "unauthorized" }), {
+      status: 401,
+      headers: { "Content-Type": "application/json" },
+    });
+  }
+
+  try {
+    const body =
+      req.method === "POST" ? await req.json().catch(() => ({})) : {};
+    const hours = Math.min(Math.max(Number(body.hours) || 24, 1), 168);
+    const dryRun = body.dry_run === true;
+    const includePersonal = body.include_personal === true;
+
+    let thoughts = await fetchRecentThoughts(hours);
+    if (!includePersonal) {
+      thoughts = thoughts.filter(
+        (t) => !PRIVATE_TIERS.has(t.sensitivity_tier ?? "")
+      );
+    }
+
+    const digest = buildDigest(thoughts, hours);
+
+    if (dryRun) {
+      return new Response(
+        JSON.stringify({ sent: false, thought_count: thoughts.length, ...digest }),
+        { headers: { "Content-Type": "application/json" } }
+      );
+    }
+
+    const sendResult = await sendEmail(digest);
+    return new Response(
+      JSON.stringify({
+        sent: true,
+        thought_count: thoughts.length,
+        subject: digest.subject,
+        resend_id: sendResult.id ?? null,
+      }),
+      { headers: { "Content-Type": "application/json" } }
+    );
+  } catch (err) {
+    console.error("daily-digest failed:", err);
+    return new Response(
+      JSON.stringify({ error: err instanceof Error ? err.message : String(err) }),
+      { status: 500, headers: { "Content-Type": "application/json" } }
+    );
+  }
+});

--- a/recipes/daily-digest/metadata.json
+++ b/recipes/daily-digest/metadata.json
@@ -1,20 +1,20 @@
 {
   "name": "Daily Digest",
-  "description": "Automated daily summary of recent thoughts delivered via Gmail draft, powered by Claude Code scheduled tasks and Open Brain MCP. Zero infrastructure required.",
+  "description": "Automated daily summary of recent thoughts — as a Gmail draft via Claude Code scheduled tasks (zero infrastructure), or fully auto-sent by a Supabase Edge Function with pg_cron and Resend.",
   "category": "recipes",
   "author": {
     "name": "Matt Hallett",
     "github": "matthallett"
   },
-  "version": "1.0.0",
+  "version": "1.1.0",
   "requires": {
     "open_brain": true,
-    "services": ["Gmail MCP"],
-    "tools": ["Claude Code or Claude Desktop"]
+    "services": ["Gmail MCP (Approach A)", "Resend (Approach B)"],
+    "tools": ["Claude Code or Claude Desktop (Approach A)", "Supabase CLI (Approach B)"]
   },
-  "tags": ["digest", "summary", "email", "automation", "scheduled-task", "gmail", "claude-code"],
+  "tags": ["digest", "summary", "email", "automation", "scheduled-task", "gmail", "claude-code", "edge-function", "pg_cron", "resend"],
   "difficulty": "beginner",
-  "estimated_time": "10 minutes",
+  "estimated_time": "20 minutes",
   "created": "2026-03-25",
-  "updated": "2026-03-25"
+  "updated": "2026-07-13"
 }

--- a/recipes/daily-digest/schedule.sql
+++ b/recipes/daily-digest/schedule.sql
@@ -1,0 +1,54 @@
+-- ============================================================
+-- Schedule the daily digest via pg_cron
+-- Run this in your Supabase SQL Editor (one-time setup).
+--
+-- BEFORE RUNNING:
+--   Replace <YOUR-PROJECT-REF> with your Supabase project reference.
+--   Replace <YOUR-DIGEST-KEY> with the value of your DIGEST_ACCESS_KEY
+--   secret (any random string you choose — used to gate the function URL).
+-- ============================================================
+--
+-- Prerequisites:
+--   pg_cron + pg_net extensions enabled.
+--   To enable: Database → Extensions → search for pg_cron and pg_net → enable both.
+--
+-- Default timing: 07:00 UTC daily. Adjust the cron expression to
+-- land the email in your morning (e.g. '0 12 * * *' for 7am US Eastern).
+-- ============================================================
+
+SELECT cron.schedule(
+  'daily-digest',
+  '0 7 * * *',
+  $$
+  SELECT net.http_post(
+    url := 'https://<YOUR-PROJECT-REF>.supabase.co/functions/v1/daily-digest?key=<YOUR-DIGEST-KEY>',
+    headers := jsonb_build_object(
+      'Content-Type', 'application/json'
+    ),
+    body := jsonb_build_object(
+      'hours', 24
+    )
+  );
+  $$
+);
+
+-- ============================================================
+-- Verify scheduled:
+--   SELECT jobname, schedule FROM cron.job WHERE jobname = 'daily-digest';
+--
+-- Run history:
+--   SELECT jobname, start_time, status, return_message
+--   FROM cron.job_run_details
+--   WHERE jobid = (SELECT jobid FROM cron.job WHERE jobname = 'daily-digest')
+--   ORDER BY start_time DESC LIMIT 5;
+--
+-- Manual test (returns the digest as JSON instead of emailing it):
+--   SELECT net.http_post(
+--     url := 'https://<YOUR-PROJECT-REF>.supabase.co/functions/v1/daily-digest?key=<YOUR-DIGEST-KEY>',
+--     headers := jsonb_build_object('Content-Type', 'application/json'),
+--     body := jsonb_build_object('hours', 24, 'dry_run', true)
+--   );
+--
+-- Remove the schedule (if needed):
+--   SELECT cron.unschedule('daily-digest');
+-- ============================================================


### PR DESCRIPTION
Fixes #14

## Contribution Type

<!-- Check one -->
- [x] Recipe (`/recipes`)
- [ ] Schema (`/schemas`)
- [ ] Dashboard (`/dashboards`)
- [ ] Integration (`/integrations`)
- [ ] Skill (`/skills`)
- [ ] Repo improvement (docs, CI, templates)

## What does this do?

Completes the daily-digest recipe. The stub already had a working Approach A (Claude Code scheduled task → Gmail draft); the Supabase Edge Function path was marked *"Planned — contributions welcome."* This PR implements it:

- **`edge-function/index.ts`** — a self-contained Deno Edge Function that queries thoughts from the last N hours (default 24, max 168) via PostgREST, groups them by type with a summary header (total count, per-type breakdown, top topics), and sends the digest through [Resend](https://resend.com) as both text and HTML. Thoughts with `sensitivity_tier` of `personal`/`restricted` (enhanced-thoughts schema) are excluded by default; rows without that column are unaffected. Supports `{ dry_run: true }` (returns the digest as JSON without sending — used for testing), `hours`, and `include_personal` body params.
- **`schedule.sql`** — pg_cron + pg_net job firing daily at 07:00 UTC, with verify/run-history/manual-test/unschedule snippets. Modeled on the editorial-policy recipe's `schedule.sql`.
- **Security** — deployed with `--no-verify-jwt` (pg_cron can't send a user JWT) and gated by a `DIGEST_ACCESS_KEY` query secret instead, the same pattern as the editorial-policy auditor.
- **README** — Approach B rewritten from "planned" to full step-by-step setup (Resend key → deploy → secrets → dry-run test → schedule), expected outcome, and a troubleshooting section covering the five failure modes I could produce (bad access key, Resend sender restrictions, wrong project link, empty-window confusion, pg_net not enabled).
- **metadata.json** — bumped to 1.1.0, description/services/tools/tags updated to cover both approaches. Original author credit unchanged.

**One deliberate simplification:** the digest is formatted with plain template code rather than the OpenRouter LLM call the original stub sketched. It keeps the recipe at "beginner" difficulty and zero marginal cost, and matches what the issue asked for (grouped, readable, with summaries). An LLM-synthesized variant already exists in the [weekly-digest](../recipes/weekly-digest/) recipe for those who want prose synthesis.

**Tested:** `deno check` passes, and the function was driven end-to-end under Deno against a mock PostgREST endpoint: auth gate rejects a bad key, dry_run returns the digest without sending, `personal`/`restricted` rows are excluded (and included with `include_personal`), grouping/summary/topic counts/truncation come out as described, and the PostgREST query carries the expected window, ordering, and limit. Not yet run against a live Supabase project — the dry_run curl in the README is the first thing to try on a real instance.

## Requirements

- Supabase CLI (deploy) and the `pg_cron` + `pg_net` extensions (schedule)
- Resend account (free tier) with its API key set as a function secret
- No LLM key, no new schema — works against the core `thoughts` table

## Checklist

- [x] I've read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] My contribution has a `README.md` with prerequisites, step-by-step instructions, and expected outcome
- [x] My `metadata.json` has all required fields
- [ ] If my contribution depends on a skill or primitive, I declared it in metadata.json and linked it in the README — *N/A*
- [ ] I tested this on my own Open Brain instance — *validated via typecheck + end-to-end mock-PostgREST run (details above); happy to post live dry-run output if wanted before merge*
- [x] No credentials, API keys, or secrets are included
