### PR TITLE
[schemas] Supersession and in-place updates for thoughts

### DIFF
--- a/docs/01-getting-started.md
+++ b/docs/01-getting-started.md
@@ -70,7 +70,12 @@ create table thoughts (
   embedding vector(1536),
   metadata jsonb default '{}'::jsonb,
   created_at timestamptz default now(),
-  updated_at timestamptz default now()
+  updated_at timestamptz default now(),
+  -- Supersession: a retired row records when it was retired and (optionally)
+  -- which newer row replaces it. A row is current iff superseded_at is null.
+  superseded_by uuid references thoughts(id) on delete set null,
+  superseded_at timestamptz,
+  supersede_reason text
 );
 
 -- Index for fast vector similarity search
@@ -82,6 +87,12 @@ create index on thoughts using gin (metadata);
 
 -- Index for date range queries
 create index on thoughts (created_at desc);
+
+-- Partial index for the default "current rows only" filter
+create index thoughts_current_idx on thoughts (id) where superseded_at is null;
+
+-- Index for looking up what replaced a given row
+create index thoughts_superseded_by_idx on thoughts (superseded_by);
 
 -- Auto-update the updated_at timestamp
 create or replace function update_updated_at()
@@ -112,14 +123,17 @@ create or replace function match_thoughts(
   query_embedding vector(1536),
   match_threshold float default 0.7,
   match_count int default 10,
-  filter jsonb default '{}'::jsonb
+  filter jsonb default '{}'::jsonb,
+  include_superseded boolean default false
 )
 returns table (
   id uuid,
   content text,
   metadata jsonb,
   similarity float,
-  created_at timestamptz
+  created_at timestamptz,
+  superseded_by uuid,
+  superseded_at timestamptz
 )
 language plpgsql
 as $$
@@ -130,10 +144,13 @@ begin
     t.content,
     t.metadata,
     1 - (t.embedding <=> query_embedding) as similarity,
-    t.created_at
+    t.created_at,
+    t.superseded_by,
+    t.superseded_at
   from thoughts t
   where 1 - (t.embedding <=> query_embedding) > match_threshold
     and (filter = '{}'::jsonb or t.metadata @> filter)
+    and (include_superseded or t.superseded_at is null)
   order by t.embedding <=> query_embedding
   limit match_count;
 end;
@@ -193,13 +210,20 @@ CREATE UNIQUE INDEX idx_thoughts_fingerprint
   ON thoughts (content_fingerprint)
   WHERE content_fingerprint IS NOT NULL;
 
--- Upsert function: inserts new thoughts, merges metadata on duplicates
-CREATE OR REPLACE FUNCTION upsert_thought(p_content TEXT, p_payload JSONB DEFAULT '{}')
+-- Upsert function: inserts new thoughts, merges metadata on duplicates,
+-- and optionally retires the rows this capture supersedes — in one transaction,
+-- so a capture whose supersession targets are invalid writes nothing at all.
+CREATE OR REPLACE FUNCTION upsert_thought(
+  p_content TEXT,
+  p_payload JSONB DEFAULT '{}',
+  p_supersedes UUID[] DEFAULT NULL,
+  p_supersede_reason TEXT DEFAULT NULL
+)
 RETURNS JSONB AS $$
 DECLARE
   v_fingerprint TEXT;
-  v_result JSONB;
   v_id UUID;
+  v_target UUID;
 BEGIN
   v_fingerprint := encode(sha256(convert_to(
     lower(trim(regexp_replace(p_content, '\s+', ' ', 'g'))),
@@ -213,8 +237,13 @@ BEGIN
       metadata = thoughts.metadata || COALESCE(EXCLUDED.metadata, '{}'::jsonb)
   RETURNING id INTO v_id;
 
-  v_result := jsonb_build_object('id', v_id, 'fingerprint', v_fingerprint);
-  RETURN v_result;
+  IF p_supersedes IS NOT NULL THEN
+    FOREACH v_target IN ARRAY p_supersedes LOOP
+      PERFORM supersede_thought(v_target, v_id, p_supersede_reason);
+    END LOOP;
+  END IF;
+
+  RETURN jsonb_build_object('id', v_id, 'fingerprint', v_fingerprint);
 END;
 $$ LANGUAGE plpgsql;
 ```
@@ -223,9 +252,134 @@ $$ LANGUAGE plpgsql;
 
 > This prevents duplicate thoughts from cluttering your database. When you capture the same thought twice, it merges the metadata instead of creating a second row.
 
-![2.7](https://img.shields.io/badge/2.7-Verify-555?style=for-the-badge&labelColor=F4511E)
+![2.7](https://img.shields.io/badge/2.7-Add_Supersession_and_Updates-555?style=for-the-badge&labelColor=F4511E)
 
-✅ **Done when:** Table Editor shows the `thoughts` table with columns: id, content, embedding, metadata, content_fingerprint, created_at, updated_at. Database → Functions shows `match_thoughts` and `upsert_thought`.
+New query → paste and Run. These two functions let a capture retire the row it replaces and let any row be corrected in place:
+
+<details>
+<summary>📋 <strong>SQL: Supersede + update functions</strong> (click to expand)</summary>
+
+```sql
+-- Retire one thought, optionally pointing at its replacement.
+-- Validation lives here (not in constraints) so the errors that reach an
+-- AI client are readable by an agent.
+create or replace function supersede_thought(
+  p_id uuid,
+  p_superseded_by uuid default null,
+  p_reason text default null
+)
+returns jsonb
+language plpgsql
+as $$
+declare
+  v_target thoughts%rowtype;
+  v_replacement thoughts%rowtype;
+  v_row thoughts%rowtype;
+begin
+  if p_superseded_by is not null and p_superseded_by = p_id then
+    raise exception 'A thought cannot supersede itself (%).', p_id;
+  end if;
+
+  select * into v_target from thoughts where id = p_id;
+  if not found then
+    raise exception 'Thought % does not exist; nothing was superseded.', p_id;
+  end if;
+  if v_target.superseded_at is not null then
+    raise exception 'Thought % is already superseded (at %, by %); refusing to change an existing supersession.',
+      p_id, v_target.superseded_at, coalesce(v_target.superseded_by::text, 'no successor');
+  end if;
+
+  if p_superseded_by is not null then
+    select * into v_replacement from thoughts where id = p_superseded_by;
+    if not found then
+      raise exception 'Replacement thought % does not exist; nothing was superseded.', p_superseded_by;
+    end if;
+    if v_replacement.superseded_at is not null then
+      raise exception 'Replacement thought % is itself superseded; point at the current head of the chain instead.',
+        p_superseded_by;
+    end if;
+  end if;
+
+  update thoughts
+  set superseded_by = p_superseded_by,
+      superseded_at = now(),
+      supersede_reason = p_reason
+  where id = p_id
+  returning * into v_row;
+
+  return jsonb_build_object(
+    'id', v_row.id,
+    'superseded_by', v_row.superseded_by,
+    'superseded_at', v_row.superseded_at,
+    'supersede_reason', v_row.supersede_reason
+  );
+end;
+$$;
+
+-- Patch a thought in place. Content changes recompute the dedup fingerprint
+-- and require a fresh embedding; metadata patches merge, and
+-- p_metadata_remove clears keys.
+create or replace function update_thought(
+  p_id uuid,
+  p_content text default null,
+  p_embedding vector(1536) default null,
+  p_metadata_patch jsonb default '{}'::jsonb,
+  p_metadata_remove text[] default array[]::text[]
+)
+returns jsonb
+language plpgsql
+as $$
+declare
+  v_row thoughts%rowtype;
+begin
+  if p_content is not null and p_embedding is null then
+    raise exception 'Content updates require a regenerated embedding; refusing to change content and leave the old embedding in place.';
+  end if;
+
+  begin
+    update thoughts
+    set content = coalesce(p_content, content),
+        content_fingerprint = case
+          when p_content is not null then encode(sha256(convert_to(
+            lower(trim(regexp_replace(p_content, '\s+', ' ', 'g'))),
+            'UTF8'
+          )), 'hex')
+          else content_fingerprint
+        end,
+        embedding = case when p_content is not null then p_embedding else embedding end,
+        metadata = (metadata || p_metadata_patch) - p_metadata_remove
+    where id = p_id
+    returning * into v_row;
+  exception when unique_violation then
+    raise exception 'Another thought already has identical content; updating % to that content would create a duplicate.', p_id;
+  end;
+
+  if v_row.id is null then
+    raise exception 'Thought % does not exist; nothing was updated.', p_id;
+  end if;
+
+  return jsonb_build_object(
+    'id', v_row.id,
+    'content', v_row.content,
+    'metadata', v_row.metadata,
+    'created_at', v_row.created_at,
+    'updated_at', v_row.updated_at,
+    'superseded_by', v_row.superseded_by,
+    'superseded_at', v_row.superseded_at,
+    'supersede_reason', v_row.supersede_reason
+  );
+end;
+$$;
+```
+
+</details>
+
+> [!NOTE]
+> **Already have an Open Brain?** Don't re-run the table creation — run [`schemas/supersession/migration.sql`](../schemas/supersession/migration.sql) instead, which adds the supersession columns and upgrades the functions in place.
+
+![2.8](https://img.shields.io/badge/2.8-Verify-555?style=for-the-badge&labelColor=F4511E)
+
+✅ **Done when:** Table Editor shows the `thoughts` table with columns: id, content, embedding, metadata, content_fingerprint, created_at, updated_at, superseded_by, superseded_at, supersede_reason. Database → Functions shows `match_thoughts`, `upsert_thought`, `supersede_thought`, and `update_thought`.
 
 ---
 

--- a/docs/02-companion-prompts.md
+++ b/docs/02-companion-prompts.md
@@ -311,6 +311,8 @@ Format:
 
 > **Why does formatting matter?** Your Open Brain's edge function uses an LLM to extract metadata from each capture — people, topics, action items, type. These templates are structured to give that LLM clear signals, which means better tagging, better search, better retrieval.
 
+> **Naming rule:** Give every person their full name, even in a list. Write "Christian Faulconer and Michelle Bennett," not "Christian and Michelle Bennett" — the extractor merges adjacent first-and-last name pairs joined by a conjunction, so the shortened form gets stored as one wrong person ("Christian Bennett").
+
 **Output feeds into:** N/A — reference tool.
 
 > **No prompt block below.** Unlike the other four, this isn't something you paste into AI. These are templates for what *you* type into your capture channel or say directly to any MCP-connected AI using "save this" or "remember this."

--- a/schemas/README.md
+++ b/schemas/README.md
@@ -7,6 +7,7 @@ Database table extensions and metadata schemas for your Supabase database. Drop 
 | Schema | What It Does |
 | ------ | ------------ |
 | [Agent Memory](agent-memory/) | Sidecar tables that turn existing `thoughts` into governed, provenance-labeled operational memory for agent workflows |
+| [Supersession and In-Place Updates](supersession/) | Lets a capture retire the row it replaces, hides retired rows from search by default, and adds in-place correction with the embedding kept consistent |
 
 > **Looking for CRM?** See [`extensions/professional-crm`](../extensions/professional-crm/) — it includes schema + a full MCP server.
 

--- a/schemas/supersession/README.md
+++ b/schemas/supersession/README.md
@@ -1,0 +1,38 @@
+# Supersession and In-Place Updates
+
+Open Brain is append-only by default: nothing can be corrected or retired once written. Two failure modes follow. Stale rows compete with current ones in semantic search — a status capture from last week can outrank the capture that resolved it, and writing "this supersedes X" into the newer capture only helps if the newer capture is retrieved first, which ranking does not guarantee. And extraction errors are permanent — a mis-parsed name in a `people` field stays wrong forever.
+
+This schema extension fixes both:
+
+- **A capture can retire the row it replaces.** The retired row gets `superseded_by` (pointer to the replacement), `superseded_at`, and `supersede_reason`.
+- **Search excludes retired rows by default.** `match_thoughts` gains an `include_superseded` flag, default false. Opting in returns the retired rows annotated with what replaced them.
+- **Any row can be corrected in place.** `update_thought` patches content and metadata; content changes recompute the dedup fingerprint and require a fresh embedding, so the row never silently keeps matching its old text.
+
+## Design notes
+
+- **The pointer lives on the retired row**, not the replacement, so the common filter is a cheap indexed predicate rather than an anti-join.
+- **A row is current iff `superseded_at is null`.** The retirement marker is the timestamp rather than the pointer because a row may be retired with *no* successor, and because the `superseded_by` foreign key is `on delete set null` — if a replacement row is ever deleted, the retired row stays retired instead of silently resurrecting.
+- **Retirement and capture share one transaction.** `upsert_thought` takes optional `p_supersedes` targets; if any target is missing or already superseded, the whole call fails and the new row is not written.
+- **Cycle guards are server-side raises, not constraints**, so the error messages that reach an AI client are readable: a row cannot supersede itself, an already-superseded row cannot be re-superseded, and a superseded row cannot be used as a replacement.
+
+## Install
+
+Run [`migration.sql`](migration.sql) in the Supabase SQL Editor. It is additive: existing rows are all current by definition (`superseded_at` is null everywhere), no backfill needed, and the upgraded `match_thoughts` / `upsert_thought` signatures are backward compatible with an older deployed MCP server.
+
+Pair it with the current `server/index.ts` MCP server, which exposes:
+
+| Tool | Change |
+| --- | --- |
+| `capture_thought` | New optional `supersedes` (id or ids to retire) and `supersede_reason` |
+| `update_thought` | New. Patch semantics; omitted fields untouched, explicit null clears. Content changes re-embed |
+| `supersede_thought` | New. Retroactively retire a row, optionally pointing at its replacement |
+| `search_thoughts`, `search`, `list_thoughts` | New `include_superseded` flag, default false |
+| `thought_stats` | Reports current and superseded counts separately |
+
+## Verify
+
+1. Capture a thought, then capture a correction with `supersedes` set to the first id. Default search returns only the correction; `include_superseded: true` returns both, with the old row carrying `superseded_by`.
+2. `update_thought` changing only `people` leaves the row's search similarity unchanged (embedding untouched).
+3. `update_thought` changing `content` changes what the row matches: a search for the new topic finds it, the old topic does not.
+4. A `capture_thought` call with a nonexistent id in `supersedes` writes nothing at all.
+5. `thought_stats` current + superseded equals the full row count.

--- a/schemas/supersession/metadata.json
+++ b/schemas/supersession/metadata.json
@@ -1,0 +1,18 @@
+{
+  "name": "Supersession and In-Place Updates",
+  "description": "Lets a capture retire the row it replaces, excludes retired rows from search by default, and adds in-place correction of a thought's content and metadata with the embedding kept consistent.",
+  "category": "schemas",
+  "author": {
+    "name": "Christian Faulconer",
+    "github": "cfaulconer"
+  },
+  "version": "1.0.0",
+  "requires": {
+    "open_brain": true
+  },
+  "tags": ["schema", "supersession", "corrections", "search", "retrieval"],
+  "difficulty": "beginner",
+  "estimated_time": "10 minutes",
+  "created": "2026-07-29",
+  "updated": "2026-07-29"
+}

--- a/schemas/supersession/migration.sql
+++ b/schemas/supersession/migration.sql
@@ -1,0 +1,218 @@
+-- Supersession and update — v1
+-- A capture can retire the row it replaces; search excludes retired rows by
+-- default; any row's metadata and content can be corrected in place with the
+-- embedding kept consistent.
+--
+-- Retirement marker: a row is retired iff superseded_at is not null.
+-- superseded_by is the pointer to the replacement and may be null for rows
+-- retired with no successor (and the FK sets it null if the replacement is
+-- ever deleted), so the "current rows only" predicate is superseded_at.
+
+-- pgvector lives in the extensions schema on hosted projects; the migration
+-- session's search_path does not include it by default.
+set search_path = public, extensions;
+
+alter table thoughts
+  add column superseded_by uuid references thoughts(id) on delete set null,
+  add column superseded_at timestamptz,
+  add column supersede_reason text;
+
+-- Partial index: supports the default "current rows only" filter.
+create index thoughts_current_idx on thoughts (id) where superseded_at is null;
+
+create index thoughts_superseded_by_idx on thoughts (superseded_by);
+
+-- match_thoughts gains include_superseded and returns supersession fields.
+-- The return type changes, so the old function must be dropped first.
+drop function if exists match_thoughts(vector, double precision, integer, jsonb);
+
+create or replace function match_thoughts(
+  query_embedding vector(1536),
+  match_threshold float default 0.7,
+  match_count int default 10,
+  filter jsonb default '{}'::jsonb,
+  include_superseded boolean default false
+)
+returns table (
+  id uuid,
+  content text,
+  metadata jsonb,
+  similarity float,
+  created_at timestamptz,
+  superseded_by uuid,
+  superseded_at timestamptz
+)
+language plpgsql
+as $$
+begin
+  return query
+  select
+    t.id,
+    t.content,
+    t.metadata,
+    1 - (t.embedding <=> query_embedding) as similarity,
+    t.created_at,
+    t.superseded_by,
+    t.superseded_at
+  from thoughts t
+  where 1 - (t.embedding <=> query_embedding) > match_threshold
+    and (filter = '{}'::jsonb or t.metadata @> filter)
+    and (include_superseded or t.superseded_at is null)
+  order by t.embedding <=> query_embedding
+  limit match_count;
+end;
+$$;
+
+-- Retire one thought, optionally pointing at its replacement.
+-- All validation lives here (not in constraints) so the errors that reach the
+-- MCP client are readable by an agent. Also reused by upsert_thought so a
+-- capture and the retirement of its targets share one transaction.
+create or replace function supersede_thought(
+  p_id uuid,
+  p_superseded_by uuid default null,
+  p_reason text default null
+)
+returns jsonb
+language plpgsql
+as $$
+declare
+  v_target thoughts%rowtype;
+  v_replacement thoughts%rowtype;
+  v_row thoughts%rowtype;
+begin
+  if p_superseded_by is not null and p_superseded_by = p_id then
+    raise exception 'A thought cannot supersede itself (%).', p_id;
+  end if;
+
+  select * into v_target from thoughts where id = p_id;
+  if not found then
+    raise exception 'Thought % does not exist; nothing was superseded.', p_id;
+  end if;
+  if v_target.superseded_at is not null then
+    raise exception 'Thought % is already superseded (at %, by %); refusing to change an existing supersession.',
+      p_id, v_target.superseded_at, coalesce(v_target.superseded_by::text, 'no successor');
+  end if;
+
+  if p_superseded_by is not null then
+    select * into v_replacement from thoughts where id = p_superseded_by;
+    if not found then
+      raise exception 'Replacement thought % does not exist; nothing was superseded.', p_superseded_by;
+    end if;
+    if v_replacement.superseded_at is not null then
+      raise exception 'Replacement thought % is itself superseded; point at the current head of the chain instead.',
+        p_superseded_by;
+    end if;
+  end if;
+
+  update thoughts
+  set superseded_by = p_superseded_by,
+      superseded_at = now(),
+      supersede_reason = p_reason
+  where id = p_id
+  returning * into v_row;
+
+  return jsonb_build_object(
+    'id', v_row.id,
+    'superseded_by', v_row.superseded_by,
+    'superseded_at', v_row.superseded_at,
+    'supersede_reason', v_row.supersede_reason
+  );
+end;
+$$;
+
+-- upsert_thought gains optional supersession targets. Insert and retirement
+-- run in the same transaction: if any target is invalid the whole call fails
+-- and the new row is not written.
+drop function if exists upsert_thought(text, jsonb);
+
+create or replace function upsert_thought(
+  p_content text,
+  p_payload jsonb default '{}'::jsonb,
+  p_supersedes uuid[] default null,
+  p_supersede_reason text default null
+)
+returns jsonb
+language plpgsql
+as $$
+declare
+  v_fingerprint text;
+  v_id uuid;
+  v_target uuid;
+begin
+  v_fingerprint := encode(sha256(convert_to(
+    lower(trim(regexp_replace(p_content, '\s+', ' ', 'g'))),
+    'UTF8'
+  )), 'hex');
+
+  insert into thoughts (content, content_fingerprint, metadata)
+  values (p_content, v_fingerprint, coalesce(p_payload->'metadata', '{}'::jsonb))
+  on conflict (content_fingerprint) where content_fingerprint is not null do update
+  set updated_at = now(),
+      metadata = thoughts.metadata || coalesce(excluded.metadata, '{}'::jsonb)
+  returning id into v_id;
+
+  if p_supersedes is not null then
+    foreach v_target in array p_supersedes loop
+      perform supersede_thought(v_target, v_id, p_supersede_reason);
+    end loop;
+  end if;
+
+  return jsonb_build_object('id', v_id, 'fingerprint', v_fingerprint);
+end;
+$$;
+
+-- Patch a thought in place. Content changes recompute the fingerprint with the
+-- same normalization as upsert_thought and require a fresh embedding; metadata
+-- patches merge, and p_metadata_remove clears keys. One statement, so partial
+-- updates cannot land.
+create or replace function update_thought(
+  p_id uuid,
+  p_content text default null,
+  p_embedding vector(1536) default null,
+  p_metadata_patch jsonb default '{}'::jsonb,
+  p_metadata_remove text[] default array[]::text[]
+)
+returns jsonb
+language plpgsql
+as $$
+declare
+  v_row thoughts%rowtype;
+begin
+  if p_content is not null and p_embedding is null then
+    raise exception 'Content updates require a regenerated embedding; refusing to change content and leave the old embedding in place.';
+  end if;
+
+  begin
+    update thoughts
+    set content = coalesce(p_content, content),
+        content_fingerprint = case
+          when p_content is not null then encode(sha256(convert_to(
+            lower(trim(regexp_replace(p_content, '\s+', ' ', 'g'))),
+            'UTF8'
+          )), 'hex')
+          else content_fingerprint
+        end,
+        embedding = case when p_content is not null then p_embedding else embedding end,
+        metadata = (metadata || p_metadata_patch) - p_metadata_remove
+    where id = p_id
+    returning * into v_row;
+  exception when unique_violation then
+    raise exception 'Another thought already has identical content; updating % to that content would create a duplicate.', p_id;
+  end;
+
+  if v_row.id is null then
+    raise exception 'Thought % does not exist; nothing was updated.', p_id;
+  end if;
+
+  return jsonb_build_object(
+    'id', v_row.id,
+    'content', v_row.content,
+    'metadata', v_row.metadata,
+    'created_at', v_row.created_at,
+    'updated_at', v_row.updated_at,
+    'superseded_by', v_row.superseded_by,
+    'superseded_at', v_row.superseded_at,
+    'supersede_reason', v_row.supersede_reason
+  );
+end;
+$$;

--- a/server/index.ts
+++ b/server/index.ts
@@ -20,6 +20,8 @@ type ThoughtMatch = {
   metadata: Record<string, unknown>;
   similarity: number;
   created_at: string;
+  superseded_by: string | null;
+  superseded_at: string | null;
 };
 
 type ThoughtRecord = {
@@ -116,9 +118,14 @@ server.registerTool(
     },
     inputSchema: {
       query: z.string().describe("The search query to run against Open Brain thoughts"),
+      include_superseded: z
+        .boolean()
+        .optional()
+        .default(false)
+        .describe("Also return thoughts that have been retired by a newer capture"),
     },
   },
-  async ({ query }) => {
+  async ({ query, include_superseded }) => {
     try {
       const qEmb = await getEmbedding(query);
       const { data, error } = await supabase.rpc("match_thoughts", {
@@ -126,6 +133,7 @@ server.registerTool(
         match_threshold: 0.5,
         match_count: 10,
         filter: {},
+        include_superseded,
       });
 
       if (error) {
@@ -139,6 +147,9 @@ server.registerTool(
         id: t.id,
         title: thoughtTitle(t.content, t.created_at),
         url: thoughtUrl(t.id),
+        ...(t.superseded_at
+          ? { superseded_by: t.superseded_by, superseded_at: t.superseded_at }
+          : {}),
       }));
 
       return {
@@ -220,9 +231,14 @@ server.registerTool(
       query: z.string().describe("What to search for"),
       limit: z.number().optional().default(10),
       threshold: z.number().optional().default(0.5),
+      include_superseded: z
+        .boolean()
+        .optional()
+        .default(false)
+        .describe("Also return thoughts that have been retired by a newer capture"),
     },
   },
-  async ({ query, limit, threshold }) => {
+  async ({ query, limit, threshold, include_superseded }) => {
     try {
       const qEmb = await getEmbedding(query);
       const { data, error } = await supabase.rpc("match_thoughts", {
@@ -230,6 +246,7 @@ server.registerTool(
         match_threshold: threshold,
         match_count: limit,
         filter: {},
+        include_superseded,
       });
 
       if (error) {
@@ -256,6 +273,12 @@ server.registerTool(
             `Captured: ${new Date(t.created_at).toLocaleDateString()}`,
             `Type: ${m.type || "unknown"}`,
           ];
+          if (t.superseded_at)
+            parts.push(
+              `SUPERSEDED: ${new Date(t.superseded_at).toLocaleDateString()}${
+                t.superseded_by ? ` — replaced by thought ${t.superseded_by}` : " (no successor)"
+              }`
+            );
           if (Array.isArray(m.topics) && m.topics.length)
             parts.push(`Topics: ${(m.topics as string[]).join(", ")}`);
           if (Array.isArray(m.people) && m.people.length)
@@ -300,16 +323,22 @@ server.registerTool(
       topic: z.string().optional().describe("Filter by topic tag"),
       person: z.string().optional().describe("Filter by person mentioned"),
       days: z.number().optional().describe("Only thoughts from the last N days"),
+      include_superseded: z
+        .boolean()
+        .optional()
+        .default(false)
+        .describe("Also list thoughts that have been retired by a newer capture"),
     },
   },
-  async ({ limit, type, topic, person, days }) => {
+  async ({ limit, type, topic, person, days, include_superseded }) => {
     try {
       let q = supabase
         .from("thoughts")
-        .select("content, metadata, created_at")
+        .select("content, metadata, created_at, superseded_by, superseded_at")
         .order("created_at", { ascending: false })
         .limit(limit);
 
+      if (!include_superseded) q = q.is("superseded_at", null);
       if (type) q = q.contains("metadata", { type });
       if (topic) q = q.contains("metadata", { topics: [topic] });
       if (person) q = q.contains("metadata", { people: [person] });
@@ -334,12 +363,23 @@ server.registerTool(
 
       const results = data.map(
         (
-          t: { content: string; metadata: Record<string, unknown>; created_at: string },
+          t: {
+            content: string;
+            metadata: Record<string, unknown>;
+            created_at: string;
+            superseded_by: string | null;
+            superseded_at: string | null;
+          },
           i: number
         ) => {
           const m = t.metadata || {};
           const tags = Array.isArray(m.topics) ? (m.topics as string[]).join(", ") : "";
-          return `${i + 1}. [${new Date(t.created_at).toLocaleDateString()}] (${m.type || "??"}${tags ? " - " + tags : ""})\n   ${t.content}`;
+          const retired = t.superseded_at
+            ? ` [SUPERSEDED ${new Date(t.superseded_at).toLocaleDateString()}${
+                t.superseded_by ? ` → ${t.superseded_by}` : ""
+              }]`
+            : "";
+          return `${i + 1}. [${new Date(t.created_at).toLocaleDateString()}] (${m.type || "??"}${tags ? " - " + tags : ""})${retired}\n   ${t.content}`;
         }
       );
 
@@ -377,9 +417,19 @@ server.registerTool(
         .from("thoughts")
         .select("*", { count: "exact", head: true });
 
+      const { count: currentCount } = await supabase
+        .from("thoughts")
+        .select("*", { count: "exact", head: true })
+        .is("superseded_at", null);
+
+      const { count: supersededCount } = await supabase
+        .from("thoughts")
+        .select("*", { count: "exact", head: true })
+        .not("superseded_at", "is", null);
+
       const { data } = await supabase
         .from("thoughts")
-        .select("metadata, created_at")
+        .select("metadata, created_at, superseded_at")
         .order("created_at", { ascending: false });
 
       const types: Record<string, number> = {};
@@ -387,6 +437,7 @@ server.registerTool(
       const people: Record<string, number> = {};
 
       for (const r of data || []) {
+        if (r.superseded_at) continue;
         const m = (r.metadata || {}) as Record<string, unknown>;
         if (m.type) types[m.type as string] = (types[m.type as string] || 0) + 1;
         if (Array.isArray(m.topics))
@@ -401,7 +452,9 @@ server.registerTool(
           .slice(0, 10);
 
       const lines: string[] = [
-        `Total thoughts: ${count}`,
+        `Current thoughts: ${currentCount}`,
+        `Superseded thoughts: ${supersededCount}`,
+        `Total rows: ${count}`,
         `Date range: ${
           data?.length
             ? new Date(data[data.length - 1].created_at).toLocaleDateString() +
@@ -410,7 +463,7 @@ server.registerTool(
             : "N/A"
         }`,
         "",
-        "Types:",
+        "Types (current thoughts only):",
         ...sort(types).map(([k, v]) => `  ${k}: ${v}`),
       ];
 
@@ -448,20 +501,40 @@ server.registerTool(
       idempotentHint: false,
     },
     inputSchema: {
-      content: z.string().describe("The thought to capture — a clear, standalone statement that will make sense when retrieved later by any AI"),
+      content: z.string().describe("The thought to capture — a clear, standalone statement that will make sense when retrieved later by any AI. Give every person their full name ('Christian Faulconer and Michelle Bennett', never 'Christian and Michelle Bennett'): adjacent first-and-last name pairs joined by a conjunction get merged into one wrong person during extraction."),
+      supersedes: z
+        .union([z.string(), z.array(z.string())])
+        .optional()
+        .describe("ID or IDs of existing thoughts this capture retires. The retired rows stop appearing in search unless include_superseded is set."),
+      supersede_reason: z
+        .string()
+        .optional()
+        .describe("Short note on why the superseded thought(s) are being retired"),
     },
   },
-  async ({ content }) => {
+  async ({ content, supersedes, supersede_reason }) => {
     try {
+      const supersedesList =
+        supersedes === undefined ? [] : Array.isArray(supersedes) ? supersedes : [supersedes];
+
       const [embedding, metadata] = await Promise.all([
         getEmbedding(content),
         extractMetadata(content),
       ]);
 
-      const { data: upsertResult, error: upsertError } = await supabase.rpc("upsert_thought", {
+      const rpcArgs: Record<string, unknown> = {
         p_content: content,
         p_payload: { metadata: { ...metadata, source: "mcp" } },
-      });
+      };
+      if (supersedesList.length) {
+        rpcArgs.p_supersedes = supersedesList;
+        rpcArgs.p_supersede_reason = supersede_reason ?? null;
+      }
+
+      const { data: upsertResult, error: upsertError } = await supabase.rpc(
+        "upsert_thought",
+        rpcArgs
+      );
 
       if (upsertError) {
         return {
@@ -491,9 +564,170 @@ server.registerTool(
         confirmation += ` | People: ${(meta.people as string[]).join(", ")}`;
       if (Array.isArray(meta.action_items) && meta.action_items.length)
         confirmation += ` | Actions: ${(meta.action_items as string[]).join("; ")}`;
+      if (supersedesList.length)
+        confirmation += ` | Retired: ${supersedesList.join(", ")}`;
 
       return {
         content: [{ type: "text" as const, text: confirmation }],
+      };
+    } catch (err: unknown) {
+      return {
+        content: [{ type: "text" as const, text: `Error: ${(err as Error).message}` }],
+        isError: true,
+      };
+    }
+  }
+);
+
+// Tool 5: Update Thought
+server.registerTool(
+  "update_thought",
+  {
+    title: "Update Thought",
+    description:
+      "Correct a thought in place. Patch semantics: omitted fields are untouched, explicit null clears a field. Changing content regenerates the embedding so search stays consistent; metadata-only changes leave the embedding alone.",
+    annotations: {
+      readOnlyHint: false,
+      openWorldHint: false,
+      destructiveHint: true,
+      idempotentHint: true,
+    },
+    inputSchema: {
+      id: z.string().describe("ID of the thought to update"),
+      content: z
+        .string()
+        .nullable()
+        .optional()
+        .describe("Replacement content. Forces a re-embed. Cannot be null."),
+      type: z
+        .string()
+        .nullable()
+        .optional()
+        .describe("Replacement type: observation, task, idea, reference, person_note. Null clears."),
+      topics: z.array(z.string()).nullable().optional().describe("Replacement topic tags. Null clears."),
+      people: z.array(z.string()).nullable().optional().describe("Replacement people list. Null clears."),
+      actions: z.array(z.string()).nullable().optional().describe("Replacement action items. Null clears."),
+    },
+  },
+  async ({ id, content, type, topics, people, actions }) => {
+    try {
+      if (content === null) {
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: "content cannot be cleared — provide replacement text, or omit it to leave the content unchanged.",
+            },
+          ],
+          isError: true,
+        };
+      }
+
+      const patch: Record<string, unknown> = {};
+      const remove: string[] = [];
+      const fields: [unknown, string][] = [
+        [type, "type"],
+        [topics, "topics"],
+        [people, "people"],
+        [actions, "action_items"],
+      ];
+      for (const [value, key] of fields) {
+        if (value === undefined) continue;
+        if (value === null) remove.push(key);
+        else patch[key] = value;
+      }
+
+      if (content === undefined && !Object.keys(patch).length && !remove.length) {
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: "Nothing to update — provide content or at least one of type, topics, people, actions.",
+            },
+          ],
+          isError: true,
+        };
+      }
+
+      // Re-embed if and only if content is changing.
+      const embedding = content !== undefined ? await getEmbedding(content) : null;
+
+      const { data, error } = await supabase.rpc("update_thought", {
+        p_id: id,
+        p_content: content ?? null,
+        p_embedding: embedding,
+        p_metadata_patch: patch,
+        p_metadata_remove: remove,
+      });
+
+      if (error) {
+        return {
+          content: [{ type: "text" as const, text: `Update failed: ${error.message}` }],
+          isError: true,
+        };
+      }
+
+      return {
+        content: [
+          {
+            type: "text" as const,
+            text: `Updated thought${content !== undefined ? " (embedding regenerated)" : " (metadata only, embedding untouched)"}:\n${JSON.stringify(data, null, 2)}`,
+          },
+        ],
+      };
+    } catch (err: unknown) {
+      return {
+        content: [{ type: "text" as const, text: `Error: ${(err as Error).message}` }],
+        isError: true,
+      };
+    }
+  }
+);
+
+// Tool 6: Supersede Thought
+server.registerTool(
+  "supersede_thought",
+  {
+    title: "Supersede Thought",
+    description:
+      "Retire a thought, optionally pointing at the newer thought that replaces it. Use this for the retroactive case where the replacement was already captured. Retired thoughts stop appearing in search unless include_superseded is set.",
+    annotations: {
+      readOnlyHint: false,
+      openWorldHint: false,
+      destructiveHint: false,
+      idempotentHint: false,
+    },
+    inputSchema: {
+      id: z.string().describe("ID of the thought to retire"),
+      superseded_by: z
+        .string()
+        .optional()
+        .describe("ID of the replacement thought. Omit to retire with no successor."),
+      reason: z.string().optional().describe("Short note on why this thought is retired"),
+    },
+  },
+  async ({ id, superseded_by, reason }) => {
+    try {
+      const { data, error } = await supabase.rpc("supersede_thought", {
+        p_id: id,
+        p_superseded_by: superseded_by ?? null,
+        p_reason: reason ?? null,
+      });
+
+      if (error) {
+        return {
+          content: [{ type: "text" as const, text: `Supersede failed: ${error.message}` }],
+          isError: true,
+        };
+      }
+
+      return {
+        content: [
+          {
+            type: "text" as const,
+            text: `Superseded:\n${JSON.stringify(data, null, 2)}`,
+          },
+        ],
       };
     } catch (err: unknown) {
       return {


### PR DESCRIPTION
## Contribution Type

- [ ] Recipe (`/recipes`)
- [x] Schema (`/schemas`)
- [ ] Dashboard (`/dashboards`)
- [ ] Integration (`/integrations`)
- [ ] Skill (`/skills`)
- [ ] Repo improvement (docs, CI, templates)

## What does this do?

Open Brain is append-only, so stale rows compete with current ones in semantic search and extraction errors are permanent. This adds supersession: a capture can retire the row it replaces (`capture_thought` gains `supersedes`), search excludes retired rows by default (`include_superseded` opt-in flag on `search`/`search_thoughts`/`list_thoughts`), and two new MCP tools — `update_thought` (patch semantics; content changes re-embed, metadata-only changes don't) and `supersede_thought` (retroactive retirement) — let rows be corrected in place. `thought_stats` now reports current and superseded counts separately.

Design notes: the pointer lives on the retired row so the default filter is a cheap indexed partial predicate; the current-row predicate is `superseded_at is null` (not `superseded_by`) because rows can retire with no successor and the FK's `on delete set null` must not resurrect retired rows; capture + retirement share one transaction, so a capture with an invalid supersession target writes nothing at all; cycle guards raise readable errors server-side instead of using constraints.

## Requirements

An existing Open Brain instance (Supabase + pgvector + the `open-brain-mcp` edge function). Migration is additive — no backfill, and the upgraded `match_thoughts`/`upsert_thought` signatures are backward compatible with an older deployed server. Fresh installs get the same schema from the updated getting-started SQL.

## Checklist

- [x] I've read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] My contribution has a `README.md` with prerequisites, step-by-step instructions, and expected outcome
- [x] My `metadata.json` has all required fields
- [x] If my contribution depends on a skill or primitive, I declared it in metadata.json and linked it in the README
- [x] I tested this on my own Open Brain instance
- [x] No credentials, API keys, or secrets are included

Tested end-to-end on a live instance (177-row store): pre/post-migration ranking regression (identical scores on five baseline queries), metadata-only update leaves similarity unchanged, content update changes what the row matches, failed supersession writes nothing, self/re-supersession rejected with readable errors, stats reconcile (current + superseded = total).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
