### PR TITLE
[extensions] Fix meal-planning shared server deploy blockers (route + secret name) + family-calendar RLS note

### DIFF
--- a/extensions/family-calendar/README.md
+++ b/extensions/family-calendar/README.md
@@ -23,7 +23,7 @@ Two kids, two parents, overlapping schedules. Soccer practice conflicts with the
 - Nullable foreign keys (activities can belong to one person or the whole family)
 - Querying across date ranges
 
-> **Note:** This extension doesn't use Row Level Security. RLS is introduced in Extension 4 (Meal Planning), where shared household access makes it necessary. Extensions 1-3 are single-user systems.
+> **Note:** This extension doesn't use Row Level Security — it is omitted here for simplicity. Extensions 1 (Household Knowledge) and 2 (Home Maintenance) already include RLS policies in their schemas, and Extension 4 (Meal Planning) builds on RLS for shared household access.
 
 ## What It Does
 

--- a/extensions/meal-planning/README.md
+++ b/extensions/meal-planning/README.md
@@ -198,7 +198,7 @@ Follow the [Deploy an Edge Function](../../primitives/deploy-edge-function/) gui
 You'll also need to set the household Supabase key:
 
 ```bash
-supabase secrets set SUPABASE_HOUSEHOLD_KEY=household-scoped-api-key
+supabase secrets set HOUSEHOLD_SUPABASE_KEY=household-scoped-api-key
 ```
 
 ### 3. Connect Your Household Member

--- a/extensions/meal-planning/shared-server.ts
+++ b/extensions/meal-planning/shared-server.ts
@@ -20,7 +20,7 @@ import { createClient } from "@supabase/supabase-js";
 
 const app = new Hono();
 
-app.post("/mcp", async (c) => {
+app.post("*", async (c) => {
   const key = c.req.query("key") || c.req.header("x-access-key");
   const expected = Deno.env.get("MCP_HOUSEHOLD_ACCESS_KEY");
   if (!key || key !== expected) {
@@ -29,7 +29,7 @@ app.post("/mcp", async (c) => {
 
   const supabase = createClient(
     Deno.env.get("SUPABASE_URL")!,
-    Deno.env.get("SUPABASE_HOUSEHOLD_KEY")!,
+    Deno.env.get("HOUSEHOLD_SUPABASE_KEY")!,
   );
 
   const server = new McpServer({ name: "meal-planning-shared", version: "1.0.0" });

--- a/primitives/shared-mcp/README.md
+++ b/primitives/shared-mcp/README.md
@@ -137,7 +137,7 @@ app.post("/mcp", async (c) => {
   // Use SCOPED credentials — not the service role key
   const supabase = createClient(
     Deno.env.get("SUPABASE_URL")!,
-    Deno.env.get("SUPABASE_HOUSEHOLD_KEY")!, // Limited key
+    Deno.env.get("HOUSEHOLD_SUPABASE_KEY")!, // Limited key
   );
 
   const server = new McpServer(
@@ -235,7 +235,7 @@ openssl rand -hex 32
 
 # Set secrets
 supabase secrets set MCP_HOUSEHOLD_ACCESS_KEY=your-generated-shared-key
-supabase secrets set SUPABASE_HOUSEHOLD_KEY=your-limited-supabase-key  # LIMITED KEY
+supabase secrets set HOUSEHOLD_SUPABASE_KEY=your-limited-supabase-key  # LIMITED KEY
 
 # Optional: Household ID for RLS
 SHARED_HOUSEHOLD_ID=uuid-here
@@ -279,7 +279,7 @@ openssl rand -hex 32
 
 # Set the shared server's secrets
 supabase secrets set MCP_HOUSEHOLD_ACCESS_KEY=generated-key-here
-supabase secrets set SUPABASE_HOUSEHOLD_KEY=household-scoped-api-key
+supabase secrets set HOUSEHOLD_SUPABASE_KEY=household-scoped-api-key
 
 # Deploy
 supabase functions deploy household-shared-mcp --no-verify-jwt


### PR DESCRIPTION
Fixes #463

## What this does

1. **Route pattern**: `shared-server.ts` registered `app.post("/mcp", ...)`, but the Edge Functions runtime keeps the function-name prefix in the request path, so every request 404s. Changed to `app.post("*", ...)`, matching the main server (`index.ts`).
2. **Reserved secret prefix**: the code read `SUPABASE_HOUSEHOLD_KEY`, but the Supabase CLI rejects secrets starting with `SUPABASE_`, so the documented deploy path could never provide the key. Renamed to `HOUSEHOLD_SUPABASE_KEY` in code and docs (meal-planning README + shared-mcp primitive).
3. **Docs**: the family-calendar README claimed "Extensions 1-3 are single-user systems", but extensions 1 and 2 already ship full RLS. Reworded the note.

## Requirements

No new requirements — same services and tools as before.

## Tested

Tested on my own Open Brain instance: with these changes the shared server deploys and responds correctly on Supabase Edge Functions (verified live with curl and a claude.ai custom connector). As shipped, every request 404s and the secret cannot be set.

---
_Generated by [Claude Code](https://claude.ai/code)_