### PR TITLE
[docs] Add contribution scaffolder script

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -51,6 +51,16 @@ Every contribution lives in its own subfolder under the right category (e.g., `r
 - **Your actual code** — SQL files, edge function code, frontend code, config files, whatever it takes
 - **NO credentials, API keys, or secrets.** The automated review will reject them. Use environment variables and document what the user needs to set.
 
+### Scaffold a New Contribution
+
+Generate a starter folder from the correct category template:
+
+```bash
+node scripts/new-contribution.mjs --category recipes --slug demo-recipe --name "Demo Recipe" --description "Adds a demonstration workflow to Open Brain." --author "Your Name" --difficulty beginner --estimated-time "20 minutes" --tags demo --yes
+```
+
+The generator creates the README, metadata, and category-specific starter artifacts without overwriting an existing folder. Dashboard scaffolds start with `index.html`, integrations with `index.ts`, and extensions with both `schema.sql` and `index.ts`, so the generated folder meets the category artifact gate before you customize it. The category `_template/` folders remain the source of truth. See [scripts/README.md](scripts/README.md) for interactive usage and all flags.
+
 ## README Standards
 
 Your contribution's README must include these sections:

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,0 +1,44 @@
+# Maintenance Scripts
+
+These dependency-free Node.js scripts support repository maintenance and contribution checks. Run them from the repository root with Node.js 18 or newer.
+
+## Scaffold a New Contribution
+
+`new-contribution.mjs` copies the selected category's `_template/` directory, fills in its README and metadata, and adds category-specific starter artifacts. Dashboard scaffolds include `index.html`, integrations include `index.ts`, and extensions include both `schema.sql` and `index.ts`. Generated primitive READMEs include a submission checklist that keeps them above the category's minimum detail threshold. Template-only maintainer files are excluded from generated contributions. The `_template/` directories remain the source of truth.
+
+```bash
+node scripts/new-contribution.mjs \
+  --category recipes \
+  --slug demo-recipe \
+  --name "Demo Recipe" \
+  --description "Adds a demonstration workflow to Open Brain." \
+  --author "Your Name" \
+  --github your-github-username \
+  --difficulty beginner \
+  --estimated-time "20 minutes" \
+  --tags demo,workflow \
+  --yes
+```
+
+Omit required flags in a terminal to answer interactive prompts. Use `--yes` for non-interactive runs; missing required values then fail instead of prompting.
+
+Available flags:
+
+- `--category`: `recipes`, `schemas`, `dashboards`, `integrations`, `skills`, `primitives`, or `extensions`
+- `--slug`: Lowercase, hyphenated destination folder name
+- `--name`, `--description`, `--author`, `--github`
+- `--difficulty`: `beginner`, `intermediate`, or `advanced`
+- `--estimated-time`, `--tags`
+- `--requires-skills`, `--requires-primitives`: Comma-separated dependency slugs
+- `--learning-order`: Positive integer required for extensions
+- `--yes`: Disable interactive prompting
+
+The command exits `0` after creating and checking the scaffold, `1` for invalid or missing input, and `2` when the destination already exists. It never overwrites an existing contribution.
+
+## Update Recent Contributions
+
+`update-readme-contributions.mjs` refreshes the recent contributions table in the root README from merged GitHub pull requests:
+
+```bash
+node scripts/update-readme-contributions.mjs
+```

--- a/scripts/new-contribution.mjs
+++ b/scripts/new-contribution.mjs
@@ -1,0 +1,412 @@
+#!/usr/bin/env node
+
+import fs from "node:fs";
+import path from "node:path";
+import process from "node:process";
+import { createInterface } from "node:readline/promises";
+import { pathToFileURL } from "node:url";
+import { parseArgs } from "node:util";
+
+const SLUG_PATTERN = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
+
+const CATEGORY_NOUNS = {
+  recipes: "Recipe",
+  schemas: "Schema",
+  dashboards: "Dashboard",
+  integrations: "Integration",
+  skills: "Skill",
+  primitives: "Primitive",
+  extensions: "Extension",
+};
+
+class ScaffoldError extends Error {
+  constructor(message, exitCode = 1) {
+    super(message);
+    this.exitCode = exitCode;
+  }
+}
+
+function commaList(value) {
+  if (Array.isArray(value)) return value.map(String).map((item) => item.trim()).filter(Boolean);
+  return String(value || "")
+    .split(",")
+    .map((item) => item.trim())
+    .filter(Boolean);
+}
+
+function validateAnswers(schema, answers, rootDir) {
+  const required = ["category", "slug", "name", "description", "author", "difficulty", "estimatedTime"];
+  for (const field of required) {
+    if (!String(answers[field] || "").trim()) throw new ScaffoldError(`Missing required value: ${field}`);
+  }
+
+  if (!CATEGORY_NOUNS[answers.category]) {
+    throw new ScaffoldError(`Invalid category: ${answers.category}`);
+  }
+  if (!SLUG_PATTERN.test(answers.slug)) {
+    throw new ScaffoldError("Slug must contain only lowercase letters, numbers, and single hyphens.");
+  }
+  // Dependency slugs land in metadata and in relative README links, so they get
+  // the same rule as the destination slug. Without it a traversal entry such as
+  // ".." is written verbatim and points outside the category. They must also
+  // actually exist: gate rule 10 rejects a contribution whose declared
+  // dependency directory is missing, so a typo would otherwise scaffold
+  // "successfully" and then fail CI.
+  for (const [flag, value, dependencyCategory] of [
+    ["--requires-skills", answers.requiresSkills, "skills"],
+    ["--requires-primitives", answers.requiresPrimitives, "primitives"],
+  ]) {
+    for (const dependency of commaList(value)) {
+      if (!SLUG_PATTERN.test(dependency)) {
+        throw new ScaffoldError(
+          `Invalid ${flag} entry: ${dependency}. Use lowercase letters, numbers, and single hyphens.`,
+        );
+      }
+      if (!fs.existsSync(path.join(rootDir, dependencyCategory, dependency))) {
+        throw new ScaffoldError(
+          `Unknown ${flag} entry: ${dependency}. ${dependencyCategory}/${dependency}/ does not exist.`,
+        );
+      }
+    }
+  }
+
+  const difficulties = schema.properties?.difficulty?.enum || [];
+  if (!difficulties.includes(answers.difficulty)) {
+    throw new ScaffoldError(`Invalid difficulty: ${answers.difficulty}. Choose ${difficulties.join(", ")}.`);
+  }
+
+  const tags = commaList(answers.tags);
+  if (tags.length === 0) throw new ScaffoldError("At least one tag is required.");
+
+  if (answers.category === "extensions" && String(answers.learningOrder ?? "").trim()) {
+    const learningOrder = Number(answers.learningOrder);
+    if (!Number.isInteger(learningOrder) || learningOrder < 1) {
+      throw new ScaffoldError("Extensions require a positive integer learning order.");
+    }
+  }
+}
+
+function buildMetadata(template, answers) {
+  const metadata = structuredClone(template);
+  metadata.name = answers.name.trim();
+  metadata.description = answers.description.trim();
+  metadata.category = answers.category;
+  metadata.author = { name: answers.author.trim() };
+  if (answers.github?.trim()) metadata.author.github = answers.github.trim().replace(/^@/, "");
+  metadata.version = "1.0.0";
+  metadata.requires = { ...metadata.requires, open_brain: true };
+  metadata.tags = commaList(answers.tags);
+  metadata.difficulty = answers.difficulty;
+  metadata.estimated_time = answers.estimatedTime.trim();
+
+  const requiredSkills = commaList(answers.requiresSkills);
+  const requiredPrimitives = commaList(answers.requiresPrimitives);
+  if (requiredSkills.length) metadata.requires_skills = requiredSkills;
+  else delete metadata.requires_skills;
+  if (requiredPrimitives.length) {
+    metadata.requires_primitives = [...new Set([...commaList(metadata.requires_primitives), ...requiredPrimitives])];
+  } else if (answers.category !== "extensions") delete metadata.requires_primitives;
+
+  if (answers.category === "extensions" && String(answers.learningOrder ?? "").trim()) {
+    metadata.learning_order = Number(answers.learningOrder);
+  } else delete metadata.learning_order;
+
+  const today = new Date().toISOString().slice(0, 10);
+  if ("created" in metadata) metadata.created = today;
+  if ("updated" in metadata) metadata.updated = today;
+  return metadata;
+}
+
+// Replacement values come from user input, so they must be inserted literally.
+// Passing them as replacement strings would let JavaScript's `$&`, `$1`, `` $` ``
+// and `$'` patterns rewrite the output (e.g. --name 'Cash $& Carry').
+const literal = (value) => () => value;
+
+function substituteTemplate(content, answers) {
+  const noun = CATEGORY_NOUNS[answers.category];
+  return content
+    .replaceAll(`${noun} Name`, literal(answers.name))
+    .replaceAll(`${noun.toUpperCase()} NAME`, literal(answers.name.toUpperCase()))
+    .replaceAll(`${noun.toLowerCase()}-name`, literal(answers.slug))
+    .replaceAll("Your Name", literal(answers.author))
+    .replaceAll("your-github-username", literal((answers.github || "your-github-username").replace(/^@/, "")))
+    .replace(/> One-line description[^\n]*/g, literal(`> ${answers.description}`));
+}
+
+function appendDependencyLinks(readme, answers) {
+  const links = [
+    ...commaList(answers.requiresSkills).map((slug) => `- [${slug}](../../skills/${slug}/)`),
+    ...commaList(answers.requiresPrimitives).map((slug) => `- [${slug}](../../primitives/${slug}/)`),
+  ];
+  if (!links.length) return readme;
+  return `${readme.trimEnd()}\n\n## Contribution Dependencies\n\nInstall or review these dependencies before continuing:\n\n${links.join("\n")}\n`;
+}
+
+function escapeHtml(value) {
+  return String(value)
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll('"', "&quot;")
+    .replaceAll("'", "&#39;");
+}
+
+function edgeFunctionStarter(answers) {
+  const contribution = JSON.stringify(
+    { name: answers.name.trim(), description: answers.description.trim() },
+    null,
+    2,
+  );
+  return `const contribution = ${contribution} as const;
+
+Deno.serve((request) => {
+  if (request.method !== "POST") {
+    return new Response("Send a POST request to this endpoint.", {
+      status: 405,
+      headers: { allow: "POST" },
+    });
+  }
+
+  return Response.json({
+    contribution,
+    message: "Replace this starter response with your remote integration handler.",
+  });
+});
+`;
+}
+
+function addCategoryArtifacts(targetDir, answers) {
+  if (answers.category === "schemas") {
+    fs.writeFileSync(
+      path.join(targetDir, "schema.sql"),
+      "-- Replace example_table with the table created by this contribution.\n-- Add CREATE TABLE, indexes, and row-level security policies above this grant.\n\ngrant select, insert, update, delete on table public.example_table to service_role;\n",
+    );
+  }
+
+  if (answers.category === "dashboards") {
+    fs.writeFileSync(
+      path.join(targetDir, "index.html"),
+      `<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>${escapeHtml(answers.name)}</title>
+  </head>
+  <body>
+    <main>
+      <h1>${escapeHtml(answers.name)}</h1>
+      <p>${escapeHtml(answers.description)}</p>
+      <p>Replace this starter page with your Open Brain dashboard.</p>
+    </main>
+  </body>
+</html>
+`,
+    );
+  }
+
+  if (answers.category === "integrations") {
+    fs.writeFileSync(path.join(targetDir, "index.ts"), edgeFunctionStarter(answers));
+  }
+
+  if (answers.category === "extensions") {
+    const tableName = `${answers.slug.replaceAll("-", "_")}_items`;
+    fs.writeFileSync(
+      path.join(targetDir, "schema.sql"),
+      `create table if not exists public.${tableName} (
+  id uuid primary key default gen_random_uuid(),
+  user_id uuid not null references auth.users(id) on delete cascade,
+  content text not null,
+  created_at timestamptz not null default now()
+);
+
+alter table public.${tableName} enable row level security;
+
+create policy "${tableName}_owner"
+on public.${tableName}
+for all
+using (auth.uid() = user_id)
+with check (auth.uid() = user_id);
+
+grant select, insert, update, delete on table public.${tableName} to service_role;
+`,
+    );
+    fs.writeFileSync(path.join(targetDir, "index.ts"), edgeFunctionStarter(answers));
+  }
+
+  if (answers.category === "primitives") {
+    const readmePath = path.join(targetDir, "README.md");
+    const readme = fs
+      .readFileSync(readmePath, "utf8")
+      .replaceAll("[Extension Name](../../extensions/extension-slug/)", "Extension Name");
+    fs.writeFileSync(
+      readmePath,
+      `${readme.trimEnd()}\n\n## Prerequisites\n\n- A working Open Brain setup\n\n## Submission Checklist\n\nBefore submitting, replace every placeholder with specific guidance drawn from a working Open Brain setup. Expand the explanation, patterns, and numbered steps so another contributor can follow the guide without guessing. Keep examples copy-paste ready, describe a concrete expected result, and document likely failure modes. Verify that the completed README contains at least 200 words and names the extensions that use this primitive.\n`,
+    );
+  }
+
+  if (["dashboards", "integrations"].includes(answers.category)) {
+    const readmePath = path.join(targetDir, "README.md");
+    const readme = fs.readFileSync(readmePath, "utf8");
+    fs.writeFileSync(
+      readmePath,
+      `${readme.trimEnd()}\n\n## Remote MCP Deployment\n\nIf this contribution exposes MCP tools, deploy them as a Supabase Edge Function and connect through your AI client's URL-based custom connector. Do not use a local MCP server.\n`,
+    );
+  }
+}
+
+function selfCheck(rootDir, metadataPath) {
+  const schema = JSON.parse(fs.readFileSync(path.join(rootDir, ".github", "metadata.schema.json"), "utf8"));
+  const metadata = JSON.parse(fs.readFileSync(metadataPath, "utf8"));
+  const missing = schema.required.filter((field) => !(field in metadata));
+  if (missing.length) throw new ScaffoldError(`Generated metadata is missing: ${missing.join(", ")}`);
+  if (metadata.requires?.open_brain !== true) {
+    throw new ScaffoldError("Generated metadata must set requires.open_brain to true.");
+  }
+  if (!schema.properties.difficulty.enum.includes(metadata.difficulty)) {
+    throw new ScaffoldError(`Generated metadata has invalid difficulty: ${metadata.difficulty}`);
+  }
+  return metadata;
+}
+
+function listFiles(dir) {
+  return fs.readdirSync(dir, { withFileTypes: true }).flatMap((entry) => {
+    const entryPath = path.join(dir, entry.name);
+    return entry.isDirectory() ? listFiles(entryPath) : [entryPath];
+  });
+}
+
+export function scaffold(rootDir, answers) {
+  const root = path.resolve(rootDir);
+  const schemaPath = path.join(root, ".github", "metadata.schema.json");
+  const schema = JSON.parse(fs.readFileSync(schemaPath, "utf8"));
+  const normalized = {
+    ...answers,
+    category: String(answers.category || "").trim(),
+    slug: String(answers.slug || "").trim(),
+  };
+  validateAnswers(schema, normalized, root);
+
+  const templateDir = path.join(root, normalized.category, "_template");
+  if (!fs.statSync(templateDir).isDirectory()) throw new ScaffoldError(`Template not found: ${templateDir}`);
+
+  const targetDir = path.join(root, normalized.category, normalized.slug);
+  if (fs.existsSync(targetDir)) throw new ScaffoldError(`Target already exists: ${targetDir}`, 2);
+
+  const temporaryDir = path.join(root, normalized.category, `.new-${normalized.slug}-${process.pid}`);
+  try {
+    const extensionSpec = path.join(templateDir, "AGENT_SPEC.md");
+    fs.cpSync(templateDir, temporaryDir, {
+      recursive: true,
+      filter: (source) => normalized.category !== "extensions" || source !== extensionSpec,
+    });
+    const templateMetadata = JSON.parse(fs.readFileSync(path.join(templateDir, "metadata.json"), "utf8"));
+    const metadata = buildMetadata(templateMetadata, normalized);
+
+    for (const filePath of listFiles(temporaryDir)) {
+      if (path.basename(filePath) === "metadata.json") continue;
+      const content = fs.readFileSync(filePath, "utf8");
+      fs.writeFileSync(filePath, substituteTemplate(content, normalized));
+    }
+
+    const readmePath = path.join(temporaryDir, "README.md");
+    fs.writeFileSync(readmePath, appendDependencyLinks(fs.readFileSync(readmePath, "utf8"), normalized));
+    addCategoryArtifacts(temporaryDir, normalized);
+    fs.writeFileSync(path.join(temporaryDir, "metadata.json"), `${JSON.stringify(metadata, null, 2)}\n`);
+    selfCheck(root, path.join(temporaryDir, "metadata.json"));
+    fs.renameSync(temporaryDir, targetDir);
+
+    return {
+      createdPaths: listFiles(targetDir),
+      metadata: selfCheck(root, path.join(targetDir, "metadata.json")),
+    };
+  } catch (error) {
+    fs.rmSync(temporaryDir, { recursive: true, force: true });
+    throw error;
+  }
+}
+
+async function collectAnswers(values) {
+  const answers = {
+    category: values.category,
+    slug: values.slug,
+    name: values.name,
+    description: values.description,
+    author: values.author,
+    github: values.github,
+    difficulty: values.difficulty,
+    estimatedTime: values["estimated-time"],
+    tags: values.tags,
+    requiresSkills: values["requires-skills"],
+    requiresPrimitives: values["requires-primitives"],
+    learningOrder: values["learning-order"],
+  };
+  const prompts = {
+    category: "Category",
+    slug: "Folder slug",
+    name: "Contribution name",
+    description: "Description",
+    author: "Author name",
+    difficulty: "Difficulty (beginner/intermediate/advanced)",
+    estimatedTime: "Estimated time",
+    tags: "Tags (comma-separated)",
+  };
+
+  const requiredFields = Object.keys(prompts);
+  const missing = requiredFields.filter((field) => !String(answers[field] || "").trim());
+  if (!missing.length) return answers;
+  if (values.yes || !process.stdin.isTTY) {
+    throw new ScaffoldError(`Missing required flags: ${missing.map((field) => `--${field.replace(/[A-Z]/g, (letter) => `-${letter.toLowerCase()}`)}`).join(", ")}`);
+  }
+
+  const readline = createInterface({ input: process.stdin, output: process.stdout });
+  try {
+    if (!answers.category) answers.category = await readline.question(`${prompts.category}: `);
+    for (const field of Object.keys(prompts)) {
+      if (!answers[field]) answers[field] = await readline.question(`${prompts[field]}: `);
+    }
+    if (!answers.github) answers.github = await readline.question("GitHub username (optional): ");
+    if (!answers.requiresSkills) answers.requiresSkills = await readline.question("Required skill slugs (comma-separated, optional): ");
+    if (!answers.requiresPrimitives) answers.requiresPrimitives = await readline.question("Required primitive slugs (comma-separated, optional): ");
+    return answers;
+  } finally {
+    readline.close();
+  }
+}
+
+async function main() {
+  const { values } = parseArgs({
+    allowPositionals: false,
+    options: {
+      category: { type: "string" },
+      slug: { type: "string" },
+      name: { type: "string" },
+      description: { type: "string" },
+      author: { type: "string" },
+      github: { type: "string" },
+      difficulty: { type: "string" },
+      "estimated-time": { type: "string" },
+      tags: { type: "string" },
+      "requires-skills": { type: "string" },
+      "requires-primitives": { type: "string" },
+      "learning-order": { type: "string" },
+      yes: { type: "boolean", default: false },
+    },
+  });
+  const answers = await collectAnswers(values);
+  const result = scaffold(process.cwd(), answers);
+  const relativeDir = path.join(answers.category, answers.slug);
+  console.log(`Created ${relativeDir}/ (${result.createdPaths.length} files).`);
+  if (fs.existsSync(path.join(process.cwd(), "scripts", "validate-contribution.mjs"))) {
+    console.log(`Next: node scripts/validate-contribution.mjs ${relativeDir}`);
+  } else {
+    console.log("Next: review the CI rule list in .github/workflows/ob1-gate-v2.yml.");
+  }
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main().catch((error) => {
+    console.error(`Error: ${error.message}`);
+    process.exitCode = error.exitCode || 1;
+  });
+}

--- a/scripts/new-contribution.test.mjs
+++ b/scripts/new-contribution.test.mjs
@@ -1,0 +1,450 @@
+import assert from "node:assert/strict";
+import { execFileSync, spawnSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import test from "node:test";
+
+import { scaffold } from "./new-contribution.mjs";
+
+const SCRIPT_PATH = fileURLToPath(new URL("./new-contribution.mjs", import.meta.url));
+const REPOSITORY_ROOT = fileURLToPath(new URL("../", import.meta.url));
+const CATEGORIES = ["recipes", "schemas", "dashboards", "integrations", "skills", "primitives", "extensions"];
+const REQUIRED_FIELDS = ["name", "description", "category", "author", "version", "requires", "tags", "difficulty", "estimated_time"];
+
+function fixture() {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "ob1-scaffold-"));
+  fs.mkdirSync(path.join(root, ".github"), { recursive: true });
+  fs.writeFileSync(
+    path.join(root, ".github", "metadata.schema.json"),
+    JSON.stringify({
+      required: REQUIRED_FIELDS,
+      properties: { difficulty: { enum: ["beginner", "intermediate", "advanced"] } },
+    }),
+  );
+
+  for (const category of CATEGORIES) {
+    const template = path.join(root, category, "_template");
+    fs.mkdirSync(template, { recursive: true });
+    const noun = category === "recipes" ? "Recipe" : `${category[0].toUpperCase()}${category.slice(1, -1)}`;
+    let readme = `# ${noun} Name\n\n> One-line description of this contribution.\n\n## What It Does\n\nTODO\n\n## Prerequisites\n\n- Open Brain\n\n## Steps\n\n1. TODO\n\n## Expected Outcome\n\nTODO\n\n## Troubleshooting\n\nTODO\n`;
+    if (category === "extensions") {
+      readme += "\n## Why This Matters\n\nTODO\n\n## Learning Path\n\nTODO\n\n## What You'll Learn\n\nTODO\n\n## Cross-Extension Integration\n\nTODO\n\n## Next Steps\n\n[Tool audit](../../docs/05-tool-audit.md)\n";
+    }
+    if (category === "skills") {
+      readme += "\n## Supported Clients\n\n- Codex\n\n## Installation\n\nTODO\n\n## Trigger Conditions\n\nTODO\n";
+      fs.writeFileSync(path.join(template, "SKILL.md"), "# Skill Name\n\nPlain-text instructions.\n");
+    }
+    fs.writeFileSync(path.join(template, "README.md"), readme);
+    fs.writeFileSync(
+      path.join(template, "metadata.json"),
+      JSON.stringify({
+        name: `${noun} Name`,
+        description: "Template description",
+        category,
+        author: { name: "Your Name", github: "your-github-username" },
+        version: "1.0.0",
+        requires: { open_brain: true, services: [], tools: [] },
+        tags: ["template"],
+        difficulty: "beginner",
+        estimated_time: "10 minutes",
+      }),
+    );
+  }
+  // Dependency directories the scaffolder now verifies before writing links.
+  for (const [category, slug] of [
+    ["skills", "auto-capture"],
+    ["skills", "meeting-triage"],
+    ["primitives", "rls"],
+    ["primitives", "deploy-edge-function"],
+    ["primitives", "remote-mcp"],
+  ]) {
+    fs.mkdirSync(path.join(root, category, slug), { recursive: true });
+    fs.writeFileSync(path.join(root, category, slug, "README.md"), `# ${slug}\n`);
+  }
+
+  return root;
+}
+
+function repositoryFixture() {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "ob1-repository-scaffold-"));
+  fs.mkdirSync(path.join(root, ".github"), { recursive: true });
+  fs.copyFileSync(
+    path.join(REPOSITORY_ROOT, ".github", "metadata.schema.json"),
+    path.join(root, ".github", "metadata.schema.json"),
+  );
+  for (const category of CATEGORIES) {
+    fs.cpSync(path.join(REPOSITORY_ROOT, category, "_template"), path.join(root, category, "_template"), {
+      recursive: true,
+    });
+  }
+  // The scaffolder verifies declared dependencies exist, so mirror the real
+  // primitives the extension template already depends on.
+  for (const slug of ["rls", "deploy-edge-function", "remote-mcp"]) {
+    fs.mkdirSync(path.join(root, "primitives", slug), { recursive: true });
+    fs.writeFileSync(path.join(root, "primitives", slug, "README.md"), `# ${slug}\n`);
+  }
+  return root;
+}
+
+function answers(overrides = {}) {
+  return {
+    category: "recipes",
+    slug: "demo-recipe",
+    name: "Demo Recipe",
+    description: "A useful demonstration recipe.",
+    author: "Test Author",
+    github: "test-author",
+    difficulty: "beginner",
+    estimatedTime: "20 minutes",
+    tags: ["demo"],
+    ...overrides,
+  };
+}
+
+function filesIn(directory) {
+  return fs.readdirSync(directory, { withFileTypes: true }).flatMap((entry) => {
+    const entryPath = path.join(directory, entry.name);
+    return entry.isDirectory() ? filesIn(entryPath) : [entryPath];
+  });
+}
+
+function hasExtension(files, extensions) {
+  return files.some((file) => extensions.includes(path.extname(file)));
+}
+
+function cleanup(t, root) {
+  t.after(() => fs.rmSync(root, { recursive: true, force: true }));
+}
+
+test("recipe scaffold produces README and metadata with all required fields", (t) => {
+  const root = fixture();
+  cleanup(t, root);
+  const result = scaffold(root, answers());
+
+  assert.ok(fs.existsSync(path.join(root, "recipes", "demo-recipe", "README.md")));
+  assert.ok(fs.existsSync(path.join(root, "recipes", "demo-recipe", "metadata.json")));
+  assert.deepEqual(REQUIRED_FIELDS.filter((field) => !(field in result.metadata)), []);
+  assert.equal(result.metadata.requires.open_brain, true);
+});
+
+test("extension scaffold includes learning order and tool-audit link", (t) => {
+  const root = fixture();
+  cleanup(t, root);
+  const result = scaffold(
+    root,
+    answers({ category: "extensions", slug: "demo-extension", name: "Demo Extension", learningOrder: 3 }),
+  );
+  const readme = fs.readFileSync(path.join(root, "extensions", "demo-extension", "README.md"), "utf8");
+
+  assert.equal(result.metadata.learning_order, 3);
+  assert.match(readme, /docs\/05-tool-audit\.md/);
+  for (const heading of ["Why This Matters", "Learning Path", "What You'll Learn", "Cross-Extension Integration", "Next Steps"]) {
+    assert.match(readme, new RegExp(`## ${heading.replace(/[.*+?^${}()|[\\]\\\\]/g, "\\$&")}`));
+  }
+});
+
+test("extension scaffold merges supplied primitives with mandatory template primitives", (t) => {
+  const root = repositoryFixture();
+  cleanup(t, root);
+  const result = scaffold(
+    root,
+    answers({
+      category: "extensions",
+      slug: "demo-extension",
+      name: "Demo Extension",
+      requiresPrimitives: "rls",
+      learningOrder: 3,
+    }),
+  );
+
+  assert.deepEqual(result.metadata.requires_primitives, ["deploy-edge-function", "remote-mcp", "rls"]);
+});
+
+test("community extension scaffold omits learning order when not supplied", (t) => {
+  const root = repositoryFixture();
+  cleanup(t, root);
+  const result = spawnSync(
+    process.execPath,
+    [
+      SCRIPT_PATH,
+      "--category",
+      "extensions",
+      "--slug",
+      "demo-extension",
+      "--name",
+      "Demo Extension",
+      "--description",
+      "A community extension.",
+      "--author",
+      "Test Author",
+      "--difficulty",
+      "beginner",
+      "--estimated-time",
+      "20 minutes",
+      "--tags",
+      "demo",
+      "--yes",
+    ],
+    { cwd: root, encoding: "utf8" },
+  );
+  assert.equal(result.status, 0, result.stderr);
+  const metadata = JSON.parse(
+    fs.readFileSync(path.join(root, "extensions", "demo-extension", "metadata.json"), "utf8"),
+  );
+
+  assert.equal("learning_order" in metadata, false);
+});
+
+test("skills scaffold emits a plain-text skill artifact", (t) => {
+  const root = fixture();
+  cleanup(t, root);
+  scaffold(root, answers({ category: "skills", slug: "demo-skill", name: "Demo Skill" }));
+
+  const skill = fs.readFileSync(path.join(root, "skills", "demo-skill", "SKILL.md"), "utf8");
+  assert.match(skill, /Demo Skill/);
+});
+
+test("schemas scaffold emits SQL containing a grant line", (t) => {
+  const root = fixture();
+  cleanup(t, root);
+  scaffold(root, answers({ category: "schemas", slug: "demo-schema", name: "Demo Schema" }));
+
+  const sql = fs.readFileSync(path.join(root, "schemas", "demo-schema", "schema.sql"), "utf8");
+  assert.match(sql, /^grant .+ to service_role;/m);
+});
+
+test("every category scaffold satisfies the rule 6 artifact requirement", (t) => {
+  const root = repositoryFixture();
+  cleanup(t, root);
+
+  for (const category of CATEGORIES) {
+    const slug = `demo-${category}`;
+    scaffold(
+      root,
+      answers({
+        category,
+        slug,
+        name: `Demo ${category}`,
+        learningOrder: category === "extensions" ? 3 : undefined,
+      }),
+    );
+
+    const contributionDir = path.join(root, category, slug);
+    const files = filesIn(contributionDir);
+    const readme = fs.readFileSync(path.join(contributionDir, "README.md"), "utf8");
+
+    switch (category) {
+      case "recipes":
+        assert.ok(
+          hasExtension(files, [".sql", ".ts", ".js", ".py"]) || (readme.match(/^\s*[0-9]+\./gim) || []).length >= 3,
+          "recipes need code or at least three numbered README instructions",
+        );
+        break;
+      case "schemas":
+        assert.ok(hasExtension(files, [".sql"]), "schemas need a SQL file");
+        break;
+      case "dashboards":
+        assert.ok(
+          hasExtension(files, [".html", ".jsx", ".tsx", ".vue", ".svelte"]) ||
+            files.some((file) => path.basename(file) === "package.json"),
+          "dashboards need frontend code or package.json",
+        );
+        break;
+      case "integrations":
+        assert.ok(hasExtension(files, [".ts", ".js", ".py"]), "integrations need a code file");
+        break;
+      case "skills":
+        assert.ok(
+          files.some((file) => /(?:^|[.-])skill\.md$/i.test(path.basename(file))),
+          "skills need a plain-text skill file",
+        );
+        break;
+      case "primitives":
+        assert.ok(readme.trim().split(/\s+/).length >= 200, "primitives need a README with at least 200 words");
+        break;
+      case "extensions":
+        assert.ok(hasExtension(files, [".sql"]), "extensions need a SQL file");
+        assert.ok(hasExtension(files, [".ts", ".js", ".py"]), "extensions need a code file");
+        break;
+    }
+  }
+});
+
+test("primitive scaffold passes README completeness and internal-link requirements", (t) => {
+  const root = repositoryFixture();
+  cleanup(t, root);
+  scaffold(root, answers({ category: "primitives", slug: "demo-primitive", name: "Demo Primitive" }));
+
+  const contributionDir = path.join(root, "primitives", "demo-primitive");
+  const readme = fs.readFileSync(path.join(contributionDir, "README.md"), "utf8");
+  const relativeLinks = [...readme.matchAll(/\]\(([^)]+)\)/g)]
+    .map((match) => match[1])
+    .filter((link) => !link.startsWith("http") && !link.startsWith("#"));
+  const brokenLinks = relativeLinks.filter((link) => {
+    const [filePath] = link.split("#");
+    return filePath && !fs.existsSync(path.resolve(contributionDir, filePath));
+  });
+
+  assert.match(readme, /^## Prerequisites$/m);
+  assert.equal(readme.includes("../../extensions/extension-slug/"), false);
+  assert.deepEqual(brokenLinks, []);
+});
+
+test("extension scaffold excludes the template-only agent specification", (t) => {
+  const root = fixture();
+  cleanup(t, root);
+  fs.writeFileSync(path.join(root, "extensions", "_template", "AGENT_SPEC.md"), "Maintainer-only instructions.");
+
+  scaffold(
+    root,
+    answers({ category: "extensions", slug: "demo-extension", name: "Demo Extension", learningOrder: 3 }),
+  );
+
+  assert.equal(fs.existsSync(path.join(root, "extensions", "demo-extension", "AGENT_SPEC.md")), false);
+});
+
+test("invalid CLI difficulty exits non-zero without writing anything", (t) => {
+  const root = fixture();
+  cleanup(t, root);
+  const result = spawnSync(
+    process.execPath,
+    [
+      SCRIPT_PATH,
+      "--category",
+      "recipes",
+      "--slug",
+      "invalid-demo",
+      "--name",
+      "Invalid Demo",
+      "--description",
+      "Invalid difficulty test.",
+      "--author",
+      "Test Author",
+      "--difficulty",
+      "expert",
+      "--estimated-time",
+      "10 minutes",
+      "--tags",
+      "demo",
+      "--yes",
+    ],
+    { cwd: root, encoding: "utf8" },
+  );
+
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /Invalid difficulty/);
+  assert.equal(fs.existsSync(path.join(root, "recipes", "invalid-demo")), false);
+});
+
+test("existing target exits 2 and remains untouched", (t) => {
+  const root = fixture();
+  cleanup(t, root);
+  const target = path.join(root, "recipes", "demo-recipe");
+  fs.mkdirSync(target);
+  fs.writeFileSync(path.join(target, "keep.txt"), "unchanged");
+
+  const result = spawnSync(
+    process.execPath,
+    [
+      SCRIPT_PATH,
+      "--category",
+      "recipes",
+      "--slug",
+      "demo-recipe",
+      "--name",
+      "Demo Recipe",
+      "--description",
+      "Existing target test.",
+      "--author",
+      "Test Author",
+      "--difficulty",
+      "beginner",
+      "--estimated-time",
+      "10 minutes",
+      "--tags",
+      "demo",
+      "--yes",
+    ],
+    { cwd: root, encoding: "utf8" },
+  );
+
+  assert.equal(result.status, 2);
+  assert.equal(fs.readFileSync(path.join(target, "keep.txt"), "utf8"), "unchanged");
+  assert.deepEqual(fs.readdirSync(target), ["keep.txt"]);
+});
+
+test("required skills are written to metadata and linked from README", (t) => {
+  const root = fixture();
+  cleanup(t, root);
+  const result = scaffold(root, answers({ requiresSkills: "auto-capture,meeting-triage" }));
+  const readme = fs.readFileSync(path.join(root, "recipes", "demo-recipe", "README.md"), "utf8");
+
+  assert.deepEqual(result.metadata.requires_skills, ["auto-capture", "meeting-triage"]);
+  assert.match(readme, /\.\.\/\.\.\/skills\/auto-capture\//);
+  assert.match(readme, /\.\.\/\.\.\/skills\/meeting-triage\//);
+});
+
+test("CLI prints the validator as the next command when present", (t) => {
+  const root = fixture();
+  cleanup(t, root);
+  fs.mkdirSync(path.join(root, "scripts"));
+  fs.writeFileSync(path.join(root, "scripts", "validate-contribution.mjs"), "");
+
+  const output = execFileSync(
+    process.execPath,
+    [
+      SCRIPT_PATH,
+      "--category",
+      "recipes",
+      "--slug",
+      "cli-demo",
+      "--name",
+      "CLI Demo",
+      "--description",
+      "CLI success test.",
+      "--author",
+      "Test Author",
+      "--difficulty",
+      "beginner",
+      "--estimated-time",
+      "10 minutes",
+      "--tags",
+      "demo",
+      "--yes",
+    ],
+    { cwd: root, encoding: "utf8" },
+  );
+
+  assert.match(output, /node scripts\/validate-contribution\.mjs recipes\/cli-demo/);
+});
+
+test("replacement tokens in user input are inserted literally", (t) => {
+  const root = fixture();
+  cleanup(t, root);
+  scaffold(root, answers({ slug: "dollar-recipe", name: "Cash $& Carry", author: "A $` B" }));
+
+  const readme = fs.readFileSync(path.join(root, "recipes", "dollar-recipe", "README.md"), "utf8");
+  assert.match(readme, /# Cash \$& Carry/);
+  assert.ok(!readme.includes("Recipe Name"));
+});
+
+test("dependency entries must be valid slugs", (t) => {
+  const root = fixture();
+  cleanup(t, root);
+
+  assert.throws(
+    () => scaffold(root, answers({ slug: "traversal-recipe", requiresSkills: ".." })),
+    /Invalid --requires-skills entry/,
+  );
+  assert.ok(!fs.existsSync(path.join(root, "recipes", "traversal-recipe")));
+
+  assert.throws(
+    () => scaffold(root, answers({ slug: "traversal-primitive", requiresPrimitives: "../../etc" })),
+    /Invalid --requires-primitives entry/,
+  );
+
+  const result = scaffold(root, answers({ slug: "valid-deps-recipe", requiresSkills: "auto-capture" }));
+  assert.deepEqual(result.metadata.requires_skills, ["auto-capture"]);
+});


### PR DESCRIPTION
## Contribution Type

<!-- Check one -->
- [ ] Recipe (`/recipes`)
- [ ] Schema (`/schemas`)
- [ ] Dashboard (`/dashboards`)
- [ ] Integration (`/integrations`)
- [ ] Skill (`/skills`)
- [x] Repo improvement (docs, CI, templates)

## What does this do?

`node scripts/new-contribution.mjs` generates a complete, correctly structured contribution folder from the category's existing `_template/`, so starting a contribution is one command instead of copy the right template, rename the folder, hand-author `metadata.json`, and remember which extra fields your category needs.

![Scaffolding a recipe contribution](https://raw.githubusercontent.com/mvanhorn/OB1/demo-assets/scaffolder-demo.gif)

### Why

Today CONTRIBUTING.md says "Check the `_template/` folder in each category for a starter README", and the rest is manual. A contributor has to pick one of seven `_template/` directories, copy it, rename it, and hand-write a `metadata.json` with nine required fields plus category-conditional extras (`learning_order` for extensions, `requires_primitives` / `requires_skills` when depending on other contributions).

Getting any of that wrong is not a soft failure, it is a rule failure in the automated review: folder structure, required files, metadata validity, category-specific artifacts, and README completeness are all mechanically checked. The contributor finds out after opening a PR.

That lands hardest on exactly the people CONTRIBUTING.md goes out of its way to invite. The "Not a Developer? You Can Still Contribute" path and the mentor model bring in contributors least likely to hand-assemble a seven-way template choice and a conditional JSON manifest correctly.

The pattern is well established elsewhere: Home Assistant ships `python3 -m script.scaffold integration`, and npm standardises on `create-*` initializers. The `.github/ISSUE_TEMPLATE/` directory here already shows the same instinct on the issue side; this is the PR-side equivalent.

### Design decisions

Three choices are load-bearing:

**The `_template/` folders stay the source of truth.** The script copies from them rather than embedding template text, so a maintainer editing a template automatically changes generator output. There is no second copy of the prose to drift. It deliberately does not modify any `_template/` folder.

**Non-interactive first.** Every value has a flag, so the AI clients this project targets can drive it directly. Interactive prompts are the fallback when a required flag is absent and stdin is a TTY.

**It refuses to do damage.** Scaffolding onto an existing folder exits without writing. `--force` is deliberately not implemented. Declared dependencies are validated as slugs and checked to exist, so a typo like `--requires-skills meeting-triage` fails immediately rather than producing metadata and README links that the review rules then reject.

### Testing

`node --test scripts/*.test.mjs` covers 15 cases: a scaffold in each of the seven categories asserting the artifacts that category requires, extension `learning_order` and tool-audit link, skills emitting a plain-text skill file, schemas emitting SQL with the required `grant` line, `requires_skills` written to metadata and linked from the README, invalid difficulty exiting without writing, refusing an existing target, and rejecting both malformed and nonexistent dependency slugs.

I also generated a scaffold in all seven categories and checked each result against the rules in `.github/workflows/ob1-gate-v2.yml` (folder structure, required files, metadata schema, category artifacts, README sections). All seven satisfied them. CI remains authoritative.

### Notes

Community extensions can omit `--learning-order`; per `extensions/_template/AGENT_SPEC.md` only curated learning-path extensions set it. Supplied `--requires-primitives` merge with the template's mandatory primitives rather than replacing them.

The generated primitive README includes the placeholder dependency reference as plain text rather than a relative link, so a fresh scaffold does not ship a link that resolves nowhere.

## Requirements

Node.js 18 or newer. Nothing else: zero runtime dependencies, built-ins only (`node:fs`, `node:path`, `node:readline/promises`, `node:util`), matching the existing `scripts/update-readme-contributions.mjs`. No root `package.json` is added and no `_template/` folder is modified.

AI was used for assistance. I ran the tests and the scaffolds shown above myself and verified the output against the repository's review rules.

## Checklist

- [x] I've read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] No credentials, API keys, or secrets are included
- [x] The new script is documented in `scripts/README.md` with usage, flags, and exit codes

The remaining template items describe a contribution folder, which this PR does not add. Marking them honestly rather than ticking them:

- `README.md` / `metadata.json` required fields: not applicable, no contribution folder is added here. The script's job is to produce those correctly, which the tests and the seven-category check above cover.
- Declared skill or primitive dependency: not applicable.
- Tested on my own Open Brain instance: not applicable, this is repository tooling and does not touch a running Open Brain. I tested the script itself, as described under Testing.
