### PR TITLE
[schemas] Thought lifecycle receipt log

### DIFF
--- a/schemas/thought-lifecycle/README.md
+++ b/schemas/thought-lifecycle/README.md
@@ -1,0 +1,143 @@
+# Thought Lifecycle Receipts
+
+> An append-only receipt log plus a single transactional write path for lifecycle and correction actions on Open Brain thoughts. Every mutation and its receipt commit — or roll back — together, so an unreceipted mutation cannot exist.
+
+## What It Does
+
+This schema adds `public.thought_lifecycle_events` (an append-only audit log) and a write-path function, `public.receipted_thought_write`, that patches a thought and records its receipt in **one transaction**. If any part fails, the whole action rolls back: you never end up with a changed thought and no receipt, or a receipt for a change that didn't land.
+
+It is additive and stays out of the way of core Open Brain:
+
+- It does **not** alter or replace the `thoughts` table (it only reads it and writes to `thoughts.metadata`/`thoughts.status`, which is ordinary usage).
+- It does **not** add a task manager, and it adds **no delete behavior**.
+- Core Open Brain tools (search, recall, dashboards) keep working unchanged and never need to read anything this pack writes.
+
+Typical adopters are agents or services that take *consequential* actions on thoughts (marking something done, deferring it, flagging it for review, correcting its content) and need a tamper-evident trail of who did what, when, and to what.
+
+## Prerequisites
+
+- A working Open Brain setup with the base `thoughts` table.
+- The [`workflow-status`](../workflow-status/migration.sql) schema applied, so `thoughts.status` and `thoughts.status_updated_at` exist. The write path projects each action onto a `thoughts.status` value.
+- `pgvector` installed (it ships with core Open Brain). The `correct_thought` action rewrites `thoughts.embedding`; the function passes the embedding as a literal that the column's own input function parses, so it never names the vector type's schema.
+- Supabase's `service_role` (the default service key). The table's row-level security and the function's `EXECUTE` grant are restricted to `service_role`; a normal edge function or MCP server using the service key can call it.
+
+## Installation
+
+> [!NOTE]
+> This is plain SQL. Run it in the Supabase SQL Editor (or any `psql` session against your project). It is safe to run more than once — every statement is idempotent (`IF NOT EXISTS` / `CREATE OR REPLACE`).
+
+**1. Apply the prerequisite** (skip if you already have it):
+
+```sql
+-- schemas/workflow-status/migration.sql
+```
+
+**2. Open the Supabase SQL Editor** → your project → **SQL Editor** → **New query**.
+
+**3. Paste and run [`schema.sql`](schema.sql).** This creates the `thought_lifecycle_events` table, its indexes, row-level security, and the two functions (`thought_state_summary` and `receipted_thought_write`).
+
+**4. (Optional, recommended once your writer is ready) run [`actor-hardening.sql`](actor-hardening.sql).** It adds a `CHECK` constraint requiring every *new* receipt to carry a real `party:context` actor (e.g. `user:chat`, `agent:review`, `system:scheduler`). Apply it only **after** the code that writes receipts is emitting real actors — see Troubleshooting.
+
+✅ **Done when:** `select proname from pg_proc where proname in ('receipted_thought_write','thought_state_summary');` returns both rows, and `select to_regclass('public.thought_lifecycle_events');` is not null.
+
+## How It Works
+
+### Supported actions
+
+The write path accepts these actions:
+
+```text
+mark_done        mark_still_open   defer          needs_review
+archive          suppress_noise    mark_superseded correct_thought
+```
+
+Seven are lifecycle transitions; `correct_thought` is a content correction (see below).
+
+### Action → status projection
+
+The single place where a lifecycle action becomes an upstream `thoughts.status` is the `CASE` inside `receipted_thought_write`. Keeping it in the database (rather than in a caller) means there is exactly one copy of this mapping and nothing to drift against it. Upstream consumers (kanban dashboards, status filters) only ever see legal Open Brain statuses:
+
+| Action | Upstream `status` | `lifecycle_state` (in metadata) | Suppressed from an operating loop? |
+| --- | --- | --- | --- |
+| `mark_done` | `done` | `done` | yes |
+| `mark_still_open` | `active` | `open` | no |
+| `defer` | `planning` | `deferred` | no |
+| `needs_review` | `review` | `needs_review` | no |
+| `archive` | `archived` | `archived` | yes |
+| `suppress_noise` | `archived` | `noise` | yes |
+| `mark_superseded` | `archived` | `superseded` | yes |
+| `correct_thought` | unchanged | unchanged | unchanged |
+
+`correct_thought` rewrites `content`, regenerates the embedding, records the correction metadata, and logs a receipt — but it is *not* a lifecycle transition, so `status` and `lifecycle_state` are left untouched.
+
+### The receipted write path
+
+`receipted_thought_write` is `SECURITY INVOKER` — it adds no authority the caller doesn't already have — and does the following in one transaction, under a row lock on the target thought:
+
+1. Reads the current state into a compact `before_state` snapshot (via the pure helper `thought_state_summary`).
+2. Applies the patch (status, lifecycle metadata, or a content correction).
+3. Writes the receipt row into `thought_lifecycle_events`, including the `after_state` snapshot.
+
+Because the read, patch, and receipt share one transaction and one row lock, a crash cannot leave a mutated thought without its receipt, and two concurrent writers cannot lose each other's metadata updates.
+
+### Metadata keys written to `thoughts.metadata`
+
+The write path stamps a small, well-defined set of keys on `thoughts.metadata` (the substrate's own envelope). This is the reference for what a receipted action records:
+
+<details>
+<summary>📋 <strong>Metadata keys</strong> (click to expand)</summary>
+
+| Key | Written by | Meaning |
+| --- | --- | --- |
+| `lifecycle_state` | every lifecycle action | `done`, `open`, `deferred`, `needs_review`, `archived`, `noise`, or `superseded` |
+| `lifecycle_action` | every lifecycle action | the last action applied |
+| `lifecycle_updated_at` | every lifecycle action | ISO timestamp of the last lifecycle write |
+| `lifecycle_note` | any action, when a note is given | optional human note |
+| `lifecycle_reason` | `archive`, `suppress_noise`, `mark_superseded` | why the thought left the loop |
+| `suppress_from_operating_loop` | every action (`true` on closing actions) | explicit visibility flag for an operating layer; the thought stays fully recallable as memory |
+| `review_after` | `defer` (set); `mark_done`/`mark_still_open` (cleared) | exact `YYYY-MM-DD` the item should resurface |
+| `next_action` | `mark_still_open`, `defer` (optional); cleared by `mark_done` | the preserved next step for an open/deferred loop |
+| `completed_at` / `reopened_at` / `deferred_at` / `needs_review_at` / `archived_at` / `suppressed_at` / `superseded_at` | the matching action | action timestamp, for evidence |
+| `superseded_by` | `mark_superseded` (optional) | UUID of the replacing thought, written on the replaced one |
+| `corrected_at` / `corrected_by` / `correction_count` / `correction_note` | `correct_thought` | correction audit trail; `corrected_by` is a `party:context` actor |
+| `correction_metadata_strategy` | `correct_thought` | always `preserved_existing_metadata` — corrections never re-run extraction or overwrite prior classification |
+
+</details>
+
+## Standalone by design
+
+This pack works on its own. Its write path has two *optional* touchpoints with other schemas, both guarded so their absence is a graceful no-op, not an error:
+
+- **`provenance-chains` (`supersedes` column).** On `mark_superseded`, the function best-effort writes the canonical `supersedes` pointer. If that schema isn't installed, the pointer is skipped, a warning rides the result, and the metadata receipt remains the record.
+- **A brief/approval outcome table (`brief_item_outcome_events`).** When a receipt is written on behalf of an approved brief item, the function tries to record an outcome event. If that table doesn't exist, it catches the error, returns a warning telling you which schema to apply, and still commits the receipt.
+
+The `thought_lifecycle_events` table carries nullable `brief_id`, `run_id`, and `brief_hash` columns so that receipts produced by an approval flow can later be tied back to the brief that authorized them. A partial `UNIQUE` index on `(brief_id, thought_id) WHERE brief_id IS NOT NULL` makes "one execution per brief item" a database rule: two racing approvals of the same item cannot both write a receipt. For direct (non-brief) actions those columns are simply `NULL` and the index doesn't apply.
+
+## Expected Outcome
+
+After running `schema.sql`, a `service_role` caller invokes `receipted_thought_write(...)` for each action. You should observe:
+
+- Every action inserts exactly one row in `thought_lifecycle_events`, with truthful `before_state` and `after_state` snapshots.
+- The thought's `status` and `metadata` reflect the action, projected consistently by the in-database `CASE`.
+- Interrupting a call mid-write leaves **neither** a partial change **nor** an orphaned receipt (atomic rollback).
+- Attempting to execute the same brief item twice is refused by the `UNIQUE` index.
+
+The table stays separate from `thoughts`, so Open Brain remains memory infrastructure while this pack adds an auditable operating-state layer on top.
+
+## Troubleshooting
+
+> [!IMPORTANT]
+> **`actor-hardening.sql` makes every lifecycle write fail with a check-constraint violation.**
+> The constraint requires each new receipt's `actor` to match `party:context` (and forbids the literal `mcp`). If your caller is still sending a placeholder actor, hardening will reject every write. Fix the caller to send a real actor (e.g. `agent:review`) *first*, then apply `actor-hardening.sql`. Existing rows are intentionally left as-is — the constraint is `NOT VALID` by design and binds new rows only, because rewriting an append-only audit log is not an option.
+
+> [!WARNING]
+> **`permission denied for function receipted_thought_write` (or for the table).**
+> Row-level security and the function grant are restricted to `service_role`. Call it with your Supabase service key, not the anon/authenticated key. On newer Supabase projects, confirm the `GRANT` statements at the bottom of `schema.sql` actually ran — Supabase no longer auto-grants CRUD to `service_role` on new projects.
+
+> [!NOTE]
+> **A `defer` in the future "disappears."**
+> That is intended: `review_after` set to a future `YYYY-MM-DD` is an explicit hold. The thought is still fully recallable as memory — `review_after` only signals when an operating layer should resurface it.
+
+> [!NOTE]
+> **`brief_item_outcome_events does not exist` warning in the result.**
+> Harmless when you aren't using brief/approval linkage — the receipt still committed. If you *do* want brief outcome events, apply the companion brief-store schema. Nothing in this pack requires it.

--- a/schemas/thought-lifecycle/actor-hardening.sql
+++ b/schemas/thought-lifecycle/actor-hardening.sql
@@ -1,0 +1,24 @@
+-- Thought Lifecycle Receipts — actor hardening.
+--
+-- Run this ONLY AFTER the caller that writes receipts is emitting real actor
+-- strings (e.g. user:chat, agent:review, system:scheduler). A caller that
+-- still passes a placeholder actor of 'mcp' on every insert will have every
+-- direct lifecycle write rejected once this constraint is in place.
+--
+-- NOT VALID by design: existing rows are left standing (the constraint binds
+-- new rows only). Do not VALIDATE it — validation would fail on any historical
+-- placeholder rows, and rewriting an append-only audit log is not an option.
+--
+-- Safe to run multiple times.
+
+ALTER TABLE public.thought_lifecycle_events
+  DROP CONSTRAINT IF EXISTS thought_lifecycle_events_actor_real;
+
+ALTER TABLE public.thought_lifecycle_events
+  ADD CONSTRAINT thought_lifecycle_events_actor_real
+  CHECK (actor <> 'mcp' AND actor ~ '^[a-z0-9._-]+:[a-z0-9._-]+$')
+  NOT VALID;
+
+COMMENT ON CONSTRAINT thought_lifecycle_events_actor_real
+  ON public.thought_lifecycle_events IS
+  'New receipts must carry a real party:context actor; the schema-level DEFAULT ''mcp'' placeholder is not storable going forward. NOT VALID by design: pre-hardening rows stand as recorded.';

--- a/schemas/thought-lifecycle/metadata.json
+++ b/schemas/thought-lifecycle/metadata.json
@@ -1,0 +1,20 @@
+{
+  "name": "Thought Lifecycle Receipts",
+  "description": "Adds an append-only thought_lifecycle_events receipt log and a single transactional write path so every lifecycle or correction action on an Open Brain thought commits together with its receipt — an unreceipted mutation cannot exist.",
+  "category": "schemas",
+  "author": {
+    "name": "Nev Harris",
+    "github": "Nev-Harris"
+  },
+  "version": "1.0.0",
+  "requires": {
+    "open_brain": true,
+    "services": [],
+    "tools": []
+  },
+  "tags": ["lifecycle", "audit", "receipts", "append-only", "workflow-status"],
+  "difficulty": "advanced",
+  "estimated_time": "20 minutes",
+  "created": "2026-07-22",
+  "updated": "2026-07-22"
+}

--- a/schemas/thought-lifecycle/schema.sql
+++ b/schemas/thought-lifecycle/schema.sql
@@ -1,0 +1,571 @@
+-- Thought Lifecycle Events
+-- Adds an append-only receipt log for lifecycle and correction actions,
+-- and (v3) the single receipted write path that makes a thought mutation
+-- and its receipt one transaction.
+-- Safe to run multiple times.
+--
+-- v2: actor carries no default — every writer must state who acted
+-- (`user:chat`, `agent:review`, `system:scheduler`), because an
+-- append-only log misattributed is history recorded wrong, permanently.
+-- Adds nullable brief/run linkage columns so receipts written by an
+-- approval executor can rejoin the brief artifact that authorized them
+-- (see the companion brief-artifact-store schema). After the caller is
+-- deployed writing real actors, also run actor-hardening.sql in this
+-- directory.
+--
+-- v3: "no consequential write without a receipt" becomes a database
+-- guarantee instead of a hope. public.receipted_thought_write below
+-- is the one write path for every governed thought mutation (lifecycle
+-- updates, brief-approval execution, content corrections): the thought
+-- patch, its receipt, the supersedes pointer, and the brief outcome event
+-- commit or roll back together. The replay lookup index on
+-- (brief_id, thought_id) becomes UNIQUE, so "one execution per brief item"
+-- is enforced by the database rather than by a check-then-write race. The
+-- action→status projection now lives here and only here; the caller passes
+-- judgment content (notes, targets, dates) and identity, and this file
+-- derives the law. This pack stands alone: the function's
+-- optional touchpoints with other packs (the provenance-chains
+-- `supersedes` column, the brief store's outcome table) are
+-- exception-guarded dynamic SQL — present, they join the transaction;
+-- absent, the write still works and says so.
+
+CREATE TABLE IF NOT EXISTS public.thought_lifecycle_events (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  -- Deliberately not a foreign key: receipt rows should survive rare manual/admin
+  -- deletion of a thought.
+  thought_id UUID NOT NULL,
+  action TEXT NOT NULL CHECK (
+    action IN (
+      'mark_done',
+      'mark_still_open',
+      'defer',
+      'needs_review',
+      'archive',
+      'suppress_noise',
+      'mark_superseded',
+      'correct_thought'
+    )
+  ),
+  actor TEXT NOT NULL,
+  note TEXT,
+  before_state JSONB NOT NULL DEFAULT '{}'::jsonb,
+  after_state JSONB NOT NULL DEFAULT '{}'::jsonb,
+  -- Brief/run linkage (nullable; no FK, same posture as thought_id above):
+  -- populated by the approval executor, absent on direct writes.
+  brief_id TEXT,
+  run_id UUID,
+  brief_hash TEXT,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+-- Upgrade path for tables created before v2. Dropping a default is a no-op
+-- when none exists; ADD COLUMN IF NOT EXISTS is a no-op when present.
+ALTER TABLE public.thought_lifecycle_events ALTER COLUMN actor DROP DEFAULT;
+ALTER TABLE public.thought_lifecycle_events ADD COLUMN IF NOT EXISTS brief_id TEXT;
+ALTER TABLE public.thought_lifecycle_events ADD COLUMN IF NOT EXISTS run_id UUID;
+ALTER TABLE public.thought_lifecycle_events ADD COLUMN IF NOT EXISTS brief_hash TEXT;
+
+COMMENT ON TABLE public.thought_lifecycle_events IS
+  'Append-only audit log for lifecycle and correction actions on Open Brain thoughts';
+COMMENT ON COLUMN public.thought_lifecycle_events.before_state IS
+  'Compact JSON snapshot of lifecycle-relevant state before the action';
+COMMENT ON COLUMN public.thought_lifecycle_events.after_state IS
+  'Compact JSON snapshot of lifecycle-relevant state after the action';
+COMMENT ON COLUMN public.thought_lifecycle_events.actor IS
+  'Who acted, as party:context (user:chat, agent:review, system:scheduler). No default: silence may not claim an identity.';
+COMMENT ON COLUMN public.thought_lifecycle_events.brief_id IS
+  'Brief artifact that authorized this write (executor path); NULL on direct writes.';
+COMMENT ON COLUMN public.thought_lifecycle_events.brief_hash IS
+  'Hash of the exact reviewed brief bytes, so each receipt independently pins what authorized it.';
+
+CREATE INDEX IF NOT EXISTS idx_thought_lifecycle_events_thought
+  ON public.thought_lifecycle_events (thought_id, created_at DESC);
+
+-- Replay refusal, database-enforced (v3): at most ONE receipt per
+-- (brief_id, thought_id), ever. brief_items holds UNIQUE (brief_id,
+-- thought_id), so this is exactly "one execution per brief item" — the
+-- rule the executor's check-then-write pre-check could only hope to hold
+-- under concurrency. Two racing approvals of the same item serialize
+-- here: the second receipt insert violates the index and its whole
+-- transaction — thought mutation included — rolls back. Relaxing the
+-- replay rule later is a receipted schema change (drop this index), not a
+-- silent code edit; that is this system's constitution applied to itself.
+-- Safe on a live table: no executor ran before v3, so every existing
+-- receipt has brief_id IS NULL and the partial index starts empty. The
+-- old non-unique index served the same lookups and is superseded.
+DROP INDEX IF EXISTS public.idx_thought_lifecycle_events_brief;
+CREATE UNIQUE INDEX IF NOT EXISTS uq_thought_lifecycle_events_brief_thought
+  ON public.thought_lifecycle_events (brief_id, thought_id)
+  WHERE brief_id IS NOT NULL;
+
+COMMENT ON INDEX public.uq_thought_lifecycle_events_brief_thought IS
+  'The replay law: one executed approval per (brief, thought), held by the database. Also serves the "does a receipt exist for this brief item?" lookup.';
+
+CREATE INDEX IF NOT EXISTS idx_thought_lifecycle_events_action
+  ON public.thought_lifecycle_events (action, created_at DESC);
+
+ALTER TABLE public.thought_lifecycle_events ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS thought_lifecycle_events_service_role_select
+  ON public.thought_lifecycle_events;
+DROP POLICY IF EXISTS thought_lifecycle_events_service_role_insert
+  ON public.thought_lifecycle_events;
+
+CREATE POLICY thought_lifecycle_events_service_role_select
+  ON public.thought_lifecycle_events
+  FOR SELECT
+  USING (auth.role() = 'service_role');
+
+CREATE POLICY thought_lifecycle_events_service_role_insert
+  ON public.thought_lifecycle_events
+  FOR INSERT
+  WITH CHECK (auth.role() = 'service_role');
+
+GRANT SELECT, INSERT ON TABLE public.thought_lifecycle_events TO service_role;
+
+-- ---------------------------------------------------------------------------
+-- v3 — the receipted write path.
+--
+-- Boundary allocation: the database derives the
+-- LAW — the action→status projection, the law-stamped metadata keys, the
+-- actor format, replay refusal, and atomicity. The caller composes the
+-- JUDGMENT — which action, whose identity, what note, which target — and
+-- validates it against brief artifacts and approval contracts before
+-- calling here. Do not reintroduce the projection in the caller: one
+-- source of truth, callers stay callers.
+--
+-- The metadata merge (metadata || patch) and both receipt snapshots happen
+-- under the row lock taken by this function, which closes two silent
+-- corruptions the old two-call path allowed: a concurrent writer's
+-- metadata keys being overwritten by a stale read-modify-write, and a
+-- receipt recording a before_state that was never actually the before.
+-- ---------------------------------------------------------------------------
+
+-- Receipt snapshot shape (the summary both tools historically wrote).
+CREATE OR REPLACE FUNCTION public.thought_state_summary(
+  p_id pg_catalog.uuid,
+  p_content pg_catalog.text,
+  p_status pg_catalog.text,
+  p_status_updated_at pg_catalog.timestamptz,
+  p_metadata pg_catalog.jsonb
+) RETURNS pg_catalog.jsonb
+LANGUAGE sql
+IMMUTABLE
+SET search_path = ''
+AS $fn$
+  SELECT pg_catalog.jsonb_build_object(
+    'id', p_id,
+    'status', p_status,
+    'status_updated_at', p_status_updated_at,
+    'lifecycle_state', pg_catalog.jsonb_extract_path(p_metadata, 'lifecycle_state'),
+    'lifecycle_reason', pg_catalog.jsonb_extract_path(p_metadata, 'lifecycle_reason'),
+    'next_action', pg_catalog.jsonb_extract_path(p_metadata, 'next_action'),
+    'review_after', pg_catalog.jsonb_extract_path(p_metadata, 'review_after'),
+    'superseded_by', pg_catalog.jsonb_extract_path(p_metadata, 'superseded_by'),
+    'suppress_from_operating_loop', CASE
+      WHEN pg_catalog.jsonb_extract_path(p_metadata, 'suppress_from_operating_loop') IS NULL
+        OR pg_catalog.jsonb_extract_path(p_metadata, 'suppress_from_operating_loop') OPERATOR(pg_catalog.=) 'null'::pg_catalog.jsonb
+      THEN pg_catalog.to_jsonb(false)
+      ELSE pg_catalog.jsonb_extract_path(p_metadata, 'suppress_from_operating_loop')
+    END,
+    'content_preview', (
+      SELECT CASE
+        WHEN pg_catalog.length(normalized) OPERATOR(pg_catalog.<=) 160 THEN normalized
+        ELSE pg_catalog.concat(pg_catalog.left(normalized, 159), '...')
+      END
+      FROM (
+        SELECT pg_catalog.btrim(pg_catalog.regexp_replace(p_content, '\s+', ' ', 'g')) AS normalized
+      ) AS preview
+    )
+  )
+$fn$;
+
+COMMENT ON FUNCTION public.thought_state_summary(uuid, text, text, timestamptz, jsonb) IS
+  'Compact lifecycle-relevant snapshot recorded as before_state/after_state on receipts. Pure; used only by receipted_thought_write.';
+
+CREATE OR REPLACE FUNCTION public.receipted_thought_write(
+  p_thought_id pg_catalog.uuid,
+  p_action pg_catalog.text,
+  p_actor pg_catalog.text,
+  p_event_time pg_catalog.timestamptz,
+  p_note pg_catalog.text DEFAULT NULL,
+  p_next_action pg_catalog.text DEFAULT NULL,
+  p_review_after pg_catalog.text DEFAULT NULL,
+  p_superseded_by pg_catalog.uuid DEFAULT NULL,
+  p_content pg_catalog.text DEFAULT NULL,
+  p_embedding pg_catalog.text DEFAULT NULL,
+  p_brief_id pg_catalog.text DEFAULT NULL,
+  p_run_id pg_catalog.uuid DEFAULT NULL,
+  p_brief_hash pg_catalog.text DEFAULT NULL,
+  p_item_id pg_catalog.text DEFAULT NULL,
+  p_acted_at pg_catalog.timestamptz DEFAULT NULL
+) RETURNS pg_catalog.jsonb
+LANGUAGE plpgsql
+SECURITY INVOKER
+SET search_path = ''
+AS $fn$
+DECLARE
+  v_note pg_catalog.text := CASE
+    WHEN p_note IS NULL OR pg_catalog.btrim(p_note) OPERATOR(pg_catalog.=) '' THEN NULL
+    ELSE pg_catalog.btrim(p_note)
+  END;
+  v_next_action pg_catalog.text := CASE
+    WHEN p_next_action IS NULL OR pg_catalog.btrim(p_next_action) OPERATOR(pg_catalog.=) '' THEN NULL
+    ELSE pg_catalog.btrim(p_next_action)
+  END;
+  v_linkage boolean := p_brief_id IS NOT NULL
+    OR p_run_id IS NOT NULL
+    OR p_brief_hash IS NOT NULL
+    OR p_item_id IS NOT NULL
+    OR p_acted_at IS NOT NULL;
+  v_content pg_catalog.text;
+  v_metadata pg_catalog.jsonb;
+  v_status pg_catalog.text;
+  v_status_updated_at pg_catalog.timestamptz;
+  v_before pg_catalog.jsonb;
+  v_after pg_catalog.jsonb;
+  v_patch pg_catalog.jsonb;
+  v_new_status pg_catalog.text;
+  v_now_iso pg_catalog.text;
+  v_receipt_id pg_catalog.uuid;
+  v_dual pg_catalog.jsonb := NULL;
+  v_outcome pg_catalog.jsonb := NULL;
+  v_outcome_label pg_catalog.text;
+  v_seq pg_catalog.int8;
+  v_rowcount pg_catalog.int4;
+  v_after_content pg_catalog.text;
+  v_after_metadata pg_catalog.jsonb;
+  v_after_status pg_catalog.text;
+  v_after_status_updated_at pg_catalog.timestamptz;
+BEGIN
+  -- The verb law: the receipts CHECK enumerates the same set, but refusing
+  -- here refuses BEFORE the thought row is touched, with a plain message.
+  IF p_action IS NULL OR NOT (
+    p_action OPERATOR(pg_catalog.=) ANY (
+      ARRAY[
+        'mark_done', 'mark_still_open', 'defer', 'needs_review',
+        'archive', 'suppress_noise', 'mark_superseded', 'correct_thought'
+      ]::pg_catalog.text[]
+    )
+  ) THEN
+    RAISE EXCEPTION 'action % is not a receiptable verb',
+      CASE WHEN p_action IS NULL THEN '(null)' ELSE p_action END;
+  END IF;
+
+  -- The actor law (store law L10, mirroring actor-hardening.sql): a real
+  -- party:context identity, never a bare machine name, never defaulted.
+  -- This function is new — no legacy write flows through it — so it holds
+  -- the law from day one, independent of when actor-hardening.sql runs.
+  IF p_actor IS NULL OR p_actor OPERATOR(pg_catalog.=) 'mcp'
+    OR p_actor OPERATOR(pg_catalog.!~) '^[a-z0-9._-]+:[a-z0-9._-]+$' THEN
+    RAISE EXCEPTION 'actor must be a real party:context identity (e.g. user:chat); % is not storable',
+      CASE WHEN p_actor IS NULL THEN '(null)' ELSE p_actor END;
+  END IF;
+
+  IF p_event_time IS NULL THEN
+    RAISE EXCEPTION 'event_time is required: law metadata stamps and status_updated_at derive from it';
+  END IF;
+
+  -- Param-shape laws. The tools are lenient (they null out inapplicable
+  -- optional arguments); this function is strict, because a service-role
+  -- caller reaching it directly gets no TypeScript courtesy.
+  IF (p_action OPERATOR(pg_catalog.=) 'correct_thought') OPERATOR(pg_catalog.<>) (p_content IS NOT NULL) THEN
+    RAISE EXCEPTION 'content is required for correct_thought and forbidden for every other action';
+  END IF;
+  IF (p_action OPERATOR(pg_catalog.=) 'correct_thought') OPERATOR(pg_catalog.<>) (p_embedding IS NOT NULL) THEN
+    RAISE EXCEPTION 'embedding is required for correct_thought and forbidden for every other action';
+  END IF;
+  IF p_content IS NOT NULL AND pg_catalog.btrim(p_content) OPERATOR(pg_catalog.=) '' THEN
+    RAISE EXCEPTION 'corrected content must not be empty';
+  END IF;
+  IF p_embedding IS NOT NULL AND p_embedding OPERATOR(pg_catalog.!~) '^\[[0-9eE+.,-]+\]$' THEN
+    RAISE EXCEPTION 'embedding must be a pgvector literal like [0.1,-0.2,...]';
+  END IF;
+  IF p_superseded_by IS NOT NULL AND p_action OPERATOR(pg_catalog.<>) 'mark_superseded' THEN
+    RAISE EXCEPTION 'superseded_by is only accepted for mark_superseded';
+  END IF;
+  IF p_superseded_by OPERATOR(pg_catalog.=) p_thought_id THEN
+    RAISE EXCEPTION 'a thought cannot supersede itself';
+  END IF;
+  IF v_next_action IS NOT NULL
+    AND NOT (p_action OPERATOR(pg_catalog.=) ANY (
+      ARRAY['mark_still_open', 'defer']::pg_catalog.text[]
+    )) THEN
+    RAISE EXCEPTION 'next_action is only accepted for mark_still_open and defer';
+  END IF;
+  IF p_action OPERATOR(pg_catalog.=) 'defer' AND p_review_after IS NULL THEN
+    RAISE EXCEPTION 'review_after is required for defer and must be an exact YYYY-MM-DD date';
+  END IF;
+  IF p_review_after IS NOT NULL AND p_action OPERATOR(pg_catalog.<>) 'defer' THEN
+    RAISE EXCEPTION 'review_after is only accepted for defer';
+  END IF;
+  IF p_review_after IS NOT NULL THEN
+    IF p_review_after OPERATOR(pg_catalog.!~) '^\d{4}-\d{2}-\d{2}$' THEN
+      RAISE EXCEPTION 'review_after must be an exact YYYY-MM-DD date';
+    END IF;
+    BEGIN
+      PERFORM p_review_after::pg_catalog.date;
+    EXCEPTION WHEN OTHERS THEN
+      RAISE EXCEPTION 'review_after must be a real calendar date in YYYY-MM-DD format';
+    END;
+  END IF;
+
+  -- Brief linkage: all five ride together or not at all, and never on a
+  -- correction (the approval contract forbids correct_thought in the loop
+  -- — correction_not_in_v0_loop — so a brief-linked correction receipt is
+  -- unstorable by construction).
+  IF v_linkage THEN
+    IF p_brief_id IS NULL OR p_run_id IS NULL OR p_brief_hash IS NULL
+      OR p_item_id IS NULL OR p_acted_at IS NULL THEN
+      RAISE EXCEPTION 'brief linkage requires brief_id, run_id, brief_hash, item_id, and acted_at together';
+    END IF;
+    IF p_action OPERATOR(pg_catalog.=) 'correct_thought' THEN
+      RAISE EXCEPTION 'correct_thought may not carry brief linkage: corrections are outside the approval loop';
+    END IF;
+    IF p_brief_hash OPERATOR(pg_catalog.!~) '^[0-9a-f]{64}$' THEN
+      RAISE EXCEPTION 'brief_hash must be 64 lowercase hex characters (SHA-256)';
+    END IF;
+  END IF;
+
+  -- Lock the row. The metadata merge and BOTH receipt snapshots happen
+  -- under this lock: before_state is the true before, and a concurrent
+  -- writer's metadata keys cannot be lost to a stale read-modify-write.
+  SELECT t.content,
+         CASE WHEN t.metadata IS NULL THEN '{}'::pg_catalog.jsonb ELSE t.metadata END,
+         t.status,
+         t.status_updated_at
+    INTO v_content, v_metadata, v_status, v_status_updated_at
+  FROM public.thoughts t
+  WHERE t.id OPERATOR(pg_catalog.=) p_thought_id
+  FOR UPDATE;
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'Thought not found: no thoughts row with id %', p_thought_id;
+  END IF;
+
+  v_before := public.thought_state_summary(
+    p_thought_id, v_content, v_status, v_status_updated_at, v_metadata);
+
+  -- Law metadata stamps use the caller-stated event time, formatted to
+  -- match the historical JS toISOString strings byte for byte.
+  v_now_iso := pg_catalog.to_char(
+    pg_catalog.timezone('UTC'::pg_catalog.text, p_event_time),
+    'YYYY-MM-DD"T"HH24:MI:SS.MS"Z"');
+
+  IF p_action OPERATOR(pg_catalog.=) 'correct_thought' THEN
+    IF pg_catalog.regexp_replace(v_content, '^\s+|\s+$', '', 'g') OPERATOR(pg_catalog.=) p_content THEN
+      RAISE EXCEPTION 'corrected_content matches the existing thought content.';
+    END IF;
+
+    -- Correction bookkeeping, derived here so the count increments under
+    -- the same lock that reads it (the old TypeScript increment raced).
+    v_patch := pg_catalog.jsonb_build_object(
+      'corrected_at', v_now_iso,
+      'corrected_by', p_actor,
+      'correction_count', CASE
+        WHEN pg_catalog.jsonb_typeof(pg_catalog.jsonb_extract_path(v_metadata, 'correction_count')) OPERATOR(pg_catalog.=) 'number'
+        THEN pg_catalog.jsonb_extract_path_text(v_metadata, 'correction_count')::pg_catalog.numeric::pg_catalog.int4 OPERATOR(pg_catalog.+) 1
+        ELSE 1
+      END,
+      'correction_metadata_strategy', 'preserved_existing_metadata'
+    );
+    IF v_note IS NOT NULL THEN
+      v_patch := v_patch OPERATOR(pg_catalog.||) pg_catalog.jsonb_build_object('correction_note', v_note);
+    END IF;
+
+    -- Dynamic SQL so the embedding rides as an unknown-typed literal (%L)
+    -- and is parsed by the vector column's own input function — this file
+    -- never has to name the pgvector type's schema.
+    EXECUTE pg_catalog.format($sql$
+      UPDATE public.thoughts
+      SET content = $1, embedding = %L, metadata = $2
+      WHERE id OPERATOR(pg_catalog.=) $3
+      RETURNING content,
+                CASE WHEN metadata IS NULL THEN '{}'::pg_catalog.jsonb ELSE metadata END,
+                status,
+                status_updated_at
+    $sql$, p_embedding)
+    INTO v_after_content, v_after_metadata, v_after_status, v_after_status_updated_at
+    USING p_content, v_metadata OPERATOR(pg_catalog.||) v_patch, p_thought_id;
+  ELSE
+    -- The action→status projection. THE single source of this law (the
+    -- read model's ACTIVE_STATUSES/CLOSED_STATUSES sets are its read-side
+    -- mirror; schemas/thought-lifecycle/README.md holds the table).
+    v_new_status := CASE
+      WHEN p_action OPERATOR(pg_catalog.=) 'mark_done' THEN 'done'
+      WHEN p_action OPERATOR(pg_catalog.=) 'mark_still_open' THEN 'active'
+      WHEN p_action OPERATOR(pg_catalog.=) 'defer' THEN 'planning'
+      WHEN p_action OPERATOR(pg_catalog.=) 'needs_review' THEN 'review'
+      WHEN p_action OPERATOR(pg_catalog.=) 'archive' THEN 'archived'
+      WHEN p_action OPERATOR(pg_catalog.=) 'suppress_noise' THEN 'archived'
+      WHEN p_action OPERATOR(pg_catalog.=) 'mark_superseded' THEN 'archived'
+    END;
+
+    v_patch := pg_catalog.jsonb_build_object(
+      'lifecycle_state', CASE
+        WHEN p_action OPERATOR(pg_catalog.=) 'mark_done' THEN 'done'
+        WHEN p_action OPERATOR(pg_catalog.=) 'mark_still_open' THEN 'open'
+        WHEN p_action OPERATOR(pg_catalog.=) 'defer' THEN 'deferred'
+        WHEN p_action OPERATOR(pg_catalog.=) 'needs_review' THEN 'needs_review'
+        WHEN p_action OPERATOR(pg_catalog.=) 'archive' THEN 'archived'
+        WHEN p_action OPERATOR(pg_catalog.=) 'suppress_noise' THEN 'noise'
+        WHEN p_action OPERATOR(pg_catalog.=) 'mark_superseded' THEN 'superseded'
+      END,
+      'lifecycle_action', p_action,
+      'lifecycle_updated_at', v_now_iso,
+      'suppress_from_operating_loop',
+        (p_action OPERATOR(pg_catalog.=) ANY (
+          ARRAY['mark_done', 'archive', 'suppress_noise', 'mark_superseded']::pg_catalog.text[]
+        ))
+    );
+    IF v_note IS NOT NULL THEN
+      v_patch := v_patch OPERATOR(pg_catalog.||) pg_catalog.jsonb_build_object('lifecycle_note', v_note);
+    END IF;
+
+    IF p_action OPERATOR(pg_catalog.=) 'mark_done' THEN
+      v_patch := v_patch OPERATOR(pg_catalog.||) pg_catalog.jsonb_build_object(
+        'completed_at', v_now_iso,
+        'next_action', NULL,
+        'review_after', NULL);
+    ELSIF p_action OPERATOR(pg_catalog.=) 'mark_still_open' THEN
+      v_patch := v_patch OPERATOR(pg_catalog.||) pg_catalog.jsonb_build_object(
+        'reopened_at', v_now_iso,
+        'review_after', NULL);
+      IF v_next_action IS NOT NULL THEN
+        v_patch := v_patch OPERATOR(pg_catalog.||) pg_catalog.jsonb_build_object('next_action', v_next_action);
+      END IF;
+    ELSIF p_action OPERATOR(pg_catalog.=) 'defer' THEN
+      v_patch := v_patch OPERATOR(pg_catalog.||) pg_catalog.jsonb_build_object(
+        'deferred_at', v_now_iso,
+        'review_after', p_review_after);
+      IF v_next_action IS NOT NULL THEN
+        v_patch := v_patch OPERATOR(pg_catalog.||) pg_catalog.jsonb_build_object('next_action', v_next_action);
+      END IF;
+    ELSIF p_action OPERATOR(pg_catalog.=) 'needs_review' THEN
+      v_patch := v_patch OPERATOR(pg_catalog.||) pg_catalog.jsonb_build_object('needs_review_at', v_now_iso);
+    ELSIF p_action OPERATOR(pg_catalog.=) 'archive' THEN
+      v_patch := v_patch OPERATOR(pg_catalog.||) pg_catalog.jsonb_build_object(
+        'archived_at', v_now_iso,
+        'lifecycle_reason', CASE WHEN v_note IS NULL THEN 'manual_archive' ELSE v_note END);
+    ELSIF p_action OPERATOR(pg_catalog.=) 'suppress_noise' THEN
+      v_patch := v_patch OPERATOR(pg_catalog.||) pg_catalog.jsonb_build_object(
+        'archived_at', v_now_iso,
+        'suppressed_at', v_now_iso,
+        'lifecycle_reason', 'noise');
+    ELSIF p_action OPERATOR(pg_catalog.=) 'mark_superseded' THEN
+      v_patch := v_patch OPERATOR(pg_catalog.||) pg_catalog.jsonb_build_object(
+        'archived_at', v_now_iso,
+        'superseded_at', v_now_iso,
+        'lifecycle_reason', 'superseded');
+      IF p_superseded_by IS NOT NULL THEN
+        v_patch := v_patch OPERATOR(pg_catalog.||)
+          pg_catalog.jsonb_build_object('superseded_by', p_superseded_by::pg_catalog.text);
+      END IF;
+    END IF;
+
+    UPDATE public.thoughts
+    SET status = v_new_status,
+        status_updated_at = p_event_time,
+        metadata = v_metadata OPERATOR(pg_catalog.||) v_patch
+    WHERE id OPERATOR(pg_catalog.=) p_thought_id
+    RETURNING content,
+              CASE WHEN metadata IS NULL THEN '{}'::pg_catalog.jsonb ELSE metadata END,
+              status,
+              status_updated_at
+    INTO v_after_content, v_after_metadata, v_after_status, v_after_status_updated_at;
+  END IF;
+
+  v_after := public.thought_state_summary(
+    p_thought_id, v_after_content, v_after_status, v_after_status_updated_at, v_after_metadata);
+
+  -- The receipt. On the executor path the UNIQUE replay index guards this
+  -- insert: a raced duplicate approval aborts here, rolling back the
+  -- thought mutation above with it.
+  INSERT INTO public.thought_lifecycle_events
+    (thought_id, action, actor, note, before_state, after_state, brief_id, run_id, brief_hash)
+  VALUES
+    (p_thought_id, p_action, p_actor, v_note, v_before, v_after, p_brief_id, p_run_id, p_brief_hash)
+  RETURNING id INTO v_receipt_id;
+
+  -- Best-effort supersedes pointer (newer.supersedes = older), inside the
+  -- transaction: when the provenance-chains column exists, the pointer
+  -- commits atomically with patch and receipt; when it is absent — or the
+  -- write fails for any reason — the exception is contained, a warning
+  -- rides the result, and the metadata receipt stays canonical.
+  -- Known accepted
+  -- risk: two crossing supersede calls lock two thought rows each and can
+  -- deadlock; Postgres aborts one cleanly and the caller retries.
+  IF p_action OPERATOR(pg_catalog.=) 'mark_superseded' AND p_superseded_by IS NOT NULL THEN
+    BEGIN
+      EXECUTE $sql$
+        UPDATE public.thoughts SET supersedes = $1 WHERE id OPERATOR(pg_catalog.=) $2
+      $sql$
+      USING p_thought_id, p_superseded_by;
+      GET DIAGNOSTICS v_rowcount = ROW_COUNT;
+      IF v_rowcount OPERATOR(pg_catalog.=) 0 THEN
+        v_dual := pg_catalog.jsonb_build_object(
+          'attempted', true, 'applied', false,
+          'warning', pg_catalog.format(
+            'supersedes dual-write matched no row for replacing thought %s (metadata receipt still recorded).',
+            p_superseded_by));
+      ELSE
+        v_dual := pg_catalog.jsonb_build_object(
+          'attempted', true, 'applied', true, 'warning', NULL);
+      END IF;
+    EXCEPTION WHEN OTHERS THEN
+      v_dual := pg_catalog.jsonb_build_object(
+        'attempted', true, 'applied', false,
+        'warning', pg_catalog.concat(
+          'supersedes dual-write skipped (metadata receipt still recorded): ', SQLERRM));
+    END;
+  END IF;
+
+  -- The brief outcome event, inside the transaction (store law L11): on
+  -- the executor path there is no receipt-without-outcome halfway state —
+  -- if this insert fails, everything above rolls back and the approval
+  -- can simply be retried. The ONLY contained failure is the table not
+  -- existing (this pack standing alone, without the brief store); any
+  -- other failure — FK, CHECK, seq collision — aborts the whole write.
+  IF v_linkage THEN
+    v_outcome_label := CASE WHEN p_action OPERATOR(pg_catalog.=) 'defer' THEN 'deferred' ELSE 'approved' END;
+    BEGIN
+      EXECUTE $sql$
+        INSERT INTO public.brief_item_outcome_events
+          (brief_id, item_id, outcome, verb, actor, acted_at, lifecycle_event_id, note, detail)
+        VALUES ($1, $2, $3, $4, $5, $6, $7, $8, '{}'::pg_catalog.jsonb)
+        RETURNING seq
+      $sql$
+      INTO v_seq
+      USING p_brief_id, p_item_id, v_outcome_label, p_action, p_actor, p_acted_at, v_receipt_id, v_note;
+      v_outcome := pg_catalog.jsonb_build_object(
+        'recorded', true, 'outcome', v_outcome_label, 'seq', v_seq);
+    EXCEPTION WHEN undefined_table THEN
+      v_outcome := pg_catalog.jsonb_build_object(
+        'recorded', false, 'outcome', v_outcome_label,
+        'warning', 'brief_item_outcome_events does not exist: the receipt committed without a store outcome event. Apply schemas/brief-artifact-store/schema.sql.');
+    END;
+  END IF;
+
+  RETURN pg_catalog.jsonb_build_object(
+    'receipt_id', v_receipt_id,
+    'thought_id', p_thought_id,
+    'action', p_action,
+    'before', v_before,
+    'after', v_after,
+    'supersedes_dual_write', v_dual,
+    'outcome', v_outcome
+  );
+END
+$fn$;
+
+COMMENT ON FUNCTION public.receipted_thought_write(uuid, text, text, timestamptz, text, text, text, uuid, text, text, text, uuid, text, text, timestamptz) IS
+  'The one write path for governed thought mutations: patch + receipt + supersedes pointer + outcome event, one transaction. Derives the action→status law, law metadata stamps, and the brief outcome label; validates actor format and per-action argument shape. SECURITY INVOKER — it adds no authority the caller lacks.';
+
+-- Posture: service-role-only, like every write surface in this pack.
+-- Postgres grants EXECUTE on new functions to PUBLIC by default; revoke it.
+REVOKE ALL ON FUNCTION public.thought_state_summary(uuid, text, text, timestamptz, jsonb) FROM PUBLIC;
+REVOKE ALL ON FUNCTION public.thought_state_summary(uuid, text, text, timestamptz, jsonb) FROM anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.thought_state_summary(uuid, text, text, timestamptz, jsonb) TO service_role;
+
+REVOKE ALL ON FUNCTION public.receipted_thought_write(uuid, text, text, timestamptz, text, text, text, uuid, text, text, text, uuid, text, text, timestamptz) FROM PUBLIC;
+REVOKE ALL ON FUNCTION public.receipted_thought_write(uuid, text, text, timestamptz, text, text, text, uuid, text, text, text, uuid, text, text, timestamptz) FROM anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.receipted_thought_write(uuid, text, text, timestamptz, text, text, text, uuid, text, text, text, uuid, text, text, timestamptz) TO service_role;


### PR DESCRIPTION
## Contribution Type
- [x] Schema (`/schemas`)

## What does this do?
Adds `schemas/thought-lifecycle/` — an append-only `thought_lifecycle_events` receipt log plus a single transactional write path for lifecycle and correction actions (done / defer / needs-review / archive / supersede / correct) on Open Brain thoughts. The mutation and its receipt commit or roll back **together**, so a thought can't be changed without a matching receipt; a partial `UNIQUE` index makes "one execution per brief item" a database rule rather than a check-then-write race.

It's purely additive — **no changes to the core `thoughts` table structure and none to the MCP server**. The action→status projection lives in the database, so upstream consumers (dashboards, status filters) only ever see legal Open Brain statuses. The pack stands alone: its optional touchpoints with `provenance-chains` and a brief-store outcome table are exception-guarded, so their absence is a graceful no-op with a warning, not a failure.

## Requirements
- A working Open Brain instance (base `thoughts` table).
- The `workflow-status` schema applied (`thoughts.status` / `status_updated_at`).
- `pgvector` (ships with core Open Brain) — `correct_thought` rewrites `thoughts.embedding`.
- Supabase `service_role` (RLS and function grants are restricted to it).

No external services, no paid dependencies.

## Checklist
- [x] I've read CONTRIBUTING.md
- [x] README has prerequisites, numbered installation steps, expected outcome, and troubleshooting
- [x] metadata.json has all required fields
- [x] Tested on my own Open Brain instance
- [x] No credentials, API keys, or secrets
