### PR TITLE
[recipes] Add Bookshelf person reading CRM

### DIFF
--- a/recipes/bookshelf/README.md
+++ b/recipes/bookshelf/README.md
@@ -1,0 +1,289 @@
+# Bookshelf
+
+> A personal reading CRM — track books, log chapter notes by type, capture verbatim quotes, and search your library by topic or problem.
+
+Most reading systems just store a list. This one gives your AI something to work with. Books get notes tagged by type (`insight`, `question`, `action`, `connection`), verbatim quotes with your personal reaction, and an honest dud flag so you remember why you abandoned something. A lightweight reading queue sits alongside the deep library — queue items bridge into the bookshelf when you start reading, and sync back when you finish.
+
+## What It Does
+
+Deploys a Supabase Edge Function with 10 MCP tools for managing a personal reading library. Supports per-user isolation so multiple people can share an Open Brain instance with completely separate bookshelves.
+
+**Tools:**
+
+| Tool | What it does |
+|---|---|
+| `add_book` | Add a book to your library |
+| `append_book_note` | Log a note by type: `summary`, `insight`, `question`, `action`, or `connection` |
+| `capture_quote` | Save a verbatim quote with your personal take |
+| `get_book_dossier` | Pull a book's full record — metadata, all notes, all quotes. Optionally filter notes by type. |
+| `update_reading_status` | Update status, rating, summary, or mark as a dud |
+| `search_books` | Search across titles, authors, tags, summaries, notes, and quotes. Duds surface separately with context. |
+| `add_to_reading_list` | Add a book, article, podcast, or video to your reading queue |
+| `browse_reading_list` | Browse your queue filtered by status, type, or tags |
+| `start_reading` | Move an item from queue to bookshelf and mark it in-progress |
+| `finish_reading` | Mark a book complete and sync rating/review back to the reading list |
+
+## Prerequisites
+
+- Working Open Brain setup ([guide](../../docs/01-getting-started.md))
+- `MCP_ACCESS_KEY` already set as a Supabase secret (from your core setup)
+- Your user UUID stored as a Supabase secret (e.g. `DEFAULT_USER_ID`)
+
+## Credential Tracker
+
+Copy this block into a text editor and fill it in as you go.
+
+```text
+BOOKSHELF -- CREDENTIAL TRACKER
+--------------------------------------
+
+FROM YOUR OPEN BRAIN SETUP
+  Supabase Project URL:      ____________  (Settings → API → Project URL)
+  MCP_ACCESS_KEY:            ____________  (already set in your secrets)
+  User UUID secret name:     ____________  (e.g. DEFAULT_USER_ID)
+
+GENERATED DURING SETUP
+  Function name:             ____________  (e.g. bookshelf-mcp)
+  Function URL:              ____________  (shown after deploy)
+
+--------------------------------------
+```
+
+## Steps
+
+### 1 — Run the schema
+
+In Supabase dashboard → **SQL Editor** → **New query**, paste the entire contents of `schema.sql` and click **Run**.
+
+<details>
+<summary>📋 <strong>SQL: Full bookshelf schema</strong> (click to expand)</summary>
+
+```sql
+-- Shared trigger function (safe to run even if it already exists)
+CREATE OR REPLACE FUNCTION update_updated_at_column()
+RETURNS TRIGGER AS $$
+BEGIN NEW.updated_at = now(); RETURN NEW; END;
+$$ LANGUAGE plpgsql;
+
+-- Reading list (intake queue)
+CREATE TABLE reading_list (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    user_id UUID NOT NULL,
+    title TEXT NOT NULL,
+    author TEXT,
+    type TEXT DEFAULT 'book' CHECK (type IN ('book', 'article', 'podcast', 'video')),
+    status TEXT DEFAULT 'want_to_read' CHECK (status IN ('want_to_read', 'reading', 'finished', 'abandoned')),
+    rating SMALLINT CHECK (rating >= 1 AND rating <= 5 OR rating IS NULL),
+    review_notes TEXT,
+    url TEXT,
+    started_date DATE,
+    finished_date DATE,
+    tags JSONB DEFAULT '[]'::jsonb,
+    created_at TIMESTAMPTZ DEFAULT now(),
+    updated_at TIMESTAMPTZ DEFAULT now(),
+    CONSTRAINT finished_after_started CHECK (
+        finished_date IS NULL OR started_date IS NULL OR finished_date >= started_date
+    )
+);
+
+CREATE INDEX idx_reading_list_user_status ON reading_list(user_id, status);
+CREATE INDEX idx_reading_list_user_type ON reading_list(user_id, type);
+CREATE INDEX idx_reading_list_user_rating ON reading_list(user_id, rating);
+CREATE INDEX idx_reading_list_tags ON reading_list USING GIN (tags);
+CREATE INDEX idx_reading_list_finished ON reading_list(finished_date DESC) WHERE finished_date IS NOT NULL;
+
+ALTER TABLE reading_list ENABLE ROW LEVEL SECURITY;
+CREATE POLICY reading_list_user_policy ON reading_list
+    FOR ALL USING (auth.uid() = user_id) WITH CHECK (auth.uid() = user_id);
+
+DROP TRIGGER IF EXISTS update_reading_list_updated_at ON reading_list;
+CREATE TRIGGER update_reading_list_updated_at
+    BEFORE UPDATE ON reading_list
+    FOR EACH ROW EXECUTE FUNCTION update_updated_at_column();
+
+CREATE OR REPLACE VIEW currently_reading AS
+    SELECT * FROM reading_list WHERE status = 'reading' ORDER BY started_date DESC;
+
+-- Books (deep reading library)
+CREATE TABLE books (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    user_id UUID NOT NULL,
+    reading_list_id UUID REFERENCES reading_list(id) ON DELETE SET NULL,
+    title TEXT NOT NULL,
+    author TEXT NOT NULL,
+    tags TEXT[] DEFAULT '{}',
+    status TEXT DEFAULT 'unread' CHECK (status IN ('unread', 'reading', 'completed', 'abandoned')),
+    started_at DATE,
+    completed_at DATE,
+    overall_rating INTEGER CHECK (overall_rating >= 1 AND overall_rating <= 5 OR overall_rating IS NULL),
+    summary TEXT,
+    dud BOOLEAN DEFAULT false,
+    dud_reason TEXT,
+    created_at TIMESTAMPTZ DEFAULT now() NOT NULL,
+    updated_at TIMESTAMPTZ DEFAULT now() NOT NULL
+);
+
+CREATE TABLE book_notes (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    book_id UUID REFERENCES books(id) ON DELETE CASCADE NOT NULL,
+    user_id UUID NOT NULL,
+    chapter TEXT,
+    note_type TEXT CHECK (note_type IN ('summary', 'insight', 'question', 'action', 'connection')),
+    content TEXT NOT NULL,
+    created_at TIMESTAMPTZ DEFAULT now() NOT NULL
+);
+
+CREATE TABLE book_quotes (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    book_id UUID REFERENCES books(id) ON DELETE CASCADE NOT NULL,
+    user_id UUID NOT NULL,
+    chapter TEXT,
+    page_number INTEGER,
+    quote TEXT NOT NULL,
+    personal_take TEXT,
+    tags TEXT[] DEFAULT '{}',
+    created_at TIMESTAMPTZ DEFAULT now() NOT NULL
+);
+
+CREATE INDEX idx_books_user_id ON books(user_id);
+CREATE INDEX idx_books_user_status ON books(user_id, status);
+CREATE INDEX idx_books_user_tags ON books USING GIN (tags);
+CREATE INDEX idx_book_notes_book_id ON book_notes(book_id);
+CREATE INDEX idx_book_notes_type ON book_notes(book_id, note_type);
+CREATE INDEX idx_book_quotes_book_id ON book_quotes(book_id);
+CREATE INDEX idx_book_quotes_tags ON book_quotes USING GIN (tags);
+
+ALTER TABLE books ENABLE ROW LEVEL SECURITY;
+ALTER TABLE book_notes ENABLE ROW LEVEL SECURITY;
+ALTER TABLE book_quotes ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY books_user_policy ON books
+    FOR ALL USING (auth.uid() = user_id) WITH CHECK (auth.uid() = user_id);
+CREATE POLICY book_notes_user_policy ON book_notes
+    FOR ALL USING (auth.uid() = user_id) WITH CHECK (auth.uid() = user_id);
+CREATE POLICY book_quotes_user_policy ON book_quotes
+    FOR ALL USING (auth.uid() = user_id) WITH CHECK (auth.uid() = user_id);
+
+DROP TRIGGER IF EXISTS update_books_updated_at ON books;
+CREATE TRIGGER update_books_updated_at
+    BEFORE UPDATE ON books
+    FOR EACH ROW EXECUTE FUNCTION update_updated_at_column();
+
+-- Permissions for service_role (required on newer Supabase projects)
+GRANT SELECT, INSERT, UPDATE, DELETE ON TABLE public.reading_list TO service_role;
+GRANT SELECT, INSERT, UPDATE, DELETE ON TABLE public.books TO service_role;
+GRANT SELECT, INSERT, UPDATE, DELETE ON TABLE public.book_notes TO service_role;
+GRANT SELECT, INSERT, UPDATE, DELETE ON TABLE public.book_quotes TO service_role;
+```
+
+</details>
+
+✅ **Done when:** The query completes with no errors. You can verify in **Table Editor** — you should see `reading_list`, `books`, `book_notes`, and `book_quotes`.
+
+### 2 — Create the Edge Function
+
+In Supabase dashboard → **Edge Functions** → **Deploy a new function**.
+
+Name it whatever you like — one function per person who will use it:
+- Your function: `bookshelf-mcp`
+- Additional users: `bookshelf-[name]-mcp`
+
+### 3 — Paste the files
+
+In the function editor, add two files:
+
+**`index.ts`** — paste the contents of `index.ts` from this directory.
+
+The function reads your UUID from a Supabase secret:
+```typescript
+const USER_ID = Deno.env.get("DEFAULT_USER_ID");
+```
+
+If you followed the standard Open Brain setup, `DEFAULT_USER_ID` is already set. For additional users, set a new secret with their UUID (e.g. `DONNA_USER_ID`) and update line 8 accordingly:
+```typescript
+const USER_ID = Deno.env.get("DONNA_USER_ID");
+```
+
+To generate a UUID for a new user:
+```bash
+uuidgen | tr '[:upper:]' '[:lower:]'
+```
+
+**`deno.json`** — paste the contents of `deno.json` from this directory. No changes needed.
+
+> [!IMPORTANT]
+> Both files must be present. Without `deno.json`, the function will fail to bundle with a "relative import path not prefixed" error.
+
+### 4 — Disable JWT verification
+
+In the function's **Details** tab, turn off **Verify JWT**. The function handles its own auth via `MCP_ACCESS_KEY`.
+
+> [!CAUTION]
+> This step is easy to miss and will cause all requests to return 401 with no helpful error message.
+
+### 5 — Deploy
+
+Click **Deploy**. Verify by opening the function URL in a browser — you should see:
+```json
+{ "status": "ok", "service": "Bookshelf", "version": "1.0.0" }
+```
+
+✅ **Done when:** The health check returns the JSON above. If it spins or times out, delete the function and create a fresh one — do not re-deploy into the same slot.
+
+### 6 — Connect to Claude
+
+Add a custom connector in Claude:
+- **Desktop:** Settings → Connectors → Add custom connector
+- **Web:** Settings → Connectors → Add custom connector
+
+Fill in:
+- **Name:** `Bookshelf` (or `Bookshelf - [Name]` for shared setups)
+- **URL:** `https://YOUR_PROJECT_REF.supabase.co/functions/v1/bookshelf-mcp?key=YOUR_MCP_ACCESS_KEY`
+
+No OAuth. The key is embedded in the URL.
+
+✅ **Done when:** The connector shows as connected and you can ask Claude "add a book called Thinking in Systems by Donella Meadows" and it confirms the insert.
+
+## Adding More Users
+
+Each person gets their own function with their own UUID secret. Repeat Steps 2–6:
+
+1. Add their UUID as a Supabase secret (e.g. `DONNA_USER_ID`)
+2. Create a new function (e.g. `bookshelf-donna-mcp`)
+3. Paste the same `index.ts` and `deno.json`, update line 8 to their secret name
+4. Disable JWT, deploy, give them their own connection URL
+
+Each user's books, notes, and quotes are fully isolated — they only see their own data.
+
+## Expected Outcome
+
+Once connected, you can have natural conversations with Claude about your reading:
+
+- *"Add Creativity Inc by Ed Catmull to my bookshelf with tags leadership and culture"*
+- *"Log an insight from chapter 8 of Creativity Inc about psychological safety"*
+- *"What open questions do I have across all my leadership books?"*
+- *"Search for anything I've read about getting buy-in from skeptical teams"*
+- *"Mark Thinking Fast and Slow as a dud — too dense, never finished it"*
+- *"Add The Great Alone to my reading list"*
+- *"I just started reading Atomic Habits — move it from my queue to my bookshelf"*
+
+## Troubleshooting
+
+**Issue: Function spins or times out on the health check URL**
+Solution: Delete the function entirely and create a fresh one with a new name. The Supabase dashboard can get into a bad state from failed deploys — re-deploying into the same slot doesn't always clear it.
+
+**Issue: 401 error when connecting from Claude**
+Solution: Check two things in order: (1) Is JWT verification turned off in the function's Details tab? (2) Is the `?key=` value in your connector URL exactly matching the `MCP_ACCESS_KEY` secret?
+
+**Issue: "Book not found" error when logging notes or quotes**
+Solution: The note and quote tools look up books by partial title match. The book must already exist via `add_book` before you can attach notes or quotes to it. Use `search_books` to confirm the exact title as stored.
+
+**Issue: Schema errors on tables that already exist**
+Solution: The `update_updated_at_column()` trigger function uses `CREATE OR REPLACE` and is safe to re-run. If individual `CREATE TABLE` statements fail because tables already exist, you can run just the missing portions or use `CREATE TABLE IF NOT EXISTS` in a one-off query.
+
+**Issue: Permission denied errors from the edge function**
+Solution: Run the GRANT statements at the bottom of the schema SQL. Newer Supabase projects do not automatically grant CRUD permissions to `service_role` on new tables.
+
+---
+
+As you add more MCP tools across extensions, your AI's context fills up. See the [MCP Tool Audit & Optimization Guide](../../docs/05-tool-audit.md) for how to manage your tool surface area.

--- a/recipes/bookshelf/deno.json
+++ b/recipes/bookshelf/deno.json
@@ -1,0 +1,9 @@
+{
+  "imports": {
+    "@hono/mcp": "npm:@hono/mcp@0.1.1",
+    "@modelcontextprotocol/sdk": "npm:@modelcontextprotocol/sdk@1.24.3",
+    "hono": "npm:hono@4.9.2",
+    "zod": "npm:zod@4.1.13",
+    "@supabase/supabase-js": "npm:@supabase/supabase-js@2.47.10"
+  }
+}

--- a/recipes/bookshelf/deploy-instructions.md
+++ b/recipes/bookshelf/deploy-instructions.md
@@ -1,0 +1,69 @@
+# Bookshelf — Deploy Instructions
+
+## Prerequisites
+- Working Open Brain / Supabase setup
+- `MCP_ACCESS_KEY` and `DEFAULT_USER_ID` already set as Supabase secrets
+
+## Step 1 — Run the schema
+
+In Supabase dashboard → SQL Editor → New query, paste the entire contents of `schema.sql` and click Run.
+
+The file creates everything in the correct order: trigger function first, then `reading_list`, then the bookshelf tables. The `CREATE OR REPLACE` on the trigger function is safe if it already exists from the CRM extension.
+
+## Step 2 — Create the Edge Function
+
+In Supabase dashboard → Edge Functions → Deploy a new function.
+
+Name it per user — one function per person who will use it:
+- Your function: `bookshelf-lauren-mcp` (or whatever label you prefer)
+- Additional users: `bookshelf-[name]-mcp`
+
+## Step 3 — Paste the files
+
+In the function editor, add two files:
+
+**`index.ts`** — paste the contents of `index.ts` from this directory.
+
+On line 8, change `USER_ID` to the user's UUID:
+```typescript
+const USER_ID = "YOUR-UUID-HERE";
+```
+
+Use your existing UUID from `DEFAULT_USER_ID` for your own function.
+For additional users, generate a new UUID:
+```bash
+uuidgen | tr '[:upper:]' '[:lower:]'
+```
+
+**`deno.json`** — paste the contents of `deno.json` from this directory. No changes needed.
+
+## Step 4 — Disable JWT verification
+
+In the function's Details tab, turn off JWT verification. This is required — the function handles its own auth via `MCP_ACCESS_KEY`.
+
+## Step 5 — Deploy
+
+Click Deploy. Verify it's running by opening the function URL in a browser — you should see:
+```json
+{"status":"ok","service":"Bookshelf","version":"1.0.0"}
+```
+
+## Step 6 — Connect to Claude
+
+Add a custom connector in Claude (Desktop: Settings → Connectors / Web: Settings → Connectors):
+
+- Name: `Bookshelf` (or `Bookshelf - [Name]` for shared users)
+- URL: `https://YOUR_PROJECT_REF.supabase.co/functions/v1/bookshelf-lauren-mcp?key=YOUR_MCP_ACCESS_KEY`
+
+No OAuth. The key is embedded in the URL.
+
+## Sharing with other users
+
+Repeat Steps 2–6 for each additional user:
+1. Generate a new UUID for them
+2. Create a new function with their name (e.g. `bookshelf-donna-mcp`)
+3. Paste the same `index.ts` and `deno.json`, swap the `USER_ID` on line 8
+4. Disable JWT verification, deploy
+5. Give them their own connection URL
+
+Each user's data is fully isolated — they only see their own books, notes, and quotes.

--- a/recipes/bookshelf/index.ts
+++ b/recipes/bookshelf/index.ts
@@ -1,0 +1,480 @@
+import { Hono } from "hono";
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { StreamableHTTPTransport } from "@hono/mcp";
+import { z } from "zod";
+import { createClient } from "@supabase/supabase-js";
+
+// ✏️ CHANGE THIS LINE PER USER
+const USER_ID =  Deno.env.get("DEFAULT_USER_ID");
+
+const app = new Hono();
+
+app.get("*", (c) => c.json({ status: "ok", service: "Bookshelf", version: "1.0.0" }));
+
+app.post("*", async (c) => {
+  if (!c.req.header("accept")?.includes("text/event-stream")) {
+    const headers = new Headers(c.req.raw.headers);
+    headers.set("Accept", "application/json, text/event-stream");
+    const patched = new Request(c.req.raw.url, {
+      method: c.req.raw.method,
+      headers,
+      body: c.req.raw.body,
+      // @ts-ignore -- duplex required for streaming body in Deno
+      duplex: "half",
+    });
+    Object.defineProperty(c.req, "raw", { value: patched, writable: true });
+  }
+
+  const key = c.req.query("key") || c.req.header("x-access-key");
+  const expected = Deno.env.get("MCP_ACCESS_KEY");
+  if (!key || key !== expected) {
+    return c.json({ error: "Unauthorized" }, 401);
+  }
+
+  const supabase = createClient(
+    Deno.env.get("SUPABASE_URL")!,
+    Deno.env.get("SUPABASE_SERVICE_ROLE_KEY")!,
+  );
+
+  const server = new McpServer({ name: "bookshelf", version: "1.0.0" });
+
+  // Internal helper — find a book by partial title match
+  async function findBook(title: string) {
+    const { data, error } = await supabase
+      .from("books")
+      .select("id, title, dud, dud_reason")
+      .eq("user_id", USER_ID)
+      .ilike("title", `%${title}%`)
+      .limit(1)
+      .single();
+    if (error) throw new Error(`Book not found: "${title}". Use add_book first.`);
+    return data;
+  }
+
+  // Tool 1: add_book
+  server.tool(
+    "add_book",
+    "Add a book to your reading library",
+    {
+      title: z.string().describe("Book title"),
+      author: z.string().describe("Author name"),
+      tags: z.array(z.string()).optional().describe("Topics/themes e.g. ['leadership', 'creativity', 'management']"),
+      summary: z.string().optional().describe("Why you want to read it or what it's about"),
+    },
+    async (args) => {
+      const { data, error } = await supabase
+        .from("books")
+        .insert({
+          user_id: USER_ID,
+          title: args.title,
+          author: args.author,
+          tags: args.tags || [],
+          summary: args.summary || null,
+        })
+        .select()
+        .single();
+      if (error) throw new Error(`Failed to add book: ${error.message}`);
+      return { content: [{ type: "text", text: JSON.stringify({ success: true, book: data }, null, 2) }] };
+    }
+  );
+
+  // Tool 2: append_book_note
+  server.tool(
+    "append_book_note",
+    "Add a note to a book — summary, insight, open question, action item, or connection to another idea",
+    {
+      book_title: z.string().describe("Book title (partial match ok)"),
+      chapter: z.string().optional().describe("Chapter name e.g. 'Ch 8 - Candor'"),
+      note_type: z.enum(["summary", "insight", "question", "action", "connection"]).describe("Type of note"),
+      content: z.string().describe("The note"),
+    },
+    async (args) => {
+      const book = await findBook(args.book_title);
+      const { data, error } = await supabase
+        .from("book_notes")
+        .insert({
+          book_id: book.id,
+          user_id: USER_ID,
+          chapter: args.chapter || null,
+          note_type: args.note_type,
+          content: args.content,
+        })
+        .select()
+        .single();
+      if (error) throw new Error(`Failed to append note: ${error.message}`);
+      return { content: [{ type: "text", text: JSON.stringify({ success: true, note: data }, null, 2) }] };
+    }
+  );
+
+  // Tool 3: capture_quote
+  server.tool(
+    "capture_quote",
+    "Save a verbatim quote from a book with your personal reaction or interpretation",
+    {
+      book_title: z.string().describe("Book title (partial match ok)"),
+      chapter: z.string().optional().describe("Chapter name e.g. 'Ch 8 - Candor'"),
+      page_number: z.number().optional().describe("Page number"),
+      quote: z.string().describe("Verbatim quote"),
+      personal_take: z.string().optional().describe("Your reaction or interpretation"),
+      tags: z.array(z.string()).optional().describe("Tags e.g. ['vulnerability', 'feedback']"),
+    },
+    async (args) => {
+      const book = await findBook(args.book_title);
+      const { data, error } = await supabase
+        .from("book_quotes")
+        .insert({
+          book_id: book.id,
+          user_id: USER_ID,
+          chapter: args.chapter || null,
+          page_number: args.page_number || null,
+          quote: args.quote,
+          personal_take: args.personal_take || null,
+          tags: args.tags || [],
+        })
+        .select()
+        .single();
+      if (error) throw new Error(`Failed to capture quote: ${error.message}`);
+      return { content: [{ type: "text", text: JSON.stringify({ success: true, quote: data }, null, 2) }] };
+    }
+  );
+
+  // Tool 4: get_book_dossier
+  server.tool(
+    "get_book_dossier",
+    "Get a book's full record — metadata, all notes, and all quotes. Optionally filter notes by type.",
+    {
+      book_title: z.string().describe("Book title (partial match ok)"),
+      note_type: z.enum(["summary", "insight", "question", "action", "connection"]).optional().describe("Filter notes by type — e.g. 'question' to surface all open questions"),
+    },
+    async (args) => {
+      const book = await findBook(args.book_title);
+
+      let notesQuery = supabase
+        .from("book_notes")
+        .select("*")
+        .eq("book_id", book.id)
+        .eq("user_id", USER_ID)
+        .order("created_at", { ascending: true });
+
+      if (args.note_type) {
+        notesQuery = notesQuery.eq("note_type", args.note_type);
+      }
+
+      const [{ data: fullBook }, { data: notes }, { data: quotes }] = await Promise.all([
+        supabase.from("books").select("*").eq("id", book.id).single(),
+        notesQuery,
+        supabase
+          .from("book_quotes")
+          .select("*")
+          .eq("book_id", book.id)
+          .eq("user_id", USER_ID)
+          .order("created_at", { ascending: true }),
+      ]);
+
+      return {
+        content: [{
+          type: "text",
+          text: JSON.stringify({
+            success: true,
+            book: fullBook,
+            notes: notes || [],
+            quotes: quotes || [],
+            note_count: notes?.length || 0,
+            quote_count: quotes?.length || 0,
+          }, null, 2),
+        }],
+      };
+    }
+  );
+
+  // Tool 5: update_reading_status
+  server.tool(
+    "update_reading_status",
+    "Update a book's reading status, rating, summary, or mark it as a dud",
+    {
+      book_title: z.string().describe("Book title (partial match ok)"),
+      status: z.enum(["unread", "reading", "completed", "abandoned"]).optional(),
+      started_at: z.string().optional().describe("Date started (YYYY-MM-DD)"),
+      completed_at: z.string().optional().describe("Date completed (YYYY-MM-DD)"),
+      overall_rating: z.number().min(1).max(5).optional().describe("Rating 1-5"),
+      summary: z.string().optional().describe("Overall takeaway or review"),
+      dud: z.boolean().optional().describe("Mark as a dud — won't be recommended but stays in library with context"),
+      dud_reason: z.string().optional().describe("Why it was a dud e.g. 'woo woo nonsense', 'too basic'"),
+    },
+    async (args) => {
+      const book = await findBook(args.book_title);
+      const updates: Record<string, any> = {};
+      if (args.status !== undefined) updates.status = args.status;
+      if (args.started_at !== undefined) updates.started_at = args.started_at;
+      if (args.completed_at !== undefined) updates.completed_at = args.completed_at;
+      if (args.overall_rating !== undefined) updates.overall_rating = args.overall_rating;
+      if (args.summary !== undefined) updates.summary = args.summary;
+      if (args.dud !== undefined) updates.dud = args.dud;
+      if (args.dud_reason !== undefined) updates.dud_reason = args.dud_reason;
+
+      const { data, error } = await supabase
+        .from("books")
+        .update(updates)
+        .eq("id", book.id)
+        .eq("user_id", USER_ID)
+        .select()
+        .single();
+      if (error) throw new Error(`Failed to update book: ${error.message}`);
+      return { content: [{ type: "text", text: JSON.stringify({ success: true, book: data }, null, 2) }] };
+    }
+  );
+
+  // Tool 6: search_books
+  server.tool(
+    "search_books",
+    "Search your library by topic, problem, or keyword across titles, authors, tags, summaries, notes, and quotes. Duds are surfaced separately with context.",
+    {
+      query: z.string().describe("Topic, problem, keyword, or book title — e.g. 'getting buy-in from leadership' or 'Creativity Inc'"),
+      tags: z.array(z.string()).optional().describe("Narrow by tags e.g. ['leadership']"),
+    },
+    async (args) => {
+      let booksQuery = supabase
+        .from("books")
+        .select("*")
+        .eq("user_id", USER_ID)
+        .or(`title.ilike.%${args.query}%,author.ilike.%${args.query}%,summary.ilike.%${args.query}%`);
+
+      if (args.tags && args.tags.length > 0) {
+        booksQuery = booksQuery.contains("tags", args.tags);
+      }
+
+      const [
+        { data: bookMatches },
+        { data: noteMatches },
+        { data: quoteMatches },
+      ] = await Promise.all([
+        booksQuery,
+        supabase
+          .from("book_notes")
+          .select("book_id, content, note_type, chapter")
+          .eq("user_id", USER_ID)
+          .ilike("content", `%${args.query}%`),
+        supabase
+          .from("book_quotes")
+          .select("book_id, quote, personal_take, chapter")
+          .eq("user_id", USER_ID)
+          .or(`quote.ilike.%${args.query}%,personal_take.ilike.%${args.query}%`),
+      ]);
+
+      const existingIds = new Set(bookMatches?.map((b: any) => b.id) || []);
+      const additionalIds = [
+        ...new Set([
+          ...(noteMatches?.map((n: any) => n.book_id) || []),
+          ...(quoteMatches?.map((q: any) => q.book_id) || []),
+        ]),
+      ].filter((id) => !existingIds.has(id));
+
+      let additionalBooks: any[] = [];
+      if (additionalIds.length > 0) {
+        const { data } = await supabase
+          .from("books")
+          .select("*")
+          .eq("user_id", USER_ID)
+          .in("id", additionalIds);
+        additionalBooks = data || [];
+      }
+
+      const allBooks = [...(bookMatches || []), ...additionalBooks];
+      const duds = allBooks.filter((b: any) => b.dud);
+      const results = allBooks.filter((b: any) => !b.dud);
+
+      return {
+        content: [{
+          type: "text",
+          text: JSON.stringify({
+            success: true,
+            query: args.query,
+            result_count: results.length,
+            results,
+            dud_count: duds.length,
+            duds: duds.map((d: any) => ({
+              title: d.title,
+              author: d.author,
+              dud_reason: d.dud_reason,
+            })),
+          }, null, 2),
+        }],
+      };
+    }
+  );
+
+  // Tool 7: add_to_reading_list
+  server.tool(
+    "add_to_reading_list",
+    "Add a book, article, podcast, or video to your reading queue",
+    {
+      title: z.string().describe("Title"),
+      author: z.string().optional().describe("Author or creator"),
+      type: z.enum(["book", "article", "podcast", "video"]).optional().describe("Type (default: book)"),
+      url: z.string().optional().describe("Link to the item"),
+      tags: z.array(z.string()).optional().describe("Topics e.g. ['leadership', 'creativity']"),
+      review_notes: z.string().optional().describe("Why you want to read/watch this"),
+    },
+    async (args) => {
+      const { data, error } = await supabase
+        .from("reading_list")
+        .insert({
+          user_id: USER_ID,
+          title: args.title,
+          author: args.author || null,
+          type: args.type || "book",
+          url: args.url || null,
+          tags: args.tags || [],
+          review_notes: args.review_notes || null,
+        })
+        .select()
+        .single();
+      if (error) throw new Error(`Failed to add to reading list: ${error.message}`);
+      return { content: [{ type: "text", text: JSON.stringify({ success: true, item: data }, null, 2) }] };
+    }
+  );
+
+  // Tool 8: browse_reading_list
+  server.tool(
+    "browse_reading_list",
+    "Browse your reading queue — filter by status, type, or tags. Use this to decide what to read next.",
+    {
+      status: z.enum(["want_to_read", "reading", "finished", "abandoned"]).optional().describe("Filter by status (omit for all)"),
+      type: z.enum(["book", "article", "podcast", "video"]).optional().describe("Filter by type"),
+      tags: z.array(z.string()).optional().describe("Filter by tags"),
+    },
+    async (args) => {
+      let query = supabase
+        .from("reading_list")
+        .select("*")
+        .eq("user_id", USER_ID)
+        .order("created_at", { ascending: false });
+
+      if (args.status) query = query.eq("status", args.status);
+      if (args.type) query = query.eq("type", args.type);
+      if (args.tags && args.tags.length > 0) query = query.contains("tags", args.tags);
+
+      const { data, error } = await query;
+      if (error) throw new Error(`Failed to browse reading list: ${error.message}`);
+      return { content: [{ type: "text", text: JSON.stringify({ success: true, count: data.length, items: data }, null, 2) }] };
+    }
+  );
+
+  // Tool 9: start_reading
+  server.tool(
+    "start_reading",
+    "Move a book from your reading list into the bookshelf — creates a bookshelf entry linked to the reading list item",
+    {
+      reading_list_title: z.string().describe("Title from your reading list (partial match ok)"),
+      tags: z.array(z.string()).optional().describe("Bookshelf tags (inherits reading list tags if omitted)"),
+      started_at: z.string().optional().describe("Date started (YYYY-MM-DD), defaults to today"),
+    },
+    async (args) => {
+      // Find reading list entry
+      const { data: rlItem, error: rlError } = await supabase
+        .from("reading_list")
+        .select("*")
+        .eq("user_id", USER_ID)
+        .ilike("title", `%${args.reading_list_title}%`)
+        .limit(1)
+        .single();
+      if (rlError) throw new Error(`Not found in reading list: "${args.reading_list_title}"`);
+
+      const today = new Date().toISOString().split("T")[0];
+
+      // Create bookshelf entry
+      const { data: book, error: bookError } = await supabase
+        .from("books")
+        .insert({
+          user_id: USER_ID,
+          title: rlItem.title,
+          author: rlItem.author || "",
+          tags: args.tags || (Array.isArray(rlItem.tags) ? rlItem.tags : []),
+          status: "reading",
+          started_at: args.started_at || today,
+          reading_list_id: rlItem.id,
+        })
+        .select()
+        .single();
+      if (bookError) throw new Error(`Failed to create bookshelf entry: ${bookError.message}`);
+
+      // Update reading list status
+      await supabase
+        .from("reading_list")
+        .update({ status: "reading", started_date: args.started_at || today })
+        .eq("id", rlItem.id);
+
+      return {
+        content: [{
+          type: "text",
+          text: JSON.stringify({ success: true, message: `Started reading "${rlItem.title}"`, book }, null, 2),
+        }],
+      };
+    }
+  );
+
+  // Tool 10: finish_reading
+  server.tool(
+    "finish_reading",
+    "Mark a book as finished — updates the bookshelf and syncs rating and review back to your reading list",
+    {
+      book_title: z.string().describe("Book title in your bookshelf (partial match ok)"),
+      overall_rating: z.number().min(1).max(5).optional().describe("Rating 1-5"),
+      summary: z.string().optional().describe("Overall takeaway or review"),
+      dud: z.boolean().optional().describe("Mark as a dud"),
+      dud_reason: z.string().optional().describe("Why it was a dud"),
+      finished_date: z.string().optional().describe("Date finished (YYYY-MM-DD), defaults to today"),
+    },
+    async (args) => {
+      const book = await findBook(args.book_title);
+      const today = new Date().toISOString().split("T")[0];
+
+      // Update bookshelf
+      const bookUpdates: Record<string, any> = {
+        status: "completed",
+        completed_at: args.finished_date || today,
+      };
+      if (args.overall_rating !== undefined) bookUpdates.overall_rating = args.overall_rating;
+      if (args.summary !== undefined) bookUpdates.summary = args.summary;
+      if (args.dud !== undefined) bookUpdates.dud = args.dud;
+      if (args.dud_reason !== undefined) bookUpdates.dud_reason = args.dud_reason;
+
+      const { data: updatedBook, error: bookError } = await supabase
+        .from("books")
+        .update(bookUpdates)
+        .eq("id", book.id)
+        .eq("user_id", USER_ID)
+        .select()
+        .single();
+      if (bookError) throw new Error(`Failed to update bookshelf: ${bookError.message}`);
+
+      // Sync back to reading list if linked
+      if (updatedBook.reading_list_id) {
+        const rlUpdates: Record<string, any> = {
+          status: "finished",
+          finished_date: args.finished_date || today,
+        };
+        if (args.overall_rating !== undefined) rlUpdates.rating = args.overall_rating;
+        if (args.summary !== undefined) rlUpdates.review_notes = args.summary;
+
+        await supabase
+          .from("reading_list")
+          .update(rlUpdates)
+          .eq("id", updatedBook.reading_list_id);
+      }
+
+      return {
+        content: [{
+          type: "text",
+          text: JSON.stringify({ success: true, message: `Finished "${updatedBook.title}"`, book: updatedBook }, null, 2),
+        }],
+      };
+    }
+  );
+
+  const transport = new StreamableHTTPTransport();
+  await server.connect(transport);
+  return transport.handleRequest(c);
+});
+
+Deno.serve(app.fetch);

--- a/recipes/bookshelf/metadata.json
+++ b/recipes/bookshelf/metadata.json
@@ -1,0 +1,21 @@
+{
+  "name": "Bookshelf",
+  "description": "A personal reading CRM — track books, log chapter notes by type, capture verbatim quotes, and search your library by topic or problem.",
+  "category": "recipes",
+  "author": {
+    "name": "Lauren",
+    "github": "ch3ck3rs"
+  },
+  "version": "1.0.0",
+  "requires": {
+    "open_brain": true,
+    "services": [],
+    "tools": []
+  },
+  "requires_primitives": ["deploy-edge-function", "remote-mcp", "rls"],
+  "tags": ["books", "reading", "notes", "quotes", "knowledge", "rls"],
+  "difficulty": "intermediate",
+  "estimated_time": "30 minutes",
+  "created": "2026-08-14",
+  "updated": "2026-08-14"
+}

--- a/recipes/bookshelf/schema.sql
+++ b/recipes/bookshelf/schema.sql
@@ -1,0 +1,131 @@
+-- Bookshelf Extension
+-- Run this entire file at once in Supabase SQL Editor.
+
+-- ============================================================
+-- Shared trigger function (must come first)
+-- ============================================================
+
+CREATE OR REPLACE FUNCTION update_updated_at_column()
+RETURNS TRIGGER AS $$
+BEGIN NEW.updated_at = now(); RETURN NEW; END;
+$$ LANGUAGE plpgsql;
+
+-- ============================================================
+-- Reading List (intake queue for books, articles, podcasts, videos)
+-- ============================================================
+
+CREATE TABLE reading_list (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    user_id UUID NOT NULL,
+    title TEXT NOT NULL,
+    author TEXT,
+    type TEXT DEFAULT 'book' CHECK (type IN ('book', 'article', 'podcast', 'video')),
+    status TEXT DEFAULT 'want_to_read' CHECK (status IN ('want_to_read', 'reading', 'finished', 'abandoned')),
+    rating SMALLINT CHECK (rating >= 1 AND rating <= 5 OR rating IS NULL),
+    review_notes TEXT,
+    url TEXT,
+    started_date DATE,
+    finished_date DATE,
+    tags JSONB DEFAULT '[]'::jsonb,
+    created_at TIMESTAMPTZ DEFAULT now(),
+    updated_at TIMESTAMPTZ DEFAULT now(),
+    CONSTRAINT finished_after_started CHECK (
+        finished_date IS NULL OR started_date IS NULL OR finished_date >= started_date
+    )
+);
+
+CREATE INDEX idx_reading_list_user_status ON reading_list(user_id, status);
+CREATE INDEX idx_reading_list_user_type ON reading_list(user_id, type);
+CREATE INDEX idx_reading_list_user_rating ON reading_list(user_id, rating);
+CREATE INDEX idx_reading_list_tags ON reading_list USING GIN (tags);
+CREATE INDEX idx_reading_list_finished ON reading_list(finished_date DESC) WHERE finished_date IS NOT NULL;
+
+ALTER TABLE reading_list ENABLE ROW LEVEL SECURITY;
+CREATE POLICY reading_list_user_policy ON reading_list
+    FOR ALL USING (auth.uid() = user_id) WITH CHECK (auth.uid() = user_id);
+
+DROP TRIGGER IF EXISTS update_reading_list_updated_at ON reading_list;
+CREATE TRIGGER update_reading_list_updated_at
+    BEFORE UPDATE ON reading_list
+    FOR EACH ROW EXECUTE FUNCTION update_updated_at_column();
+
+CREATE OR REPLACE VIEW currently_reading AS
+    SELECT * FROM reading_list
+    WHERE status = 'reading'
+    ORDER BY started_date DESC;
+
+-- ============================================================
+-- Bookshelf (deep reading — notes, quotes, reviews)
+-- ============================================================
+
+CREATE TABLE books (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    user_id UUID NOT NULL,
+    reading_list_id UUID REFERENCES reading_list(id) ON DELETE SET NULL,
+    title TEXT NOT NULL,
+    author TEXT NOT NULL,
+    tags TEXT[] DEFAULT '{}',
+    status TEXT DEFAULT 'unread' CHECK (status IN ('unread', 'reading', 'completed', 'abandoned')),
+    started_at DATE,
+    completed_at DATE,
+    overall_rating INTEGER CHECK (overall_rating >= 1 AND overall_rating <= 5 OR overall_rating IS NULL),
+    summary TEXT,
+    dud BOOLEAN DEFAULT false,
+    dud_reason TEXT,
+    created_at TIMESTAMPTZ DEFAULT now() NOT NULL,
+    updated_at TIMESTAMPTZ DEFAULT now() NOT NULL
+);
+
+CREATE TABLE book_notes (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    book_id UUID REFERENCES books(id) ON DELETE CASCADE NOT NULL,
+    user_id UUID NOT NULL,
+    chapter TEXT,
+    note_type TEXT CHECK (note_type IN ('summary', 'insight', 'question', 'action', 'connection')),
+    content TEXT NOT NULL,
+    created_at TIMESTAMPTZ DEFAULT now() NOT NULL
+);
+
+CREATE TABLE book_quotes (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    book_id UUID REFERENCES books(id) ON DELETE CASCADE NOT NULL,
+    user_id UUID NOT NULL,
+    chapter TEXT,
+    page_number INTEGER,
+    quote TEXT NOT NULL,
+    personal_take TEXT,
+    tags TEXT[] DEFAULT '{}',
+    created_at TIMESTAMPTZ DEFAULT now() NOT NULL
+);
+
+CREATE INDEX idx_books_user_id ON books(user_id);
+CREATE INDEX idx_books_user_status ON books(user_id, status);
+CREATE INDEX idx_books_user_tags ON books USING GIN (tags);
+CREATE INDEX idx_book_notes_book_id ON book_notes(book_id);
+CREATE INDEX idx_book_notes_type ON book_notes(book_id, note_type);
+CREATE INDEX idx_book_quotes_book_id ON book_quotes(book_id);
+CREATE INDEX idx_book_quotes_tags ON book_quotes USING GIN (tags);
+
+ALTER TABLE books ENABLE ROW LEVEL SECURITY;
+ALTER TABLE book_notes ENABLE ROW LEVEL SECURITY;
+ALTER TABLE book_quotes ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY books_user_policy ON books
+    FOR ALL USING (auth.uid() = user_id) WITH CHECK (auth.uid() = user_id);
+
+CREATE POLICY book_notes_user_policy ON book_notes
+    FOR ALL USING (auth.uid() = user_id) WITH CHECK (auth.uid() = user_id);
+
+CREATE POLICY book_quotes_user_policy ON book_quotes
+    FOR ALL USING (auth.uid() = user_id) WITH CHECK (auth.uid() = user_id);
+
+DROP TRIGGER IF EXISTS update_books_updated_at ON books;
+CREATE TRIGGER update_books_updated_at
+    BEFORE UPDATE ON books
+    FOR EACH ROW EXECUTE FUNCTION update_updated_at_column();
+
+-- Permissions for service_role (required on newer Supabase projects)
+GRANT SELECT, INSERT, UPDATE, DELETE ON TABLE public.reading_list TO service_role;
+GRANT SELECT, INSERT, UPDATE, DELETE ON TABLE public.books TO service_role;
+GRANT SELECT, INSERT, UPDATE, DELETE ON TABLE public.book_notes TO service_role;
+GRANT SELECT, INSERT, UPDATE, DELETE ON TABLE public.book_quotes TO service_role;


### PR DESCRIPTION
## Contribution Type

<!-- Check one -->
- [x] Recipe (`/recipes`)
- [ ] Schema (`/schemas`)
- [ ] Dashboard (`/dashboards`)
- [ ] Integration (`/integrations`)
- [ ] Skill (`/skills`)
- [ ] Repo improvement (docs, CI, templates)

## What does this do?

Adds a personal reading CRM as a Supabase Edge Function with 10 MCP tools. Books get chapter notes tagged by type (insight, question, action, connection, summary), verbatim quotes with personal reactions, ratings, and an honest dud flag so you remember why you abandoned something. A lightweight reading queue sits alongside the deep library — queue items bridge into the bookshelf when you start reading and sync rating/review back when you finish. Supports per-user isolation so multiple people can share an Open Brain instance with completely separate bookshelves.

## Requirements

  - Working Open Brain setup
  - MCP_ACCESS_KEY already set as a Supabase secret (from core setup)
  - User UUID stored as a Supabase secret (e.g. DEFAULT_USER_ID)
  - No external services or APIs required beyond Supabase

## Checklist

- [x] I've read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] My contribution has a `README.md` with prerequisites, step-by-step instructions, and expected outcome
- [x] My `metadata.json` has all required fields
- [x] If my contribution depends on a skill or primitive, I declared it in metadata.json and linked it in the README
- [x] I tested this on my own Open Brain instance
- [x] No credentials, API keys, or secrets are included
