### PR TITLE
fix(thought-enrichment): three silent failures — metadata corruption,…

### DIFF
--- a/recipes/thought-enrichment/README.md
+++ b/recipes/thought-enrichment/README.md
@@ -119,6 +119,53 @@ After running the full pipeline:
 - Thoughts containing sensitive patterns are flagged with `sensitivity_tier` = `personal` or `restricted`
 - The `enriched` boolean is set to `true` for all processed thoughts
 
+## Troubleshooting
+
+**`TypeError: Failed to parse URL from /rest/v1/thoughts?...`**
+
+`SUPABASE_URL` is empty, so the request path is relative. Config is read from
+`.env.local` layered over `process.env` — confirm the variable is set in one of
+them. (Before the fix in this recipe's history, only `.env.local` was consulted,
+so env-injected credentials from CI or a wrapper script were invisible.)
+
+**`invalid input syntax for type uuid: "0"` from `backfill-sensitivity.mjs`**
+
+An older revision seeded its pagination cursor with the integer `0`, which
+PostgREST rejects when `thoughts.id` is a uuid. The symptom was a run reporting
+`Scanned: 0` with `Errors: 1` — a false all-clear. Update to a revision that
+seeds the all-zeros uuid.
+
+**Metadata lookups return NULL after a successful enrichment run**
+
+If `metadata->>'source'` is NULL, `metadata ? 'topics'` is false, or
+`jsonb_object_keys(metadata)` raises `cannot call jsonb_object_keys on a scalar`,
+the column holds a JSON *string* rather than an object. An older revision
+pre-stringified `metadata` before serializing the request body, double-encoding
+it. Check for affected rows:
+
+```sql
+select jsonb_typeof(metadata), count(*) from thoughts group by 1;
+-- 'string' rows are double-encoded
+```
+
+No data is lost — the original object survives verbatim inside the string. To
+repair, confirm every affected row parses back to an object, then un-nest:
+
+```sql
+select count(*) from thoughts
+where jsonb_typeof(metadata)='string'
+  and jsonb_typeof((metadata #>> '{}')::jsonb)='object';
+
+update thoughts set metadata = (metadata #>> '{}')::jsonb
+where jsonb_typeof(metadata)='string'
+  and jsonb_typeof((metadata #>> '{}')::jsonb)='object';
+```
+
+**A few thoughts fail every run**
+
+Malformed LLM JSON, typically well under 1%. Re-run with `--apply
+--retry-failed`. Persistent failures are usually very short or non-prose content.
+
 ## File overview
 
 | File | Purpose |

--- a/recipes/thought-enrichment/backfill-sensitivity.mjs
+++ b/recipes/thought-enrichment/backfill-sensitivity.mjs
@@ -102,7 +102,9 @@ console.log();
 
 const BATCH_SIZE = 500;
 const PROGRESS_EVERY = 5000;
-let afterId = 0;
+// Keyset-pagination cursor over `thoughts.id` (uuid). The all-zeros uuid sorts
+// before every generated id, so the first page starts at the beginning.
+let afterId = "00000000-0000-0000-0000-000000000000";
 let scanned = 0;
 let scannedAtLastProgress = 0;
 let upgradedPersonal = 0;

--- a/recipes/thought-enrichment/enrich-thoughts.mjs
+++ b/recipes/thought-enrichment/enrich-thoughts.mjs
@@ -587,10 +587,9 @@ async function fetchByIds(config, ids) {
 
 async function patchThought(id, patch, config, retries = 4) {
   const url = `${config.supabaseUrl}/rest/v1/thoughts?id=eq.${id}`;
+  // `metadata` is jsonb and is serialized by the JSON.stringify(body) below.
+  // Pre-stringifying it here would store a jsonb scalar string, not an object.
   const body = { ...patch };
-  if (body.metadata) {
-    body.metadata = JSON.stringify(body.metadata);
-  }
   const opts = {
     method: "PATCH",
     headers: {
@@ -820,16 +819,21 @@ function parseArgs(argv) {
   return args;
 }
 
+/**
+ * Load config env from `.env.local` layered over `process.env`.
+ * File entries take precedence; `process.env` supplies anything the file omits.
+ */
 function parseEnvFile(filePath) {
-  if (!fs.existsSync(filePath)) return {};
   const env = {};
-  for (const line of fs.readFileSync(filePath, "utf8").split("\n")) {
-    const idx = line.indexOf("=");
-    if (idx > 0 && !line.startsWith("#")) {
-      env[line.slice(0, idx).trim()] = line.slice(idx + 1).trim().replace(/^['"]|['"]$/g, "");
+  if (fs.existsSync(filePath)) {
+    for (const line of fs.readFileSync(filePath, "utf8").split("\n")) {
+      const idx = line.indexOf("=");
+      if (idx > 0 && !line.startsWith("#")) {
+        env[line.slice(0, idx).trim()] = line.slice(idx + 1).trim().replace(/^['"]|['"]$/g, "");
+      }
     }
   }
-  return env;
+  return { ...process.env, ...env };
 }
 
 function printUsage() {

--- a/recipes/thought-enrichment/metadata.json
+++ b/recipes/thought-enrichment/metadata.json
@@ -6,7 +6,7 @@
     "name": "Alan Shurafa",
     "github": "alanshurafa"
   },
-  "version": "1.0.0",
+  "version": "1.0.1",
   "requires": {
     "open_brain": true,
     "services": ["OpenRouter API", "Anthropic API", "Supabase"],


### PR DESCRIPTION
## Contribution Type

<!-- Check one -->
- [ ] Recipe (`/recipes`)
- [ ] Schema (`/schemas`)
- [ ] Dashboard (`/dashboards`)
- [ ] Integration (`/integrations`)
- [ ] Skill (`/skills`)
- [x] Repo improvement (docs, CI, templates)

> Bug fix to an existing recipe (`recipes/thought-enrichment`) rather than a new
> contribution — no category above fits exactly, so "repo improvement" is the
> closest. Happy to recategorize.

## What does this do?

Fixes three bugs in `recipes/thought-enrichment` that all fail silently — the
scripts print success while corrupting data, writing nothing, or scanning zero
rows. One of them (`patchThought()` double-encoding the `metadata` jsonb column)
corrupts metadata on **every** enriched row of a stock install, so anyone who has
run this recipe is affected and has no reason to suspect it. Also adds a
Troubleshooting section to the recipe README with recovery SQL, and bumps
`metadata.json` to 1.0.1.

## Requirements

No new requirements. Unchanged from the recipe's existing prerequisites:
Node.js 18+, Supabase, and an OpenRouter or Anthropic API key. No new
dependencies, no schema changes, no `requires_skills` additions.

## Checklist

- [x] I've read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] My contribution has a `README.md` with prerequisites, step-by-step instructions, and expected outcome
- [x] My `metadata.json` has all required fields
- [x] If my contribution depends on a skill or primitive, I declared it in metadata.json and linked it in the README
- [x] I tested this on my own Open Brain instance
- [x] No credentials, API keys, or secrets are included

---

## The three bugs

### 1. `metadata` double-encoded — data corruption

**`enrich-thoughts.mjs` → `patchThought()`**