### PR TITLE
[server] Normalize BIGINT IDs in compatibility tools

### DIFF
--- a/docs/01-getting-started.md
+++ b/docs/01-getting-started.md
@@ -428,7 +428,7 @@ supabase secrets set OPENROUTER_API_KEY=your-openrouter-key-here
 
 ![6.6](https://img.shields.io/badge/6.6-Download_the_Server_Files-555?style=for-the-badge&labelColor=1E88E5)
 
-Three commands, run them one at a time in order:
+Four commands, run them one at a time in order:
 
 **1. Create the function folder:**
 
@@ -442,14 +442,20 @@ supabase functions new open-brain-mcp
 curl -o supabase/functions/open-brain-mcp/index.ts https://raw.githubusercontent.com/NateBJones-Projects/OB1/main/server/index.ts
 ```
 
-**3. Download the dependencies file:**
+**3. Download the compatibility helper:**
+
+```bash
+curl -o supabase/functions/open-brain-mcp/compatibility.ts https://raw.githubusercontent.com/NateBJones-Projects/OB1/main/server/compatibility.ts
+```
+
+**4. Download the dependencies file:**
 
 ```bash
 curl -o supabase/functions/open-brain-mcp/deno.json https://raw.githubusercontent.com/NateBJones-Projects/OB1/main/server/deno.json
 ```
 
 > [!WARNING]
-> ❌ **`No such file or directory`** on command 2 or 3 — you skipped command 1. Run it first, then retry.
+> ❌ **`No such file or directory`** on commands 2, 3, or 4 — you skipped command 1. Run it first, then retry.
 
 Verify the download worked — this should print the first line of the server code, **not** "Hello from Functions":
 
@@ -606,7 +612,7 @@ supabase secrets set OPENROUTER_API_KEY=your-openrouter-key-here
 
 ![6.6](https://img.shields.io/badge/6.6-Download_the_Server_Files-555?style=for-the-badge&labelColor=1E88E5)
 
-Three commands, run them one at a time in order:
+Four commands, run them one at a time in order:
 
 **1. Create the function folder:**
 
@@ -620,14 +626,20 @@ supabase functions new open-brain-mcp
 Invoke-WebRequest -Uri https://raw.githubusercontent.com/NateBJones-Projects/OB1/main/server/index.ts -OutFile supabase\functions\open-brain-mcp\index.ts
 ```
 
-**3. Download the dependencies file:**
+**3. Download the compatibility helper:**
+
+```powershell
+Invoke-WebRequest -Uri https://raw.githubusercontent.com/NateBJones-Projects/OB1/main/server/compatibility.ts -OutFile supabase\functions\open-brain-mcp\compatibility.ts
+```
+
+**4. Download the dependencies file:**
 
 ```powershell
 Invoke-WebRequest -Uri https://raw.githubusercontent.com/NateBJones-Projects/OB1/main/server/deno.json -OutFile supabase\functions\open-brain-mcp\deno.json
 ```
 
 > [!WARNING]
-> ❌ **`No such file or directory`** on command 2 or 3 — you skipped command 1. Run it first, then retry.
+> ❌ **`No such file or directory`** on commands 2, 3, or 4 — you skipped command 1. Run it first, then retry.
 
 Verify the download worked — this should print the first line of the server code, **not** "Hello from Functions":
 

--- a/server/compatibility.test.mjs
+++ b/server/compatibility.test.mjs
@@ -1,0 +1,11 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { normalizeThoughtId } from "./compatibility.ts";
+
+test("normalizes a BIGINT thought ID without losing precision", () => {
+  const id = normalizeThoughtId(9007199254740993n);
+
+  assert.equal(id, "9007199254740993");
+  assert.equal(JSON.stringify({ id }), '{"id":"9007199254740993"}');
+});

--- a/server/compatibility.ts
+++ b/server/compatibility.ts
@@ -1,0 +1,5 @@
+export type ThoughtId = string | number | bigint;
+
+export function normalizeThoughtId(id: ThoughtId): string {
+  return String(id);
+}

--- a/server/index.ts
+++ b/server/index.ts
@@ -5,6 +5,7 @@ import { StreamableHTTPTransport } from "@hono/mcp";
 import { Hono } from "hono";
 import { z } from "zod";
 import { createClient } from "@supabase/supabase-js";
+import { normalizeThoughtId, type ThoughtId } from "./compatibility.ts";
 
 const SUPABASE_URL = Deno.env.get("SUPABASE_URL")!;
 const SUPABASE_SERVICE_ROLE_KEY = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY")!;
@@ -15,7 +16,7 @@ const OPENROUTER_BASE = "https://openrouter.ai/api/v1";
 const supabase = createClient(SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY);
 
 type ThoughtMatch = {
-  id: string;
+  id: ThoughtId;
   content: string;
   metadata: Record<string, unknown>;
   similarity: number;
@@ -23,7 +24,7 @@ type ThoughtMatch = {
 };
 
 type ThoughtRecord = {
-  id: string;
+  id: ThoughtId;
   content: string;
   metadata: Record<string, unknown>;
   created_at: string;
@@ -136,11 +137,14 @@ function buildServer(): McpServer {
           };
         }
 
-        const results = ((data || []) as ThoughtMatch[]).map((t) => ({
-          id: t.id,
-          title: thoughtTitle(t.content, t.created_at),
-          url: thoughtUrl(t.id),
-        }));
+        const results = ((data || []) as ThoughtMatch[]).map((t) => {
+          const id = normalizeThoughtId(t.id);
+          return {
+            id,
+            title: thoughtTitle(t.content, t.created_at),
+            url: thoughtUrl(id),
+          };
+        });
 
         return {
           content: [{ type: "text" as const, text: JSON.stringify({ results }) }],
@@ -183,11 +187,12 @@ function buildServer(): McpServer {
         }
 
         const thought = data as ThoughtRecord;
+        const thoughtId = normalizeThoughtId(thought.id);
         const document = {
-          id: thought.id,
+          id: thoughtId,
           title: thoughtTitle(thought.content, thought.created_at),
           text: thought.content,
-          url: thoughtUrl(thought.id),
+          url: thoughtUrl(thoughtId),
           metadata: {
             ...thought.metadata,
             created_at: thought.created_at,

--- a/server/package.json
+++ b/server/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "test": "node test-stateless.mjs"
+    "test": "node --test compatibility.test.mjs && node test-stateless.mjs"
   },
   "devDependencies": {
     "@hono/mcp": "^0.1.5",


### PR DESCRIPTION
## Contribution Type

- [x] Repo improvement (core server and docs)

## What does this do?

Normalizes thought IDs to exact decimal strings before the read-only `search` and `fetch` compatibility tools serialize JSON responses. This prevents PostgreSQL-style BIGINT values from throwing `Do not know how to serialize a BigInt` while preserving IDs above JavaScript's safe integer range.

The setup guide now downloads the compatibility helper with the canonical server files.

## Requirements

No new runtime services or credentials.

## Verification

- `cd server && npm test` (BigInt regression plus 20 protocol assertions)
- Deno 2.3.3 type check for `server/index.ts`
- Live self-hosted deployment verified with compatibility `search` and follow-up `fetch`

## Checklist

- [x] I've read `CONTRIBUTING.md`
- [x] I tested this on my own Open Brain instance
- [x] No credentials, API keys, or secrets are included
- [x] README and metadata requirements are not applicable to this core server change

The PostgreSQL/Kubernetes companion change is split into a linked integration PR so each PR passes the repository path gate independently.