### PR TITLE
[integrations] Normalize Kubernetes BIGINT IDs

### DIFF
--- a/integrations/kubernetes-deployment/Dockerfile
+++ b/integrations/kubernetes-deployment/Dockerfile
@@ -7,7 +7,7 @@ COPY deno.json ./
 RUN deno install
 
 # Copy server source
-COPY index.ts ./
+COPY index.ts compatibility.ts ./
 
 # Run as non-root
 USER deno

--- a/integrations/kubernetes-deployment/compatibility.test.mjs
+++ b/integrations/kubernetes-deployment/compatibility.test.mjs
@@ -1,0 +1,11 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { normalizeThoughtId } from "./compatibility.ts";
+
+test("normalizes a PostgreSQL BIGINT thought ID without losing precision", () => {
+  const id = normalizeThoughtId(9007199254740993n);
+
+  assert.equal(id, "9007199254740993");
+  assert.equal(JSON.stringify({ id }), '{"id":"9007199254740993"}');
+});

--- a/integrations/kubernetes-deployment/compatibility.ts
+++ b/integrations/kubernetes-deployment/compatibility.ts
@@ -1,0 +1,5 @@
+export type ThoughtId = string | number | bigint;
+
+export function normalizeThoughtId(id: ThoughtId): string {
+  return String(id);
+}

--- a/integrations/kubernetes-deployment/index.ts
+++ b/integrations/kubernetes-deployment/index.ts
@@ -22,6 +22,7 @@ import { StreamableHTTPTransport } from "@hono/mcp";
 import { Hono } from "hono";
 import { z } from "zod";
 import { Pool } from "postgres";
+import { normalizeThoughtId, type ThoughtId } from "./compatibility.ts";
 
 // --- Configuration ---
 
@@ -52,7 +53,7 @@ const pool = new Pool({
 }, 20);
 
 type ThoughtMatch = {
-  id: string;
+  id: ThoughtId;
   content: string;
   metadata: Record<string, unknown>;
   similarity: number;
@@ -60,7 +61,7 @@ type ThoughtMatch = {
 };
 
 type ThoughtRecord = {
-  id: string;
+  id: ThoughtId;
   content: string;
   metadata: Record<string, unknown>;
   created_at: string;
@@ -175,11 +176,14 @@ function buildServer(): McpServer {
             [embStr, 0.5, 10]
           );
 
-          const results = result.rows.map((t) => ({
-            id: t.id,
-            title: thoughtTitle(t.content, t.created_at),
-            url: thoughtUrl(t.id),
-          }));
+          const results = result.rows.map((t) => {
+            const id = normalizeThoughtId(t.id);
+            return {
+              id,
+              title: thoughtTitle(t.content, t.created_at),
+              url: thoughtUrl(id),
+            };
+          });
 
           return {
             content: [{ type: "text" as const, text: JSON.stringify({ results }) }],
@@ -229,11 +233,12 @@ function buildServer(): McpServer {
             };
           }
 
+          const thoughtId = normalizeThoughtId(thought.id);
           const document = {
-            id: thought.id,
+            id: thoughtId,
             title: thoughtTitle(thought.content, thought.created_at),
             text: thought.content,
-            url: thoughtUrl(thought.id),
+            url: thoughtUrl(thoughtId),
             metadata: {
               ...thought.metadata,
               created_at: thought.created_at,


### PR DESCRIPTION
## Contribution Type

- [x] Integration (`/integrations`)

## What does this do?

Applies the BIGINT-safe compatibility response boundary to the Kubernetes/PostgreSQL MCP server. Thought IDs returned by the Deno PostgreSQL driver are converted to exact decimal strings before `search` and `fetch` serialize them.

The Docker image now includes the compatibility helper.

## Requirements

No new services or credentials. This updates the existing Kubernetes deployment integration.

## Verification

- `node --test compatibility.test.mjs`
- Deno 2.3.3 type check for `index.ts`
- Production Docker image build
- Live self-hosted PostgreSQL deployment verified end to end

## Checklist

- [x] I've read `CONTRIBUTING.md`
- [x] Existing integration README and metadata remain valid
- [x] I tested this on my own Open Brain instance
- [x] No credentials, API keys, or secrets are included

Companion to #479. The canonical server and setup-guide changes are kept there so both PRs satisfy the current repository path gate.