### PR TITLE
[integrations] Chrome capture: skip per-turn LLM classification on bulk sync

### DIFF
--- a/integrations/chrome-capture-extension/README.md
+++ b/integrations/chrome-capture-extension/README.md
@@ -230,5 +230,6 @@ If you're weighing whether to add more MCP-exposing extensions on top, see the [
 
 ## Changelog
 
+- **0.6.1** — Bulk sync captures now send `skip_classification: true` to the ingest gateway, skipping the per-turn LLM classification pass during backfills (manual captures still classify). Gateways that don't support the flag ignore it.
 - **0.5.1** — Added the branded icon set (16/32/48/128 PNGs); the toolbar button now shows the Open Brain mark instead of Chrome's default puzzle-piece glyph.
 - **0.5.0** — Gemini bulk history sync, host-permission hardening, error surfacing, fingerprint dedup, retry caps, and race fixes.

--- a/integrations/chrome-capture-extension/background/service-worker.js
+++ b/integrations/chrome-capture-extension/background/service-worker.js
@@ -449,6 +449,11 @@ async function processCaptureRequest(message) {
       source_label: capture.sourceLabel,
       source_type: capture.sourceType,
       auto_execute: capture.autoExecute,
+      // Bulk sync captures skip the gateway's per-turn LLM classification
+      // pass — a 400-turn backfill would otherwise fire 400 classification
+      // calls. Manual captures (user clicked Capture on one exchange) still
+      // classify. Gateways that don't support the flag simply ignore it.
+      skip_classification: capture.captureMode === 'sync',
       source_metadata: {
         ...capture.sourceMetadata,
         extension_capture_mode: capture.captureMode,

--- a/integrations/chrome-capture-extension/manifest.json
+++ b/integrations/chrome-capture-extension/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Open Brain Capture",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "Capture AI conversations from Claude, ChatGPT, and Gemini into your Open Brain via the REST API gateway.",
   "icons": {
     "16": "icons/icon16.png",

--- a/integrations/chrome-capture-extension/metadata.json
+++ b/integrations/chrome-capture-extension/metadata.json
@@ -6,7 +6,7 @@
     "name": "Alan Shurafa",
     "github": "alanshurafa"
   },
-  "version": "1.1.1",
+  "version": "1.1.2",
   "requires": {
     "open_brain": true,
     "services": ["REST API gateway (integrations/open-brain-rest)"],
@@ -16,5 +16,5 @@
   "difficulty": "intermediate",
   "estimated_time": "20 minutes",
   "created": "2026-04-17",
-  "updated": "2026-06-14"
+  "updated": "2026-07-14"
 }


### PR DESCRIPTION
## What

Bulk sync captures from the Chrome capture extension now send `skip_classification: true` on the `/ingest` payload. Manual captures are unchanged and still classify.

## Why

All three bulk-sync paths (Claude, ChatGPT, Gemini) funnel every turn through the gateway's smart-ingest pipeline. Without the flag, a 400-turn backfill fires ~400 per-item classification LLM calls on top of extraction — pure cost, since sync-mode turns arrive with full source provenance already attached (`extension_platform`, conversation IDs, page URL, client fingerprint).

Verified against a live smart-ingest deployment: A/B dry-runs of the same conversational turn with and without the flag produce identical extraction results (the flag only gates the later per-item classification pass), so no capture behavior changes other than skipping that call.

## How

One line in the shared payload builder in `processCaptureRequest` (`background/service-worker.js`):

```js
skip_classification: capture.captureMode === 'sync',
```

- All bulk paths set `captureMode: 'sync'`; manual clicks arrive as `'manual'` → flag is `false`.
- The retry queue re-sends the stored payload whole, so the flag survives retries.
- Gateways that don't read the field simply ignore it (backward compatible).

Also bumps `manifest.json` to 0.6.1, adds a README changelog entry, and updates `metadata.json` (1.1.2 / 2026-07-14).

## Testing

- `node --check` on service-worker.js; JSON validity on manifest/metadata.
- Live A/B smoke test against a deployed open-brain-rest → smart-ingest stack: identical `extracted_count` with/without the flag; provenance metadata persisted; dedup statuses unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LxP7M99m4EF5Ve7rn3SNKH