### PR TITLE
[integrations] delete-thought-mcp: audit trail before hard delete

### DIFF
--- a/integrations/delete-thought-mcp/index.ts
+++ b/integrations/delete-thought-mcp/index.ts
@@ -19,11 +19,14 @@
  *   SUPABASE_SERVICE_ROLE_KEY
  *   MCP_ACCESS_KEY
  *
- * Extension hook:
- *   If you install the thought_audit schema (see `schemas/thought-audit`)
- *   you can extend this function to write an audit row before the delete
- *   so the prior content is preserved for recovery. Left out of the base
- *   integration to keep dependencies minimal.
+ * Audit trail:
+ *   Requires the thought_audit schema (see `schemas/thought-audit`).
+ *   Before each hard delete, this function writes an append-only audit
+ *   row preserving the prior content and metadata under
+ *   diff.previous_content / diff.previous_metadata, so a deleted thought
+ *   is recoverable from the audit trail alone. The audit write is
+ *   fire-and-forget by contract — a failure there is logged but never
+ *   blocks the delete.
  */
 
 import "jsr:@supabase/functions-js/edge-runtime.d.ts";
@@ -60,9 +63,10 @@ server.registerTool(
   async ({ id }) => {
     try {
       // Pre-flight fetch so "not found" is a clear, distinct outcome.
+      // Also pull metadata so the audit row can preserve it for recovery.
       const { data: existing, error: fetchError } = await supabase
         .from("thoughts")
-        .select("id, content")
+        .select("id, content, metadata")
         .eq("id", id)
         .single();
 
@@ -76,6 +80,31 @@ server.registerTool(
           ],
           isError: true,
         };
+      }
+
+      // Audit-before-delete: preserve the prior content and metadata so the
+      // hard delete below is recoverable from the append-only audit trail
+      // alone. Fire-and-forget by contract — an audit failure is logged but
+      // MUST NOT block the delete (see schemas/thought-audit).
+      const meta = (existing.metadata ?? {}) as Record<string, unknown>;
+      const { error: auditError } = await supabase.from("thought_audit").insert({
+        thought_id: id,
+        action: "delete",
+        source: typeof meta.source === "string" ? meta.source : null,
+        author_session_id:
+          typeof meta.author_session_id === "string"
+            ? meta.author_session_id
+            : null,
+        diff: {
+          previous_content: existing.content,
+          previous_metadata: existing.metadata ?? null,
+        },
+        actor_context: { tool: "delete_thought", via: "delete-thought-mcp" },
+      });
+      if (auditError) {
+        console.warn(
+          `thought_audit insert failed for ${id} (continuing with delete): ${auditError.message}`,
+        );
       }
 
       const { error } = await supabase.from("thoughts").delete().eq("id", id);
@@ -99,7 +128,7 @@ server.registerTool(
         content: [
           {
             type: "text" as const,
-            text: `Deleted thought ${id} (prior content length: ${priorLength} chars).`,
+            text: `Deleted thought ${id} (prior content length: ${priorLength} chars).${auditError ? " Warning: audit row could not be written." : " Prior content preserved in thought_audit for recovery."}`,
           },
         ],
       };


### PR DESCRIPTION
## Contribution Type

- [x] Integration (`/integrations`)

## What does this do?

Wires the existing `delete-thought-mcp` integration into the `thought_audit` schema. Before each hard delete, it writes an append-only audit row preserving the prior content and metadata (`diff.previous_content` / `diff.previous_metadata`), so a deleted thought is recoverable from the audit trail alone. This implements the "Extension hook" that the integration's header comment previously described but left unbuilt.

## Requirements

- The `thought_audit` schema (`schemas/thought-audit`) must be installed. The audit write targets `public.thought_audit` (service_role needs the SELECT/INSERT grants that schema provides).
- No new external services or dependencies.

## Behavior notes

- The audit write is **fire-and-forget by contract**: a failure is logged via `console.warn` but never blocks the delete, matching the guarantee documented in `schemas/thought-audit`.
- The write happens **before** the delete so prior content is preserved even if the delete step is interrupted.
- The pre-flight fetch now also selects `metadata`, used to populate `source` / `author_session_id` and `diff.previous_metadata`.
- Success message now signals whether the audit row was written.

## Checklist

- [x] I've read CONTRIBUTING.md
- [x] Integration already has a README.md; header doc comment updated to describe the audit behavior
- [x] No metadata.json changes required (no new service/tool/primitive deps)
- [x] I tested this on my own Open Brain instance (schema installed; the exact service_role INSERT verified against grants + CHECK + JSONB shape; function redeployed and live)
- [x] No credentials, API keys, or secrets are included

🤖 Generated with [Claude Code](https://claude.com/claude-code)