### PR TITLE
[integrations] Fix enhanced-mcp search returning zero rows and captures losing embeddings

### DIFF
--- a/integrations/enhanced-mcp/index.ts
+++ b/integrations/enhanced-mcp/index.ts
@@ -149,12 +149,16 @@ server.registerTool(
       }
 
       if (mode === "text") {
+        // `p_filter` is a metadata *containment* test in search_thoughts_text
+        // (`t.metadata @> coalesce(p_filter, '{}')`), not a bag of control
+        // flags. Adding exclude_restricted/start_date/end_date here asks for
+        // thoughts whose metadata literally contains those keys, which no
+        // thought does — so every text query matched zero rows. Only genuine
+        // metadata filters may go into the payload; sensitivity and date
+        // bounds are applied below, as the semantic branch already does.
         const filter: Record<string, unknown> = {
           ...(metadataFilter as Record<string, unknown>),
         };
-        filter.exclude_restricted = true;
-        if (startDate) filter.start_date = startDate;
-        if (endDate) filter.end_date = endDate;
 
         const { data, error } = await supabase.rpc("search_thoughts_text", {
           p_query: query,
@@ -167,7 +171,10 @@ server.registerTool(
           throw new Error(`search_thoughts_text failed: ${error.message}`);
         }
 
-        const rows = (data ?? []) as ThoughtRow[];
+        const rows = ((data ?? []) as ThoughtRow[])
+          .filter((row) => row.sensitivity_tier !== "restricted")
+          .filter((row) => !startDate || row.created_at >= startDate)
+          .filter((row) => !endDate || row.created_at <= endDate);
         const totalCount =
           rows.length > 0
             ? Number(
@@ -212,15 +219,14 @@ server.registerTool(
       // over-fetch slack to avoid silently returning zero results on active
       // brains with old date windows. See `known limitations` in the README.
       const dateFilterActive = !!(startDate || endDate);
-      // Forward filters into the RPC payload — ignored by older RPC versions
-      // but used by versions that support them, at which point the
-      // post-filter becomes a no-op.
+      // Only genuine metadata filters belong in the RPC payload. The getting-
+      // started `match_thoughts` applies `filter = '{}' OR metadata @> filter`,
+      // so unknown keys are NOT ignored as previously assumed here — they make
+      // the containment test fail and the query returns zero rows. Sensitivity
+      // and date bounds are post-filtered below instead.
       const semanticFilter: Record<string, unknown> = {
         ...(metadataFilter as Record<string, unknown>),
-        exclude_restricted: true,
       };
-      if (startDate) semanticFilter.start_date = startDate;
-      if (endDate) semanticFilter.end_date = endDate;
 
       // Over-fetch when date filter is active so client-side post-filter
       // has headroom. 3x the requested limit is a reasonable compromise
@@ -387,17 +393,16 @@ server.registerTool(
     description:
       "Fetch a thought by ID with its full metadata and provenance.",
     inputSchema: z.object({
-      id: z.number().int().min(1).describe("Thought ID"),
+      // The core Open Brain schema defines `thoughts.id` as
+      // `uuid default gen_random_uuid()`, so an integer declaration made this
+      // tool impossible to call on a standard install. The lookup below is a
+      // plain `.eq()`, so a uuid string works unchanged.
+      id: z.string().uuid().describe("Thought ID (uuid)"),
     }),
   },
   async (params) => {
     try {
-      const id = asInteger(
-        (params as Record<string, unknown>).id,
-        0,
-        1,
-        Number.MAX_SAFE_INTEGER,
-      );
+      const id = String((params as Record<string, unknown>).id ?? "").trim();
 
       if (!id) {
         return toolFailure("id is required");
@@ -687,17 +692,39 @@ server.registerTool(
         throw new Error(`upsert_thought failed: ${error.message}`);
       }
 
-      const result = data as UpsertThoughtResult | null;
-      if (!result?.thought_id) {
+      // The `upsert_thought` shipped in schemas/enhanced-thoughts returns
+      // `{id, fingerprint}` and never reads `p_payload.embedding` — the
+      // embedding column is not in its INSERT list. Reading only `thought_id`
+      // therefore threw *after* the row had already been inserted, leaving a
+      // thought with a NULL embedding that semantic search can never return.
+      // Accept either key, then persist the embedding in a follow-up update,
+      // which is the same two-step the stock core server performs.
+      const result = data as (UpsertThoughtResult & { id?: string }) | null;
+      const thoughtId = result?.thought_id ?? result?.id;
+      if (!thoughtId) {
         throw new Error("upsert_thought returned no result");
       }
 
+      if (safeEmbedding(prepared.embedding)) {
+        const { error: embError } = await supabase
+          .from("thoughts")
+          .update({ embedding: prepared.embedding })
+          .eq("id", thoughtId);
+        if (embError) {
+          return toolFailure(
+            `Thought ${thoughtId} saved, but its embedding failed to store (${embError.message}). ` +
+              `It will not appear in semantic search until re-embedded.`,
+          );
+        }
+      }
+
       return toolSuccess(
-        `${result.action === "inserted" ? "Captured new" : "Updated"} thought #${result.thought_id} as ${prepared.type}.`,
+        `${result?.action === "inserted" ? "Captured new" : "Saved"} thought #${thoughtId} as ${prepared.type}.`,
         {
-          thought_id: result.thought_id,
-          action: result.action,
-          content_fingerprint: result.content_fingerprint,
+          thought_id: thoughtId,
+          action: result?.action,
+          content_fingerprint: result?.content_fingerprint ??
+            (result as Record<string, unknown> | null)?.fingerprint,
           type: prepared.type,
           sensitivity_tier: prepared.sensitivity_tier,
           metadata: prepared.metadata,
@@ -804,7 +831,10 @@ server.registerTool(
       const { data, error } = await supabase.rpc("search_thoughts_text", {
         p_query: query,
         p_limit: limit,
-        p_filter: { exclude_restricted: true },
+        // Was `{ exclude_restricted: true }`, which the RPC treats as a
+        // metadata containment test and so matched nothing. Restricted rows
+        // are dropped client-side below instead.
+        p_filter: {},
         p_offset: offset,
       });
 
@@ -812,7 +842,8 @@ server.registerTool(
         throw new Error(`search_thoughts_text failed: ${error.message}`);
       }
 
-      const rows = (data ?? []) as ThoughtRow[];
+      const rows = ((data ?? []) as ThoughtRow[])
+        .filter((row) => row.sensitivity_tier !== "restricted");
 
       if (rows.length === 0) {
         return toolSuccess("No matches found.", { results: [] });


### PR DESCRIPTION
## Contribution Type

- [x] Integration (`/integrations`)

## What does this do?

Fixes three defects that make `integrations/enhanced-mcp` non-functional against the schemas it ships against. All search returned zero rows, captures were stored with a `NULL` embedding (and reported an error while doing so), and `get_thought` could not be called at all. All three were found by testing a fresh install built from `docs/01-getting-started.md` plus `schemas/enhanced-thoughts`.

### 1. All search returned zero rows

`brain_search_thoughts` (both semantic and text modes) and `search_thoughts_text` passed `{exclude_restricted: true}` — plus `start_date`/`end_date` — inside the RPC filter payload. But both RPCs treat that payload as a **metadata containment test**:

```sql
AND t.metadata @> coalesce(p_filter, '{}'::jsonb)
```

So the query asked Postgres for thoughts whose metadata literally contains `{"exclude_restricted": true}`. No thought carries that key, so **every semantic and full-text query matched nothing**. A comment in the code assumed older RPC versions would ignore unknown filter keys — they don't; a non-matching containment test returns zero rows.

**Fix:** pass only genuine metadata filters, and apply sensitivity and date filtering client-side. The semantic branch already post-filtered `sensitivity_tier !== "restricted"`, which made the payload flag both redundant and fatal; the text paths now do the same.

### 2. Captures were stored with a NULL embedding

`brain_capture_thought` sends the embedding in `p_payload`, but the `upsert_thought` in `schemas/enhanced-thoughts` never reads it — `embedding` is not in that function's INSERT list. The handler then checked `result.thought_id`, while that RPC returns `{id, fingerprint}`, so it threw `"upsert_thought returned no result"` **after the row had already been inserted**.

The result was an error message on a write that actually succeeded, leaving a thought with a `NULL` embedding that semantic search can never return. Re-capturing does not heal it, because the fingerprint dedup path short-circuits before computing an embedding.

**Fix:** accept either key, then persist the embedding in a follow-up update — the same two-step the stock core server in `server/index.ts` already performs — and report explicitly if that update fails rather than claiming success.

### 3. `get_thought` could not be called

It declared `id` as `z.number().int().min(1)`, but the core schema defines `thoughts.id` as `uuid default gen_random_uuid()`. No valid call was possible on a standard install. The lookup is a plain `.eq()`, so accepting a uuid string is sufficient.

### Deliberately not fixed here

`update_thought` and `related_thoughts` carry the same integer-id declaration. `related_thoughts` additionally requires the `knowledge-graph` schema, which I don't have installed, so I couldn't verify a change to either and left them alone rather than ship untested edits. Happy to follow up if a maintainer with that schema can confirm the expected id type.

Separately, `graph_search` throws a raw `Could not find the table 'public.entities'` rather than the graceful "install required schema" message the README describes. Left as-is to keep this PR scoped.

## Requirements

No new requirements. Same services as the existing integration: Supabase (with `pgvector`) and OpenRouter. No dependency, schema, or API changes — this is a behavior fix confined to `integrations/enhanced-mcp/index.ts`.

## Testing

Tested on my own Open Brain instance (Supabase + pgvector, `us-west-2`, Postgres 17), built from `docs/01-getting-started.md` with `schemas/enhanced-thoughts` applied.

Before:

- `search_thoughts_text` → `{"results":[]}` for every query, including exact phrases present in stored content
- `brain_search_thoughts` → `[]` in both `text` and `semantic` mode
- `brain_capture_thought` → `Error: upsert_thought returned no result` (row inserted anyway, embedding NULL)
- `get_thought` → uncallable; schema rejects a uuid

After:

- `search_thoughts_text` returns a phrase that semantic search scored at **0.348** and silently missed (rank 0.6)
- `brain_search_thoughts` text mode returns both stored thoughts, ranked 0.665 / 0.6
- `brain_search_thoughts` semantic mode returns correctly ordered results at 0.507 / 0.481
- `brain_capture_thought` returns `{thought_id, action: "inserted"}` and the thought is retrievable semantically at **0.590**
- `get_thought` returns full metadata and provenance for a uuid
- `count_thoughts` and `brain_thought_stats` unaffected, still correct

## Checklist

- [x] I've read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] My contribution has a `README.md` with prerequisites, step-by-step instructions, and expected outcome *(existing integration README unchanged — this is a bug fix, no doc changes needed)*
- [x] My `metadata.json` has all required fields *(unchanged)*
- [x] If my contribution depends on a skill or primitive, I declared it in metadata.json and linked it in the README *(no new dependencies)*
- [x] I tested this on my own Open Brain instance
- [x] No credentials, API keys, or secrets are included
