### PR TITLE
[recipes] Fix work-operating-model health endpoint routing

### DIFF
--- a/recipes/work-operating-model-activation/index.ts
+++ b/recipes/work-operating-model-activation/index.ts
@@ -827,11 +827,15 @@ server.tool(
   }
 );
 
-app.get("/health", (c) =>
-  c.json({ status: "ok", service: "Work Operating Model Activation MCP", version: "1.0.0" })
-);
-
 app.all("*", async (c) => {
+  // Public health check. Supabase mounts the function at /functions/v1/<name>
+  // and does NOT strip the function-name segment, so an absolute app.get("/health")
+  // never matches. Suffix-match here (before the auth gate) so it works under any
+  // mount prefix and stays reachable without the MCP access key.
+  if (c.req.method === "GET" && c.req.path.endsWith("/health")) {
+    return c.json({ status: "ok", service: "Work Operating Model Activation MCP", version: "1.0.0" });
+  }
+
   if (!c.req.header("accept")?.includes("text/event-stream")) {
     const headers = new Headers(c.req.raw.headers);
     headers.set("Accept", "application/json, text/event-stream");

--- a/recipes/work-operating-model-activation/schema.sql
+++ b/recipes/work-operating-model-activation/schema.sql
@@ -14,7 +14,7 @@ BEGIN
   NEW.updated_at = now();
   RETURN NEW;
 END;
-$$ LANGUAGE plpgsql;
+$$ LANGUAGE plpgsql SET search_path = public, pg_temp;
 
 CREATE TABLE IF NOT EXISTS operating_model_profiles (
   id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
@@ -255,7 +255,7 @@ BEGIN
 
   RETURN 'review';
 END;
-$$ LANGUAGE plpgsql;
+$$ LANGUAGE plpgsql SET search_path = public, pg_temp;
 
 CREATE OR REPLACE FUNCTION operating_model_start_session(
   p_user_id UUID,
@@ -387,7 +387,7 @@ BEGIN
     'latest_checkpoints', v_latest_checkpoints
   );
 END;
-$$ LANGUAGE plpgsql;
+$$ LANGUAGE plpgsql SET search_path = public, pg_temp;
 
 CREATE OR REPLACE FUNCTION operating_model_save_layer(
   p_session_id UUID,
@@ -610,7 +610,7 @@ BEGIN
     'entries', v_saved_entries
   );
 END;
-$$ LANGUAGE plpgsql;
+$$ LANGUAGE plpgsql SET search_path = public, pg_temp;
 
 GRANT EXECUTE ON FUNCTION public.operating_model_next_layer(TEXT[]) TO service_role;
 GRANT EXECUTE ON FUNCTION public.operating_model_start_session(UUID, TEXT) TO service_role;


### PR DESCRIPTION
## What

Fixes the health endpoint routing in the `work-operating-model-activation` recipe's MCP server.

## Problem

The server registered its health check as `app.get("/health")`. Supabase mounts edge functions at `/functions/v1/<name>` and does **not** strip the function-name segment before handing the request to the function. Hono therefore sees the path as `/work-operating-model-mcp/health`, never `/health` — so the route misses and the request falls through to the `app.all("*")` catch-all, which enforces the MCP access key and returns **401** for what should be a public health check.

## Fix

Move the health check into the `app.all("*")` catch-all as a prefix-agnostic suffix match (`c.req.method === "GET" && c.req.path.endsWith("/health")`), placed **before** the API-key gate so it stays public and works under any mount prefix. The absolute `app.get("/health")` route is removed. MCP request handling is unchanged.

## Testing

Deployed to a live Supabase project and verified against the function URL:

- `GET .../work-operating-model-mcp/health` (no key) → **200** `{"status":"ok",...}`
- `POST .../work-operating-model-mcp` (no key) → **401** (MCP still gated)
- `POST .../work-operating-model-mcp?key=...` `initialize` → **200** with `serverInfo` (MCP unaffected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LxP7M99m4EF5Ve7rn3SNKH
