### PR TITLE
[schemas] Decision ledger with ranked recall

### DIFF
--- a/schemas/decision-ledger/README.md
+++ b/schemas/decision-ledger/README.md
@@ -120,14 +120,23 @@ After the migration you have: `agent_decision_ledger` (one row per decision memo
 The ranking formula, per row:
 
 ```text
-score = 0.45 * relevance       (cosine similarity, or scaled full-text rank, or 0)
+score = 0.45 * relevance       (cosine similarity, or saturated full-text rank, or 0)
       + 0.25 * importance      (ledger value, initialized from confidence)
-      + 0.15 * recency         (exp(-step_distance / 120), or wall-clock decay)
-      + 0.15 * dependency      (live decisions depending on this one, capped at 3)
+      + 0.15 * recency         (exp(-step_distance / 30))
+      + 0.15 * dependency      (live decisions depending on this one, saturating at 3)
       - 0.30 if not active     (only reachable with p_include_superseded)
 ```
 
-All weights and half-lives are function parameters — tune them per brain, and treat the view in Step 4 as the scoreboard for whether your tuning helps.
+Every component is normalized into `[0,1]` before it is weighted, so the weights above are the whole story about how far each signal can move a row. Each returned row also carries `relevance_source` — `cosine`, `fts`, or `none` — so a corpus that is only partly embedded shows up in the trace instead of quietly ranking on structure alone.
+
+Four of those properties were measured rather than assumed, on a 1024-dim port of this schema running under a local agent brain:
+
+- **The full-text query is disjunctive.** `plainto_tsquery` and `websearch_to_tsquery` AND their terms together, so a natural-language question matches a row only if that one row contains every content word in the question — 0 of 15 rows matched that way, which left the FTS arm (and 45% of the score) dead for exactly the local setup it exists to serve. The query's lexemes are ORed instead: same configuration, same stemming and stopword list, one operator changed.
+- **The full-text rank saturates rather than clipping.** `LEAST(ts_rank_cd * 10, 1.0)` pins every non-trivial match to exactly `1.0`, after which recency alone decides the order; `x / (1 + x)` is monotone over the whole range and bounded by 1.
+- **Cosine similarity is clamped.** It is `-1` on opposed vectors, not 0, and an unclamped negative relevance quietly subtracts from the blend.
+- **The step half-life is 30, not 120.** `exp(-d/120)` spreads 0.0165 of the score across 15 steps — inert at session scale. Step distance is measured from `max(p_current_step, the stream's own newest step)`, which is defined for every row, so a caller that passes a stale step or none at all no longer floors every row to a recency of `1.0`.
+
+All weights, the half-life, and the dependency saturation point are function parameters — tune them per brain, and treat the view in Step 4 as the scoreboard for whether your tuning helps.
 
 ## Troubleshooting
 
@@ -138,7 +147,7 @@ Solution: Run [`schemas/agent-memory/schema.sql`](../agent-memory/schema.sql) fi
 Solution: Only `memory_type = 'decision'` rows enroll. Check that your write-back payload puts decision text in the `decisions` array (the API maps it to that type), and that the trigger `trg_agent_decision_ledger_enroll` exists on `agent_memories`.
 
 **Issue: `match_decision_ledger` returns rows but relevance is always 0**
-Solution: You called it with neither `p_query_embedding` nor `p_query`. Pass the raw query text at minimum — the full-text fallback needs it. Ranking still works (importance/recency/structure), which is also the correct behavior for "no-query" core recall.
+Solution: Check `relevance_source` on the returned rows. `none` means you called it with neither `p_query_embedding` nor `p_query` — pass the raw query text at minimum, since the full-text fallback needs it. (Ranking still works on importance/recency/structure, which is also the correct behavior for "no-query" core recall.) `fts` with a 0 relevance means the query reduced to stopwords, or none of its lexemes appear in the ledger text. A mix of `cosine` and `fts` across one result set means part of your corpus has no embedding on its linked thought.
 
 **Issue: two concurrent writers produced duplicate step_index values**
 Solution: The max+1 fallback assumes a single writer per `(workspace, task)` stream. Concurrent writers should pass explicit `metadata.step_index` values from the agent loop's own step counter. Duplicate indexes don't break ranking; they only blur step-distance recency.

--- a/schemas/decision-ledger/README.md
+++ b/schemas/decision-ledger/README.md
@@ -1,0 +1,144 @@
+# Decision Ledger
+
+> Ranked-recall sidecar for agent decisions — importance × step-recency × relevance scoring with dependency edges, usage feedback, and a per-policy recall report.
+
+```mermaid
+flowchart LR
+  Writeback["/writeback<br/>(unchanged)"] --> AM["agent_memories<br/>memory_type = decision"]
+  AM -- "AFTER INSERT trigger" --> Ledger["agent_decision_ledger<br/>step_index, importance,<br/>rationale, pins"]
+  Ledger --> Rank["match_decision_ledger()<br/>ranked recall RPC"]
+  Edges["agent_decision_edges<br/>depends_on / informs / blocks"] --> Rank
+  Rank --> Runtime["Agent runtime"]
+  Runtime -- "usage feedback" --> Stats["agent_recall_policy_stats<br/>policy comparison view"]
+```
+
+## What It Does
+
+Adds a decisions ledger on top of the [Agent Memory schema](../agent-memory/): every `memory_type = 'decision'` write is auto-enrolled (via trigger — the write path doesn't change) with a **step index**, an adjustable **importance**, an optional **rationale**, and **dependency edges** to other decisions. A ranked-recall RPC, `match_decision_ledger()`, scores ledger entries by relevance × importance × step-recency × dependency degree instead of raw vector similarity — with a full-text fallback so recall works on a fully local stack with no embedding service at all.
+
+Why: in Stefania Druga's memory-harness experiments (Sakana.ai, [AI Engineer 2026](https://www.youtube.com/watch?v=R3-anFK1YM8)), a ranked decisions ledger beat plain vector RAG on long-horizon recall — on both accuracy and token cost — and she argues recall policy should be a first-class metric. This schema implements that ledger and wires the metric into the recall traces OB1 already keeps.
+
+## Prerequisites
+
+- Working Open Brain setup ([guide](../../docs/01-getting-started.md)) — including the core capture path (`upsert_thought` → `public.thoughts`): ledger rows hang off memories whose thoughts arrive through it
+- The [Agent Memory schema](../agent-memory/) (`agent_memories` and its sidecar tables must exist)
+- Optional: the [Agent Memory API](../../integrations/agent-memory-api/) if you want the `recall_policy` patch in Step 3
+
+## Credential Tracker
+
+```text
+DECISION LEDGER -- CREDENTIAL TRACKER
+--------------------------------------
+
+SUPABASE (from your Open Brain setup)
+  Project URL:           ____________
+  Secret key:            ____________
+
+--------------------------------------
+```
+
+## Steps
+
+![Step 1](https://img.shields.io/badge/Step_1-Run_the_Ledger_Schema-1E88E5?style=for-the-badge)
+
+1. Open the Supabase SQL Editor.
+2. Paste the contents of [`schema.sql`](./schema.sql).
+3. Run it.
+
+**Done when:** Table Editor shows `agent_decision_ledger` and `agent_decision_edges`, and the Functions list shows `match_decision_ledger` and `touch_decision_recall`.
+
+![Step 2](https://img.shields.io/badge/Step_2-Verify_Auto_Enrollment-1E88E5?style=for-the-badge)
+
+Insert a test decision and confirm the trigger enrolls it:
+
+```sql
+INSERT INTO agent_memories (workspace_id, task_id, memory_type, summary, content, confidence, metadata)
+VALUES ('test-ws', 'test-task', 'decision', 'Test decision',
+        'Decision: verify the ledger trigger works', 0.8,
+        '{"rationale": "smoke test"}');
+
+SELECT step_index, importance, rationale
+FROM agent_decision_ledger
+WHERE workspace_id = 'test-ws';
+```
+
+**Done when:** one ledger row exists with `step_index = 0`, `importance = 0.80`, and the rationale populated. (Pass `metadata.step_index` explicitly when your agent loop knows its own step; the max+1 fallback assumes one writer per task stream.)
+
+![Step 3](https://img.shields.io/badge/Step_3-Optional:_Wire_Into_the_Agent_Memory_API-1E88E5?style=for-the-badge)
+
+To expose the ledger as a recall policy in the [Agent Memory API](../../integrations/agent-memory-api/), add two fields to `recallSchema` in `index.ts` (`current_step` must be a real schema field — zod strips unknown keys, so a cast can never see it):
+
+```ts
+recall_policy: z.enum(["vector", "ranked_ledger"]).default("vector"),
+current_step: z.number().int().nullable().optional(),
+```
+
+Then, in the `/recall` handler, branch on the policy when computing the ranked list, before the vector path:
+
+```ts
+if (req.recall_policy === "ranked_ledger") {
+  const { data: ledger, error: ledgerError } = await supabase.rpc("match_decision_ledger", {
+    p_workspace_id: req.workspace_id,
+    p_query: req.query,
+    p_query_embedding: embedding,
+    p_project_id: req.scope.project_only ? req.project_id ?? null : null,
+    p_task_id: req.task_id ?? null,
+    p_current_step: req.current_step ?? null,
+    p_match_count: Math.max(req.limits.max_items * 4, 20),
+  });
+  if (ledgerError) return c.json({ error: ledgerError.message }, 500, corsHeaders);
+  // Fetch the returned memory_ids from agent_memories, apply the same scope
+  // filter, attach ledger[i].relevance / ledger[i].ranking_score, and reuse
+  // the existing trace + recall-items + response tail.
+}
+```
+
+Record the policy on every trace by extending the existing trace insert:
+
+```ts
+response_policy: { recall_policy: req.recall_policy, max_items: req.limits.max_items, include_unconfirmed: req.scope.include_unconfirmed },
+```
+
+Redeploy the Edge Function.
+
+**Done when:** a `/recall` request with `"recall_policy": "ranked_ledger"` returns memories and its trace row carries `response_policy.recall_policy = "ranked_ledger"`.
+
+![Step 4](https://img.shields.io/badge/Step_4-Compare_Recall_Policies-1E88E5?style=for-the-badge)
+
+After running tasks under different policies (and posting usage feedback to `/recall/:request_id/usage`), compare them:
+
+```sql
+SELECT * FROM agent_recall_policy_stats;
+```
+
+**Done when:** you see one row per policy with request volume, items returned, and used/ignored rates. This is the recall ladder: `vector` vs `ranked_ledger` side by side, and a `none` baseline is simply not calling `/recall`. For an oracle condition in evals, fetch the known-correct memory by id and inject it directly — then compare against the ladder.
+
+## Expected Outcome
+
+After the migration you have: `agent_decision_ledger` (one row per decision memory, auto-enrolled by trigger, with step index, importance, rationale, pin flag, and recall/usage counters), `agent_decision_edges` (`depends_on` / `informs` / `blocks` edges between decisions), the `match_decision_ledger()` ranking RPC, the `touch_decision_recall()` bookkeeping function, and the `agent_recall_policy_stats` view. Lifecycle state stays in `agent_memories` — supersede a decision through the normal review flow and it drops out of ranked recall automatically (pass `p_include_superseded => true` in eval runs to keep it visible with a scoring penalty).
+
+The ranking formula, per row:
+
+```text
+score = 0.45 * relevance       (cosine similarity, or scaled full-text rank, or 0)
+      + 0.25 * importance      (ledger value, initialized from confidence)
+      + 0.15 * recency         (exp(-step_distance / 120), or wall-clock decay)
+      + 0.15 * dependency      (live decisions depending on this one, capped at 3)
+      - 0.30 if not active     (only reachable with p_include_superseded)
+```
+
+All weights and half-lives are function parameters — tune them per brain, and treat the view in Step 4 as the scoreboard for whether your tuning helps.
+
+## Troubleshooting
+
+**Issue: `decision-ledger requires public.agent_memories`**
+Solution: Run [`schemas/agent-memory/schema.sql`](../agent-memory/schema.sql) first.
+
+**Issue: ledger rows aren't created for my writebacks**
+Solution: Only `memory_type = 'decision'` rows enroll. Check that your write-back payload puts decision text in the `decisions` array (the API maps it to that type), and that the trigger `trg_agent_decision_ledger_enroll` exists on `agent_memories`.
+
+**Issue: `match_decision_ledger` returns rows but relevance is always 0**
+Solution: You called it with neither `p_query_embedding` nor `p_query`. Pass the raw query text at minimum — the full-text fallback needs it. Ranking still works (importance/recency/structure), which is also the correct behavior for "no-query" core recall.
+
+**Issue: two concurrent writers produced duplicate step_index values**
+Solution: The max+1 fallback assumes a single writer per `(workspace, task)` stream. Concurrent writers should pass explicit `metadata.step_index` values from the agent loop's own step counter. Duplicate indexes don't break ranking; they only blur step-distance recency.

--- a/schemas/decision-ledger/metadata.json
+++ b/schemas/decision-ledger/metadata.json
@@ -1,0 +1,20 @@
+{
+  "name": "Decision Ledger",
+  "description": "Ranked-recall sidecar for agent decisions: step-indexed ledger with importance, rationale, and dependency edges, a relevance-importance-recency ranking RPC with full-text fallback for local stacks, usage feedback counters, and a per-policy recall stats view.",
+  "category": "schemas",
+  "author": {
+    "name": "Sean Krayer",
+    "github": "osquashblossomo"
+  },
+  "version": "0.1.0",
+  "requires": {
+    "open_brain": true,
+    "services": [],
+    "tools": []
+  },
+  "tags": ["agent-memory", "decision-ledger", "ranked-recall", "recall-policy", "long-horizon"],
+  "difficulty": "advanced",
+  "estimated_time": "20 minutes",
+  "created": "2026-08-17",
+  "updated": "2026-08-26"
+}

--- a/schemas/decision-ledger/metadata.json
+++ b/schemas/decision-ledger/metadata.json
@@ -16,5 +16,5 @@
   "difficulty": "advanced",
   "estimated_time": "20 minutes",
   "created": "2026-08-17",
-  "updated": "2026-08-26"
+  "updated": "2026-09-01"
 }

--- a/schemas/decision-ledger/schema.sql
+++ b/schemas/decision-ledger/schema.sql
@@ -1,0 +1,410 @@
+-- ============================================================
+-- OB1 Decision Ledger
+-- Ranked-recall sidecar for agent decisions.
+--
+-- Motivation:
+--   In Stefania Druga's memory-harness experiments (Sakana.ai,
+--   AI Engineer 2026), a ranked decisions ledger beat plain
+--   vector RAG on long-horizon recall — on both accuracy AND
+--   token cost. The existing agent-memory schema already stores
+--   memory_type = 'decision' rows, but recall reaches them only
+--   through vector similarity on the linked thought. This sidecar
+--   adds what a ledger needs and vector search lacks:
+--
+--     * step_index        — where in the task the decision happened
+--     * importance        — an explicit, adjustable priority
+--     * rationale         — why, kept separate from what
+--     * dependency edges  — which decisions rest on which
+--     * a ranking RPC     — importance x step-recency x relevance,
+--                           with a full-text fallback so recall
+--                           works with no embedding service at all
+--
+-- This migration is additive only. public.thoughts and all
+-- agent-memory tables are untouched. Lifecycle state (active /
+-- superseded / stale) stays in agent_memories — the ledger reads
+-- it, never duplicates it.
+--
+-- Requires: the agent-memory sidecar schema (schemas/agent-memory).
+-- Safe to run more than once.
+-- ============================================================
+
+BEGIN;
+
+SET search_path TO public, extensions;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM information_schema.tables
+    WHERE table_schema = 'public' AND table_name = 'agent_memories'
+  ) THEN
+    RAISE EXCEPTION
+      'decision-ledger requires public.agent_memories. Run schemas/agent-memory/schema.sql first.';
+  END IF;
+END $$;
+
+-- ------------------------------------------------------------
+-- 1. Ledger rows: one per decision-type agent memory
+-- ------------------------------------------------------------
+
+CREATE TABLE IF NOT EXISTS public.agent_decision_ledger (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  memory_id UUID NOT NULL UNIQUE REFERENCES public.agent_memories(id) ON DELETE CASCADE,
+  workspace_id TEXT NOT NULL,
+  project_id TEXT,
+  task_id TEXT,
+  flow_id TEXT,
+  -- Monotonic position of the decision within its (workspace, task)
+  -- stream. This is the coordinate that makes "the answer was at
+  -- step 124, the question arrived at step 500" testable.
+  step_index INTEGER NOT NULL CHECK (step_index >= 0),
+  -- Why the decision was made, separate from the decision text
+  -- itself (which lives in agent_memories.content).
+  rationale TEXT,
+  -- Explicit priority, adjustable by review or by usage feedback.
+  importance NUMERIC(3,2) NOT NULL DEFAULT 0.50 CHECK (importance >= 0 AND importance <= 1),
+  -- Pinned decisions always surface first (harness "core" behavior).
+  pinned BOOLEAN NOT NULL DEFAULT false,
+  -- Usage bookkeeping — raw material for learned ranking later.
+  recall_count INTEGER NOT NULL DEFAULT 0,
+  used_count INTEGER NOT NULL DEFAULT 0,
+  last_recalled_at TIMESTAMPTZ,
+  metadata JSONB NOT NULL DEFAULT '{}'::jsonb,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_agent_decision_ledger_stream
+  ON public.agent_decision_ledger (workspace_id, task_id, step_index DESC);
+
+CREATE INDEX IF NOT EXISTS idx_agent_decision_ledger_scope
+  ON public.agent_decision_ledger (workspace_id, project_id, created_at DESC);
+
+-- ------------------------------------------------------------
+-- 2. Dependency edges between decisions
+--    (supersedes/merged_into already live in agent_memory_relations;
+--    this table holds the ledger-specific structural edges.)
+-- ------------------------------------------------------------
+
+CREATE TABLE IF NOT EXISTS public.agent_decision_edges (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  from_memory_id UUID NOT NULL REFERENCES public.agent_memories(id) ON DELETE CASCADE,
+  to_memory_id UUID NOT NULL REFERENCES public.agent_memories(id) ON DELETE CASCADE,
+  relation TEXT NOT NULL CHECK (relation IN ('depends_on', 'informs', 'blocks')),
+  metadata JSONB NOT NULL DEFAULT '{}'::jsonb,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  UNIQUE (from_memory_id, to_memory_id, relation),
+  CHECK (from_memory_id <> to_memory_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_agent_decision_edges_to
+  ON public.agent_decision_edges (to_memory_id, relation);
+
+-- ------------------------------------------------------------
+-- 3. Auto-enrollment: every decision-type agent memory gets a
+--    ledger row. The write path (agent-memory-api /writeback)
+--    does not need to change at all.
+--
+--    step_index comes from metadata.step_index when the caller
+--    provides it, otherwise it is assigned as max+1 within the
+--    (workspace, task) stream. Note: the fallback counter assumes
+--    a single writer per task stream (true for the serial agent
+--    loops this is built for). Concurrent writers to one task
+--    should pass explicit step_index values.
+-- ------------------------------------------------------------
+
+CREATE OR REPLACE FUNCTION public.agent_decision_ledger_enroll()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+AS $$
+DECLARE
+  v_step INTEGER;
+BEGIN
+  IF NEW.memory_type <> 'decision' THEN
+    RETURN NEW;
+  END IF;
+
+  v_step := NULLIF(NEW.metadata #>> '{agent_memory,step_index}', '')::INTEGER;
+  IF v_step IS NULL THEN
+    v_step := NULLIF(NEW.metadata ->> 'step_index', '')::INTEGER;
+  END IF;
+  IF v_step IS NULL THEN
+    SELECT COALESCE(MAX(l.step_index), -1) + 1 INTO v_step
+    FROM public.agent_decision_ledger l
+    WHERE l.workspace_id = NEW.workspace_id
+      AND l.task_id IS NOT DISTINCT FROM NEW.task_id;
+  END IF;
+
+  INSERT INTO public.agent_decision_ledger (
+    memory_id, workspace_id, project_id, task_id, flow_id,
+    step_index, rationale, importance
+  )
+  VALUES (
+    NEW.id, NEW.workspace_id, NEW.project_id, NEW.task_id, NEW.flow_id,
+    v_step,
+    NULLIF(NEW.metadata ->> 'rationale', ''),
+    COALESCE(NEW.confidence, 0.50)
+  )
+  ON CONFLICT (memory_id) DO NOTHING;
+
+  RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS trg_agent_decision_ledger_enroll ON public.agent_memories;
+CREATE TRIGGER trg_agent_decision_ledger_enroll
+  AFTER INSERT ON public.agent_memories
+  FOR EACH ROW EXECUTE FUNCTION public.agent_decision_ledger_enroll();
+
+CREATE OR REPLACE FUNCTION public.agent_decision_ledger_set_updated_at()
+RETURNS TRIGGER AS $$
+BEGIN
+  NEW.updated_at = now();
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS trg_agent_decision_ledger_updated_at ON public.agent_decision_ledger;
+CREATE TRIGGER trg_agent_decision_ledger_updated_at
+  BEFORE UPDATE ON public.agent_decision_ledger
+  FOR EACH ROW EXECUTE FUNCTION public.agent_decision_ledger_set_updated_at();
+
+-- ------------------------------------------------------------
+-- 4. Ranked recall RPC
+--
+--    score = w_similarity  * relevance      (vector, or FTS fallback)
+--          + w_importance  * importance
+--          + w_recency     * exp(-step_distance / half_life_steps)
+--          + w_dependency  * inbound_live_dependency_degree
+--
+--    Superseded/stale/rejected decisions are excluded by default
+--    (pass p_include_superseded => true for eval runs that need
+--    them). Pinned decisions always sort first.
+--
+--    Relevance fallback order:
+--      1. p_query_embedding provided and the linked thought has an
+--         embedding  -> cosine similarity
+--      2. p_query text provided -> websearch full-text rank (scaled
+--         into the 0-1 range) — this is what makes the ledger usable
+--         on a fully local stack with no embedding service
+--      3. neither -> 0 (rank purely on importance/recency/structure)
+-- ------------------------------------------------------------
+
+CREATE OR REPLACE FUNCTION public.match_decision_ledger(
+  p_workspace_id        TEXT,
+  p_query               TEXT              DEFAULT NULL,
+  p_query_embedding     vector(1536)      DEFAULT NULL,
+  p_project_id          TEXT              DEFAULT NULL,
+  p_task_id             TEXT              DEFAULT NULL,
+  p_current_step        INTEGER           DEFAULT NULL,
+  p_match_count         INTEGER           DEFAULT 10,
+  p_w_similarity        FLOAT             DEFAULT 0.45,
+  p_w_importance        FLOAT             DEFAULT 0.25,
+  p_w_recency           FLOAT             DEFAULT 0.15,
+  p_w_dependency        FLOAT             DEFAULT 0.15,
+  p_half_life_steps     FLOAT             DEFAULT 120.0,
+  p_half_life_days      FLOAT             DEFAULT 30.0,
+  p_include_superseded  BOOLEAN           DEFAULT false
+)
+RETURNS TABLE (
+  memory_id        UUID,
+  summary          TEXT,
+  content          TEXT,
+  rationale        TEXT,
+  step_index       INTEGER,
+  importance       NUMERIC,
+  pinned           BOOLEAN,
+  lifecycle_status TEXT,
+  relevance        FLOAT,
+  recency          FLOAT,
+  dependency_boost FLOAT,
+  ranking_score    FLOAT
+)
+LANGUAGE plpgsql
+STABLE
+AS $$
+BEGIN
+  IF p_half_life_steps <= 0.0 THEN p_half_life_steps := 120.0; END IF;
+  IF p_half_life_days  <= 0.0 THEN p_half_life_days  := 30.0;  END IF;
+  IF p_match_count IS NULL OR p_match_count < 1 THEN p_match_count := 10; END IF;
+
+  RETURN QUERY
+  WITH scored AS (
+    SELECT
+      m.id                                            AS s_memory_id,
+      m.summary                                       AS s_summary,
+      m.content                                       AS s_content,
+      l.rationale                                     AS s_rationale,
+      l.step_index                                    AS s_step_index,
+      l.importance                                    AS s_importance,
+      l.pinned                                        AS s_pinned,
+      m.lifecycle_status                              AS s_lifecycle_status,
+      -- relevance: vector similarity when available, FTS fallback otherwise
+      COALESCE(
+        CASE
+          WHEN p_query_embedding IS NOT NULL AND t.embedding IS NOT NULL
+            THEN (1 - (t.embedding <=> p_query_embedding))::FLOAT
+          WHEN p_query IS NOT NULL AND length(trim(p_query)) > 0
+            -- ts_rank_cd emits small raw values (~0.01-0.1); scale x10
+            -- so a solid text match lands in the same 0-1 range as
+            -- cosine similarity and can actually move the blend.
+            THEN LEAST(
+              ts_rank_cd(
+                to_tsvector('english', m.content || ' ' || COALESCE(l.rationale, '')),
+                websearch_to_tsquery('english', p_query)
+              )::FLOAT * 10.0,
+              1.0
+            )
+          ELSE 0.0
+        END,
+        0.0
+      ) AS s_relevance,
+      -- recency: step distance when the caller knows its step,
+      -- wall-clock decay otherwise
+      CASE
+        WHEN p_current_step IS NOT NULL
+          THEN exp(
+            -GREATEST((p_current_step - l.step_index)::FLOAT, 0.0)
+            / p_half_life_steps
+          )::FLOAT
+        ELSE exp(
+          -GREATEST(extract(epoch FROM (now() - l.created_at)) / 86400.0, 0.0)
+          / p_half_life_days
+        )::FLOAT
+      END AS s_recency,
+      -- dependency degree: how many live decisions depend on this one
+      LEAST(
+        (
+          SELECT COUNT(*)
+          FROM public.agent_decision_edges e
+          JOIN public.agent_memories fm ON fm.id = e.from_memory_id
+          WHERE e.to_memory_id = m.id
+            AND e.relation = 'depends_on'
+            AND fm.lifecycle_status = 'active'
+        )::FLOAT / 3.0,
+        1.0
+      ) AS s_dependency_boost
+    FROM public.agent_decision_ledger l
+    JOIN public.agent_memories m ON m.id = l.memory_id
+    LEFT JOIN public.thoughts t ON t.id = m.thought_id
+    WHERE l.workspace_id = p_workspace_id
+      AND (p_project_id IS NULL OR l.project_id = p_project_id)
+      AND (p_task_id IS NULL OR l.task_id = p_task_id)
+      AND (
+        p_include_superseded
+        OR m.lifecycle_status = 'active'
+      )
+  )
+  SELECT
+    s.s_memory_id,
+    s.s_summary,
+    s.s_content,
+    s.s_rationale,
+    s.s_step_index,
+    s.s_importance,
+    s.s_pinned,
+    s.s_lifecycle_status,
+    s.s_relevance,
+    s.s_recency,
+    s.s_dependency_boost,
+    (
+      p_w_similarity * s.s_relevance
+      + p_w_importance * s.s_importance::FLOAT
+      + p_w_recency    * s.s_recency
+      + p_w_dependency * s.s_dependency_boost
+      -- non-active rows (only reachable with p_include_superseded)
+      -- carry an explicit penalty so eval runs can still rank them
+      + CASE WHEN s.s_lifecycle_status <> 'active' THEN -0.30 ELSE 0.0 END
+    )::FLOAT AS ranking_score
+  FROM scored s
+  ORDER BY s.s_pinned DESC, ranking_score DESC, s.s_step_index DESC
+  LIMIT p_match_count;
+END;
+$$;
+
+COMMENT ON FUNCTION public.match_decision_ledger IS
+  'Ranked recall over the decision ledger. score = w_sim*relevance + w_imp*importance + w_rec*exp(-step_distance/half_life) + w_dep*dependency_degree. Vector similarity when an embedding is passed; websearch FTS fallback when only text is passed (fully local operation). Pinned rows first. Non-active decisions excluded unless p_include_superseded.';
+
+-- ------------------------------------------------------------
+-- 5. Recall bookkeeping + usage feedback
+-- ------------------------------------------------------------
+
+CREATE OR REPLACE FUNCTION public.touch_decision_recall(
+  p_memory_ids UUID[],
+  p_used BOOLEAN DEFAULT false
+)
+RETURNS INTEGER
+LANGUAGE plpgsql
+AS $$
+DECLARE
+  v_count INTEGER;
+BEGIN
+  UPDATE public.agent_decision_ledger l
+  SET recall_count = l.recall_count + 1,
+      used_count = l.used_count + CASE WHEN p_used THEN 1 ELSE 0 END,
+      last_recalled_at = now()
+  WHERE l.memory_id = ANY(p_memory_ids);
+  GET DIAGNOSTICS v_count = ROW_COUNT;
+  RETURN v_count;
+END;
+$$;
+
+-- ------------------------------------------------------------
+-- 6. Recall-policy eval view
+--
+--    The agent-memory-api already writes a recall trace per request
+--    and per-item used/ignored flags. Tag each request's policy in
+--    response_policy.recall_policy (see README patch) and this view
+--    becomes the "recall policy as a first-class metric" report:
+--    one row per policy with volume, hit-rate, and usage-rate.
+-- ------------------------------------------------------------
+
+CREATE OR REPLACE VIEW public.agent_recall_policy_stats AS
+SELECT
+  COALESCE(t.response_policy ->> 'recall_policy', 'vector') AS recall_policy,
+  COUNT(DISTINCT t.id)                                      AS recall_requests,
+  COUNT(i.id)                                               AS items_returned,
+  ROUND(AVG(i.similarity)::NUMERIC, 4)                      AS avg_similarity,
+  ROUND(AVG(i.ranking_score)::NUMERIC, 4)                   AS avg_ranking_score,
+  ROUND(
+    (SUM(CASE WHEN i.used IS TRUE THEN 1 ELSE 0 END)::NUMERIC
+      / NULLIF(SUM(CASE WHEN i.used IS NOT NULL THEN 1 ELSE 0 END), 0)),
+    4
+  )                                                         AS used_rate,
+  ROUND(
+    (SUM(CASE WHEN i.used IS FALSE THEN 1 ELSE 0 END)::NUMERIC
+      / NULLIF(SUM(CASE WHEN i.used IS NOT NULL THEN 1 ELSE 0 END), 0)),
+    4
+  )                                                         AS ignored_rate
+FROM public.agent_memory_recall_traces t
+LEFT JOIN public.agent_memory_recall_items i ON i.trace_id = t.id
+GROUP BY 1;
+
+COMMENT ON VIEW public.agent_recall_policy_stats IS
+  'Per-recall-policy report over existing recall traces: request volume, items returned, average scores, and used/ignored rates from usage feedback. Policies are read from response_policy.recall_policy on each trace.';
+
+-- ------------------------------------------------------------
+-- 7. RLS + grants (matches agent-memory conventions)
+-- ------------------------------------------------------------
+
+ALTER TABLE public.agent_decision_ledger ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.agent_decision_edges ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS agent_decision_ledger_service_role_all ON public.agent_decision_ledger;
+CREATE POLICY agent_decision_ledger_service_role_all ON public.agent_decision_ledger
+  FOR ALL TO service_role USING (true) WITH CHECK (true);
+
+DROP POLICY IF EXISTS agent_decision_edges_service_role_all ON public.agent_decision_edges;
+CREATE POLICY agent_decision_edges_service_role_all ON public.agent_decision_edges
+  FOR ALL TO service_role USING (true) WITH CHECK (true);
+
+GRANT SELECT, INSERT, UPDATE, DELETE ON TABLE public.agent_decision_ledger TO service_role;
+GRANT SELECT, INSERT, UPDATE, DELETE ON TABLE public.agent_decision_edges TO service_role;
+GRANT SELECT ON public.agent_recall_policy_stats TO service_role;
+GRANT EXECUTE ON FUNCTION public.match_decision_ledger TO service_role;
+GRANT EXECUTE ON FUNCTION public.touch_decision_recall(UUID[], BOOLEAN) TO service_role;
+
+NOTIFY pgrst, 'reload schema';
+
+COMMIT;

--- a/schemas/decision-ledger/schema.sql
+++ b/schemas/decision-ledger/schema.sql
@@ -178,34 +178,102 @@ CREATE TRIGGER trg_agent_decision_ledger_updated_at
 --          + w_recency     * exp(-step_distance / half_life_steps)
 --          + w_dependency  * inbound_live_dependency_degree
 --
+--    Every component is normalised into [0,1] before it is weighted,
+--    so the weights above are the whole story about how far each
+--    signal can move a row.
+--
 --    Superseded/stale/rejected decisions are excluded by default
 --    (pass p_include_superseded => true for eval runs that need
 --    them). Pinned decisions always sort first.
 --
 --    Relevance fallback order:
 --      1. p_query_embedding provided and the linked thought has an
---         embedding  -> cosine similarity
---      2. p_query text provided -> websearch full-text rank (scaled
---         into the 0-1 range) — this is what makes the ledger usable
---         on a fully local stack with no embedding service
+--         embedding  -> cosine similarity, clamped into [0,1]
+--      2. p_query text provided -> full-text rank over a disjunctive
+--         tsquery, saturated into the 0-1 range — this is what makes
+--         the ledger usable on a fully local stack with no embedding
+--         service at all
 --      3. neither -> 0 (rank purely on importance/recency/structure)
+--
+--    Each row reports which of the three produced its relevance, in
+--    relevance_source, so a partly-embedded corpus is visible in the
+--    trace instead of silently ranking on structure alone.
+--
+--    Four of the properties below were measured rather than assumed,
+--    on a 1024-dim port of this schema running under a local agent
+--    brain:
+--
+--      * The tsquery is disjunctive. plainto_tsquery and
+--        websearch_to_tsquery AND their terms together, so a
+--        natural-language question matches a row only when that one
+--        row contains every content word in the question — 0 of 15
+--        rows matched a question that way, which left the FTS arm,
+--        and with it 45% of the score, dead for exactly the local
+--        setup it exists to serve. The query's lexemes are ORed
+--        instead: same text search configuration, same stemming and
+--        stopword list, one operator changed. An all-stopword query
+--        reduces to the empty tsquery, which ranks every row 0 — a
+--        quiet no-match, not an error.
+--
+--      * The full-text rank saturates instead of clipping.
+--        LEAST(ts_rank_cd * 10, 1.0) pins every non-trivial match to
+--        exactly 1.0: a row matching four query terms and a row
+--        matching one both scored 1.0, and recency alone decided the
+--        order. x / (1 + x) is monotone over the whole range and
+--        bounded by 1, and keeps the same scale constant.
+--
+--      * Cosine similarity is clamped. It is -1 on opposed vectors,
+--        not 0, and an unclamped negative relevance quietly subtracts
+--        from the blend.
+--
+--      * The step half-life is 30, not 120. exp(-d/120) spreads
+--        0.0165 of the score across 15 steps, which is inert at
+--        session scale. Distance is measured from max(the caller's
+--        step, the stream's own newest step), so a caller that passes
+--        a stale step — or none at all — no longer floors every row
+--        to a recency of 1.0. That anchor is defined for every row,
+--        which is what let the wall-clock fallback, and its
+--        p_half_life_days parameter, go away entirely.
+--
+--    p_dependency_saturation is the in-degree at which the dependency
+--    term reaches 1. It is deliberately a constant rather than the
+--    candidate set's own maximum degree: normalising by the maximum
+--    makes a row's score depend on what else happened to match, and
+--    scored the same decision 0.333 and 0.5 across two queries.
 -- ------------------------------------------------------------
 
-CREATE OR REPLACE FUNCTION public.match_decision_ledger(
-  p_workspace_id        TEXT,
-  p_query               TEXT              DEFAULT NULL,
-  p_query_embedding     vector(1536)      DEFAULT NULL,
-  p_project_id          TEXT              DEFAULT NULL,
-  p_task_id             TEXT              DEFAULT NULL,
-  p_current_step        INTEGER           DEFAULT NULL,
-  p_match_count         INTEGER           DEFAULT 10,
-  p_w_similarity        FLOAT             DEFAULT 0.45,
-  p_w_importance        FLOAT             DEFAULT 0.25,
-  p_w_recency           FLOAT             DEFAULT 0.15,
-  p_w_dependency        FLOAT             DEFAULT 0.15,
-  p_half_life_steps     FLOAT             DEFAULT 120.0,
-  p_half_life_days      FLOAT             DEFAULT 30.0,
-  p_include_superseded  BOOLEAN           DEFAULT false
+-- Dropping every existing overload by name, rather than relying on
+-- CREATE OR REPLACE, is what keeps re-running this file from leaving a
+-- superseded signature behind for PostgREST to choose between.
+DO $$
+DECLARE
+  v_fn RECORD;
+BEGIN
+  FOR v_fn IN
+    SELECT p.oid::regprocedure AS signature
+    FROM pg_proc p
+    JOIN pg_namespace n ON n.oid = p.pronamespace
+    WHERE n.nspname = 'public' AND p.proname = 'match_decision_ledger'
+  LOOP
+    EXECUTE format('DROP FUNCTION %s', v_fn.signature);
+  END LOOP;
+END $$;
+
+CREATE FUNCTION public.match_decision_ledger(
+  p_workspace_id          TEXT,
+  p_query                 TEXT            DEFAULT NULL,
+  p_query_embedding       vector(1536)    DEFAULT NULL,
+  p_project_id            TEXT            DEFAULT NULL,
+  p_task_id               TEXT            DEFAULT NULL,
+  p_current_step          INTEGER         DEFAULT NULL,
+  p_match_count           INTEGER         DEFAULT 10,
+  p_w_similarity          FLOAT           DEFAULT 0.45,
+  p_w_importance          FLOAT           DEFAULT 0.25,
+  p_w_recency             FLOAT           DEFAULT 0.15,
+  p_w_dependency          FLOAT           DEFAULT 0.15,
+  p_half_life_steps       FLOAT           DEFAULT 30.0,
+  p_dependency_saturation FLOAT           DEFAULT 3.0,
+  p_include_superseded    BOOLEAN         DEFAULT false
 )
 RETURNS TABLE (
   memory_id        UUID,
@@ -217,6 +285,7 @@ RETURNS TABLE (
   pinned           BOOLEAN,
   lifecycle_status TEXT,
   relevance        FLOAT,
+  relevance_source TEXT,
   recency          FLOAT,
   dependency_boost FLOAT,
   ranking_score    FLOAT
@@ -224,67 +293,51 @@ RETURNS TABLE (
 LANGUAGE plpgsql
 STABLE
 AS $$
+DECLARE
+  v_tsquery tsquery;
 BEGIN
-  IF p_half_life_steps <= 0.0 THEN p_half_life_steps := 120.0; END IF;
-  IF p_half_life_days  <= 0.0 THEN p_half_life_days  := 30.0;  END IF;
+  IF p_half_life_steps IS NULL OR p_half_life_steps <= 0.0 THEN
+    p_half_life_steps := 30.0;
+  END IF;
+  IF p_dependency_saturation IS NULL OR p_dependency_saturation <= 0.0 THEN
+    p_dependency_saturation := 3.0;
+  END IF;
   IF p_match_count IS NULL OR p_match_count < 1 THEN p_match_count := 10; END IF;
 
+  -- Built once per call, not once per row. quote_literal keeps a lexeme
+  -- containing a quote or a backslash from ending the tsquery early.
+  IF p_query IS NOT NULL AND length(trim(p_query)) > 0 THEN
+    SELECT COALESCE(string_agg(quote_literal(lexeme), ' | '), '')::tsquery
+      INTO v_tsquery
+      FROM unnest(tsvector_to_array(to_tsvector('english', p_query))) AS lexeme;
+  END IF;
+
   RETURN QUERY
-  WITH scored AS (
+  WITH candidate AS (
     SELECT
-      m.id                                            AS s_memory_id,
-      m.summary                                       AS s_summary,
-      m.content                                       AS s_content,
-      l.rationale                                     AS s_rationale,
-      l.step_index                                    AS s_step_index,
-      l.importance                                    AS s_importance,
-      l.pinned                                        AS s_pinned,
-      m.lifecycle_status                              AS s_lifecycle_status,
-      -- relevance: vector similarity when available, FTS fallback otherwise
-      COALESCE(
-        CASE
-          WHEN p_query_embedding IS NOT NULL AND t.embedding IS NOT NULL
-            THEN (1 - (t.embedding <=> p_query_embedding))::FLOAT
-          WHEN p_query IS NOT NULL AND length(trim(p_query)) > 0
-            -- ts_rank_cd emits small raw values (~0.01-0.1); scale x10
-            -- so a solid text match lands in the same 0-1 range as
-            -- cosine similarity and can actually move the blend.
-            THEN LEAST(
-              ts_rank_cd(
-                to_tsvector('english', m.content || ' ' || COALESCE(l.rationale, '')),
-                websearch_to_tsquery('english', p_query)
-              )::FLOAT * 10.0,
-              1.0
-            )
-          ELSE 0.0
-        END,
-        0.0
-      ) AS s_relevance,
-      -- recency: step distance when the caller knows its step,
-      -- wall-clock decay otherwise
+      m.id                                            AS c_memory_id,
+      m.summary                                       AS c_summary,
+      m.content                                       AS c_content,
+      l.rationale                                     AS c_rationale,
+      l.step_index                                    AS c_step_index,
+      l.importance                                    AS c_importance,
+      l.pinned                                        AS c_pinned,
+      m.lifecycle_status                              AS c_lifecycle_status,
+      t.embedding                                     AS c_embedding,
+      -- ts_rank_cd emits small raw values (~0.01-0.1); the x10 scale
+      -- puts a solid text match in the same range as cosine similarity.
+      -- Applied once per row because the saturating transform below
+      -- needs the value twice, and Postgres does not fold two
+      -- ts_rank_cd() calls into a single evaluation.
       CASE
-        WHEN p_current_step IS NOT NULL
-          THEN exp(
-            -GREATEST((p_current_step - l.step_index)::FLOAT, 0.0)
-            / p_half_life_steps
-          )::FLOAT
-        ELSE exp(
-          -GREATEST(extract(epoch FROM (now() - l.created_at)) / 86400.0, 0.0)
-          / p_half_life_days
-        )::FLOAT
-      END AS s_recency,
-      -- dependency degree: how many live decisions depend on this one
-      LEAST(
-        (
-          SELECT COUNT(*)
-          FROM public.agent_decision_edges e
-          JOIN public.agent_memories fm ON fm.id = e.from_memory_id
-          WHERE e.to_memory_id = m.id
-            AND e.relation = 'depends_on'
-            AND fm.lifecycle_status = 'active'
-        )::FLOAT / 3.0,
-        1.0
-      ) AS s_dependency_boost
+        WHEN v_tsquery IS NULL THEN NULL
+        ELSE 10.0 * ts_rank_cd(
+               to_tsvector('english', m.content || ' ' || COALESCE(l.rationale, '')),
+               v_tsquery)::FLOAT
+      END                                             AS c_scaled_fts_rank,
+      -- The recency anchor is per stream: a step distance measured
+      -- across two tasks is not a distance at all.
+      MAX(l.step_index) OVER (PARTITION BY l.task_id) AS c_stream_max_step
     FROM public.agent_decision_ledger l
     JOIN public.agent_memories m ON m.id = l.memory_id
     LEFT JOIN public.thoughts t ON t.id = m.thought_id
@@ -295,36 +348,82 @@ BEGIN
         p_include_superseded
         OR m.lifecycle_status = 'active'
       )
+  ),
+  scored AS (
+    SELECT
+      c.*,
+      -- Which arm produced the relevance, so a corpus that is only
+      -- partly embedded is visible rather than silent.
+      CASE
+        WHEN p_query_embedding IS NOT NULL AND c.c_embedding IS NOT NULL THEN 'cosine'
+        WHEN v_tsquery IS NOT NULL THEN 'fts'
+        ELSE 'none'
+      END AS c_relevance_source,
+      CASE
+        WHEN p_query_embedding IS NOT NULL AND c.c_embedding IS NOT NULL
+          THEN LEAST(GREATEST((1 - (c.c_embedding <=> p_query_embedding))::FLOAT, 0.0), 1.0)
+        WHEN v_tsquery IS NOT NULL
+          -- Saturating, not clipping. GREATEST also folds a NULL rank
+          -- to 0 rather than letting it poison the score.
+          THEN LEAST(GREATEST(
+                 c.c_scaled_fts_rank / (1.0 + c.c_scaled_fts_rank),
+                 0.0), 1.0)
+        ELSE 0.0
+      END AS c_relevance,
+      -- GREATEST ignores NULL arguments, so a caller that passes no
+      -- step leaves the stream's newest step standing on its own; the
+      -- outer GREATEST floors the distance at 0 so a stale caller step
+      -- cannot make it negative.
+      exp(
+        -GREATEST(
+           GREATEST(p_current_step, c.c_stream_max_step) - c.c_step_index,
+           0)::FLOAT
+        / p_half_life_steps
+      )::FLOAT AS c_recency,
+      -- dependency degree: how many live decisions depend on this one
+      LEAST(
+        GREATEST((
+          SELECT COUNT(*)
+          FROM public.agent_decision_edges e
+          JOIN public.agent_memories fm ON fm.id = e.from_memory_id
+          WHERE e.to_memory_id = c.c_memory_id
+            AND e.relation = 'depends_on'
+            AND fm.lifecycle_status = 'active'
+        )::FLOAT / p_dependency_saturation, 0.0),
+        1.0
+      ) AS c_dependency_boost
+    FROM candidate c
   )
   SELECT
-    s.s_memory_id,
-    s.s_summary,
-    s.s_content,
-    s.s_rationale,
-    s.s_step_index,
-    s.s_importance,
-    s.s_pinned,
-    s.s_lifecycle_status,
-    s.s_relevance,
-    s.s_recency,
-    s.s_dependency_boost,
+    s.c_memory_id,
+    s.c_summary,
+    s.c_content,
+    s.c_rationale,
+    s.c_step_index,
+    s.c_importance,
+    s.c_pinned,
+    s.c_lifecycle_status,
+    s.c_relevance,
+    s.c_relevance_source,
+    s.c_recency,
+    s.c_dependency_boost,
     (
-      p_w_similarity * s.s_relevance
-      + p_w_importance * s.s_importance::FLOAT
-      + p_w_recency    * s.s_recency
-      + p_w_dependency * s.s_dependency_boost
+      p_w_similarity * s.c_relevance
+      + p_w_importance * LEAST(GREATEST(s.c_importance::FLOAT, 0.0), 1.0)
+      + p_w_recency    * s.c_recency
+      + p_w_dependency * s.c_dependency_boost
       -- non-active rows (only reachable with p_include_superseded)
       -- carry an explicit penalty so eval runs can still rank them
-      + CASE WHEN s.s_lifecycle_status <> 'active' THEN -0.30 ELSE 0.0 END
+      + CASE WHEN s.c_lifecycle_status <> 'active' THEN -0.30 ELSE 0.0 END
     )::FLOAT AS ranking_score
   FROM scored s
-  ORDER BY s.s_pinned DESC, ranking_score DESC, s.s_step_index DESC
+  ORDER BY s.c_pinned DESC, ranking_score DESC, s.c_step_index DESC
   LIMIT p_match_count;
 END;
 $$;
 
 COMMENT ON FUNCTION public.match_decision_ledger IS
-  'Ranked recall over the decision ledger. score = w_sim*relevance + w_imp*importance + w_rec*exp(-step_distance/half_life) + w_dep*dependency_degree. Vector similarity when an embedding is passed; websearch FTS fallback when only text is passed (fully local operation). Pinned rows first. Non-active decisions excluded unless p_include_superseded.';
+  'Ranked recall over the decision ledger. score = w_sim*relevance + w_imp*importance + w_rec*exp(-step_distance/half_life_steps) + w_dep*dependency_degree, every component clamped into [0,1] before it is weighted, non-active rows penalised 0.30 when admitted. Relevance is clamped cosine similarity when an embedding is passed and the row is embedded, a saturated disjunctive full-text rank when only query text is passed (fully local operation), 0 otherwise — reported per row as relevance_source. Pinned rows first. Non-active decisions excluded unless p_include_superseded.';
 
 -- ------------------------------------------------------------
 -- 5. Recall bookkeeping + usage feedback


### PR DESCRIPTION
<!-- Title: [schemas] Decision ledger with ranked recall -->
<!-- Branch: contrib/osquashblossomo/decision-ledger (base: main @ 9543c29, rebased 2026-09-01) -->

## Contribution Type

- [ ] Recipe
- [x] Schema
- [ ] Dashboard
- [ ] Integration
- [ ] Skill
- [ ] Repo improvement

## What does this do?

Adds a **step-indexed decisions ledger** on top of the [agent-memory schema](../schemas/agent-memory/): every `memory_type = 'decision'` write is auto-enrolled (via trigger — the write path doesn't change) with a step index, adjustable importance, an optional rationale, and dependency edges to other decisions. A ranked-recall RPC, `match_decision_ledger()`, scores entries by relevance × importance × step-recency × dependency degree — with a full-text fallback so recall works with no embedding service at all — and a per-policy stats view makes recall policies comparable side by side.

## Why this is more than `memory_type = 'decision'`

The agent-memory schema already stores decision rows, but recall reaches them only through vector similarity on the linked thought. In Stefania Druga's memory-harness experiments (Sakana.ai, AI Engineer 2026), a *ranked decisions ledger* beat plain vector RAG on long-horizon recall on both accuracy and token cost. This sidecar adds what a ledger needs and vector search lacks: where in the task a decision happened (`step_index`), an explicit priority (`importance`), the why kept apart from the what (`rationale`), which decisions rest on which (`agent_decision_edges`), and a ranking RPC that blends those signals. Lifecycle state stays in `agent_memories` — the ledger reads it, never duplicates it.

## Requirements

- Working Open Brain setup, including the core capture path (`upsert_thought` → `public.thoughts`) — ledger rows hang off memories whose thoughts arrive through it.
- The [agent-memory schema](../schemas/agent-memory/) applied (`agent_memories` and its sidecar tables).
- No external services beyond Supabase; no primitives or skills dependencies.
- Strictly sidecar-only: `public.thoughts` and every agent-memory table are untouched (no `ALTER` on any existing table). New tables carry RLS, `service_role` policies, and explicit grants per the agent-memory pattern, and the migration ends with `NOTIFY pgrst, 'reload schema';`. Safe to run more than once.

An **optional companion patch** (separate, not in this PR) wires the ledger into [`integrations/agent-memory-api`](../integrations/agent-memory-api/) as a `recall_policy: "ranked_ledger"` option on `/recall`, with the policy recorded on every recall trace — README Step 3 documents the exact change.

## The ranking is measured, not guessed

A 1024-dim port of this schema has been running under a local agent brain, and running it turned up five things the first cut of `match_decision_ledger()` got wrong. All five are fixed here, and the RPC's own header says why:

1. **The full-text query is disjunctive.** `websearch_to_tsquery` and `plainto_tsquery` AND their terms, so a natural-language question matches a row only if that one row contains every content word in the question — **0 of 15** rows matched that way, which left the FTS arm, and with it 45% of the score, dead for exactly the no-embedding-service setup it exists to serve. The query's lexemes are ORed instead: same configuration, same stemming and stopword list, one operator changed.
2. **The full-text rank saturates rather than clipping.** `LEAST(ts_rank_cd * 10, 1.0)` pins every non-trivial match to exactly `1.0`, after which recency alone decides the order; `x / (1 + x)` is monotone over the whole range and bounded by 1.
3. **Every component is clamped into `[0,1]` before it is weighted.** Cosine similarity is `-1` on opposed vectors, not 0. Each row also reports `relevance_source` (`cosine` / `fts` / `none`), so a partly-embedded corpus is visible in the trace rather than silently ranking on structure alone.
4. **The dependency normaliser is a frozen parameter, not the candidate set's maximum degree.** Normalising by the maximum makes a row's score depend on what else happened to match — it scored the same decision 0.333 and 0.5 across two queries. `p_dependency_saturation` defaults to 3.
5. **The step half-life is 30, not 120.** `exp(-d/120)` spreads 0.0165 of the score across 15 steps, which is inert at session scale. Step distance is measured from `max(p_current_step, the stream's own newest step)` — defined for every row, so a caller that passes a stale step or none at all no longer floors every row to a recency of `1.0`.

All weights, the half-life and the saturation point remain function parameters; these are the defaults, not a hardcoding.

## Testing

Tested on my own Open Brain instance in two forms:

- **This exact artifact** (1536-dim, RLS + `service_role` grants) installs green on a scratch Postgres with the Supabase environment present, re-runs idempotently, and is checked by a dual-install parity suite that diffs its installed schema against my production port line by line — every remaining difference is a reviewed allowlist entry. The five fixes above are no longer among them: they are shared by both installs now, which is the point of contributing them rather than keeping them local. What still differs is my deployment's own policy (a pin sidecar, a recall gate, a role model instead of RLS), not the ranking.
- **The ledger design end-to-end**: the 1024-dim port has been running under a local agent brain and was exercised by a 486-row live eval (54 items × 9 recall-policy arms) with zero anomalies, including the FTS fallback path and the dependency edges.

## Checklist

- [x] I've read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] My contribution includes a README with prerequisites, steps, and expected outcome
- [x] My `metadata.json` is complete and valid
- [x] Dependencies are declared and linked (agent-memory + core capture path in Prerequisites; `requires.open_brain: true`)
- [x] I've tested this on my own Open Brain instance
- [x] No credentials, API keys, or secrets are included
