### PR TITLE
[integrations] Report the real cause when all LLM providers fail

### DIFF
--- a/integrations/entity-extraction-worker/index.ts
+++ b/integrations/entity-extraction-worker/index.ts
@@ -296,6 +296,10 @@ async function extractEntities(content: string): Promise<ExtractionResult> {
   // literal occurrences of the tags so an adversarial thought can't break out.
   const prompt = ENTITY_EXTRACTION_PROMPT.replace("{content}", wrapThoughtContent(content));
 
+  // Remember why each configured provider gave up, so that exhausting the
+  // chain reports the actual cause instead of "no API key configured".
+  let lastProviderError: string | null = null;
+
   // OpenRouter (primary)
   if (OPENROUTER_API_KEY) {
     try {
@@ -314,6 +318,7 @@ async function extractEntities(content: string): Promise<ExtractionResult> {
       if (!response.ok) throw new Error(`OpenRouter failed (${response.status}): ${await response.text()}`);
       return parseExtractionResult(readChatCompletionText(await response.json()));
     } catch (err) {
+      lastProviderError = `OpenRouter: ${(err as Error).message}`;
       console.warn("OpenRouter extraction failed:", (err as Error).message);
     }
   }
@@ -334,6 +339,7 @@ async function extractEntities(content: string): Promise<ExtractionResult> {
       if (!response.ok) throw new Error(`OpenAI failed (${response.status}): ${await response.text()}`);
       return parseExtractionResult(readChatCompletionText(await response.json()));
     } catch (err) {
+      lastProviderError = `OpenAI: ${(err as Error).message}`;
       console.warn("OpenAI extraction failed:", (err as Error).message);
     }
   }
@@ -356,6 +362,13 @@ async function extractEntities(content: string): Promise<ExtractionResult> {
     });
     if (!response.ok) throw new Error(`Anthropic failed (${response.status}): ${await response.text()}`);
     return parseExtractionResult(readAnthropicText(await response.json()));
+  }
+
+  // A provider was configured and tried, but every one of them failed. This is
+  // an availability problem, not a configuration problem — say so, and carry
+  // the underlying cause into last_error on the queue row.
+  if (lastProviderError) {
+    throw new Error(`All configured LLM providers failed. Last error: ${lastProviderError}`);
   }
 
   throw new Error("No LLM API key configured (OPENROUTER_API_KEY, OPENAI_API_KEY, or ANTHROPIC_API_KEY)");


### PR DESCRIPTION
# Report the real cause when all LLM providers fail

## Problem

If `OPENROUTER_API_KEY` is the only provider configured and an OpenRouter request fails, the worker reports:

```
No LLM API key configured (OPENROUTER_API_KEY, OPENAI_API_KEY, or ANTHROPIC_API_KEY)
```

The key is configured. The request failed.

In `extractEntities()`, the OpenRouter branch throws inside a `try` whose `catch` only calls `console.warn` and swallows the error. Execution then falls through the OpenAI and Anthropic branches (skipped, since those keys aren't set) and lands on the final `throw` at the bottom of the function, which assumes the only way to get there is a missing key.

That message is written to `entity_extraction_queue.last_error`, so the queue row records a configuration problem that doesn't exist. The actual cause survives only as a `console.warn`, which doesn't surface in the Edge Function request logs alongside the failure.

I hit this on a run of about 800 thoughts. One thought failed all 5 attempts and reported a missing API key throughout, while the other 795 extracted successfully using that same key. Diagnosing it meant reading the source, because every signal pointed at configuration.

## Change

Track the last provider error and distinguish "nothing was configured" from "everything configured was tried and failed":

```ts
let lastProviderError: string | null = null;
```

Set in each provider's `catch`, then checked before the existing throw:

```ts
if (lastProviderError) {
  throw new Error(`All configured LLM providers failed. Last error: ${lastProviderError}`);
}
```

The original message stays for the case it was actually written for.

## Effect

Same failure now records:

```
All configured LLM providers failed. Last error: OpenRouter: OpenRouter failed (400): ...
```

Diagnosable from `last_error` alone, without reading the source or correlating logs.

## Notes

Four hunks, no behavioral change beyond the error text. The existing `console.warn` calls are left in place. The Anthropic branch already throws directly, so it needs no tracking.

Not addressed here: the underlying reason that request failed in the first place. Filed separately as an issue, since fixing it involves a design decision rather than a one-line correction.
