### PR TITLE
[recipes] repo-learning-coach: load .env via dotenv + fix research frontmatter

### DIFF
--- a/recipes/repo-learning-coach/package-lock.json
+++ b/recipes/repo-learning-coach/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "dependencies": {
         "@supabase/supabase-js": "^2.47.10",
+        "dotenv": "^17.4.2",
         "express": "^5.2.1",
         "gray-matter": "^4.0.3",
         "react": "^19.2.0",
@@ -2558,6 +2559,18 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "17.4.2",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.4.2.tgz",
+      "integrity": "sha512-nI4U3TottKAcAD9LLud4Cb7b2QztQMUEfHbvhTH09bqXTxnSie8WnjPALV/WMCrJZ6UV/qHJ6L03OqO3LcdYZw==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
       }
     },
     "node_modules/dunder-proto": {

--- a/recipes/repo-learning-coach/package.json
+++ b/recipes/repo-learning-coach/package.json
@@ -15,6 +15,7 @@
   },
   "dependencies": {
     "@supabase/supabase-js": "^2.47.10",
+    "dotenv": "^17.4.2",
     "express": "^5.2.1",
     "gray-matter": "^4.0.3",
     "react": "^19.2.0",

--- a/recipes/repo-learning-coach/research/01-what-the-recipe-builds.md
+++ b/recipes/repo-learning-coach/research/01-what-the-recipe-builds.md
@@ -1,7 +1,7 @@
 ---
 slug: recipe-overview
 title: What Repo Learning Coach Builds
-summary: The product boundary for the recipe: a local learning app backed by Supabase tables inside an existing Open Brain project.
+summary: "The product boundary for the recipe: a local learning app backed by Supabase tables inside an existing Open Brain project."
 category: orientation
 ---
 

--- a/recipes/repo-learning-coach/research/02-content-contract.md
+++ b/recipes/repo-learning-coach/research/02-content-contract.md
@@ -1,7 +1,7 @@
 ---
 slug: content-contract
 title: The Content Contract
-summary: The repo-specific surface is plain files: one config file, research markdown, and lesson markdown with frontmatter.
+summary: "The repo-specific surface is plain files: one config file, research markdown, and lesson markdown with frontmatter."
 category: architecture
 ---
 

--- a/recipes/repo-learning-coach/server/index.ts
+++ b/recipes/repo-learning-coach/server/index.ts
@@ -1,3 +1,5 @@
+import 'dotenv/config'
+
 import express from 'express'
 import { existsSync } from 'node:fs'
 import { z } from 'zod'

--- a/recipes/repo-learning-coach/server/sync-content.ts
+++ b/recipes/repo-learning-coach/server/sync-content.ts
@@ -1,3 +1,5 @@
+import 'dotenv/config'
+
 import { syncContentToSupabase } from './db.js'
 
 const run = async () => {


### PR DESCRIPTION
## What & why

The **repo-learning-coach** recipe documents a `.env` workflow (Step 2: copy `.env.example`, fill in Supabase + OpenRouter credentials) but the app never loaded `.env`. Following the README as written, `npm run sync` and `npm run dev` both fail immediately:

```
Error: Missing required environment variable: SUPABASE_URL
```

There was no `dotenv`, no `--env-file`, and Node does not auto-load `.env`, so the server process (`tsx server/index.ts`) started with an empty environment.

## Changes

- Add `dotenv` as a dependency and `import 'dotenv/config'` as the first import in the two server entry points (`server/index.ts`, `server/sync-content.ts`). Placed first so `.env` is loaded before `server/supabase.ts` reads `process.env` at module-init time. The client half (Vite) already loads `.env` on its own; this only affects the Node server process.
- Quote two `research/*.md` frontmatter `summary:` values that contained unquoted colons (`"...the recipe: a local..."`, `"...plain files: one config file..."`). Unquoted colons are parsed as YAML mappings, which broke `npm run sync` with an "incomplete explicit mapping pair" error.

## Testing

On a fresh `.env` (from `.env.example`) against an existing Open Brain Supabase project:

- `npm run sync` → `Synced 3 lessons and 3 research documents.`
- `npm run dev` → server `GET /api/bootstrap` returns HTTP 200 with the project + 3 lessons; Vite client returns HTTP 200.

No schema or app-logic changes; the core `thoughts` table is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)