### PR TITLE
[recipes] Fix ob-graph MCP GET route causing SSE reconnect storm

### DIFF
--- a/recipes/ob-graph/index.ts
+++ b/recipes/ob-graph/index.ts
@@ -19,7 +19,7 @@
  *   - list_edge_types   — List all relationship types in use
  */
 
-import { Hono } from "hono";
+import { Hono, type Context } from "hono";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StreamableHTTPTransport } from "@hono/mcp";
 import { z } from "zod";
@@ -27,7 +27,20 @@ import { createClient } from "@supabase/supabase-js";
 
 const app = new Hono();
 
-app.post("*", async (c) => {
+// Health probe on a dedicated path. It MUST NOT live on the "*" wildcard:
+// MCP's Streamable HTTP transport opens a long-lived GET SSE stream, and a
+// wildcard GET that returns plain JSON instead of a stream makes clients
+// reconnect in a tight ~1/sec loop (a real free-tier-burning incident).
+// Supabase routes the request to the function with the "/<function-name>"
+// prefix intact, so match both the prefixed and bare forms.
+const health = (c: Context) =>
+  c.json({ status: "ok", service: "OB-Graph MCP", version: "1.0.1" });
+app.get("/health", health);
+app.get("/:fn/health", health);
+
+// Route ALL methods (GET included) to the MCP transport so the GET opens a
+// real SSE stream. Do not split GET onto a non-streaming handler.
+app.all("*", async (c) => {
   // Fix: Claude Desktop connectors don't send the Accept header that
   // StreamableHTTPTransport requires. Build a patched request if missing.
   if (!c.req.header("accept")?.includes("text/event-stream")) {
@@ -533,7 +546,5 @@ app.post("*", async (c) => {
   await server.connect(transport);
   return transport.handleRequest(c);
 });
-
-app.get("*", (c) => c.json({ status: "ok", service: "OB-Graph MCP", version: "1.0.1" }));
 
 Deno.serve(app.fetch);


### PR DESCRIPTION
## Problem

The `ob-graph` recipe serves MCP only on **POST** and returns a static `{"status":"ok"}` JSON on `app.get("*")`:

```ts
app.post("*", async (c) => { ... transport.handleRequest(c) });   // MCP
app.get("*",  (c) => c.json({ status: "ok", ... }));              // <- returns non-stream on the SSE GET
```

MCP's Streamable HTTP transport opens a **long-lived GET SSE stream** for server→client messages. Returning a plain JSON body (not `text/event-stream`) on that GET makes clients treat the stream as immediately dropped and **reconnect in a tight loop**.

Every other Open Brain MCP function routes all methods to the transport with `app.all("*")`. Only this recipe splits GET off, so a connected client hammers the endpoint continuously.

**Measured on a live deployment:** ~1.4 GET requests/sec to this one function — on the order of millions of Edge Function invocations/month, enough to blow the Supabase 500K free tier by itself, with zero real tool usage.

## Fix

- Route **all** methods (GET included) to the transport (`app.post` → `app.all`) so the GET opens a real SSE stream.
- Remove the static wildcard health GET that shadowed the SSE stream.
- Move the health probe to dedicated paths (`/health` and `/:fn/health`, covering Supabase's `/{function-name}` path prefix) so it can't intercept `"*"`.

## Verification

- Deployed the equivalent fix to a live project. Before: `GET /?key=…` returned an instant non-stream JSON. After: the same GET **holds the SSE stream open** (verified via curl timing out on a held connection), the ~1/sec reconnect loop is gone, and auth is now enforced on GET.
- `deno check` passes with the recipe's `deno.json` import map.
- Diff is a single file (`recipes/ob-graph/index.ts`), +15/−4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LxP7M99m4EF5Ve7rn3SNKH